### PR TITLE
Support reverse proxy public URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ openship up           # installs Openship as a background service (starts on boo
 
 `openship open` opens the dashboard; `openship stop` stops the service. Want a one-off attached run instead? `openship up --foreground`. To deploy a project:
 
+When a reverse proxy exposes the dashboard and `/api` on one origin, configure
+the browser-facing URL with `openship up --public-url https://openship.example.com`.
+
 ```bash
 cd your-project
 openship init         # link this directory to a project

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsup && bun run build/stage-server.ts",
     "lint": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist .turbo node_modules"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "@types/node": "^22.13.0",
     "tsx": "^4.21.0",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/cli/src/commands/up.ts
+++ b/apps/cli/src/commands/up.ts
@@ -9,12 +9,14 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { ensureDashboard } from "../lib/dashboard";
+import { mergeTrustedOrigin, normalizePublicUrl } from "../lib/public-url";
 import { installAndStart, preview } from "../lib/service";
 
 interface UpOpts {
   port?: string;
   dataDir?: string;
   dashboardPort?: string;
+  publicUrl?: string;
   ui?: boolean;
   uiVersion?: string;
   foreground?: boolean;
@@ -46,11 +48,13 @@ export const upCommand = new Command("up")
   .option("--port <port>", "API port to listen on", "4000")
   .option("--data-dir <dir>", "Directory for the embedded database")
   .option("--dashboard-port <port>", "Dashboard port", "3001")
+  .option("--public-url <url>", "Public dashboard/API origin when running behind a reverse proxy")
   .option("--no-ui", "Run the API only — don't download/serve the dashboard")
   .option("--ui-version <tag>", "Dashboard release tag to run (default: this CLI's version)")
   .option("-f, --foreground", "Run attached in this terminal instead of as a background service")
   .option("--dry-run", "Print the service definition that would be installed, then exit")
   .action(async (opts: UpOpts) => {
+    opts.publicUrl = normalizePublicUrl(opts.publicUrl);
     if (opts.foreground) return runForeground(opts);
     startService(opts);
   });
@@ -64,6 +68,7 @@ function startService(opts: UpOpts): void {
     port: opts.port,
     dataDir: opts.dataDir,
     dashboardPort: opts.dashboardPort,
+    publicUrl: opts.publicUrl,
     ui: opts.ui,
     uiVersion: opts.uiVersion,
   };
@@ -78,10 +83,11 @@ function startService(opts: UpOpts): void {
     const res = installAndStart(flags);
     const port = String(opts.port || "4000");
     const dashPort = String(opts.dashboardPort || "3001");
+    const dashboardUrl = opts.publicUrl || `http://localhost:${dashPort}`;
     console.log(
       chalk.green("\n  ✔ Openship is running as a service.\n") +
         chalk.dim(`  API:       http://localhost:${port}/api\n`) +
-        (opts.ui !== false ? chalk.dim(`  Dashboard: http://localhost:${dashPort}\n`) : "") +
+        (opts.ui !== false ? chalk.dim(`  Dashboard: ${dashboardUrl}\n`) : "") +
         chalk.dim(`  ${res.detail}\n`) +
         chalk.dim("  Starts on boot and auto-restarts. Stop with `openship stop`.\n"),
     );
@@ -106,6 +112,7 @@ async function runForeground(opts: UpOpts): Promise<void> {
     }
 
     const port = String(opts.port || "4000");
+    const publicUrl = normalizePublicUrl(opts.publicUrl);
     const dataDir: string = opts.dataDir || join(OS_DIR, "data");
     mkdirSync(dataDir, { recursive: true });
 
@@ -123,6 +130,15 @@ async function runForeground(opts: UpOpts): Promise<void> {
       OPENSHIP_MIGRATIONS_DIR: join(SERVER_DIR, "migrations"),
       OPENSHIP_PGLITE_ASSETS_DIR: join(SERVER_DIR, "pglite"),
       BETTER_AUTH_SECRET: ensureAuthSecret(),
+      ...(publicUrl
+        ? {
+            OPENSHIP_LOCAL_DASHBOARD_URL: publicUrl,
+            OPENSHIP_EXTRA_TRUSTED_ORIGINS: mergeTrustedOrigin(
+              process.env.OPENSHIP_EXTRA_TRUSTED_ORIGINS,
+              publicUrl,
+            ),
+          }
+        : {}),
     };
     delete env.DATABASE_URL;
     delete env.POSTGRES_URL;
@@ -216,7 +232,8 @@ async function runForeground(opts: UpOpts): Promise<void> {
             // window.__OPENSHIP_API_ORIGIN__ so both target our local API. It
             // does NOT read API_INTERNAL_URL — using that leaves it defaulting
             // to :4000 (possibly a different instance).
-            OPENSHIP_LOCAL_API_URL: `http://127.0.0.1:${port}`,
+            OPENSHIP_LOCAL_API_URL:
+              publicUrl || process.env.OPENSHIP_LOCAL_API_URL || `http://127.0.0.1:${port}`,
           },
           stdio: ["ignore", "pipe", "pipe"],
         });

--- a/apps/cli/src/lib/public-url.test.ts
+++ b/apps/cli/src/lib/public-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeTrustedOrigin, normalizePublicUrl } from "./public-url";
+
+describe("normalizePublicUrl", () => {
+  it("accepts and canonicalizes an HTTP(S) origin", () => {
+    expect(normalizePublicUrl("https://openship.example.com/")).toBe(
+      "https://openship.example.com",
+    );
+  });
+
+  it.each([
+    "ssh://openship.example.com",
+    "https://openship.example.com/path",
+    "https://user:secret@openship.example.com",
+    "not a url",
+  ])("rejects non-origin input %s", (value) => {
+    expect(() => normalizePublicUrl(value)).toThrow();
+  });
+});
+
+describe("mergeTrustedOrigin", () => {
+  it("preserves existing origins and de-duplicates the public origin", () => {
+    expect(
+      mergeTrustedOrigin(
+        "https://admin.example.com, https://openship.example.com",
+        "https://openship.example.com",
+      ),
+    ).toBe("https://admin.example.com,https://openship.example.com");
+  });
+});

--- a/apps/cli/src/lib/public-url.ts
+++ b/apps/cli/src/lib/public-url.ts
@@ -1,0 +1,32 @@
+/** Validate and canonicalize the single public origin used by a reverse proxy. */
+export function normalizePublicUrl(raw?: string): string | undefined {
+  if (!raw) return undefined;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Invalid --public-url: ${raw}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("--public-url must use http:// or https://");
+  }
+  if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(
+      "--public-url must be an origin without credentials, a path, query, or fragment",
+    );
+  }
+  return url.origin;
+}
+
+/** Add the proxy origin without discarding operator-provided trusted origins. */
+export function mergeTrustedOrigin(existing: string | undefined, publicUrl: string): string {
+  return [
+    ...new Set([
+      ...(existing ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+      publicUrl,
+    ]),
+  ].join(",");
+}

--- a/apps/cli/src/lib/service.ts
+++ b/apps/cli/src/lib/service.ts
@@ -29,6 +29,7 @@ export interface UpFlags {
   port?: string;
   dataDir?: string;
   dashboardPort?: string;
+  publicUrl?: string;
   /** false → pass --no-ui */
   ui?: boolean;
   uiVersion?: string;
@@ -46,6 +47,7 @@ function upArgs(flags: UpFlags): string[] {
   if (flags.port) a.push("--port", flags.port);
   if (flags.dataDir) a.push("--data-dir", flags.dataDir);
   if (flags.dashboardPort) a.push("--dashboard-port", flags.dashboardPort);
+  if (flags.publicUrl) a.push("--public-url", flags.publicUrl);
   if (flags.ui === false) a.push("--no-ui");
   if (flags.uiVersion) a.push("--ui-version", flags.uiVersion);
   return a;

--- a/apps/dashboard/src/app/(auth)/login/page.tsx
+++ b/apps/dashboard/src/app/(auth)/login/page.tsx
@@ -106,7 +106,9 @@ function LoginPageInner() {
 
   /* ── Zero-auth mode (desktop): auto-redirect to create session ── */
   if (authMode === "none") {
-    const apiUrl = getApiOrigin(typeof window !== "undefined" ? window.location.origin : undefined);
+    // The no-argument form honors the API origin injected by self-hosted
+    // installs behind a reverse proxy, even when it is not a known target.
+    const apiUrl = getApiOrigin();
     // Redirect to the desktop-login endpoint which creates a real
     // session cookie and redirects back to the dashboard.
     if (typeof window !== "undefined") {
@@ -123,7 +125,7 @@ function LoginPageInner() {
 
   /* ── Cloud mode (desktop): redirect to Openship Cloud for all auth ── */
   if (authMode === "cloud") {
-    const apiUrl = getApiOrigin(typeof window !== "undefined" ? window.location.origin : undefined);
+    const apiUrl = getApiOrigin();
     const callbackUrl = `${apiUrl}/api/auth/cloud-callback`;
     // The actual cloud-authorize URL is built inside handleCloudSignIn so
     // PKCE state can be minted + stashed in localStorage just before the

--- a/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/DeployTargetStep.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/DeployTargetStep.tsx
@@ -337,7 +337,9 @@ export function useDesktopTargets(): ResolvedTargets {
     servers,
     hasCloudConnected,
     hasCloudOption,
-    hasChoice: ready && Number(hasServers) + Number(hasCloudOption) > 1,
+    // Self-hosted/desktop installs can always deploy on the machine running
+    // Openship. Count it as a real target, independently from where builds run.
+    hasChoice: ready && Number(selfHosted) + Number(hasServers) + Number(hasCloudOption) > 1,
     refreshServers: fetchServers,
   };
 }
@@ -898,6 +900,15 @@ const DeployTargetStep: React.FC<DeployTargetStepProps> = ({ targets, onContinue
     description: string;
   }> = [];
 
+  if (selfHosted) {
+    deployTargetOptions.push({
+      value: "local",
+      icon: <Cpu className="size-5" />,
+      label: ts.options.local,
+      description: ts.options.localDesc,
+    });
+  }
+
   if (hasServers) {
     if (isSingleServer) {
       // Single server → show directly by name
@@ -1027,6 +1038,7 @@ const DeployTargetStep: React.FC<DeployTargetStepProps> = ({ targets, onContinue
 
   const hasAnyDeployTarget = deployTargetOptions.length > 0;
   const canContinue = ready && (
+    (config.deployTarget === "local" && selfHosted) ||
     config.deployTarget === "cloud" ||
     (config.deployTarget === "server" && !!config.serverId && hasServers)
   );

--- a/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import ProjectSettings from "@/components/import-project/ProjectSettings";
 import BuildSettings from "@/components/import-project/BuildSettings";
@@ -10,7 +10,7 @@ import EnvironmentVariables from "@/components/import-project/EnvironmentVariabl
 import MonorepoApps from "@/components/import-project/MonorepoApps";
 import RoutingSection from "@/components/import-project/RoutingSection";
 import Sidebar from "./components/Sidebar";
-import DeployTargetStep, { DeployTargetSummary, lastPickStore, useDesktopTargets } from "./components/DeployTargetStep";
+import DeployTargetStep, { DeployTargetSummary, useDesktopTargets } from "./components/DeployTargetStep";
 // Clone-strategy gate moved from inline render to a preflight modal
 // triggered from <Sidebar>'s handleDeploy. The inline placement was
 // wrong (showed before the user clicked Deploy). See
@@ -106,47 +106,12 @@ const DeployRepository: React.FC = () => {
     // Step: "target" = pick build/deploy target, "config" = project settings
     // Only desktop gets step 1. Non-desktop skips straight to config.
     //
-    // Returning users land directly on "config": we read their soft
-    // last-pick from localStorage SYNCHRONOUSLY in the useState initializer
-    // and skip the target picker entirely. Avoids the brief flash of
-    // "Where do you want to deploy?" + spinner that DeployTargetStep
-    // would otherwise show while waiting for settingsApi.get() to resolve.
-    // The settings-API default is still authoritative and gets applied
-    // if the user clicks "edit" to reopen the picker.
-    const [step, setStep] = useState<"target" | "config">(() => {
-        if (!isDesktop) return "config";
-        if (typeof window === "undefined") return "target";
-        return lastPickStore.read() ? "config" : "target";
-    });
-
-    // Apply the soft last-pick to config so step="config" renders with the
-    // correct target/serverId. Runs TWICE:
-    //   Pass 1: pre-paint (useLayoutEffect) so the summary bar doesn't
-    //           flash with DEFAULT_CONFIG.deployTarget="cloud".
-    //   Pass 2: AFTER initializeFromRepo's setConfig settles — that path
-    //           goes through buildPreparedConfig which overwrites
-    //           buildStrategy / runtimeMode based on stack defaults,
-    //           clobbering the user's last pick. The applied flag is
-    //           reset right before pass 2 so it fires once more.
-    const appliedLastPickRef = useRef(false);
-
-    const applyLastPick = useCallback(() => {
-        if (!isDesktop || appliedLastPickRef.current) return;
-        const last = typeof window !== "undefined" ? lastPickStore.read() : null;
-        if (!last) return;
-        appliedLastPickRef.current = true;
-        if (last.target === "server" && last.serverId) {
-            updateConfig({ deployTarget: "server", serverId: last.serverId });
-        } else if (last.target === "cloud") {
-            updateConfig({ deployTarget: "cloud", serverId: undefined, buildStrategy: "server" });
-        } else if (last.target === "local") {
-            updateConfig({ deployTarget: "local", serverId: undefined });
-        }
-    }, [isDesktop, updateConfig]);
-
-    useLayoutEffect(() => {
-        applyLastPick();
-    }, [applyLastPick]);
+    // Always enter the target step on desktop. DeployTargetStep resolves the
+    // authoritative settings default first, then the soft browser last-pick,
+    // and auto-skips when either applies cleanly.
+    const [step, setStep] = useState<"target" | "config">(
+        isDesktop ? "target" : "config",
+    );
 
     // Track whether the user explicitly came back to step 1 via the edit
     // affordance. If they did, we must NOT auto-skip past it again - they
@@ -191,16 +156,6 @@ const DeployRepository: React.FC = () => {
                     branch: branch ?? decoded.branch,
                     projectId: projectId ?? decoded.projectId,
                 });
-            }
-
-            // Re-apply last-pick: initializeFromRepo's buildPreparedConfig
-            // overwrites buildStrategy + runtimeMode from the detected stack's
-            // defaults, which clobbers what useLayoutEffect set above. Reset
-            // the guard and re-apply so the summary bar (and the rest of the
-            // page) reflects the user's actual saved preference.
-            if (result.success) {
-                appliedLastPickRef.current = false;
-                applyLastPick();
             }
 
             if (!result.success) {

--- a/apps/dashboard/src/i18n/locales/ar/deploy.json
+++ b/apps/dashboard/src/i18n/locales/ar/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "الاستنساخ على الخادم باستخدام هوية ",
     "gitForwardDescPost": " المحلية لديك — دون بناء ورفع. لا يُخزَّن أي شيء على الخادم.",
     "options": {
+      "local": "هذا الجهاز",
+      "localDesc": "النشر مباشرة على الجهاز الذي يشغّل Openship.",
       "serverViaSsh": "انشر إلى خادمك البعيد عبر SSH.",
       "servers": "الخوادم",
       "serversCount": "اختر من بين {count} خوادم مُهيّأة.",

--- a/apps/dashboard/src/i18n/locales/en/deploy.json
+++ b/apps/dashboard/src/i18n/locales/en/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "Clone on the server using your local ",
     "gitForwardDescPost": " identity — no build-and-upload. Nothing is stored on the server.",
     "options": {
+      "local": "This Machine",
+      "localDesc": "Deploy directly on the machine running Openship.",
       "serverViaSsh": "Deploy to your remote server via SSH.",
       "servers": "Your servers",
       "serversCount": "{count} configured servers.",

--- a/apps/dashboard/src/i18n/locales/es/deploy.json
+++ b/apps/dashboard/src/i18n/locales/es/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "Clona en el servidor usando tu identidad local de ",
     "gitForwardDescPost": " — sin compilar y subir. No se almacena nada en el servidor.",
     "options": {
+      "local": "Esta máquina",
+      "localDesc": "Desplegar directamente en la máquina donde se ejecuta Openship.",
       "serverViaSsh": "Despliega en tu servidor remoto a través de SSH.",
       "servers": "Tus servidores",
       "serversCount": "{count} servidores configurados.",

--- a/apps/dashboard/src/i18n/locales/fr/deploy.json
+++ b/apps/dashboard/src/i18n/locales/fr/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "Clonez sur le serveur en utilisant votre identité locale ",
     "gitForwardDescPost": " — sans build ni téléversement. Rien n'est stocké sur le serveur.",
     "options": {
+      "local": "Cette machine",
+      "localDesc": "Déployer directement sur la machine qui exécute Openship.",
       "serverViaSsh": "Déployez sur votre serveur distant via SSH.",
       "servers": "Vos serveurs",
       "serversCount": "{count} serveurs configurés.",

--- a/apps/dashboard/src/i18n/locales/ja/deploy.json
+++ b/apps/dashboard/src/i18n/locales/ja/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "ローカルの ",
     "gitForwardDescPost": " のIDを使ってサーバー上でクローンします — ビルドとアップロードは行いません。サーバーには何も保存されません。",
     "options": {
+      "local": "このマシン",
+      "localDesc": "Openshipを実行しているマシンに直接デプロイします。",
       "serverViaSsh": "SSH経由でリモートサーバーにデプロイします。",
       "servers": "あなたのサーバー",
       "serversCount": "設定済みのサーバー{count}台。",

--- a/apps/dashboard/src/i18n/locales/pt/deploy.json
+++ b/apps/dashboard/src/i18n/locales/pt/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "Clone no servidor usando a sua identidade local do ",
     "gitForwardDescPost": " — sem compilar e enviar. Nada é armazenado no servidor.",
     "options": {
+      "local": "Esta máquina",
+      "localDesc": "Executar diretamente na máquina onde o Openship está instalado.",
       "serverViaSsh": "Implante no seu servidor remoto via SSH.",
       "servers": "Seus servidores",
       "serversCount": "{count} servidores configurados.",

--- a/apps/dashboard/src/i18n/locales/zh/deploy.json
+++ b/apps/dashboard/src/i18n/locales/zh/deploy.json
@@ -129,6 +129,8 @@
     "gitForwardDescPre": "在服务器上使用你本地的 ",
     "gitForwardDescPost": " 身份进行克隆——无需构建并上传。服务器上不会存储任何内容。",
     "options": {
+      "local": "此计算机",
+      "localDesc": "直接部署到运行 Openship 的计算机。",
       "serverViaSsh": "通过 SSH 部署到你的远程服务器。",
       "servers": "你的服务器",
       "serversCount": "{count} 台已配置的服务器。",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openship",
@@ -16,7 +17,7 @@
     },
     "apps/api": {
       "name": "@repo/api",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@better-auth/drizzle-adapter": "^1.5.4",
         "@hono/node-server": "^1.19.11",
@@ -48,7 +49,7 @@
     },
     "apps/cli": {
       "name": "openship",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "bin": {
         "openship": "./dist/index.js",
       },
@@ -65,6 +66,7 @@
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
       },
     },
     "apps/dashboard": {
@@ -106,7 +108,7 @@
     },
     "apps/desktop": {
       "name": "@repo/desktop",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@repo/core": "workspace:*",
         "@repo/onboarding": "workspace:*",
@@ -126,11 +128,11 @@
     },
     "apps/email": {
       "name": "@repo/email",
-      "version": "0.1.9",
+      "version": "0.1.11",
     },
     "apps/web": {
       "name": "@repo/web",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@repo/core": "workspace:*",
         "@repo/ui": "workspace:*",


### PR DESCRIPTION
## Summary

- add `openship up --public-url <origin>` for installations behind a reverse proxy
- persist the public URL when `openship up` installs an OS service
- use the configured public origin for dashboard auth redirects instead of falling back to `localhost:4000`
- preserve existing trusted origins and validate that the supplied URL is an HTTP(S) origin

## Why

The dashboard login flow passed `window.location.origin` into the static runtime-target resolver. A custom hostname, such as a private Tailscale DNS name or a normal reverse-proxy domain, does not match a compiled target and therefore fell back to the local target at `http://localhost:4000`.

The CLI also unconditionally replaced `OPENSHIP_LOCAL_API_URL` with its loopback API URL when launching the dashboard, which prevented operators from supplying the browser-facing origin.

With this change, an operator can put the dashboard and `/api` behind one proxy and run:

```bash
openship up --public-url https://openship.example.com
```

Authentication callbacks, cookies, CORS trusted origins, and the dashboard API client then use that origin. Existing local-only behavior remains unchanged when the option is omitted.

## Validation

- `bun run --cwd apps/cli test` — 6 tests passed
- `bun run --cwd apps/cli lint`
- `bunx tsc --noEmit -p apps/dashboard/tsconfig.json`
- `bun run --cwd apps/cli build`
- verified the generated service command retains `--public-url`
- verified URLs containing paths are rejected

Note: the existing dashboard `next lint` script is incompatible with the installed Next 16 CLI because `next lint` is interpreted as a project directory, so dashboard validation used TypeScript directly.
