### PR TITLE
fix: correct stale env doc comments and close orphaned SSH exec stream on timeout

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -119,9 +119,9 @@ const envSchema = z.object({
    * Cloud-session IP/UA pinning policy. Applied by cloudSessionAuth
    * middleware when a local instance presents a cloud_session_token.
    *
-   *   - "off"  (default) → log mismatches as warnings, allow the request.
+   *   - "off"            → log mismatches as warnings, allow the request.
    *                        Friendly to mobile carriers/VPN switches.
-   *   - "warn"           → same as "off" but also emits an audit log
+   *   - "warn" (default) → same as "off" but also emits an audit log
    *                        entry per mismatch (for SOC review).
    *   - "strict"         → 401 on IP OR User-Agent mismatch with the
    *                        IP/UA stored when the session was created.
@@ -210,10 +210,9 @@ const envSchema = z.object({
 
   /* ---------- Backup destinations ---------- */
   /**
-   * Allow `kind: 'local'` backup destinations. Defaults OFF in CLOUD_MODE
-   * (the SaaS would otherwise expose its multi-tenant filesystem to any
-   * authenticated user), defaults ON for self-hosted single-operator
-   * installs where the API process owns the host.
+   * Allow `kind: 'local'` backup destinations. Defaults OFF everywhere
+   * (including self-hosted single-operator installs) - the operator must
+   * explicitly opt in with BACKUP_ALLOW_LOCAL_DESTINATION=true.
    */
   BACKUP_ALLOW_LOCAL_DESTINATION: envBool(),
   /**

--- a/packages/adapters/src/system/ssh-client.ts
+++ b/packages/adapters/src/system/ssh-client.ts
@@ -111,15 +111,38 @@ export async function execSshCommand(
   return new Promise((resolve, reject) => {
     let stdout = "";
     let stderr = "";
+    let stream: ClientChannel | undefined;
+    let timedOut = false;
 
     const timer = setTimeout(() => {
+      timedOut = true;
+      if (stream) {
+        try {
+          stream.close();
+        } catch {
+          /* already closed */
+        }
+      }
       reject(new Error(`SSH command timed out after ${timeout}ms: ${command}`));
     }, timeout);
 
-    client.exec(command, (err, stream) => {
+    client.exec(command, (err, execStream) => {
       if (err) {
         clearTimeout(timer);
         reject(err);
+        return;
+      }
+
+      stream = execStream;
+
+      if (timedOut) {
+        // Timer already fired (exec itself was slow to hand back the
+        // channel) - tear this one down too instead of leaving it orphaned.
+        try {
+          stream.close();
+        } catch {
+          /* already closed */
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Three small, unrelated fixes found while reading through `apps/api/src/config/env.ts` and `packages/adapters/src/system/ssh-client.ts`. Bundled into one PR since each is a one-line-of-reasoning fix; happy to split into separate PRs if preferred.

1. **`apps/api/src/config/env.ts` - `CLOUD_SESSION_PINNING` doc comment**
   The comment said `"off"` is the default. The schema (`z.enum([...]).default("warn")`) actually defaults to `"warn"`. Fixed the comment only - `"warn"` is the safer default (adds an audit-log entry per mismatch) and I left it untouched.

2. **`apps/api/src/config/env.ts` - `BACKUP_ALLOW_LOCAL_DESTINATION` doc comment**
   The comment claimed this "defaults ON for self-hosted single-operator installs." `envBool()` is called with no argument, which always defaults to `false` regardless of deploy mode - confirmed by tracing the only consumer at `destination.service.ts:54`, which reads the raw env value with no mode-dependent override anywhere. Fixed the comment to match the actual (safe, disabled-by-default) behavior. Did not touch the default itself - changing a security-relevant default isn't something I wanted to do opportunistically in a doc-fix PR.

3. **`packages/adapters/src/system/ssh-client.ts` - `execSshCommand` timeout leak**
   On timeout, the `setTimeout` handler rejected the promise but never closed the `stream` returned by `client.exec()`. The remote command kept running and the local stdout/stderr listeners stayed attached to an orphaned channel. Now the timeout handler closes the stream (via `stream.close()`, wrapped in try/catch - matching the existing pattern already used for `ClientChannel` cleanup in `ssh-executor.ts`), including the edge case where `exec()`'s callback returns the stream after the timer has already fired.

## Testing

- Doc-comment fixes (#1, #2) verified by re-reading the schema and tracing the only consumer of `BACKUP_ALLOW_LOCAL_DESTINATION`.
- For #3, ran `bun run --cwd apps/api lint` and `bun run --cwd packages/adapters lint` (both clean) plus `bun run --cwd packages/adapters test` (vitest) against the pinned `bun@1.3.10` version in a throwaway Docker container - 109/110 tests passed. The one failure (`remote-journal.test.ts`, a timing-sensitive test in an unrelated module) is pre-existing and unaffected by this change - it doesn't import `ssh-client.ts`.

## Disclosure

I used Claude Code (AI pair-programming) to help investigate and draft this change. I reviewed the diff and verification results myself before opening the PR.