### PR TITLE
fix(dashboard): make single-host proxy mode (NEXT_PUBLIC_API_PROXY) usable

### DIFF
--- a/apps/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/apps/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -83,10 +83,7 @@ function buildForwardedHeaders(req: NextRequest, upstream: URL): Headers {
   // already accepts loopback peers, but a real X-Forwarded-For makes
   // the rate-limit key match the actual client).
   const xff = req.headers.get("x-forwarded-for");
-  const clientIp =
-    req.headers.get("x-real-ip") ??
-    (req as unknown as { ip?: string }).ip ??
-    "";
+  const clientIp = req.headers.get("x-real-ip") ?? (req as unknown as { ip?: string }).ip ?? "";
   if (clientIp && !xff) {
     out.set("x-forwarded-for", clientIp);
   }
@@ -116,8 +113,7 @@ async function proxy(req: NextRequest, pathSegments: string[]): Promise<Response
     // is off, but a stray dev fetch shouldn't 200-with-loopback-data.
     return new Response(
       JSON.stringify({
-        error:
-          "API proxy is disabled. Set NEXT_PUBLIC_API_PROXY=true to enable single-host mode.",
+        error: "API proxy is disabled. Set NEXT_PUBLIC_API_PROXY=true to enable single-host mode.",
       }),
       { status: 503, headers: { "content-type": "application/json" } },
     );
@@ -160,7 +156,18 @@ async function proxy(req: NextRequest, pathSegments: string[]): Promise<Response
   const responseHeaders = new Headers();
   for (const [name, value] of upstreamRes.headers) {
     if (RESPONSE_HOP_BY_HOP.has(name.toLowerCase())) continue;
+    // set-cookie is handled separately below: `.set()` overwrites, so a
+    // multi-cookie auth response (Better Auth sends session_token +
+    // session_data) would lose all but the last one and the browser would
+    // never receive a session.
+    if (name.toLowerCase() === "set-cookie") continue;
     responseHeaders.set(name, value);
+  }
+
+  // Preserve EVERY Set-Cookie header individually. getSetCookie() is the
+  // only spec-correct way to read multiples off a fetch Response.
+  for (const cookie of upstreamRes.headers.getSetCookie()) {
+    responseHeaders.append("set-cookie", cookie);
   }
 
   // Stream the body straight through — for SSE (text/event-stream)

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -19,6 +19,15 @@ const SESSION_COOKIE_SUFFIX = ".session_token";
 
 export function proxy(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
+
+  // Never redirect API routes. The page-auth redirect below is meant for
+  // navigations; applying it to /api/* breaks single-host proxy mode
+  // (NEXT_PUBLIC_API_PROXY=true), where the sign-in POST itself goes to
+  // /api/proxy/api/auth/sign-in/email — with no session cookie yet, it
+  // was being bounced to /login, making login impossible. API auth is
+  // enforced by the API process, which returns 401 rather than a redirect.
+  if (pathname.startsWith("/api/")) return NextResponse.next();
+
   const isPublic = PUBLIC_ROUTES.some((r) => pathname.startsWith(r));
   const hasCookie = req.cookies.getAll().some((c) => c.name.endsWith(SESSION_COOKIE_SUFFIX));
 


### PR DESCRIPTION
Fixes #29.

Two independent bugs that together make login impossible when `NEXT_PUBLIC_API_PROXY=true`. One commit each.

### 1. `fix(dashboard): don't redirect /api/* in auth proxy middleware`

The `proxy.ts` matcher matches `/api/proxy/*`, which is not in `PUBLIC_ROUTES`. Without a session cookie the request is redirected to `/login` — including the sign-in POST itself, which in proxy mode goes to `/api/proxy/api/auth/sign-in/email` and by definition has no cookie yet. The request that would establish the session is bounced before reaching the API.

Added an early `return NextResponse.next()` for `/api/*`. Page-auth redirects only make sense for navigations; the API enforces auth itself and returns `401` rather than a `307` to an HTML page.

### 2. `fix(dashboard): preserve multiple Set-Cookie headers in API proxy`

Response headers were mirrored with `responseHeaders.set(name, value)` inside the loop. `.set()` replaces, so with more than one `Set-Cookie` only the last survives. Better Auth sets two cookies on sign-in, so after fixing (1) alone sign-in returns `200` but the browser has no usable session and every later request `401`s.

`set-cookie` is now skipped in the mirroring loop and each value appended via `getSetCookie()`.

### Verification

Against a running self-hosted instance (`v0.1.11`, Postgres + Redis, proxy mode on), exercising only the dashboard origin:

| step | before | after |
| --- | --- | --- |
| unauthenticated `/` | `307` → `/login` | `307` → `/login` |
| sign-in via proxy | `307` → `/login` | `200`, 2 cookies |
| authenticated `/` | n/a | `200` |
| `/api/proxy/api/projects` | n/a | `200` |
| wrong password | n/a | `403` |

Auth is still enforced: without the cookie `/api/proxy/api/projects` returns `401`, and a bad password returns `403`.

### Notes

- No behaviour change when `NEXT_PUBLIC_API_PROXY` is unset — the proxy route already returns `503` in that case, and the `/api/*` early return only skips a redirect that the API itself would have rejected with `401`.
- `bun format` (Prettier) run on both files.
