### PR TITLE
fix(dashboard): keep the local API on the same loopback host as the page (#27)

### DIFF
--- a/apps/dashboard/src/lib/api/urls.test.ts
+++ b/apps/dashboard/src/lib/api/urls.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { alignLoopbackOrigin } from "./urls";
+
+describe("alignLoopbackOrigin", () => {
+  it("rewrites a 127.0.0.1 API origin when the page is served from localhost", () => {
+    // The bug in #27: dashboard on localhost:3001, API injected as 127.0.0.1:4000.
+    // Cross-site for the browser, so the session cookie is dropped.
+    expect(alignLoopbackOrigin("http://127.0.0.1:4000", "http://localhost:3001")).toBe(
+      "http://localhost:4000",
+    );
+  });
+
+  it("rewrites the other way round too", () => {
+    expect(alignLoopbackOrigin("http://localhost:4000", "http://127.0.0.1:3001")).toBe(
+      "http://127.0.0.1:4000",
+    );
+  });
+
+  it("leaves the origin alone when hosts already match", () => {
+    expect(alignLoopbackOrigin("http://localhost:4000", "http://localhost:3001")).toBe(
+      "http://localhost:4000",
+    );
+  });
+
+  it("does not touch non-loopback origins", () => {
+    expect(alignLoopbackOrigin("https://api.example.com", "http://localhost:3001")).toBe(
+      "https://api.example.com",
+    );
+    expect(alignLoopbackOrigin("http://127.0.0.1:4000", "https://app.example.com")).toBe(
+      "http://127.0.0.1:4000",
+    );
+  });
+
+  it("passes a malformed override through unchanged", () => {
+    expect(alignLoopbackOrigin("not a url", "http://localhost:3001")).toBe("not a url");
+  });
+});

--- a/apps/dashboard/src/lib/api/urls.ts
+++ b/apps/dashboard/src/lib/api/urls.ts
@@ -80,11 +80,41 @@ function sameOriginProxyOrigin(): string | null {
 // into `window.__OPENSHIP_API_ORIGIN__` for the browser bundle (whose base URL
 // is a module-load constant — a build-time NEXT_PUBLIC var can't carry it).
 
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Align a loopback API origin with the loopback host the page is served from.
+ *
+ * `localhost` and `127.0.0.1` are the same machine but *different sites* to a
+ * browser: a request between them is cross-site, so the session cookie
+ * (host-only, SameSite=Lax) is never stored or sent back — sign-in returns 200
+ * and the next get-session returns 401. The CLI advertises the dashboard on
+ * `localhost` while injecting a `127.0.0.1` API origin, which trips exactly
+ * this. Rewriting the host (port preserved) keeps the pair same-site either
+ * way round. Non-loopback origins are left untouched.
+ */
+export function alignLoopbackOrigin(injected: string, pageOrigin: string): string {
+  try {
+    const api = new URL(injected);
+    const page = new URL(pageOrigin);
+    if (!LOOPBACK_HOSTNAMES.has(api.hostname) || !LOOPBACK_HOSTNAMES.has(page.hostname)) {
+      return injected;
+    }
+    api.hostname = page.hostname;
+    return `${api.protocol}//${api.host}`;
+  } catch {
+    // ponytail: a malformed override is passed through untouched — callers already
+    // tolerate a bad origin, and repairing it here would hide the real config bug.
+    return injected;
+  }
+}
+
 function localApiOverride(): string | null {
   if (typeof window !== "undefined") {
     const injected = (window as { __OPENSHIP_API_ORIGIN__?: string })
       .__OPENSHIP_API_ORIGIN__;
-    return injected ? injected.replace(/\/+$/, "") : null;
+    if (!injected) return null;
+    return alignLoopbackOrigin(injected.replace(/\/+$/, ""), window.location.origin);
   }
   const env = process.env.OPENSHIP_LOCAL_API_URL;
   return env ? env.replace(/\/+$/, "") : null;


### PR DESCRIPTION
Fixes #27 — self-hosted/desktop login where `POST /api/auth/sign-in/email` returns 200 but the very next `GET /api/auth/get-session` returns 401.

## Root cause

The CLI advertises the dashboard on `localhost` (`apps/cli/src/commands/up.ts:84`, `:245`) but spawns it with a `127.0.0.1` API origin:

```ts
OPENSHIP_LOCAL_API_URL: `http://127.0.0.1:${port}`,   // up.ts:219
```

That reaches the browser as `window.__OPENSHIP_API_ORIGIN__` (`layout.tsx:96`) → `localApiOverride()` → `getAuthBaseUrl()` → the Better Auth client's `baseURL`. Verified live:

```
$ curl -s http://localhost:3001/login | grep -o '__OPENSHIP_API_ORIGIN__[^<]*'
__OPENSHIP_API_ORIGIN__="http://127.0.0.1:4000"
```

`localhost` and `127.0.0.1` are the same machine but **different sites** to a browser, so the sign-in request is cross-site and the returned cookie —

```
openship.session_token=...; Path=/; HttpOnly; SameSite=Lax
```

— host-only and `SameSite=Lax`, is never sent back. `getSession` (`apps/api/src/modules/auth/auth.controller.ts:84-102`) then correctly 401s a request that carries no session. The server behaves correctly throughout; the browser is the one discarding the cookie, which is why server logs look clean and `curl` can't reproduce it.

## Fix

Normalise the injected origin against `window.location.hostname` when both are loopback, keeping the port.

I put this in `localApiOverride()` rather than in the CLI on purpose: it's the shared point every caller routes through, and it also covers the symmetric case (dashboard opened on `127.0.0.1:3001` with a `localhost` API origin would break identically) plus Electron, which injects the same variable. Non-loopback origins are untouched, so cloud and proxy modes are unaffected. No cookie config was changed — `SameSite=Lax` is correct once the two surfaces are same-site.

Changing `up.ts:219` to `localhost` would fix the reported path too, and is a fine addition if you'd rather have both, but on its own it leaves the reverse direction broken.

## Verification

```
$ cd apps/dashboard && npx vitest run
 Test Files  2 passed (2)
      Tests  17 passed (17)

$ npx tsc --noEmit    # exit 0
```

New unit test `apps/dashboard/src/lib/api/urls.test.ts` covers both rewrite directions, the already-matching case, non-loopback pass-through, and a malformed override.

Not verified end-to-end in a browser against a rebuilt instance — I confirmed the injected origin and the cookie attributes on a live instance, but didn't rebuild the dashboard to watch the login succeed. Worth one manual pass before merge.