### PR TITLE
feat(tunneling): implement the ngrok tunnel provider

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,8 @@
     "@hono/node-server": "^1.19.11",
     "@hono/node-ws": "^1.3.1",
     "@hono/typebox-validator": "^0.3.0",
+    "@ngrok/ngrok": "^1.7.0",
+    "@ngrok/ngrok-api": "^0.19.0",
     "@repo/adapters": "workspace:*",
     "@repo/core": "workspace:*",
     "@repo/db": "workspace:*",

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -177,6 +177,20 @@ const envSchema = z.object({
    */
   OBLIEN_WEBHOOK_SECRET: z.string().optional(),
 
+  /* ---------- ngrok tunnel provider ---------- */
+  /**
+   * Agent authtoken (from the ngrok dashboard → "Your Authtoken").
+   * Required to open any tunnel, free or paid. A per-call override
+   * can be passed via TunnelProvisionInput.context.authtoken.
+   */
+  NGROK_AUTHTOKEN: z.string().optional(),
+  /**
+   * API key (dashboard → API Keys — distinct from the authtoken above).
+   * Only needed to reserve a custom domain on a paid plan via the
+   * ngrok REST API. Free-tier dev-domain tunnels work without it.
+   */
+  NGROK_API_KEY: z.string().optional(),
+
   /* ---------- Backup destinations ---------- */
   /**
    * Allow `kind: 'local'` backup destinations. Defaults OFF in CLOUD_MODE

--- a/apps/api/src/modules/tunneling/index.ts
+++ b/apps/api/src/modules/tunneling/index.ts
@@ -44,7 +44,7 @@ export { resolveProvider, listProviders, describeProviders } from "./registry";
  *   - ProviderNotReadyError if preflight rejects (e.g. missing creds)
  *   - SlugTakenError if the chosen slug is in use
  *   - ProvisionFailedError on any other create failure
- *   - ProviderNotImplementedError for stub providers (ngrok/cloudflare)
+ *   - ProviderNotImplementedError for stub providers (cloudflare)
  *
  * Caller is responsible for persisting the returned TunnelRecord —
  * the tunneling module is intentionally stateless about ownership.

--- a/apps/api/src/modules/tunneling/providers/ngrok.provider.ts
+++ b/apps/api/src/modules/tunneling/providers/ngrok.provider.ts
@@ -1,43 +1,203 @@
 /**
- * ngrok tunnel provider — STUB.
+ * ngrok tunnel provider.
  *
- * Planned shape:
- *   - Credentials: NGROK_AUTHTOKEN env var (cloud-mode) OR per-user
- *     encrypted setting (self-hosted). Provider context can carry
- *     a token override per-call.
- *   - Slug behavior: free tier emits random URLs and ignores slug.
- *     Paid tier honors `subdomain` (slug-equivalent) and `hostname`.
- *   - Agent: official @ngrok/ngrok SDK opens an inline tunnel,
- *     emits "disconnect"/"error"/"close" events matching the
- *     TunnelAgent interface — just wrap.
- *
- * Not implemented yet. Calls throw ProviderNotImplementedError so
- * the registry can list the provider as known-but-unavailable
- * (useful for UI dropdowns that need to dim a coming-soon row).
+ * NGROK_AUTHTOKEN (agent token, required) opens the tunnel via
+ * @ngrok/ngrok. NGROK_API_KEY (optional) additionally lets us reserve
+ * a custom hostname for input.slug via @ngrok/ngrok-api — without it,
+ * free-tier accounts just use their auto-assigned dev-domain. Both
+ * are overridable per-call via context.authtoken / context.apiKey.
  */
 
-import type { TunnelProvider } from "../types";
-import { ProviderNotImplementedError } from "../types";
+import { EventEmitter } from "node:events";
+import * as ngrok from "@ngrok/ngrok";
+import { Ngrok as NgrokApiClient } from "@ngrok/ngrok-api";
+import { env } from "../../../config/env";
+import type {
+  TunnelAgent,
+  TunnelProvider,
+  TunnelProvisionInput,
+  TunnelRecord,
+} from "../types";
+import { ProvisionFailedError, SlugTakenError } from "../types";
+
+function resolveAuthtoken(input?: TunnelProvisionInput): string {
+  const override = input?.context?.authtoken;
+  const token = (typeof override === "string" && override) || env.NGROK_AUTHTOKEN;
+  if (!token) {
+    throw new ProvisionFailedError(
+      "ngrok",
+      "No authtoken configured. Set NGROK_AUTHTOKEN or pass context.authtoken.",
+    );
+  }
+  return token;
+}
+
+function resolveApiKey(input?: TunnelProvisionInput): string | undefined {
+  const override = input?.context?.apiKey;
+  return (typeof override === "string" && override) || env.NGROK_API_KEY || undefined;
+}
+
+/** ngrok-api throws a plain deserialized error object, not an Error instance. */
+function errorMessage(err: unknown): string {
+  const e = err as { msg?: string } | undefined;
+  return e?.msg ?? (err instanceof Error ? err.message : String(err));
+}
+
+function isConflict(err: unknown): boolean {
+  const e = err as { statusCode?: number } | undefined;
+  if (e?.statusCode === 409) return true;
+  return /already (reserved|exists|in use)|conflict|belongs|forbidden/i.test(errorMessage(err));
+}
+
+/** Resource id of a reserved domain we already own (by name), or undefined. */
+async function findOwnedDomainId(apiKey: string, domain: string): Promise<string | undefined> {
+  const client = new NgrokApiClient({ apiToken: apiKey });
+  const domains = await client.reservedDomains.list();
+  return domains.find((d) => d.domain === domain)?.id;
+}
 
 export const ngrokProvider: TunnelProvider = {
   name: "ngrok",
 
   async preflight() {
-    return {
-      ok: false,
-      reason: "ngrok provider is not implemented yet.",
-    };
+    if (!env.NGROK_AUTHTOKEN) {
+      return {
+        ok: false,
+        reason: "ngrok provider requires NGROK_AUTHTOKEN to be configured.",
+      };
+    }
+    return { ok: true };
   },
 
-  async create() {
-    throw new ProviderNotImplementedError("ngrok");
+  async create(input) {
+    const authtoken = resolveAuthtoken(input);
+    const apiKey = resolveApiKey(input);
+
+    if (input.slug) {
+      if (apiKey) {
+        let reservationId: string;
+        try {
+          const created = await new NgrokApiClient({ apiToken: apiKey }).reservedDomains.create({
+            domain: input.slug,
+            region: "us",
+          });
+          reservationId = created.id;
+        } catch (err) {
+          if (!isConflict(err)) {
+            throw new ProvisionFailedError("ngrok", errorMessage(err));
+          }
+          // Conflict may just mean we already own it (re-provision) — verify before rejecting.
+          const ownedId = await findOwnedDomainId(apiKey, input.slug);
+          if (!ownedId) {
+            throw new SlugTakenError("ngrok", input.slug);
+          }
+          reservationId = ownedId;
+        }
+        // externalId is the rd_... resource id, not the hostname — see delete().
+        return {
+          externalId: reservationId,
+          slug: input.slug,
+          publicUrl: `https://${input.slug}`,
+        };
+      }
+
+      // No API key — probe-connect to confirm the hostname is actually usable.
+      let probe: ngrok.Listener;
+      try {
+        probe = await ngrok.forward({ addr: input.port, authtoken, domain: input.slug });
+      } catch (err) {
+        const message = errorMessage(err);
+        if (/domain|hostname/i.test(message) && /taken|use|reserved|belongs|forbidden/i.test(message)) {
+          throw new SlugTakenError("ngrok", input.slug);
+        }
+        throw new ProvisionFailedError("ngrok", message);
+      }
+      const publicUrl = probe.url() ?? `https://${input.slug}`;
+      await probe.close();
+      return {
+        externalId: input.slug,
+        slug: input.slug,
+        publicUrl,
+      };
+    }
+
+    // No slug — learn ngrok's auto-assigned hostname by probe-connecting once.
+    let probe: ngrok.Listener;
+    try {
+      probe = await ngrok.forward({ addr: input.port, authtoken });
+    } catch (err) {
+      throw new ProvisionFailedError("ngrok", errorMessage(err));
+    }
+    const publicUrl = probe.url();
+    await probe.close();
+    if (!publicUrl) {
+      throw new ProvisionFailedError("ngrok", "ngrok did not return a public URL for the new listener.");
+    }
+    const slug = new URL(publicUrl).hostname;
+    return { externalId: slug, slug, publicUrl };
   },
 
-  async delete() {
-    throw new ProviderNotImplementedError("ngrok");
+  async delete(externalId) {
+    // Only rd_... ids are reservations we actually created — a bare
+    // hostname means nothing was reserved, so there's nothing to delete.
+    if (!externalId.startsWith("rd_")) {
+      return;
+    }
+    const apiKey = env.NGROK_API_KEY;
+    if (!apiKey) {
+      console.warn("[tunneling.ngrok] delete skipped — no NGROK_API_KEY to remove reservation", { externalId });
+      return;
+    }
+    try {
+      await new NgrokApiClient({ apiToken: apiKey }).reservedDomains.delete(externalId);
+    } catch (err) {
+      console.warn("[tunneling.ngrok] delete failed", {
+        externalId,
+        error: errorMessage(err),
+      });
+    }
   },
 
-  async connect() {
-    throw new ProviderNotImplementedError("ngrok");
+  async connect(record: TunnelRecord, port: number) {
+    const authtoken = resolveAuthtoken();
+    const listener = await ngrok.forward({
+      addr: port,
+      authtoken,
+      domain: record.slug,
+    });
+    return new NgrokTunnelAgent(listener);
   },
 };
+
+class NgrokTunnelAgent extends EventEmitter implements TunnelAgent {
+  private connected = true;
+  private closing = false;
+
+  constructor(private readonly listener: ngrok.Listener) {
+    super();
+    // join() settles when the forwarding task exits; only signal we get.
+    void this.listener.join().then(
+      () => this.handleExit(null),
+      (err) => this.handleExit(err),
+    );
+  }
+
+  private handleExit(err: unknown): void {
+    this.connected = false;
+    if (this.closing) {
+      this.emit("close");
+      return;
+    }
+    this.emit("disconnect", 0, err ? errorMessage(err) : "listener task exited unexpectedly");
+  }
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  close(): void {
+    this.closing = true;
+    this.connected = false;
+    void this.listener.close();
+  }
+}

--- a/apps/api/test/modules/tunneling/ngrok.provider.test.ts
+++ b/apps/api/test/modules/tunneling/ngrok.provider.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { forward } = vi.hoisted(() => ({ forward: vi.fn() }));
+vi.mock("@ngrok/ngrok", () => ({ forward }));
+
+const { reservedDomainsCreate, reservedDomainsList, reservedDomainsDelete, NgrokApiClientCtor } =
+  vi.hoisted(() => {
+    const reservedDomainsCreate = vi.fn();
+    const reservedDomainsList = vi.fn();
+    const reservedDomainsDelete = vi.fn();
+    const NgrokApiClientCtor = vi.fn().mockImplementation(function () {
+      return {
+        reservedDomains: {
+          create: reservedDomainsCreate,
+          list: reservedDomainsList,
+          delete: reservedDomainsDelete,
+        },
+      };
+    });
+    return { reservedDomainsCreate, reservedDomainsList, reservedDomainsDelete, NgrokApiClientCtor };
+  });
+vi.mock("@ngrok/ngrok-api", () => ({ Ngrok: NgrokApiClientCtor }));
+
+vi.mock("../../../src/config/env", () => ({
+  env: { NGROK_AUTHTOKEN: undefined, NGROK_API_KEY: undefined },
+}));
+
+import { env } from "../../../src/config/env";
+import { ngrokProvider } from "../../../src/modules/tunneling/providers/ngrok.provider";
+import { ProvisionFailedError, SlugTakenError, type TunnelProvisionInput, type TunnelRecord } from "../../../src/modules/tunneling/types";
+
+function input(overrides: Partial<TunnelProvisionInput> = {}): TunnelProvisionInput {
+  return { name: "test-tunnel", port: 4000, ...overrides };
+}
+
+function makeListener(overrides: { url?: string | null; join?: () => Promise<void> } = {}) {
+  return {
+    url: vi.fn().mockReturnValue(overrides.url === undefined ? "https://abc123.ngrok-free.app" : overrides.url),
+    id: vi.fn().mockReturnValue("lis_123"),
+    close: vi.fn().mockResolvedValue(undefined),
+    join: overrides.join ?? vi.fn().mockReturnValue(new Promise(() => {})),
+  };
+}
+
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  env.NGROK_AUTHTOKEN = "authtok_test";
+  env.NGROK_API_KEY = undefined;
+});
+
+describe("ngrokProvider.preflight", () => {
+  it("rejects when NGROK_AUTHTOKEN is unset", async () => {
+    env.NGROK_AUTHTOKEN = undefined;
+    await expect(ngrokProvider.preflight()).resolves.toEqual({
+      ok: false,
+      reason: expect.stringContaining("NGROK_AUTHTOKEN"),
+    });
+  });
+
+  it("passes when NGROK_AUTHTOKEN is set", async () => {
+    await expect(ngrokProvider.preflight()).resolves.toEqual({ ok: true });
+  });
+});
+
+describe("ngrokProvider.create — no slug (auto-assigned dev-domain)", () => {
+  it("probe-connects, closes the probe, and derives the record from the returned URL", async () => {
+    const listener = makeListener({ url: "https://sunny-otter-42.ngrok-free.app" });
+    forward.mockResolvedValue(listener);
+
+    const record = await ngrokProvider.create(input());
+
+    expect(forward).toHaveBeenCalledWith({ addr: 4000, authtoken: "authtok_test" });
+    expect(listener.close).toHaveBeenCalledOnce();
+    expect(record).toEqual({
+      externalId: "sunny-otter-42.ngrok-free.app",
+      slug: "sunny-otter-42.ngrok-free.app",
+      publicUrl: "https://sunny-otter-42.ngrok-free.app",
+    });
+  });
+
+  it("wraps a forward() failure in ProvisionFailedError", async () => {
+    forward.mockRejectedValue(new Error("network unreachable"));
+    await expect(ngrokProvider.create(input())).rejects.toBeInstanceOf(ProvisionFailedError);
+  });
+
+  it("throws ProvisionFailedError if the listener never returns a URL", async () => {
+    forward.mockResolvedValue(makeListener({ url: null }));
+    await expect(ngrokProvider.create(input())).rejects.toBeInstanceOf(ProvisionFailedError);
+  });
+});
+
+describe("ngrokProvider.create — slug + NGROK_API_KEY (reserved domain)", () => {
+  beforeEach(() => {
+    env.NGROK_API_KEY = "apikey_test";
+  });
+
+  it("reserves the domain and returns a record without probe-connecting", async () => {
+    reservedDomainsCreate.mockResolvedValue({ id: "rd_1", domain: "myapp.ngrok.app" });
+
+    const record = await ngrokProvider.create(input({ slug: "myapp.ngrok.app" }));
+
+    expect(reservedDomainsCreate).toHaveBeenCalledWith({ domain: "myapp.ngrok.app", region: "us" });
+    expect(forward).not.toHaveBeenCalled();
+    expect(record).toEqual({
+      externalId: "rd_1",
+      slug: "myapp.ngrok.app",
+      publicUrl: "https://myapp.ngrok.app",
+    });
+  });
+
+  it("treats a conflict as success when we already own the domain", async () => {
+    reservedDomainsCreate.mockRejectedValue({ statusCode: 409, msg: "domain already reserved" });
+    reservedDomainsList.mockResolvedValue([{ id: "rd_1", domain: "myapp.ngrok.app" }]);
+
+    await expect(ngrokProvider.create(input({ slug: "myapp.ngrok.app" }))).resolves.toMatchObject({
+      externalId: "rd_1",
+      slug: "myapp.ngrok.app",
+    });
+  });
+
+  it("throws SlugTakenError on conflict when the domain belongs to someone else", async () => {
+    reservedDomainsCreate.mockRejectedValue({ statusCode: 409, msg: "domain already reserved" });
+    reservedDomainsList.mockResolvedValue([]);
+
+    await expect(ngrokProvider.create(input({ slug: "myapp.ngrok.app" }))).rejects.toBeInstanceOf(SlugTakenError);
+  });
+
+  it("wraps a non-conflict reservation failure in ProvisionFailedError", async () => {
+    reservedDomainsCreate.mockRejectedValue({ statusCode: 500, msg: "internal error" });
+    await expect(ngrokProvider.create(input({ slug: "myapp.ngrok.app" }))).rejects.toBeInstanceOf(ProvisionFailedError);
+  });
+});
+
+describe("ngrokProvider.create — slug, no NGROK_API_KEY", () => {
+  it("probe-connects to confirm the domain is usable and trusts the SDK's returned URL", async () => {
+    const listener = makeListener({ url: "https://myapp.ngrok.app" });
+    forward.mockResolvedValue(listener);
+
+    const record = await ngrokProvider.create(input({ slug: "myapp.ngrok.app" }));
+
+    expect(forward).toHaveBeenCalledWith({ addr: 4000, authtoken: "authtok_test", domain: "myapp.ngrok.app" });
+    expect(listener.close).toHaveBeenCalledOnce();
+    expect(record.publicUrl).toBe("https://myapp.ngrok.app");
+  });
+
+  it("throws SlugTakenError when the probe connect fails with a domain-taken message", async () => {
+    forward.mockRejectedValue(new Error("this domain is already reserved by another account"));
+    await expect(ngrokProvider.create(input({ slug: "myapp.ngrok.app" }))).rejects.toBeInstanceOf(SlugTakenError);
+  });
+
+  it("wraps other probe failures in ProvisionFailedError", async () => {
+    forward.mockRejectedValue(new Error("boom"));
+    await expect(ngrokProvider.create(input({ slug: "myapp.ngrok.app" }))).rejects.toBeInstanceOf(ProvisionFailedError);
+  });
+});
+
+describe("ngrokProvider.create — per-call context overrides", () => {
+  it("prefers context.authtoken / context.apiKey over env vars", async () => {
+    reservedDomainsCreate.mockResolvedValue({ id: "rd_1", domain: "myapp.ngrok.app" });
+
+    await ngrokProvider.create(
+      input({ slug: "myapp.ngrok.app", context: { authtoken: "override_tok", apiKey: "override_key" } }),
+    );
+
+    expect(NgrokApiClientCtor).toHaveBeenCalledWith({ apiToken: "override_key" });
+  });
+});
+
+describe("ngrokProvider.delete", () => {
+  it("is a no-op for a bare hostname — never deletes by name, even with an API key set", async () => {
+    env.NGROK_API_KEY = "apikey_test";
+    await ngrokProvider.delete("myapp.ngrok.app");
+    expect(NgrokApiClientCtor).not.toHaveBeenCalled();
+  });
+
+  it("deletes a real reservation id directly, without listing", async () => {
+    env.NGROK_API_KEY = "apikey_test";
+    await ngrokProvider.delete("rd_1");
+    expect(reservedDomainsList).not.toHaveBeenCalled();
+    expect(reservedDomainsDelete).toHaveBeenCalledWith("rd_1");
+  });
+
+  it("warns and skips if a reservation id needs deleting but no API key is set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await ngrokProvider.delete("rd_1");
+    expect(reservedDomainsDelete).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("is best-effort — swallows failures instead of throwing", async () => {
+    env.NGROK_API_KEY = "apikey_test";
+    reservedDomainsDelete.mockRejectedValue(new Error("api down"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ngrokProvider.delete("rd_1")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("ngrokProvider.connect + TunnelAgent adapter", () => {
+  const record: TunnelRecord = {
+    externalId: "myapp.ngrok.app",
+    slug: "myapp.ngrok.app",
+    publicUrl: "https://myapp.ngrok.app",
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens a listener bound to the record's slug", async () => {
+    forward.mockResolvedValue(makeListener());
+
+    await ngrokProvider.connect(record, 4000);
+
+    expect(forward).toHaveBeenCalledWith({ addr: 4000, authtoken: "authtok_test", domain: "myapp.ngrok.app" });
+  });
+
+  it("starts connected and exposes an EventEmitter-style on()", async () => {
+    forward.mockResolvedValue(makeListener());
+    const agent = await ngrokProvider.connect(record, 4000);
+
+    expect(agent.isConnected).toBe(true);
+    expect(typeof agent.on).toBe("function");
+  });
+
+  it("emits disconnect (not close) when the listener exits without an explicit close()", async () => {
+    const join = deferred<void>();
+    forward.mockResolvedValue(makeListener({ join: () => join.promise }));
+    const agent = await ngrokProvider.connect(record, 4000);
+
+    const disconnect = vi.fn();
+    const close = vi.fn();
+    agent.on("disconnect", disconnect);
+    agent.on("close", close);
+
+    join.resolve();
+    await flush();
+
+    expect(agent.isConnected).toBe(false);
+    expect(disconnect).toHaveBeenCalledWith(0, expect.stringContaining("exited"));
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("emits disconnect with the error message when the listener task rejects", async () => {
+    const join = deferred<void>();
+    forward.mockResolvedValue(makeListener({ join: () => join.promise }));
+    const agent = await ngrokProvider.connect(record, 4000);
+
+    const disconnect = vi.fn();
+    agent.on("disconnect", disconnect);
+
+    join.reject(new Error("session dropped"));
+    await flush();
+
+    expect(disconnect).toHaveBeenCalledWith(0, "session dropped");
+  });
+
+  it("emits close (not disconnect) when close() was called intentionally", async () => {
+    const join = deferred<void>();
+    const listener = makeListener({ join: () => join.promise });
+    forward.mockResolvedValue(listener);
+    const agent = await ngrokProvider.connect(record, 4000);
+
+    const disconnect = vi.fn();
+    const close = vi.fn();
+    agent.on("disconnect", disconnect);
+    agent.on("close", close);
+
+    agent.close();
+    expect(agent.isConnected).toBe(false);
+    expect(listener.close).toHaveBeenCalledOnce();
+
+    join.resolve();
+    await flush();
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openship",
@@ -16,12 +17,14 @@
     },
     "apps/api": {
       "name": "@repo/api",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@better-auth/drizzle-adapter": "^1.5.4",
         "@hono/node-server": "^1.19.11",
         "@hono/node-ws": "^1.3.1",
         "@hono/typebox-validator": "^0.3.0",
+        "@ngrok/ngrok": "^1.7.0",
+        "@ngrok/ngrok-api": "^0.19.0",
         "@repo/adapters": "workspace:*",
         "@repo/core": "workspace:*",
         "@repo/db": "workspace:*",
@@ -48,7 +51,7 @@
     },
     "apps/cli": {
       "name": "openship",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "bin": {
         "openship": "./dist/index.js",
       },
@@ -106,7 +109,7 @@
     },
     "apps/desktop": {
       "name": "@repo/desktop",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@repo/core": "workspace:*",
         "@repo/onboarding": "workspace:*",
@@ -126,11 +129,11 @@
     },
     "apps/email": {
       "name": "@repo/email",
-      "version": "0.1.9",
+      "version": "0.1.11",
     },
     "apps/web": {
       "name": "@repo/web",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "@repo/core": "workspace:*",
         "@repo/ui": "workspace:*",
@@ -403,7 +406,7 @@
 
     "@electron/get": ["@electron/get@3.1.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ=="],
 
-    "@electron/node-gyp": ["@electron/node-gyp@github:electron/node-gyp#06b29aa", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^8.1.0", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.2.1", "nopt": "^6.0.0", "proc-log": "^2.0.1", "semver": "^7.3.5", "tar": "^6.2.1", "which": "^2.0.2" }, "bin": "./bin/node-gyp.js" }, "electron-node-gyp-06b29aa"],
+    "@electron/node-gyp": ["@electron/node-gyp@github:electron/node-gyp#06b29aa", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^8.1.0", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.2.1", "nopt": "^6.0.0", "proc-log": "^2.0.1", "semver": "^7.3.5", "tar": "^6.2.1", "which": "^2.0.2" }, "bin": "./bin/node-gyp.js" }, "electron-node-gyp-06b29aa", "sha512-UJwi6aXMAiUaOvqPHVlMtCOLRa1QAU2SqYD9H07KHpN+I2mBoFuxP1HnUOkt86+j+/o/XyHpM7D33JFFQi/jfA=="],
 
     "@electron/notarize": ["@electron/notarize@2.5.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1", "promise-retry": "^2.0.1" } }, "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A=="],
 
@@ -642,6 +645,36 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A=="],
+
+    "@ngrok/ngrok": ["@ngrok/ngrok@1.7.0", "", { "optionalDependencies": { "@ngrok/ngrok-android-arm64": "1.7.0", "@ngrok/ngrok-darwin-arm64": "1.7.0", "@ngrok/ngrok-darwin-universal": "1.7.0", "@ngrok/ngrok-darwin-x64": "1.7.0", "@ngrok/ngrok-freebsd-x64": "1.7.0", "@ngrok/ngrok-linux-arm-gnueabihf": "1.7.0", "@ngrok/ngrok-linux-arm64-gnu": "1.7.0", "@ngrok/ngrok-linux-arm64-musl": "1.7.0", "@ngrok/ngrok-linux-x64-gnu": "1.7.0", "@ngrok/ngrok-linux-x64-musl": "1.7.0", "@ngrok/ngrok-win32-arm64-msvc": "1.7.0", "@ngrok/ngrok-win32-ia32-msvc": "1.7.0", "@ngrok/ngrok-win32-x64-msvc": "1.7.0" } }, "sha512-P06o9TpxrJbiRbHQkiwy/rUrlXRupc+Z8KT4MiJfmcdWxvIdzjCaJOdnNkcOTs6DMyzIOefG5tvk/HLdtjqr0g=="],
+
+    "@ngrok/ngrok-android-arm64": ["@ngrok/ngrok-android-arm64@1.7.0", "", { "os": "android", "cpu": "arm64" }, "sha512-8tco3ID6noSaNy+CMS7ewqPoIkIM6XO5COCzsUp3Wv3XEbMSyn65RN6cflX2JdqLfUCHcMyD0ahr9IEiHwqmbQ=="],
+
+    "@ngrok/ngrok-api": ["@ngrok/ngrok-api@0.19.0", "", { "dependencies": { "form-data": "^4.0.0", "node-fetch": "^2.6.1", "wretch": "^1.7.4" } }, "sha512-Ne5wD014kRBWaD3/gSmQ0LGI597fpMCdQhXbhI5fhOUEdBV43qklCLiSKLYWNy9eeyVw1W00HoCraK/IkxHfzQ=="],
+
+    "@ngrok/ngrok-darwin-arm64": ["@ngrok/ngrok-darwin-arm64@1.7.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+dmJSOzSO+MNDVrPOca2yYDP1W3KfP4qOlAkarIeFRIfqonQwq3QCBmcR7HAlZocLsSqEwyG6KP4RRvAuT0WGQ=="],
+
+    "@ngrok/ngrok-darwin-universal": ["@ngrok/ngrok-darwin-universal@1.7.0", "", { "os": "darwin" }, "sha512-fDEfewyE2pWGFBhOSwQZObeHUkc65U1l+3HIgSOe094TMHsqmyJD0KTCgW9KSn0VP4OvDZbAISi1T3nvqgZYhQ=="],
+
+    "@ngrok/ngrok-darwin-x64": ["@ngrok/ngrok-darwin-x64@1.7.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+fwMi5uHd9G8BS42MMa9ye6exI5lwTcjUO6Ut497Vu0qgLONdVRenRqnEePV+Q3KtQR7NjqkMnomVfkr9MBjtw=="],
+
+    "@ngrok/ngrok-freebsd-x64": ["@ngrok/ngrok-freebsd-x64@1.7.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2OGgbrjy3yLRrqAz5N6hlUKIWIXSpR5RjQa2chtZMsSbszQ6c9dI+uVQfOKAeo05tHMUgrYAZ7FocC+ig0dzdQ=="],
+
+    "@ngrok/ngrok-linux-arm-gnueabihf": ["@ngrok/ngrok-linux-arm-gnueabihf@1.7.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SN9YIfEQiR9xN90QVNvdgvAemqMLoFVSeTWZs779145hQMhvF9Qd9rnWi6J+2uNNK10OczdV1oc/nq1es7u/3g=="],
+
+    "@ngrok/ngrok-linux-arm64-gnu": ["@ngrok/ngrok-linux-arm64-gnu@1.7.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KDMgzPKFU2kbpVSaA2RZBBia5IPdJEe063YlyVFnSMJmPYWCUnMwdybBsucXfV9u1Lw/ZjKTKotIlbTWGn3HGw=="],
+
+    "@ngrok/ngrok-linux-arm64-musl": ["@ngrok/ngrok-linux-arm64-musl@1.7.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-e66vUdVrBlQ0lT9ZdamB4U604zt5Gualt8/WVcUGzbu8s5LajWd6g/mzZCUjK4UepjvMpfgmCp1/+rX7Rk8d5A=="],
+
+    "@ngrok/ngrok-linux-x64-gnu": ["@ngrok/ngrok-linux-x64-gnu@1.7.0", "", { "os": "linux", "cpu": "x64" }, "sha512-M6gF0DyOEFqXLfWxObfL3bxYZ4+PnKBHuyLVaqNfFN9Y5utY2mdPOn5422Ppbk4XoIK5/YkuhRqPJl/9FivKEw=="],
+
+    "@ngrok/ngrok-linux-x64-musl": ["@ngrok/ngrok-linux-x64-musl@1.7.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4Ijm0dKeoyzZTMaYxR2EiNjtlK81ebflg/WYIO1XtleFrVy4UJEGnxtxEidYoT4BfCqi4uvXiK2Mx216xXKvog=="],
+
+    "@ngrok/ngrok-win32-arm64-msvc": ["@ngrok/ngrok-win32-arm64-msvc@1.7.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-u7qyWIJI2/YG1HTBnHwUR1+Z2tyGfAsUAItJK/+N1G0FeWJhIWQvSIFJHlaPy4oW1Dc8mSDBX9qvVsiQgLaRFg=="],
+
+    "@ngrok/ngrok-win32-ia32-msvc": ["@ngrok/ngrok-win32-ia32-msvc@1.7.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-/UdYUsLNv/Q8j9YJsyIfq/jLCoD8WP+NidouucTUzSoDtmOsXBBT3itLrmPiZTEdEgKiFYLuC1Zon8XQQvbVLA=="],
+
+    "@ngrok/ngrok-win32-x64-msvc": ["@ngrok/ngrok-win32-x64-msvc@1.7.0", "", { "os": "win32", "cpu": "x64" }, "sha512-UFJg/duEWzZlLkEs61Gz6/5nYhGaKI62I8dvUGdBR3NCtIMagehnFaFxmnXZldyHmCM8U0aCIFNpWRaKcrQkoA=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -1163,6 +1196,8 @@
 
     "async": ["async@1.5.2", "", {}, "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
@@ -1307,6 +1342,8 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
@@ -1401,6 +1438,8 @@
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
@@ -1478,6 +1517,8 @@
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-toolkit": ["es-toolkit@1.47.1", "", {}, "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q=="],
 
@@ -1615,6 +1656,8 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
     "form-data-encoder": ["form-data-encoder@1.9.0", "", {}, "sha512-rahaRMkN8P8d/tgK/BLPX+WBVM27NbvdXBxqQujBtkDAIFspaRqN7Od7lfdGQA6KAD+f82fYCLBq1ipvcu8qLw=="],
 
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
@@ -1705,7 +1748,9 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
 
@@ -2093,9 +2138,9 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimer": ["mimer@2.0.2", "", { "bin": { "mimer": "bin/mimer" } }, "sha512-izxvjsB7Ur5HrTbPu6VKTrzxSMBFBqyZQc6dWlZNQ4/wAvf886fD4lrjtFd8IQ8/WmZKdxKjUtqFFNaj3hQ52g=="],
 
@@ -2895,6 +2940,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "wretch": ["wretch@1.7.10", "", {}, "sha512-UgF2o63bZRsz3LoOxaxzAUdFdlIJzVYbCHHhQ+LNMSBD1FeFJn8ADaekopJclHUm6sN8Lhu0DQFGQloliS0Twg=="],
+
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
@@ -3039,6 +3086,8 @@
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "api/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -3101,6 +3150,8 @@
 
     "eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -3127,9 +3178,13 @@
 
     "fumadocs-ui/motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
 
+    "get-intrinsic/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
     "get-package-info/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "is-core-module/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
@@ -3211,6 +3266,8 @@
 
     "schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
@@ -3235,6 +3292,8 @@
 
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "username/execa": ["execa@1.0.0", "", { "dependencies": { "cross-spawn": "^6.0.0", "get-stream": "^4.0.0", "is-stream": "^1.1.0", "npm-run-path": "^2.0.0", "p-finally": "^1.0.0", "signal-exit": "^3.0.0", "strip-eof": "^1.0.0" } }, "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA=="],
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
@@ -3242,8 +3301,6 @@
     "vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "webpack/es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
-
-    "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -3319,6 +3376,8 @@
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "api/ora/cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
     "api/ora/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
@@ -3354,6 +3413,8 @@
     "electron/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "electron/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "fumadocs-core/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
@@ -3430,6 +3491,8 @@
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "read-pkg-up/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -3537,6 +3600,8 @@
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "username/execa/cross-spawn": ["cross-spawn@6.0.6", "", { "dependencies": { "nice-try": "^1.0.4", "path-key": "^2.0.1", "semver": "^5.5.0", "shebang-command": "^1.2.0", "which": "^1.2.9" } }, "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw=="],
 
     "username/execa/get-stream": ["get-stream@4.1.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w=="],
@@ -3596,8 +3661,6 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
-
-    "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 


### PR DESCRIPTION
## Summary

- Implements the ngrok tunnel provider (was a stub throwing `ProviderNotImplementedError`), matching the shape of the existing Oblien provider.
- Uses `@ngrok/ngrok` (agent SDK) to open/manage the tunnel, and `@ngrok/ngrok-api` (optional, needs `NGROK_API_KEY`) to reserve a custom domain when `input.slug` is given.
- Free-tier accounts (only `NGROK_AUTHTOKEN` set) get their auto-assigned dev-domain — `create()` probe-connects once to learn the hostname, then `connect()` opens the real long-lived listener against it.
- `TunnelAgent` adapter wraps `@ngrok/ngrok`'s `Listener` (which has no native disconnect/error events, only `listener.join()`) into the `disconnect`/`close` events `manager.ts`'s reconnect-with-backoff expects.


## Test plan

- [x] `tsc --noEmit` clean across `apps/api`
- [x] New unit test suite (`apps/api/test/modules/tunneling/ngrok.provider.test.ts`, 22 tests, mocked SDKs) covering preflight, both create() paths (with/without API key, no-slug probe path), conflict/ownership disambiguation, delete()'s resource-id gating, and the TunnelAgent adapter's close-vs-drop event distinction
- [x] Live-tested against a real ngrok pay-as-you-go account: auto-assigned dev-domain tunnel created, connected, and confirmed reachable end-to-end (real HTTP response through the tunnel); reserved custom-domain path created/connected/deleted and verified via the API that only the test reservation was removed, account's existing dev-domain untouched
- [x] Full existing test suite passes with no new failures (`bun run test`)