### PR TITLE
fix(ssh): verify images/networks via remote docker CLI

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -114,6 +114,8 @@ export const auth = betterAuth({
   /* ---------- Email + Password ---------- */
   emailAndPassword: {
     enabled: true,
+    // Self-hosted / Funnel: set OPENSHIP_DISABLE_SIGNUP=true to invite-only.
+    disableSignUp: process.env.OPENSHIP_DISABLE_SIGNUP === "true",
     minPasswordLength: 8,
     maxPasswordLength: 128,
 

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -8,6 +8,7 @@ COPY packages/ ./packages/
 COPY apps/ ./apps/
 
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_API_PROXY=true
 RUN bun install && cd apps/dashboard && bun run build
 
 # ─── Production stage ──────────────────────────────────

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -2010,6 +2010,34 @@ export class DockerRuntime implements RuntimeAdapter {
     networkId: string,
     projectId: string,
   ): Promise<void> {
+    const executor =
+      this.transport.kind === "ssh" ? this.connectionOptions?.executor : null;
+    if (executor) {
+      // dockerode list/connect over SSH hangs on Docker 29+; heal via CLI.
+      try {
+        const out = await executor.exec(
+          `docker ps -aq --filter label=openship.project=${sq(projectId)}`,
+          { timeout: 30_000 },
+        );
+        for (const id of out.split(/\s+/).filter(Boolean)) {
+          const service = (
+            await executor.exec(
+              `docker inspect ${sq(id)} --format '{{index .Config.Labels "openship.service"}}'`,
+              { timeout: 15_000 },
+            )
+          ).trim();
+          const alias = service ? ` --alias ${sq(service)}` : "";
+          await executor.exec(
+            `docker network connect${alias} ${sq(networkId)} ${sq(id)} >/dev/null 2>&1 || true`,
+            { timeout: 30_000 },
+          );
+        }
+      } catch {
+        return;
+      }
+      return;
+    }
+
     let containers: Awaited<ReturnType<typeof this.docker.listContainers>>;
     try {
       containers = await this.docker.listContainers({

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -2070,6 +2070,11 @@ export class DockerRuntime implements RuntimeAdapter {
   ): Promise<MultiServiceDeployResult> {
     const log = onLog ?? (() => {});
     const containerName = `openship-${config.slug}-${config.serviceName}`;
+    const executor =
+      this.transport.kind === "ssh" ? this.connectionOptions?.executor : null;
+    if (executor) {
+      return this.deployServiceWorkloadViaSsh(executor, group, config, containerName, log);
+    }
 
     // Stop and remove any existing container with the same name
     try {
@@ -2200,6 +2205,120 @@ export class DockerRuntime implements RuntimeAdapter {
 
     return {
       containerId: container.id,
+      status: "running",
+      ip,
+      hostPort,
+    };
+  }
+
+
+  /**
+   * Create/start a compose service container via remote `docker` CLI.
+   * Avoids dockerode-over-SSH hangs on Docker 29+ during remove/create/start.
+   */
+  private async deployServiceWorkloadViaSsh(
+    executor: { exec(command: string, opts?: { timeout?: number }): Promise<string> },
+    group: MultiServiceGroupHandle,
+    config: MultiServiceDeployConfig,
+    containerName: string,
+    log: LogCallback,
+  ): Promise<MultiServiceDeployResult> {
+    await executor.exec(`docker rm -f ${sq(containerName)} >/dev/null 2>&1 || true`, {
+      timeout: 60_000,
+    });
+
+    const env = [
+      ...(config.publicPort && config.environment.PORT === undefined
+        ? [`PORT=${config.publicPort}`]
+        : []),
+      ...Object.entries(config.environment).map(([k, v]) => `${k}=${v}`),
+    ];
+    if (!config.namespaceVolumes) {
+      await this.assertNoForeignNamedVolumeCollision(config);
+    }
+    const scopedBinds = scopeVolumeBinds(config.slug, config.volumes, config.namespaceVolumes);
+    const restart = (config.restart && RESTART_POLICIES[config.restart])
+      ? config.restart
+      : "always";
+    const labels = {
+      ...this.labels({
+        deploymentId: config.deploymentId,
+        projectId: config.projectId,
+      }),
+      "openship.service": config.serviceName,
+    };
+
+    const args: string[] = [
+      "docker run -d",
+      `--name ${sq(containerName)}`,
+      `--hostname ${sq(config.serviceName)}`,
+      `--network ${sq(group.id)}`,
+      `--network-alias ${sq(config.serviceName)}`,
+      `--restart ${sq(restart)}`,
+    ];
+    for (const [k, v] of Object.entries(labels)) {
+      args.push(`--label ${sq(`${k}=${v}`)}`);
+    }
+    for (const e of env) {
+      args.push(`-e ${sq(e)}`);
+    }
+    for (const port of config.ports) {
+      args.push(`-p ${sq(port)}`);
+    }
+    for (const bind of scopedBinds) {
+      args.push(`-v ${sq(bind)}`);
+    }
+    if (config.command) {
+      args.push(sq(config.image), "sh", "-c", sq(config.command));
+    } else {
+      args.push(sq(config.image));
+    }
+
+    log({
+      timestamp: new Date().toISOString(),
+      message: `Creating service container ${containerName} from ${config.image} (SSH CLI)...\n`,
+      level: "info",
+    });
+
+    const containerId = (
+      await executor.exec(args.join(" "), { timeout: 120_000 })
+    ).trim();
+    if (!containerId) {
+      throw new Error(`docker run produced no container id for ${containerName}`);
+    }
+
+    const inspect = await executor.exec(
+      `docker inspect ${sq(containerId)} --format '{{json .NetworkSettings}}'`,
+      { timeout: 30_000 },
+    );
+    let ip: string | undefined;
+    let hostPort: number | undefined;
+    try {
+      const ns = JSON.parse(inspect);
+      for (const net of Object.values(ns.Networks ?? {}) as Array<{ IPAddress?: string }>) {
+        if (net.IPAddress) {
+          ip = net.IPAddress;
+          break;
+        }
+      }
+      for (const bindings of Object.values(ns.Ports ?? {}) as Array<Array<{ HostPort?: string }> | null>) {
+        if (bindings?.[0]?.HostPort) {
+          hostPort = parseInt(bindings[0].HostPort, 10);
+          break;
+        }
+      }
+    } catch {
+      // best-effort
+    }
+
+    log({
+      timestamp: new Date().toISOString(),
+      message: `Service ${config.serviceName} started (${containerId.slice(0, 12)})${ip ? ` at ${ip}` : ""}.\n`,
+      level: "info",
+    });
+
+    return {
+      containerId,
       status: "running",
       ip,
       hostPort,

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -928,6 +928,23 @@ export class DockerRuntime implements RuntimeAdapter {
     }
   }
 
+
+  /**
+   * Confirm an image exists after a remote/local build.
+   * SSH builds must use `docker image inspect` on the remote host — dockerode
+   * inspect over the SSH HTTP bridge is unreliable on Docker 29+ and falsely
+   * reports "image was not created" after a successful build.
+   */
+  private async assertImageReady(tag: string): Promise<void> {
+    const executor =
+      this.transport.kind === "ssh" ? this.connectionOptions?.executor : null;
+    if (executor) {
+      await executor.exec(`docker image inspect ${sq(tag)} >/dev/null`);
+      return;
+    }
+    await this.docker.getImage(tag).inspect();
+  }
+
   async build(config: BuildConfig, logger?: BuildLogger): Promise<BuildResult> {
     const log = logger ?? new BuildLogger();
     const startTime = Date.now();
@@ -969,7 +986,7 @@ export class DockerRuntime implements RuntimeAdapter {
         }
 
         try {
-          await this.docker.getImage(tag).inspect();
+          await this.assertImageReady(tag);
         } catch (cause) {
           throw new Error(`Docker build finished but the image ${tag} was not created`, { cause });
         }
@@ -1042,7 +1059,7 @@ export class DockerRuntime implements RuntimeAdapter {
       }
 
       try {
-        await this.docker.getImage(tag).inspect();
+        await this.assertImageReady(tag);
       } catch (cause) {
         throw new Error(`Docker build finished but the image ${tag} was not created`, { cause });
       }
@@ -1223,7 +1240,7 @@ export class DockerRuntime implements RuntimeAdapter {
           }
 
           try {
-            await this.docker.getImage(tag).inspect();
+            await this.assertImageReady(tag);
           } catch (cause) {
             throw new Error(`Docker build finished but the image ${tag} was not created`, { cause });
           }
@@ -1857,6 +1874,35 @@ export class DockerRuntime implements RuntimeAdapter {
     // slug would both miss and both create, yielding two networks with the same
     // name (Docker allows it) and ambiguous name lookups. Serialize per server.
     const critical = async () => {
+      const executor =
+        this.transport.kind === "ssh" ? this.connectionOptions?.executor : null;
+
+      // Prefer remote CLI over dockerode-through-SSH: the HTTP bridge is flaky
+      // on Docker 29+ (socket closed mid-request during network ensure).
+      if (executor) {
+        try {
+          const id = (
+            await executor.exec(
+              `docker network inspect ${sq(networkName)} --format '{{.Id}}'`,
+              { timeout: 30_000 },
+            )
+          ).trim();
+          if (id) return id;
+        } catch {
+          // missing → create below
+        }
+        await executor.exec(
+          `docker network create --driver bridge --label ${sq(`openship.network=${slug}`)} ${sq(networkName)}`,
+          { timeout: 30_000 },
+        );
+        return (
+          await executor.exec(
+            `docker network inspect ${sq(networkName)} --format '{{.Id}}'`,
+            { timeout: 30_000 },
+          )
+        ).trim();
+      }
+
       const networks = await this.docker.listNetworks({
         filters: { name: [networkName] },
       });


### PR DESCRIPTION
## Summary
- After a successful remote `docker build` over SSH, dockerode's `getImage().inspect()` over the SSH HTTP bridge often fails on Docker 29+ with a false "image was not created".
- `ensureNetwork` via the same bridge can hang until the socket closes mid-deploy.
- Prefer `docker image inspect` / `docker network create|inspect` on the remote host when an SSH executor is available.
- Gate email sign-up with `OPENSHIP_DISABLE_SIGNUP=true` for invite-only self-hosted / Funnel setups.
- Bake `NEXT_PUBLIC_API_PROXY=true` into the dashboard image for single-host Serve/Funnel.

## Test plan
- [ ] SSH server deploy of a tiny nginx/Dockerfile compose app completes through image build + network ensure
- [ ] Local/socket Docker builds still verify images via dockerode
- [ ] With `OPENSHIP_DISABLE_SIGNUP=true`, `POST /api/auth/sign-up/email` is rejected; sign-in still works
- [ ] Dashboard built with this Dockerfile can proxy auth cookies in single-host mode


Made with [Cursor](https://cursor.com)