### PR TITLE
fix(dashboard): replace stale Oblien help links with Openship URLs

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/[[...slug]]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/[[...slug]]/page.tsx
@@ -604,7 +604,7 @@ const ProjectSettingsContent = () => {
       label: t.projects.help.contactSupport,
       icon: <HelpCircle className="w-4 h-4" />,
       onClick: () => {
-        window.open("https://oblien.com/support", "_blank");
+        window.open("https://openship.io/contact", "_blank");
       },
     },
     {
@@ -612,7 +612,7 @@ const ProjectSettingsContent = () => {
       label: t.projects.help.reportIssue,
       icon: <Bug className="w-4 h-4" />,
       onClick: () => {
-        window.open("https://github.com/oblien/deployments/issues/new", "_blank");
+        window.open("https://github.com/oblien/openship/issues/new", "_blank");
       },
     },
     {
@@ -620,7 +620,7 @@ const ProjectSettingsContent = () => {
       label: t.projects.help.sendFeedback,
       icon: <MessageSquare className="w-4 h-4" />,
       onClick: () => {
-        window.open("https://oblien.com/feedback", "_blank");
+        window.open("https://github.com/oblien/openship/issues/new", "_blank");
       },
     },
     {
@@ -632,7 +632,7 @@ const ProjectSettingsContent = () => {
       label: t.projects.help.documentation,
       icon: <BookOpen className="w-4 h-4" />,
       onClick: () => {
-        window.open("https://oblien.com/docs", "_blank");
+        window.open("https://openship.io/docs", "_blank");
       },
     },
     {
@@ -640,7 +640,7 @@ const ProjectSettingsContent = () => {
       label: t.projects.help.joinCommunity,
       icon: <ExternalLink className="w-4 h-4" />,
       onClick: () => {
-        window.open("https://discord.gg/oblien", "_blank");
+        window.open("https://discord.gg/openship", "_blank");
       },
     },
   ];

--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/ProjectNotFound.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/ProjectNotFound.tsx
@@ -75,7 +75,7 @@ export const ProjectNotFound: React.FC = () => {
               </p>
               <div className="flex justify-center gap-2 text-xs">
                 <a
-                  href="https://docs.oblien.com"
+                  href="https://openship.io/docs"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-foreground hover:text-primary font-semibold transition-colors"
@@ -84,7 +84,7 @@ export const ProjectNotFound: React.FC = () => {
                 </a>
                 <span className="text-muted-foreground/70">·</span>
                 <a
-                  href="mailto:support@oblien.com"
+                  href="mailto:hello@openship.io"
                   className="text-foreground hover:text-primary font-semibold transition-colors"
                 >
                   {t.projects.notFound.support}


### PR DESCRIPTION
## Summary

The project help menu and project-not-found page still linked to old **Oblien** destinations (wrong product domain, dead docs host, wrong GitHub repo, old Discord invite).

This updates those help/support entry points to the current Openship URLs used elsewhere in the repo (marketing contact page, footer, docs).

### Changes

| Location | Before | After |
|---|---|---|
| Help → Contact support | `oblien.com/support` | `openship.io/contact` |
| Help → Report issue | `github.com/oblien/deployments/issues/new` | `github.com/oblien/openship/issues/new` |
| Help → Send feedback | `oblien.com/feedback` | `github.com/oblien/openship/issues/new` |
| Help → Documentation | `oblien.com/docs` | `openship.io/docs` |
| Help → Community | `discord.gg/oblien` | `discord.gg/openship` |
| Project not found → Docs | `docs.oblien.com` | `openship.io/docs` |
| Project not found → Support | `support@oblien.com` | `hello@openship.io` |

Related to #8 (docs/help discoverability).

## Test plan

- [ ] Open a project in the dashboard → Help menu
- [ ] Click each help action and confirm the correct page/repo/Discord opens
- [ ] Visit a missing project URL and confirm Documentation / Support links work