### PR TITLE
fix(dashboard): don't crash outside a secure context

### DIFF
--- a/apps/dashboard/src/components/terminal/ServerTerminalTabs.tsx
+++ b/apps/dashboard/src/components/terminal/ServerTerminalTabs.tsx
@@ -28,6 +28,7 @@ import { Plus, X } from "lucide-react";
 import { ServerTerminal, type ServerTerminalHandle } from "./ServerTerminal";
 import { useTheme } from "@/components/theme-provider";
 import { useI18n, interpolate } from "@/components/i18n-provider";
+import { randomUUID } from "@/lib/random-uuid";
 
 interface ServerTerminalTabsProps {
   serverId: string;
@@ -54,11 +55,9 @@ interface ShellEntry {
 }
 
 function genId(): string {
-  // Crypto for collision-free IDs without pulling in a uuid dep.
-  return (
-    globalThis.crypto?.randomUUID?.() ??
-    `shell-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-  );
+  // Crypto for collision-free IDs without pulling in a uuid dep. The secure
+  // context fallback lives in the shared helper.
+  return randomUUID();
 }
 
 const STORAGE_PREFIX = "openship.terminal.shells";

--- a/apps/dashboard/src/components/toast.tsx
+++ b/apps/dashboard/src/components/toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useCallback, useContext, useState } from "react";
+import { randomUUID } from "@/lib/random-uuid";
 
 /* ── Types ────────────────────────────────────────────────────── */
 
@@ -33,7 +34,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const toast = useCallback((type: ToastType, message: string, title?: string) => {
-    const id = crypto.randomUUID();
+    const id = randomUUID();
     let added = false;
     setToasts((prev) => {
       // Skip an identical toast that's already on screen so the same

--- a/apps/dashboard/src/context/deployment/types.ts
+++ b/apps/dashboard/src/context/deployment/types.ts
@@ -3,6 +3,7 @@ import type { FrameworkId, EnvironmentVariable } from "@/components/import-proje
 import type { PrepareComposeService, PrepareSingleAppCandidate } from "@/lib/api/deploy";
 import { getBuildImage, STACKS, type ProjectType, type BuildStrategy, type DeployTarget, type RuntimeMode, type StackId, type RoutingConfig } from "@repo/core";
 import type { BuildLog } from "@/utils/deploymentPhaseDetector";
+import { randomUUID } from "@/lib/random-uuid";
 
 // ─── Monorepo sub-app ────────────────────────────────────────────────────────
 
@@ -422,7 +423,7 @@ export function createPublicEndpoint(
   overrides: Partial<PublicEndpoint> = {},
 ): PublicEndpoint {
   return {
-    id: overrides.id ?? crypto.randomUUID(),
+    id: overrides.id ?? randomUUID(),
     port: overrides.port ?? "",
     targetPath: overrides.targetPath ?? "",
     domain: overrides.domain ?? "",

--- a/apps/dashboard/src/context/deployment/useDeploymentBuild.tsx
+++ b/apps/dashboard/src/context/deployment/useDeploymentBuild.tsx
@@ -10,6 +10,7 @@ import { useGitHub } from "@/context/GitHubContext";
 import type { BuildLog } from "@/utils/deploymentPhaseDetector";
 import { useBuildStream } from "@/hooks/useSSEConnection";
 import { deployApi, projectsApi } from "@/lib/api";
+import { randomUUID } from "@/lib/random-uuid";
 import { invalidateProjectCaches } from "@/hooks/useProjectEndpoints";
 import { ApiError, getApiErrorMessage } from "@/lib/api/client";
 import { DeployCredentialModal } from "@/components/deployments/DeployCredentialModal";
@@ -990,7 +991,7 @@ export function useDeploymentBuild(
               }
 
               return {
-                id: crypto.randomUUID(),
+                id: randomUUID(),
                 port: endpoint.port || "",
                 targetPath: endpoint.targetPath || "",
                 domain: cleanDomain,

--- a/apps/dashboard/src/lib/random-uuid.ts
+++ b/apps/dashboard/src/lib/random-uuid.ts
@@ -1,0 +1,22 @@
+/**
+ * `crypto.randomUUID` is only exposed in a secure context — HTTPS, or a
+ * `localhost` origin. Self-hosted instances reached over plain HTTP on a
+ * LAN/VPN address (`http://10.0.0.5:3001`, a Tailscale IP, …) are not one,
+ * so the method is simply undefined there and every call throws
+ * "crypto.randomUUID is not a function", tripping the global error boundary.
+ *
+ * These IDs are React keys and local list identifiers, never secrets, so a
+ * non-cryptographic fallback is fine. Prefer the real thing when it exists.
+ */
+export function randomUUID(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return uuid;
+
+  // RFC 4122 shape, version/variant bits included, so anything parsing these
+  // as UUIDs keeps working.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+    const rand = (Math.random() * 16) | 0;
+    const value = char === "x" ? rand : (rand & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}


### PR DESCRIPTION
## Problem

`crypto.randomUUID` is [only available in a secure context](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) — HTTPS, or a `localhost` origin. A self-hosted instance reached over plain HTTP at a LAN/VPN address (`http://10.0.0.5:3001`, a Tailscale IP, …) is **not** one, so the method is simply undefined there and every call throws:

```
TypeError: crypto.randomUUID is not a function
```

The call in `toast.tsx` is the damaging one. It runs while rendering a toast, so any recoverable API failure that surfaces an error toast escalates into the global error boundary and takes down the entire page — "Something went wrong. The app hit an unexpected error." I hit this trying to fetch a repo; the underlying request was fine, the toast reporting it is what killed the page.

This is squarely a self-hosting bug: plain-HTTP-on-a-private-address is a normal way to run Openship.

## Fix

Add `lib/random-uuid.ts` exporting `randomUUID()` — uses the native implementation when present, otherwise an RFC 4122-shaped `Math.random` fallback. These IDs are React keys and local list identifiers, never secrets, so a non-cryptographic fallback is fine.

Converted call sites:

- `components/toast.tsx:36`
- `context/deployment/useDeploymentBuild.tsx:993`
- `context/deployment/types.ts:425`

`components/terminal/ServerTerminalTabs.tsx:59` **already had this exact guard** (`globalThis.crypto?.randomUUID?.() ?? …`), which is decent evidence the bug has been hit before and patched at one site. It now delegates to the shared helper instead of keeping a second implementation.

Server-side `randomUUID` usage in `apps/api` and `packages/db` is untouched — Node always provides it.

## Testing

- `tsc --noEmit` clean, `next build` clean
- Verified against a self-hosted instance behind Cloudflare Tunnel: repo fetch previously threw and tripped the error boundary, now works

## Note

This stops the crash but doesn't make plain HTTP a secure context — clipboard, service workers, and `crypto.subtle` will still fail as features reach for them. Worth documenting an HTTPS recommendation, or warning at startup when `OPENSHIP_PUBLIC_URL` is neither HTTPS nor localhost. Happy to open a separate issue if that's useful.