### PR TITLE
fix(dashboard): compute real deployment stats for Activity widget

### DIFF
--- a/apps/api/src/modules/projects/project.controller.ts
+++ b/apps/api/src/modules/projects/project.controller.ts
@@ -164,7 +164,7 @@ export async function getHome(c: Context) {
     return c.json({
       success: true,
       projects: [],
-      numbers: { total_projects: 0, total_deployments: 0, total_success_deployments: 0 },
+      numbers: { total_active_projects: 0, total_deployments: 0, total_success_deployments: 0 },
       otherOrgs: [],
     });
   }
@@ -176,13 +176,19 @@ export async function getHome(c: Context) {
   // reconnect" client-side from `deployTarget === 'cloud'` +
   // CloudContext.connected — no duplicate server-side flag.
   const projectIds = result.rows.map((p) => p.id);
-  const [enrichedProjectsResolved, latestByProject, primariesByProject, servicesByProject] =
-    await Promise.all([
-      projectService.enrichProjectsBatch(result.rows),
-      repos.deployment.findLatestByProjects(projectIds),
-      repos.domain.getPrimariesByProjects(projectIds),
-      repos.service.listByProjects(projectIds),
-    ]);
+  const [
+    enrichedProjectsResolved,
+    latestByProject,
+    primariesByProject,
+    servicesByProject,
+    deploymentStats,
+  ] = await Promise.all([
+    projectService.enrichProjectsBatch(result.rows),
+    repos.deployment.findLatestByProjects(projectIds),
+    repos.domain.getPrimariesByProjects(projectIds),
+    repos.service.listByProjects(projectIds),
+    repos.deployment.countStatsByProjects(projectIds),
+  ]);
 
   const projects = enrichedProjectsResolved.map((enriched, idx) => {
     const original = result.rows[idx];
@@ -250,6 +256,8 @@ export async function getHome(c: Context) {
 
   let mergedProjects: unknown[] = localProjects;
   let cloudProjectCount = 0;
+  let cloudDeploymentCount = 0;
+  let cloudSuccessDeploymentCount = 0;
   let cloudPartial = false;
   if (cloud.state === "merged") {
     const localIds = new Set(localProjects.map((p) => (p as { id: string }).id));
@@ -259,6 +267,8 @@ export async function getHome(c: Context) {
     mergedProjects = [...localProjects, ...cloudProjects];
     cloudProjectCount =
       Number(cloud.numbers.total_projects ?? cloudProjects.length) || cloudProjects.length;
+    cloudDeploymentCount = Number(cloud.numbers.total_deployments ?? 0) || 0;
+    cloudSuccessDeploymentCount = Number(cloud.numbers.total_success_deployments ?? 0) || 0;
   } else if (cloud.state === "unavailable") {
     cloudPartial = true;
   }
@@ -271,9 +281,9 @@ export async function getHome(c: Context) {
     success: true,
     projects: mergedProjects,
     numbers: {
-      total_projects: result.total + cloudProjectCount,
-      total_deployments: 0,
-      total_success_deployments: 0,
+      total_active_projects: result.total + cloudProjectCount,
+      total_deployments: deploymentStats.total + cloudDeploymentCount,
+      total_success_deployments: deploymentStats.success + cloudSuccessDeploymentCount,
     },
     otherOrgs,
     ...(cloudPartial ? { cloudPartial: true } : {}),

--- a/packages/db/src/repos/deployment.repo.ts
+++ b/packages/db/src/repos/deployment.repo.ts
@@ -323,6 +323,24 @@ export function createDeploymentRepo(db: Database) {
       return out;
     },
 
+    /**
+     * Total + successful deployment counts across a set of projects, in one
+     * aggregate query. Used by getHome for the dashboard's Activity widget.
+     * "ready" and "partial_failure" both count as success — see
+     * getLatestSuccessfulForBranch above for why partial_failure counts.
+     */
+    async countStatsByProjects(projectIds: string[]): Promise<{ total: number; success: number }> {
+      if (projectIds.length === 0) return { total: 0, success: 0 };
+      const [row] = await db
+        .select({
+          total: sql<number>`count(*)`,
+          success: sql<number>`count(*) filter (where ${deployment.status} in ('ready', 'partial_failure'))`,
+        })
+        .from(deployment)
+        .where(inArray(deployment.projectId, projectIds));
+      return { total: Number(row?.total ?? 0), success: Number(row?.success ?? 0) };
+    },
+
     /** Bulk lookup by id — used by enrichProject batching. */
     async findManyById(ids: string[]): Promise<Map<string, Deployment>> {
       if (ids.length === 0) return new Map();


### PR DESCRIPTION
## Summary

The dashboard's Activity card always showed `Projects: 0`,
`Deployments: 0`, `Success rate: 0%` regardless of how many projects
or deployments actually existed.

## Root cause

Two independent bugs in `GET /projects/home`:

| Field | Before | After |
|---|---|---|
| Projects count | Backend returned `total_projects`; frontend reads `total_active_projects` — key never matched, always fell back to `0` | Backend now returns `total_active_projects` |
| Deployments count | Hardcoded to `0` in `project.controller.ts` | Computed from the `deployment` table via a real query |
| Success rate | Derived client-side from the two hardcoded-zero fields above → always `0%` | Derived from real success/total counts |

## Changes

- `packages/db/src/repos/deployment.repo.ts` — added `countStatsByProjects()`, a single aggregate query (`count(*)` + `count(*) filter (where status in ('ready', 'partial_failure'))`).
- `apps/api/src/modules/projects/project.controller.ts` — wired the new query into `getHome`, fixed the response key, and merged cloud deployment/success counts the same way cloud project counts were already merged.

## Test plan

- [x] `tsc --noEmit` on `packages/db` and `apps/api` — no type errors
- [x] Seeded an isolated dev instance with 1 project and 3 deployments (2 `ready`, 1 `failed`)
- [x] Verified `GET /projects/home` returns `{ total_active_projects: 1, total_deployments: 3, total_success_deployments: 2 }`
- [x] Verified the dashboard's Activity card renders `Projects: 1`, `Deployments: 3`, `Success rate: 67%`
