### PR TITLE
fix(dashboard): move locale cookie outside client boundary

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -3,12 +3,19 @@ import { cookies, headers } from "next/headers";
 import "./globals.css";
 import { ThemeProvider, ThemeScript } from "@/components/theme-provider";
 import { ToastProvider } from "@/components/toast";
-import { I18nProvider, LOCALE_COOKIE } from "@/components/i18n-provider";
+import { I18nProvider } from "@/components/i18n-provider";
 import { AuthProvider } from "@/context/AuthContext";
 import { NetworkErrorHandler } from "@/components/network-error-handler";
 import { ModalProvider } from "@/context/ModalContext";
 import { DesktopChrome } from "@/components/desktop-chrome";
-import { defaultLocale, isRtl, loadDictionary, locales, type Locale } from "@/i18n";
+import {
+  defaultLocale,
+  isRtl,
+  loadDictionary,
+  LOCALE_COOKIE,
+  locales,
+  type Locale,
+} from "@/i18n";
 
 /** Resolve the request locale server-side: explicit cookie first, then the
  *  browser's Accept-Language, else the default. Keeps SSR and first paint in

--- a/apps/dashboard/src/components/i18n-provider.tsx
+++ b/apps/dashboard/src/components/i18n-provider.tsx
@@ -13,6 +13,7 @@ import {
   defaultLocale,
   isRtl,
   loadDictionary,
+  LOCALE_COOKIE,
   locales,
   type Dictionary,
   type Locale,
@@ -34,8 +35,6 @@ const I18nContext = createContext<I18nContextValue | null>(null);
 /* ------------------------------------------------------------------ */
 /*  Provider                                                           */
 /* ------------------------------------------------------------------ */
-
-export const LOCALE_COOKIE = "openship-locale";
 
 /** Read the chosen locale on the client: cookie first (what SSR also reads),
  *  then the localStorage mirror. Returns null when nothing valid is stored. */

--- a/apps/dashboard/src/i18n/index.ts
+++ b/apps/dashboard/src/i18n/index.ts
@@ -43,6 +43,7 @@ export type Dictionary = typeof baseDictionary;
 export const locales = ["en", "ar", "es", "fr", "de", "pt", "ja", "zh"] as const;
 export type Locale = (typeof locales)[number];
 export const defaultLocale: Locale = "en";
+export const LOCALE_COOKIE = "openship-locale";
 
 /** RTL languages. */
 const rtlLocales = new Set<Locale>(["ar"]);


### PR DESCRIPTION
## Summary

- move `LOCALE_COOKIE` from the client-only i18n provider to the shared i18n module
- prevent Next.js from replacing the cookie value with an RSC client-reference stub in the server-rendered bootstrap script
- preserve the existing SSR, cookie, and local-storage locale behavior

## Verification

- existing dashboard tests still pass: `bun --cwd apps/dashboard test`
- TypeScript check passes: `bunx tsc --noEmit -p apps/dashboard/tsconfig.json`
- production webpack build passes: `bun --cwd apps/dashboard build`
- verified the emitted production bundle contains the locale cookie literal and no `LOCALE_COOKIE()` RSC server-function stub

No focused unit test was added because Vitest does not apply Next.js's production RSC transform; the reported failure was verified against the emitted production bundle instead.

## Scope

The touched files contain pre-existing Prettier differences on upstream; this PR intentionally avoids unrelated formatting churn. The existing `openship-locale` literal in `proxy.ts` is unchanged because it runs outside the affected RSC import boundary.

Fixes #70
