### PR TITLE
fix(api): serve OAuth discovery metadata behind a public URL

### DIFF
--- a/apps/api/src/lib/public-url.ts
+++ b/apps/api/src/lib/public-url.ts
@@ -70,27 +70,18 @@ export function domainWebhookUrl(hostname: string, scheme: "http" | "https" = "h
  * Better Auth `baseURL` — the origin every absolute auth/OAuth URL (issuer,
  * authorize, token, discovery metadata, email links) is built from.
  *
- * With a public URL configured we return Better Auth's DYNAMIC config: it builds
- * the base from the request's `x-forwarded-host`/`-proto` (set by the dashboard
- * same-origin proxy) when that host is allow-listed, so a remote MCP/OAuth client
- * is handed reachable `https://<public-host>/api/auth/...` URLs instead of
- * `http://localhost:4000`. Requests without a matching forwarded host (internal
- * loopback calls, health checks) fall back to the static API URL — so this is
- * safe: routing is path-based, only CONSTRUCTED URLs change.
+ * With a public URL configured, return it as a stable static base so remote
+ * MCP/OAuth clients are handed reachable `https://<public-host>/api/auth/...`
+ * URLs instead of `http://localhost:4000`. It must be static: Better Auth
+ * materialises the OAuth authorization-server metadata at startup, with no
+ * request in scope, so a `DynamicBaseURLConfig` resolves to an empty issuer
+ * there; a discovery `issuer` also has to be stable across requests.
  *
- * Without a public URL (cloud / dev / desktop) we return the static
- * `runtimeTarget.api` exactly as before — zero behavior change.
+ * Without a public URL (cloud / dev / desktop) fall back to the static
+ * `runtimeTarget.api` — zero behavior change.
  */
-export function resolveAuthBaseUrl(): string | { allowedHosts: string[]; fallback: string } {
-  const pub = publicUrl();
-  if (!pub) return runtimeTarget.api;
-  let host: string;
-  try {
-    host = new URL(pub).host;
-  } catch {
-    return runtimeTarget.api;
-  }
-  return { allowedHosts: [host], fallback: runtimeTarget.api };
+export function resolveAuthBaseUrl(): string {
+  return publicUrl() ?? runtimeTarget.api;
 }
 
 /**


### PR DESCRIPTION
## Summary

When a self-hosted instance is served behind a reverse proxy with `OPENSHIP_PUBLIC_URL` set, the OAuth 2.0 discovery endpoints are broken, so no MCP/OAuth client can connect:

- `GET /.well-known/oauth-authorization-server` → `200` with a literal `null` body
- `GET /.well-known/oauth-protected-resource` → `500` (`TypeError: "" cannot be parsed as a URL`)

Because discovery fails, `claude mcp add --transport http … /api/proxy/api/mcp` (and any other OAuth-capable client) can't determine the authorization server, so authentication dead-ends.

## Root cause

`resolveAuthBaseUrl()` (`apps/api/src/lib/public-url.ts`) returns a Better Auth `DynamicBaseURLConfig` (`{ allowedHosts, fallback }`) as `baseURL` when `OPENSHIP_PUBLIC_URL` is set. Better Auth resolves a dynamic base URL **per request**, but the OAuth discovery metadata handlers are materialised **once at startup** in `apps/api/src/app.ts` (`oAuthDiscoveryMetadata(auth)` / `oAuthProtectedResourceMetadata(auth)`) with no request in scope. There, `ctx.context.baseURL` resolves to `""`, so the authorization-server metadata serialises to `null` and the protected-resource handler throws on `new URL("")`.

An OAuth issuer must also be stable across requests (RFC 8414 — clients key discovery on the issuer), so deriving the auth base URL per request is not appropriate for these endpoints regardless.

## Fix

Return `OPENSHIP_PUBLIC_URL` as a stable static `baseURL`. Remote MCP/OAuth clients still receive reachable `https://<public-host>/api/auth/...` URLs (the intent of the dynamic config), and the discovery handlers now have a concrete issuer at startup. Behaviour is unchanged when `OPENSHIP_PUBLIC_URL` is unset.

## Testing

Self-hosted instance, `OPENSHIP_PUBLIC_URL` set, behind the dashboard same-origin proxy + a tunnel.

Before:

```
GET /.well-known/oauth-authorization-server  → 200  null
GET /.well-known/oauth-protected-resource    → 500
```

After:

```
GET /.well-known/oauth-authorization-server  → 200  {"issuer":"https://…","authorization_endpoint":"https://…/api/auth/mcp/authorize","token_endpoint":"https://…/api/auth/mcp/token",…}
GET /.well-known/oauth-protected-resource    → 200
```

A remote `claude mcp add --transport http … /api/proxy/api/mcp` then completes discovery → dynamic client registration → PKCE authorize → token, and the MCP connects.

`bun run --cwd apps/api lint` passes.

## Notes

Distinct from #15 (reverse-proxy `--public-url` support): that PR adds a new `apps/cli/src/lib/public-url.ts` and fixes the dashboard login redirect; this change is in the unrelated `apps/api/src/lib/public-url.ts` and fixes the API's OAuth discovery. No overlap despite the identical filename.
