### PR TITLE
fix(migration): tear down failed target deployment on same-server rollback

### DIFF
--- a/apps/api/src/modules/migration/migration.orchestrator.ts
+++ b/apps/api/src/modules/migration/migration.orchestrator.ts
@@ -435,8 +435,16 @@ class MigrationOrchestratorImpl {
   ): Promise<void> {
     // Best-effort: tear down whatever landed on the target, then bring the
     // originals back up on the source. Never destroy the source.
+    //
+    // This must run for same-server migrations too: `listDeploymentContainers`
+    // scopes strictly by `openship.deployment=<deploymentId>` label, which
+    // never overlaps with the pre-migration `scannedContainerIds` restarted
+    // below, so it's safe regardless of source/target identity. Skipping it
+    // for same-server previously left the newly-deployed (and possibly
+    // port/name-colliding) containers running while the originals were also
+    // restarted on the same daemon.
     try {
-      if (deploymentId && !ctx.sameServer) {
+      if (deploymentId) {
         const rtB = await createServerDockerRuntime(ctx.targetServerId, ctx.organizationId);
         try {
           const containers = await rtB.listDeploymentContainers(deploymentId);


### PR DESCRIPTION
## Summary

Found while reading through the (previously un-audited) Docker-migration
module — `apps/api/src/modules/migration/migration.orchestrator.ts`.

`rollback()` only tears down the newly-deployed containers on the target
when the run crosses servers:

```ts
if (deploymentId && !ctx.sameServer) {
  const rtB = await createServerDockerRuntime(ctx.targetServerId, ctx.organizationId);
  ...
  const containers = await rtB.listDeploymentContainers(deploymentId);
  for (const c of containers) await rtB.destroy(c.containerId).catch(() => {});
}
```

For a `same_server` migration (`sourceServerId === targetServerId`), this
skips the teardown entirely. The function then unconditionally restarts the
originals on the source:

```ts
const rtA = await createServerDockerRuntime(ctx.sourceServerId, ctx.organizationId);
for (const cid of Object.values(scannedContainerIds)) await rtA.start(cid).catch(() => {});
```

So: a same-server migration that fails after the `deploying`/`verifying`
step (e.g. the target deployment never becomes ready) leaves the
just-deployed replacement stack running *and* restarts the original
containers on the same daemon — two stacks of the same services fighting
over the same published ports/container names. The `moveData` step
explicitly stops the originals earlier "to free ports... for a same-server
redeploy" (see the comment a few lines above `moveData`), which only
confirms the intent that the two stacks aren't meant to coexist.

The `!ctx.sameServer` guard isn't needed for safety:
`listDeploymentContainers` scopes strictly by the
`openship.deployment=<deploymentId>` label (see
`packages/adapters/src/runtime/docker.ts`), which can never overlap with the
pre-migration `scannedContainerIds` restarted right after — so running the
teardown unconditionally is safe regardless of whether source and target
are the same server.

## Fix

Drop the `!ctx.sameServer` condition so the target-deployment teardown runs
for same-server rollbacks too, before the originals are restarted. Added a
short comment explaining why this is safe (label-scoped, no overlap with
`scannedContainerIds`).

## Testing

- `bun run --cwd apps/api lint` (tsc --noEmit) — clean, before and after.
- `bun run --cwd apps/api test` (vitest) in a throwaway, resource-bounded
  `oven/bun:1.3.10` container — 497/505 passing both before and after this
  change (verified identical pass/fail counts against the unmodified file).
  The 8 pre-existing failures are unrelated environment/config issues (no
  `apps/api/.env` in the throwaway container, an unrelated rate-limit-policy
  test expectation, and an unrelated `listReposForOwner` import mismatch) —
  none touch the migration module or this code path. There's no existing
  unit test covering `MigrationOrchestratorImpl.rollback`.