### PR TITLE
test: make TCP timeout test deterministic

### DIFF
--- a/packages/adapters/src/system/reachability.test.ts
+++ b/packages/adapters/src/system/reachability.test.ts
@@ -3,7 +3,11 @@ import { createServer } from "node:net";
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { probeTcp, probeHttp, waitForReady } from "./reachability";
 
-const tcpMock = vi.hoisted(() => ({ simulateTimeout: false }));
+const tcpMock = vi.hoisted(() => ({
+  simulateTimeout: false,
+  setTimeout: vi.fn(),
+  destroy: vi.fn(),
+}));
 
 vi.mock("node:net", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:net")>();
@@ -17,7 +21,8 @@ vi.mock("node:net", async (importOriginal) => {
 
       const listeners = new Map<string, (() => void)[]>();
       const socket = {
-        setTimeout: () => {
+        setTimeout: (timeoutMs: number) => {
+          tcpMock.setTimeout(timeoutMs);
           queueMicrotask(() => {
             for (const listener of listeners.get("timeout") ?? []) listener();
           });
@@ -29,7 +34,7 @@ vi.mock("node:net", async (importOriginal) => {
           listeners.set(event, eventListeners);
           return socket;
         },
-        destroy: () => socket,
+        destroy: () => tcpMock.destroy(),
       };
 
       return socket as unknown as ReturnType<typeof actual.connect>;
@@ -86,10 +91,12 @@ describe("probeTcp", () => {
 
   test("resolves false when the connection times out", async () => {
     tcpMock.simulateTimeout = true;
-    const start = Date.now();
+    tcpMock.setTimeout.mockClear();
+    tcpMock.destroy.mockClear();
     try {
       expect(await probeTcp("example.test", 22, 600)).toBe(false);
-      expect(Date.now() - start).toBeLessThan(100);
+      expect(tcpMock.setTimeout).toHaveBeenCalledWith(600);
+      expect(tcpMock.destroy).toHaveBeenCalledOnce();
     } finally {
       tcpMock.simulateTimeout = false;
     }

--- a/packages/adapters/src/system/reachability.test.ts
+++ b/packages/adapters/src/system/reachability.test.ts
@@ -1,7 +1,41 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { createServer } from "node:net";
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { probeTcp, probeHttp, waitForReady } from "./reachability";
+
+const tcpMock = vi.hoisted(() => ({ simulateTimeout: false }));
+
+vi.mock("node:net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:net")>();
+
+  return {
+    ...actual,
+    connect: (...args: unknown[]) => {
+      if (!tcpMock.simulateTimeout) {
+        return (actual.connect as (...params: unknown[]) => ReturnType<typeof actual.connect>)(...args);
+      }
+
+      const listeners = new Map<string, (() => void)[]>();
+      const socket = {
+        setTimeout: () => {
+          queueMicrotask(() => {
+            for (const listener of listeners.get("timeout") ?? []) listener();
+          });
+          return socket;
+        },
+        once: (event: string, listener: () => void) => {
+          const eventListeners = listeners.get(event) ?? [];
+          eventListeners.push(listener);
+          listeners.set(event, eventListeners);
+          return socket;
+        },
+        destroy: () => socket,
+      };
+
+      return socket as unknown as ReturnType<typeof actual.connect>;
+    },
+  };
+});
 
 /** Bind a throwaway TCP server on an ephemeral port and return {port, close}. */
 async function listenEphemeral(): Promise<{ port: number; close: () => void }> {
@@ -50,14 +84,15 @@ describe("probeTcp", () => {
     expect(await probeTcp("127.0.0.1", port, 1000)).toBe(false);
   });
 
-  test("resolves false (never throws) on an unroutable host within the timeout", async () => {
-    // TEST-NET-1 (192.0.2.0/24, RFC 5737) is guaranteed non-routable — the
-    // connect stalls and must hit our timeout, resolving false rather than hanging.
+  test("resolves false when the connection times out", async () => {
+    tcpMock.simulateTimeout = true;
     const start = Date.now();
-    const result = await probeTcp("192.0.2.1", 22, 600);
-    expect(result).toBe(false);
-    // Bounded by the timeout, not the OS default (~20s+).
-    expect(Date.now() - start).toBeLessThan(3000);
+    try {
+      expect(await probeTcp("example.test", 22, 600)).toBe(false);
+      expect(Date.now() - start).toBeLessThan(100);
+    } finally {
+      tcpMock.simulateTimeout = false;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Replace the external TCP connection with a simulated timeout.
The test no longer depends on network routing.

## Root cause

`192.0.2.1:22` can be reachable on private networks.
The test expected a timeout and failed when the connection succeeded.

## Validation

- `bun run --cwd packages/adapters test -- src/system/reachability.test.ts`
- `bun run --cwd packages/adapters lint`

Fixes #40