### PR TITLE
fix(deployments): fall back to saved project env vars in requestBuildAccess

### DIFF
--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -884,6 +884,18 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
     snapshot.branch,
   );
 
+  // Caller-supplied envVars win (and get persisted as the new project
+  // defaults below); when this deploy request didn't include any — the
+  // typical wizard/CLI "just redeploy" call — fall back to the project's
+  // already-saved env vars, the same way triggerDeployment's fresh-deploy
+  // path does. Without this, a bare/server-build deploy silently ships with
+  // no env at all even though `PATCH /api/projects/:id/env` succeeded.
+  let deploymentEnvVars = encryptEnvVars(envVars);
+  if (!deploymentEnvVars) {
+    const rawEnvMap = await repos.project.getEnvMap(project.id, env);
+    deploymentEnvVars = Object.keys(rawEnvMap).length > 0 ? rawEnvMap : null;
+  }
+
   const dep = await createQueuedDeployment({
     projectId: project.id,
     organizationId: project.organizationId,
@@ -893,7 +905,7 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
     environment: env,
     framework: snapshot.framework,
     meta: metaWithPrevious(snapshot, project),
-    envVars: encryptEnvVars(envVars),
+    envVars: deploymentEnvVars,
     rollbackStrategy,
     commitShaBefore,
   });


### PR DESCRIPTION
Fixes #43

## Bug

Env vars saved via `PATCH /api/projects/:id/env` (or `openship project
env set`) never reach the running process for a self-hosted, non-Docker
("bare") deployment triggered through `POST /deployments/build/access`
without an inline `envVars` body — the generated systemd unit only ever
gets `PORT`/`NODE_ENV`.

## Root cause

`requestBuildAccess` only ever encrypted whatever `envVars` the caller
passed inline in the request body. `triggerDeployment`'s fresh-deploy
path already handles the "caller didn't send any" case by falling back
to `repos.project.getEnvMap(project.id, environment)` — the same table
`GET`/`PATCH /api/projects/:id/env` read/write — but `requestBuildAccess`
had no equivalent fallback. Since the wizard docs call `envVars`
"optional", any `build/access` call that omits it (the typical
self-hosted "Deploy" trigger) ends up with `dep.envVars = null`, and
that null propagates all the way to `BareRuntime.deploy()`'s `opts.env`
→ the systemd unit's `Environment=` lines — silently dropping the
project's saved env vars, even though passing them inline in the
request body works fine.

## Fix

Mirror `triggerDeployment`'s fallback in `requestBuildAccess`: when the
caller didn't supply `envVars` inline, read the project's persisted env
map before creating the queued deployment.

## Verification

`bun run --cwd apps/api lint` (`tsc --noEmit`) passes clean.