### PR TITLE
fix(api): paginate GitHub App installation repositories

### DIFF
--- a/apps/api/src/modules/github/sources/app-source.ts
+++ b/apps/api/src/modules/github/sources/app-source.ts
@@ -93,11 +93,24 @@ export class GitHubAppSource implements GitHubSource {
       () => null,
     );
     if (!token) return [];
-    const data = await ghFetch<{ repositories: GitHubRepository[] }>(token, {
-      url: "https://api.github.com/installation/repositories",
-      params: { per_page: 100 },
-    });
-    return mapRepositories(data.repositories ?? []).map((r) => ({
+    const perPage = 100;
+    const repositories: GitHubRepository[] = [];
+    for (let page = 1; page <= 100; page++) {
+      const data = await ghFetch<{ total_count?: number; repositories?: GitHubRepository[] }>(
+        token,
+        {
+          url: "https://api.github.com/installation/repositories",
+          params: { per_page: perPage, page },
+        },
+      );
+      const batch = data.repositories ?? [];
+      repositories.push(...batch);
+      const total = data.total_count ?? repositories.length;
+      if (batch.length < perPage || repositories.length >= total) {
+        break;
+      }
+    }
+    return mapRepositories(repositories).map((r) => ({
       ...r,
       source: "app" as const,
     }));


### PR DESCRIPTION
## Summary

`GitHubAppSource.listInstallationRepos` made a single `GET /installation/repositories?per_page=100` request, so an App installation with **more than 100 accessible repositories** was silently truncated to the first 100. Everything downstream — `getHome`, `listReposForOwner`, and the dashboard's repo picker — could only ever see those first 100, so a user's newer repos were unselectable.

## Fix

Walk every page (`per_page=100`, incrementing `page`) until the response's `total_count` is reached, hard-capped at 100 pages (10k repos) as a safety bound. `ghFetch` already serializes `params` into the GET query string, so no other change is needed.

## Testing

- `bun run --cwd apps/api lint` passes (`tsc --noEmit`).
- On an account with >100 repos accessible to the installation, the repo list now returns all of them instead of the first 100.
