### PR TITLE
fix(email): revoke blob URL when attachment popup is blocked

### DIFF
--- a/apps/email/client/components/mail/mail-display.tsx
+++ b/apps/email/client/components/mail/mail-display.tsx
@@ -498,6 +498,10 @@ const openAttachment = async (attachment: {
       popup.focus();
       // Clean up the URL after a short delay to ensure the browser has time to load it
       setTimeout(() => window.URL.revokeObjectURL(url), 1000);
+    } else {
+      // Popup was blocked: nothing will ever load the URL, so revoke it now
+      // instead of leaking the blob until the tab closes.
+      window.URL.revokeObjectURL(url);
     }
   } catch (error) {
     console.error('Error opening attachment:', error);


### PR DESCRIPTION
### Problem

`openAttachment()` in `apps/email/client/components/mail/mail-display.tsx` creates a blob URL and only revokes it inside the `if (popup)` branch:

```js
const url = window.URL.createObjectURL(blob);
const popup = window.open(url, 'attachment-viewer', ...);
if (popup) {
  popup.focus();
  setTimeout(() => window.URL.revokeObjectURL(url), 1000);
}
```

When `window.open` returns `null` — e.g. a popup blocker prevents the window — the blob URL is **never revoked** and leaks until the tab is closed. Every blocked attachment-open orphans one blob. The other download helpers in this same file (`downloadAttachment`, the zip export) already revoke unconditionally; only `openAttachment` misses the blocked-popup path.

### Fix

Revoke the URL in the `else` branch. When the popup is blocked nothing will load the URL, so it's safe to revoke immediately (one line + comment).

### Verification

Isolated repro of the URL lifecycle (mocked `createObjectURL`/`revokeObjectURL`, `window.open` → `null`):

| | before | after |
|---|---|---|
| blob URLs still live after `openAttachment()` | **1 (leaked)** | **0** |

No behavior change on the normal (popup-opened) path.