### PR TITLE
fix(dashboard): point docs links to openship.io/docs instead of dead …

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/DashboardHomeClient.tsx
+++ b/apps/dashboard/src/app/(dashboard)/DashboardHomeClient.tsx
@@ -192,7 +192,7 @@ export default function DashboardHomeClient({ initialData }: DashboardHomeClient
                 <p className="text-xs text-muted-foreground mt-0.5">{t.dashboard.home.settingsCardDesc}</p>
               </Link>
               <a
-                href="https://docs.openship.io"
+                href="https://openship.io/docs"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-card border border-border/50 rounded-xl p-4 hover:bg-muted/40 hover:border-border transition-all group"

--- a/apps/dashboard/src/app/(onboarding)/onboarding/_components/ssh-step.tsx
+++ b/apps/dashboard/src/app/(onboarding)/onboarding/_components/ssh-step.tsx
@@ -308,7 +308,7 @@ export function SshStep({ state, onUpdate, onNext, onBack }: StepProps) {
 
         <a
           className="ob-tutorial-link"
-          href="https://docs.openship.io/self-hosting"
+          href="https://openship.io/docs/getting-started/installation"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
…subdomain## Summary

Fixes #52 — the "Docs" quick-action link on the dashboard home page (and a
similar link in the SSH onboarding step) pointed at `docs.openship.io`, a
subdomain that doesn't resolve (`DNS_PROBE_POSSIBLE`).

## Changes

| Location | Before | After |
|---|---|---|
| Dashboard home → "Docs" quick action (`DashboardHomeClient.tsx`) | `https://docs.openship.io` | `https://openship.io/docs` |
| Onboarding → SSH step tutorial link (`ssh-step.tsx`) | `https://docs.openship.io/self-hosting` | `https://openship.io/docs/getting-started/installation` |

`openship.io/docs` is the real, live docs host (confirmed by browsing it);
`docs.openship.io` was never a valid destination. The SSH-step link now
points at the actual "Installation" doc page instead of a `/self-hosting`
path that didn't exist under either host.

## Test plan

- [x] Grepped the repo for `docs.openship.io` — no remaining references
- [x] Confirmed `openship.io/docs` and `openship.io/docs/getting-started/installation` both resolve
