### PR TITLE
fix(dashboard): resolve API origin correctly in docker-compose

### DIFF
--- a/apps/dashboard/src/lib/server/api.ts
+++ b/apps/dashboard/src/lib/server/api.ts
@@ -120,15 +120,12 @@ function getServerApiBaseUrl(requestHeaders: Headers): string {
   // Desktop: the API runs on a dynamic port Electron injects here. Wins over
   // the header→table fallback (which can't know a dynamic port).
   const localOverride = process.env.OPENSHIP_LOCAL_API_URL?.replace(/\/+$/, "");
+  const internal = process.env.INTERNAL_API_URL?.replace(/\/+$/, "");
   if (localOverride) {
     origin = localOverride;
-  } else if (process.env.NEXT_PUBLIC_API_PROXY === "true") {
-    const internal = process.env.INTERNAL_API_URL;
-    if (internal) {
-      origin = internal.replace(/\/+$/, "");
-    } else {
-      origin = getApiOrigin(getRequestOriginFromHeaders(requestHeaders));
-    }
+  } else if (internal) {
+    // SSR-only override; the public origin used by the browser may not resolve from here (e.g. Docker service DNS).
+    origin = internal;
   } else {
     origin = getApiOrigin(getRequestOriginFromHeaders(requestHeaders));
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3001"
+      INTERNAL_API_URL: http://api:4000
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Dashboard SSR fetches (e.g. `GET /health/env`) always resolved the API origin from a static runtime-target table, which defaults to `http://localhost:4000`. Inside the dashboard container that never reaches the `api` container, so every `docker compose up` fails with `Cannot resolve deployment info: GET /health/env is unreachable ... ECONNREFUSED`.
- `INTERNAL_API_URL` already existed as an override in `apps/dashboard/src/lib/server/api.ts`, but was only honored when `NEXT_PUBLIC_API_PROXY=true` — a `NEXT_PUBLIC_*` build-time flag the dashboard `Dockerfile` never sets, so the override was effectively dead code in this deployment path.
- Loosened `getServerApiBaseUrl` to honor `INTERNAL_API_URL` unconditionally for server-side requests (browser-side resolution is untouched), and set it in `docker-compose.yml` to the in-cluster DNS name (`http://api:4000`) for the `dashboard` service — matching the same pattern already used for `api`'s own `DATABASE_URL`/`REDIS_URL` overrides.

## Test plan
- [x] `docker compose up -d --build dashboard` — dashboard boots clean, no `ECONNREFUSED` / `health/env` error in logs
- [x] `curl http://localhost:3001` returns a normal redirect instead of the fatal error page
- [ ] Maintainers verify no regression for non-docker (bare-metal/desktop) `OPENSHIP_LOCAL_API_URL` and proxy-mode (`NEXT_PUBLIC_API_PROXY=true`) paths, which are unaffected in code review but worth a sanity check