### PR TITLE
fix(mail): detect duplicate SPF records in DNS scan

### DIFF
--- a/apps/api/src/modules/mail/admin/dns-scan.service.ts
+++ b/apps/api/src/modules/mail/admin/dns-scan.service.ts
@@ -18,13 +18,7 @@
  * resolved in parallel). The Health tab refreshes on demand.
  */
 
-import {
-  resolve4,
-  resolve6,
-  resolveMx,
-  resolveTxt,
-  reverse,
-} from "node:dns/promises";
+import { resolve4, resolve6, resolveMx, resolveTxt, reverse } from "node:dns/promises";
 import { sshManager } from "../../../lib/ssh-manager";
 import { readState } from "../mail-state";
 import { safeErrorMessage } from "@repo/core";
@@ -87,10 +81,7 @@ export interface DnsScanResult {
  *     those test the shared `mail.<installDomain>` host, which the primary
  *     scan already covers, and additional domains never carry them.
  */
-export async function scanDns(
-  serverId: string,
-  domain?: string,
-): Promise<DnsScanResult> {
+export async function scanDns(serverId: string, domain?: string): Promise<DnsScanResult> {
   const state = await sshManager.withExecutor(serverId, (exec) => readState(exec));
   if (!state || !state.domain) {
     return { domain: "", scannedAt: Date.now(), checks: [] };
@@ -167,10 +158,7 @@ async function checkA(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | 
   }
 }
 
-async function checkAaaa(
-  domain: string,
-  exp?: ExpectedRecord,
-): Promise<DnsCheck | null> {
+async function checkAaaa(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | null> {
   if (!exp?.value) return null;
   const name = exp.name || `mail.${domain}`;
   try {
@@ -209,10 +197,7 @@ async function checkAaaa(
   }
 }
 
-async function checkMx(
-  domain: string,
-  exp?: ExpectedRecord,
-): Promise<DnsCheck | null> {
+async function checkMx(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | null> {
   if (!exp?.value) return null;
   try {
     const mxs = await resolveMx(domain);
@@ -239,9 +224,7 @@ async function checkMx(
       recordType: "MX",
       status: match ? "pass" : "warn",
       expected: wanted,
-      actual: mxs
-        .map((m) => `${trimDot(m.exchange)} (priority ${m.priority})`)
-        .join(", "),
+      actual: mxs.map((m) => `${trimDot(m.exchange)} (priority ${m.priority})`).join(", "),
       message: match
         ? "MX record points at the mail server."
         : `MX records exist but none point at ${wanted}. Mail will be delivered elsewhere.`,
@@ -251,10 +234,7 @@ async function checkMx(
   }
 }
 
-async function checkSpf(
-  domain: string,
-  exp?: ExpectedRecord,
-): Promise<DnsCheck | null> {
+async function checkSpf(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | null> {
   if (!exp?.value) return null;
   try {
     const txt = (await resolveTxt(domain)).map((parts) => parts.join(""));
@@ -295,10 +275,7 @@ async function checkSpf(
   }
 }
 
-async function checkDkim(
-  domain: string,
-  exp?: ExpectedRecord,
-): Promise<DnsCheck | null> {
+async function checkDkim(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | null> {
   if (!exp?.value) return null;
   const name = exp.name || `dkim._domainkey.${domain}`;
   try {
@@ -336,10 +313,7 @@ async function checkDkim(
   }
 }
 
-async function checkDmarc(
-  domain: string,
-  exp?: ExpectedRecord,
-): Promise<DnsCheck | null> {
+async function checkDmarc(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | null> {
   if (!exp?.value) return null;
   const name = exp.name || `_dmarc.${domain}`;
   try {
@@ -424,8 +398,7 @@ async function checkPtr(
         status: "fail",
         expected: expectedHost,
         actual: "",
-        message:
-          "No PTR record set. Configure it at your VPS provider's panel.",
+        message: "No PTR record set. Configure it at your VPS provider's panel.",
       };
     }
     return missing("ptr", "PTR (reverse DNS)", aRecord.value, "PTR", expectedHost, err);

--- a/apps/api/src/modules/mail/admin/dns-scan.service.ts
+++ b/apps/api/src/modules/mail/admin/dns-scan.service.ts
@@ -238,7 +238,8 @@ async function checkSpf(domain: string, exp?: ExpectedRecord): Promise<DnsCheck 
   if (!exp?.value) return null;
   try {
     const txt = (await resolveTxt(domain)).map((parts) => parts.join(""));
-    const spf = txt.find((t) => /^v=spf1\b/i.test(t));
+    const spfRecords = txt.filter((t) => /^v=spf1\b/i.test(t));
+    const spf = spfRecords[0];
     if (!spf) {
       return {
         key: "spf",
@@ -251,6 +252,20 @@ async function checkSpf(domain: string, exp?: ExpectedRecord): Promise<DnsCheck 
         actual: "",
         message:
           "No SPF record found. Outbound mail will be marked as suspicious by most receivers.",
+      };
+    }
+    if (spfRecords.length > 1) {
+      return {
+        key: "spf",
+        label: "SPF record",
+        description: "Lets receivers verify this server is authorised to send for the domain.",
+        queriedName: domain,
+        recordType: "TXT",
+        status: "fail",
+        expected: exp.value,
+        actual: spfRecords.join(" | "),
+        message:
+          "Multiple SPF records found. A domain must publish exactly one v=spf1 TXT record or receivers treat SPF as invalid.",
       };
     }
     // We can't do a strict equality - operators sometimes add their own

--- a/apps/api/test/modules/mail/dns-scan.service.test.ts
+++ b/apps/api/test/modules/mail/dns-scan.service.test.ts
@@ -1,0 +1,125 @@
+import "./_setup-env";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const dns = vi.hoisted(() => ({
+  resolve4: vi.fn(),
+  resolve6: vi.fn(),
+  resolveMx: vi.fn(),
+  resolveTxt: vi.fn(),
+  reverse: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => dns);
+
+const state = {
+  version: 1,
+  serverId: "srv_test",
+  domain: "example.com",
+  startedAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+  finishedAt: null,
+  completedSteps: {},
+  secrets: {},
+  dnsAcknowledged: true,
+  ptrAcknowledged: true,
+  resumeStep: null,
+  errorMessage: null,
+  dnsRecords: {
+    spf: {
+      type: "TXT",
+      name: "example.com",
+      value: "v=spf1 mx -all",
+      required: true,
+    },
+  },
+};
+
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: {
+    withExecutor: async (_serverId: string, fn: (exec: unknown) => unknown) => fn({}),
+  },
+}));
+
+vi.mock("../../../src/modules/mail/mail-state", () => ({
+  readState: async () => state,
+}));
+
+import { scanDns } from "../../../src/modules/mail/admin/dns-scan.service";
+
+describe("scanDns SPF checks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dns.resolveTxt.mockResolvedValue([["v=spf1 mx -all"]]);
+  });
+
+  test("fails when no SPF record exists", async () => {
+    dns.resolveTxt.mockResolvedValue([["google-site-verification=abc"]]);
+
+    const result = await scanDns("srv_test");
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        key: "spf",
+        status: "fail",
+      }),
+    );
+  });
+
+  test("passes when the single SPF record authorizes mx", async () => {
+    dns.resolveTxt.mockResolvedValue([["v=spf1 mx -all"]]);
+
+    const result = await scanDns("srv_test");
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        key: "spf",
+        status: "pass",
+      }),
+    );
+  });
+
+  test("warns when the single SPF record does not authorize mx", async () => {
+    dns.resolveTxt.mockResolvedValue([["v=spf1 include:example.net -all"]]);
+
+    const result = await scanDns("srv_test");
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        key: "spf",
+        status: "warn",
+      }),
+    );
+  });
+
+  test("fails when a domain publishes multiple SPF records", async () => {
+    dns.resolveTxt.mockResolvedValue([["v=spf1 mx -all"], ["v=spf1 include:example.net -all"]]);
+
+    const result = await scanDns("srv_test");
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        key: "spf",
+        status: "fail",
+      }),
+    );
+    expect(result.checks.find((c) => c.key === "spf")?.message).toMatch(/multiple SPF records/i);
+  });
+
+  test("fails when duplicate SPF records differ only by casing", async () => {
+    dns.resolveTxt.mockResolvedValue([
+      ["V=SPF1 mx -all"],
+      ["v=spf1 include:example.net -all"],
+      ["v=spf1 ip4:203.0.113.10 -all"],
+    ]);
+
+    const result = await scanDns("srv_test");
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        key: "spf",
+        status: "fail",
+      }),
+    );
+    expect(result.checks.find((c) => c.key === "spf")?.message).toMatch(/multiple SPF records/i);
+  });
+});


### PR DESCRIPTION
## Summary

- detect multiple SPF TXT records during mail DNS scans
- report duplicate SPF as a failing configuration because receivers treat it as SPF permerror
- add focused regression coverage for SPF scan outcomes, including mixed-case duplicate records

## Notes

- This file was not Prettier-clean on `main`; `bunx prettier --write` reformatted unrelated wrapping in `dns-scan.service.ts` per the project formatting workflow.
- The formatting-only changes are isolated in the first commit: `style(mail): apply prettier to dns-scan service`.
- The functional fix and tests are isolated in the second commit: `fix(mail): detect duplicate SPF records in DNS scan`.

## Test

- `bunx prettier --check apps/api/src/modules/mail/admin/dns-scan.service.ts apps/api/test/modules/mail/dns-scan.service.test.ts`
- `bun --cwd apps/api test -- test/modules/mail/dns-scan.service.test.ts`
- `bun --cwd apps/api test -- test/modules/mail`
- `bun --cwd apps/api lint`

## Scope

This is intentionally limited to SPF DNS scan correctness. It does not change routes, UI, schemas, mail delivery, or installer behavior.