### PR TITLE
fix(docs): update contributor guide for current workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,49 +2,67 @@
 
 Thanks for your interest in contributing! This guide covers everything you need to get started.
 
+## Prerequisites
+
+- [Bun 1.3.10](https://bun.sh/) (pinned in `.bun-version` and `package.json`)
+- [Node.js 22 or newer](https://nodejs.org/) (see `.nvmrc` and `package.json`)
+- Docker, when using the Compose stack or testing Docker-based deployments
+
 ## Development Setup
 
 ```bash
 git clone https://github.com/oblien/openship.git
 cd openship
-cp .env.example .env
-bun install
-bun dev
+bun install --frozen-lockfile
+cp apps/api/.env.example apps/api/.env
+cp apps/dashboard/.env.example apps/dashboard/.env
+bun dev:local
 ```
 
-This starts all three services:
+This starts the API and dashboard used for local development:
 
-| Service     | URL                   |
-| ----------- | --------------------- |
-| Web         | http://localhost:3009  |
-| Dashboard   | http://localhost:3001  |
-| API         | http://localhost:4000  |
+| Service   | URL                   |
+| --------- | --------------------- |
+| Dashboard | http://localhost:3001 |
+| API       | http://localhost:4000 |
 
-To work on a single app:
+Use the root scripts to run a different workspace or the full development graph:
 
 ```bash
-bun dev --filter @repo/api          # API only
-bun dev --filter @repo/dashboard    # Dashboard only
-bun dev --filter @repo/web          # Web only
+bun dev:api          # API and its workspace dependencies
+bun dev:dashboard    # Dashboard only
+bun dev:web          # Marketing site (http://localhost:3009)
+bun dev:desktop      # Electron desktop app
+bun dev:email        # Email server and client
+bun dev              # All workspace dev tasks
 ```
+
+The root `.env.example` is for the Docker Compose stack. To run that stack instead, copy it
+to `.env` and run `docker compose up -d --build`. Compose starts PostgreSQL, Redis, the API,
+the dashboard, and the web app; its web app is exposed at `http://localhost:3000`.
 
 ## Project Structure
 
 ```
 apps/
-  web/            → Next.js marketing site (port 3009)
-  dashboard/      → Next.js deployment dashboard (port 3001)
   api/            → Hono API engine (port 4000)
   cli/            → CLI tool (`openship deploy`)
+  dashboard/      → Next.js deployment dashboard (port 3001)
+  desktop/        → Electron desktop app and local service launcher
+  email/          → Email engine and Zero server/client orchestrator
+  web/            → Next.js marketing site (port 3009 in development)
 
 packages/
-  adapters/       → DockerAdapter (self-host) + OblienAdapter (cloud)
+  adapters/       → Docker, bare, and cloud runtimes plus infrastructure adapters
   core/           → Shared types, constants, utilities, errors
   db/             → Drizzle ORM schema + client + repositories
+  db-email/       → Email-server Drizzle schemas + client
+  onboarding/     → Shared onboarding flows, validation, and API client
   ui/             → Shared React components (Tailwind)
 ```
 
-All apps and packages extend `tsconfig.base.json` at the repo root.
+Most workspaces extend `tsconfig.base.json` at the repo root. The email client and server
+maintain their own strict TypeScript configurations.
 
 ## Conventions
 
@@ -80,10 +98,24 @@ If you're adding something that should only exist in the cloud version:
 bun db:generate     # Generate Drizzle migration files from schema
 bun db:push         # Push schema to dev database (no migration file)
 bun db:migrate      # Run pending migrations (production)
-bun db:studio       # Open Drizzle Studio (database browser)
+bun run --cwd packages/db db:studio  # Open Drizzle Studio (database browser)
 ```
 
 Schema lives in `packages/db/src/schema/`.
+
+## Verification
+
+The root test and build scripts run the corresponding tasks across the workspaces that
+define them:
+
+```bash
+bun run test
+bun run build
+```
+
+Run workspace checks directly when working on a single area. For example, the API typecheck
+is `bun run --cwd apps/api lint`. Run `bun format` before committing and review the resulting
+diff so unrelated files are not included.
 
 ## Need Help?
 


### PR DESCRIPTION
## Motivation

The contributor guide described an outdated three-service development setup,
omitted current workspaces, and included stale environment and database commands.

## Changes

- document the pinned Bun and Node.js prerequisites
- distinguish app-local development from the Docker Compose stack
- document the current scoped development scripts
- update the complete apps and packages workspace map
- correct the Drizzle Studio command and verification guidance

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd apps/api lint`
- `bun run --cwd packages/core test`
- `bun run --cwd packages/core build`
- Turbo dry-runs for the documented development, test, and build tasks
- `docker compose config --services`
- `prettier --check CONTRIBUTING.md`
- `git diff --check`

Full workspace test/build execution was not run because email lifecycle
dependencies were intentionally skipped for this documentation-only change.

Related to #8
