### PR TITLE
fix(cli): bundle OpenResty lua scripts into the published npm package

### DIFF
--- a/apps/cli/build/stage-server.ts
+++ b/apps/cli/build/stage-server.ts
@@ -7,6 +7,7 @@
  *                  cpu-features left external — ssh2 guards it and falls back)
  *   pglite/        pglite.wasm + pglite.data → OPENSHIP_PGLITE_ASSETS_DIR
  *   migrations/    drizzle .sql → OPENSHIP_MIGRATIONS_DIR
+ *   lua/           OpenResty scripts read by openresty-lua.ts relative to its own bundled path
  *
  * Runs (under bun) after tsup, since tsup's `clean` wipes dist first. This only
  * runs at build/publish time in the monorepo; the published package ships the
@@ -53,5 +54,9 @@ for (const file of ["pglite.wasm", "pglite.data"]) {
 
 cpSync(join(REPO_ROOT, "packages/db/drizzle"), join(OUT, "migrations"), { recursive: true });
 
+// openresty-lua.ts resolves LUA_SRC_DIR relative to its own bundled module path
+// (dist/server/index.js after bundling), i.e. it expects dist/server/lua/*.lua.
+cpSync(join(REPO_ROOT, "packages/adapters/src/infra/lua"), join(OUT, "lua"), { recursive: true });
+
 const mb = (statSync(join(OUT, "index.js")).size / 1024 / 1024).toFixed(1);
-console.log(`[stage-server] staged API bundle → dist/server (${mb} MB) + pglite + migrations`);
+console.log(`[stage-server] staged API bundle → dist/server (${mb} MB) + pglite + migrations + lua`);


### PR DESCRIPTION
Fixes #42

## Bug

`openship server install -c openresty <id>` fails at the last step with:
```
OpenResty installation failed: ENOENT: no such file or directory, open
'<npm-global>/lib/node_modules/openship/dist/server/lua/site_logger.lua'
```

## Root cause

`openresty-lua.ts` resolves `LUA_SRC_DIR` relative to its own bundled
module path — after `stage-server.ts` bundles the API into
`dist/server/index.js`, that resolves to `dist/server/lua/`. `stage-server.ts`
already stages pglite assets and drizzle migrations into `dist/server/`
the same way, but never copied `packages/adapters/src/infra/lua/*.lua`
into `dist/server/lua/`, so a plain `npm i -g openship` install is missing
the files the runtime expects.

## Fix

Add a `cpSync` of `packages/adapters/src/infra/lua` → `dist/server/lua`
in `apps/cli/build/stage-server.ts`, alongside the existing pglite/migrations
copies.

## Verification

Ran `bun run --cwd apps/cli build` and confirmed `dist/server/lua/` now
contains `site_logger.lua`, `pipe_log.lua`, `pipe_stream.lua`,
`geo_country.lua`, `mgmt_api.lua` (plus `webhook_handler.lua`, copied
incidentally since it lives in the same source directory — harmless, not
read by `readLua`).