### PR TITLE
fix(auth): align desktop-login redirect with the request's loopback host

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -26,8 +26,27 @@
 
 import type { Context } from "hono";
 import { setSignedCookie } from "hono/cookie";
+import { alignLoopbackOrigin } from "@repo/core";
 import { auth, COOKIE_PREFIX } from "../../lib/auth";
 import { env, localDashboardUrl } from "../../config/env";
+
+/**
+ * Resolve the dashboard redirect target for THIS request. The session cookie
+ * we set is host-only (bound to whichever loopback host the request actually
+ * hit — 127.0.0.1 vs localhost), so redirecting to a fixed
+ * `localDashboardUrl` breaks the round trip whenever that fixed host differs
+ * from the request's. Align the two when both are loopback; a non-loopback
+ * request host (or a missing Host header) falls back to the configured URL.
+ */
+function resolveDashboardRedirect(c: Context): string {
+  const host = c.req.header("host");
+  if (!host) return localDashboardUrl;
+  try {
+    return alignLoopbackOrigin(localDashboardUrl, new URL(`http://${host}`).hostname);
+  } catch {
+    return localDashboardUrl;
+  }
+}
 
 // ─── HTML result page ────────────────────────────────────────────────────────
 
@@ -143,10 +162,12 @@ export async function getSession(c: Context) {
  * the cookie, and reaches the dashboard.
  */
 export async function desktopLogin(c: Context) {
+  const dashboardUrl = resolveDashboardRedirect(c);
+
   const { getAuthMode } = await import("../../lib/auth-mode");
   const authMode = await getAuthMode();
   if (authMode !== "none") {
-    return c.redirect(`${localDashboardUrl}/login`);
+    return c.redirect(`${dashboardUrl}/login`);
   }
 
   const { ensureLocalUser } = await import("../../lib/local-user");
@@ -161,7 +182,7 @@ export async function desktopLogin(c: Context) {
   });
   await setSessionCookie(c, session.token, session.expiresAt);
 
-  return c.redirect(localDashboardUrl);
+  return c.redirect(dashboardUrl);
 }
 
 /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -57,3 +57,26 @@ export function formatDuration(seconds: number): string {
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Align a loopback origin with another loopback host (port preserved).
+ *
+ * `localhost` and `127.0.0.1` are the same machine but *different sites* to a
+ * browser: a request/redirect between them is cross-site, so a host-only
+ * SameSite=Lax cookie set on one is never sent back on the other. Non-loopback
+ * origins are left untouched.
+ */
+export function alignLoopbackOrigin(origin: string, otherHost: string): string {
+  try {
+    const target = new URL(origin);
+    if (!LOOPBACK_HOSTNAMES.has(target.hostname) || !LOOPBACK_HOSTNAMES.has(otherHost)) {
+      return origin;
+    }
+    target.hostname = otherHost;
+    return `${target.protocol}//${target.host}`;
+  } catch {
+    return origin;
+  }
+}


### PR DESCRIPTION
Fixes #44

Related to #27 / PR #28.

## Bug

`GET /api/auth/desktop-login` sets a host-only session cookie scoped to
whichever host actually served the request, but always redirects to the
fixed `localDashboardUrl` (`OPENSHIP_LOCAL_DASHBOARD_URL`, default
`http://localhost:<dashboardPort>`) regardless of the request's own
host. When that fixed origin differs from the host the cookie was
minted against, the browser lands on the dashboard without the cookie
and bounces back to `/login` — this survives even the workaround
suggested in #27, since `apps/dashboard/.../login/page.tsx` already
derives the *API* URL correctly via `getApiOrigin`/`alignLoopbackOrigin`,
but the *redirect back* from `desktopLogin` was still fixed.

## Fix

`alignLoopbackOrigin` (the loopback-hostname-alignment helper added for
#27 in `apps/dashboard/src/lib/api/urls.ts`) is moved into `@repo/core`
— already a shared dependency of both `apps/api` and `apps/dashboard` —
so `desktopLogin` can use the same logic server-side: align
`localDashboardUrl`'s hostname with the incoming request's `Host` header
when both are loopback hostnames, instead of always trusting the fixed
env-configured URL. `apps/dashboard`'s own copy is untouched (out of
scope for this fix, and it's already covered by its own test).

## Verification

`bun run --cwd packages/core lint` and `bun run --cwd apps/api lint`
(both `tsc --noEmit`) pass clean.