### PR TITLE
fix(dashboard): Update docs urls to the correct domain

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/DashboardHomeClient.tsx
+++ b/apps/dashboard/src/app/(dashboard)/DashboardHomeClient.tsx
@@ -192,7 +192,7 @@ export default function DashboardHomeClient({ initialData }: DashboardHomeClient
                 <p className="text-xs text-muted-foreground mt-0.5">{t.dashboard.home.settingsCardDesc}</p>
               </Link>
               <a
-                href="https://docs.openship.io"
+                href="https://openship.io/docs"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-card border border-border/50 rounded-xl p-4 hover:bg-muted/40 hover:border-border transition-all group"

--- a/apps/dashboard/src/app/(onboarding)/onboarding/_components/ssh-step.tsx
+++ b/apps/dashboard/src/app/(onboarding)/onboarding/_components/ssh-step.tsx
@@ -308,7 +308,7 @@ export function SshStep({ state, onUpdate, onNext, onBack }: StepProps) {
 
         <a
           className="ob-tutorial-link"
-          href="https://docs.openship.io/self-hosting"
+          href="https://openship.io/docs/installation"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## Simple patch

When navigating the dashboard documentation urls are pointing to an inccorect subdomain

Updated any reference of `docs.openship.io` to `openship.io/docs`