### PR TITLE
fix(mail): detect duplicate DMARC records in DNS scan

### DIFF
--- a/apps/api/src/modules/mail/admin/dns-scan.service.ts
+++ b/apps/api/src/modules/mail/admin/dns-scan.service.ts
@@ -328,12 +328,21 @@ async function checkDkim(domain: string, exp?: ExpectedRecord): Promise<DnsCheck
   }
 }
 
+// DMARC Policy Record identification, per RFC 9989 sections 4.7/4.8/4.10:
+// the record must start with the version tag (no leading WSP), the tag name
+// is case-insensitive while the value is case-sensitively "DMARC1", WSP
+// (space/tab) may surround "=", and the tag must end at ";", WSP, or end of
+// record. So "v=dmarc1" is ignored outright and "v=DMARC10" is not a policy
+// record for this version of DMARC.
+const DMARC_VERSION_TAG = /^[vV][ \t]*=[ \t]*DMARC1(?:[ \t;]|$)/;
+
 async function checkDmarc(domain: string, exp?: ExpectedRecord): Promise<DnsCheck | null> {
   if (!exp?.value) return null;
   const name = exp.name || `_dmarc.${domain}`;
   try {
     const txt = (await resolveTxt(name)).map((parts) => parts.join(""));
-    const dmarc = txt.find((t) => /^v=DMARC1\b/i.test(t));
+    const dmarcRecords = txt.filter((t) => DMARC_VERSION_TAG.test(t));
+    const dmarc = dmarcRecords[0];
     if (!dmarc) {
       return {
         key: "dmarc",
@@ -345,6 +354,20 @@ async function checkDmarc(domain: string, exp?: ExpectedRecord): Promise<DnsChec
         expected: exp.value,
         actual: "",
         message: "No DMARC record found. Some receivers will treat this as a risk signal.",
+      };
+    }
+    if (dmarcRecords.length > 1) {
+      return {
+        key: "dmarc",
+        label: "DMARC policy",
+        description: "Tells receivers what to do when SPF/DKIM fail for this domain.",
+        queriedName: name,
+        recordType: "TXT",
+        status: "fail",
+        expected: exp.value,
+        actual: dmarcRecords.join(" | "),
+        message:
+          "Multiple DMARC records found. Receivers discard every DMARC record at this name, so none of them apply. Publish exactly one v=DMARC1 TXT record at this name.",
       };
     }
     return {

--- a/apps/api/test/modules/mail/dns-scan.service.test.ts
+++ b/apps/api/test/modules/mail/dns-scan.service.test.ts
@@ -31,6 +31,12 @@ const state = {
       value: "v=spf1 mx -all",
       required: true,
     },
+    dmarc: {
+      type: "TXT",
+      name: "_dmarc.example.com",
+      value: "v=DMARC1; p=reject",
+      required: true,
+    },
   },
 };
 
@@ -49,7 +55,11 @@ import { scanDns } from "../../../src/modules/mail/admin/dns-scan.service";
 describe("scanDns SPF checks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dns.resolveTxt.mockResolvedValue([["v=spf1 mx -all"]]);
+    // Name-aware default so the DMARC check (now part of the fixture state)
+    // sees a valid record; individual tests override with their own TXT sets.
+    dns.resolveTxt.mockImplementation(async (name: string) =>
+      name === "_dmarc.example.com" ? [["v=DMARC1; p=reject"]] : [["v=spf1 mx -all"]],
+    );
   });
 
   test("fails when no SPF record exists", async () => {
@@ -121,5 +131,92 @@ describe("scanDns SPF checks", () => {
       }),
     );
     expect(result.checks.find((c) => c.key === "spf")?.message).toMatch(/multiple SPF records/i);
+  });
+});
+
+describe("scanDns DMARC checks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dns.resolveTxt.mockImplementation(async (name: string) =>
+      name === "_dmarc.example.com"
+        ? [["google-site-verification=abc"], ["v=DMARC1; p=reject"]]
+        : [["v=spf1 mx -all"]],
+    );
+  });
+
+  test("passes when exactly one DMARC policy record is published among other TXT records", async () => {
+    const result = await scanDns("srv_test");
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        key: "dmarc",
+        status: "pass",
+      }),
+    );
+  });
+
+  test("fails when multiple DMARC policy records are published", async () => {
+    dns.resolveTxt.mockImplementation(async (name: string) =>
+      name === "_dmarc.example.com"
+        ? [["v=DMARC1; p=reject"], ["V=DMARC1; p=none"]]
+        : [["v=spf1 mx -all"]],
+    );
+
+    const result = await scanDns("srv_test");
+    const dmarc = result.checks.find((check) => check.key === "dmarc");
+
+    expect(dmarc).toEqual(
+      expect.objectContaining({
+        status: "fail",
+        actual: "v=DMARC1; p=reject | V=DMARC1; p=none",
+      }),
+    );
+    expect(dmarc?.message).toMatch(/multiple DMARC records/i);
+  });
+
+  test("fails when a second policy record uses permitted whitespace around =", async () => {
+    dns.resolveTxt.mockImplementation(async (name: string) =>
+      name === "_dmarc.example.com"
+        ? [["v=DMARC1; p=reject"], ["v = DMARC1; p=none"]]
+        : [["v=spf1 mx -all"]],
+    );
+
+    const result = await scanDns("srv_test");
+    const dmarc = result.checks.find((check) => check.key === "dmarc");
+
+    expect(dmarc?.status).toBe("fail");
+    expect(dmarc?.actual).toBe("v=DMARC1; p=reject | v = DMARC1; p=none");
+  });
+
+  test("passes when a second TXT record uses a lowercase dmarc1 version value", async () => {
+    dns.resolveTxt.mockImplementation(async (name: string) =>
+      name === "_dmarc.example.com"
+        ? [["v=DMARC1; p=reject"], ["v=dmarc1; p=none"]]
+        : [["v=spf1 mx -all"]],
+    );
+
+    const result = await scanDns("srv_test");
+    const dmarc = result.checks.find((check) => check.key === "dmarc");
+
+    expect(dmarc).toEqual(
+      expect.objectContaining({
+        status: "pass",
+        actual: "v=DMARC1; p=reject",
+      }),
+    );
+  });
+
+  test("passes when lookalike records do not terminate the version tag", async () => {
+    dns.resolveTxt.mockImplementation(async (name: string) =>
+      name === "_dmarc.example.com"
+        ? [["v=DMARC1; p=reject"], ["v=DMARC10; p=none"], ["v=DMARC1-legacy; p=none"]]
+        : [["v=spf1 mx -all"]],
+    );
+
+    const result = await scanDns("srv_test");
+    const dmarc = result.checks.find((check) => check.key === "dmarc");
+
+    expect(dmarc?.status).toBe("pass");
+    expect(dmarc?.actual).toBe("v=DMARC1; p=reject");
   });
 });


### PR DESCRIPTION
## Summary

- Detect multiple DMARC policy TXT records during mail DNS scans.
- Report a failed health check because receivers discard every DMARC record published at the same DNS name.
- Recognize the DMARC version tag using the case and whitespace rules from RFC 9989.

Previously, the scan selected only the first matching record, so domains with multiple DMARC policies incorrectly received a green result. The previous matcher also treated the `DMARC1` value as case-insensitive and did not support permitted whitespace around `=`.

RFC 9989 sections 4.7, 4.8, and 4.10: https://www.rfc-editor.org/rfc/rfc9989.html

## Testing

- Focused DNS scan tests: 10 passed
- All mail tests: 25 passed
- API TypeScript check passed
- Prettier check passed
- Git diff check passed