### PR TITLE
fix(mail): allow cascading additional domains

### DIFF
--- a/apps/api/src/modules/mail/admin/mailboxes.service.ts
+++ b/apps/api/src/modules/mail/admin/mailboxes.service.ts
@@ -22,14 +22,7 @@
  */
 
 import { sshManager } from "../../../lib/ssh-manager";
-import {
-  execute,
-  queryOne,
-  queryRows,
-  q,
-  qInt,
-  transaction,
-} from "./psql-runner";
+import { execute, queryOne, queryRows, q, qInt, transaction } from "./psql-runner";
 import { hashPassword } from "./password";
 import {
   createMaildirOnDisk,
@@ -39,10 +32,7 @@ import {
   STORAGE_NODE,
 } from "./maildir";
 import { recountDomain, validateDomain } from "./domains.service";
-import {
-  buildInsertMailboxSql,
-  buildInsertSelfForwardingSql,
-} from "./platform-mailbox.service";
+import { buildInsertMailboxSql, buildInsertSelfForwardingSql } from "./platform-mailbox.service";
 import { safeErrorMessage } from "@repo/core";
 
 const EMAIL_RE = /^[a-z0-9._+-]+@[a-z0-9.-]+\.[a-z]{2,}$/;
@@ -137,10 +127,7 @@ function validateDisplayName(name: string): void {
   }
 }
 
-export async function listMailboxes(
-  serverId: string,
-  domain: string,
-): Promise<MailboxRow[]> {
+export async function listMailboxes(serverId: string, domain: string): Promise<MailboxRow[]> {
   validateDomain(domain);
   return queryRows<MailboxRow>(
     serverId,
@@ -148,10 +135,7 @@ export async function listMailboxes(
   );
 }
 
-export async function getMailbox(
-  serverId: string,
-  email: string,
-): Promise<MailboxRow | null> {
+export async function getMailbox(serverId: string, email: string): Promise<MailboxRow | null> {
   validateEmail(email);
   return queryOne<MailboxRow>(
     serverId,
@@ -219,9 +203,7 @@ export async function createMailbox(
         `DELETE FROM forwardings WHERE address = ${q(username)} AND forwarding = ${q(username)};`,
       );
       throw new Error(
-        `Failed to create Maildir; mailbox was rolled back: ${
-          safeErrorMessage(err)
-        }`,
+        `Failed to create Maildir; mailbox was rolled back: ${safeErrorMessage(err)}`,
       );
     }
 
@@ -269,10 +251,7 @@ export async function updateMailbox(
     }
 
     if (sets.length > 1) {
-      await execute(
-        exec,
-        `UPDATE mailbox SET ${sets.join(", ")} WHERE username = ${q(username)}`,
-      );
+      await execute(exec, `UPDATE mailbox SET ${sets.join(", ")} WHERE username = ${q(username)}`);
     }
 
     // Mirror active flag on the forwardings row so Postfix stops accepting
@@ -336,10 +315,7 @@ export async function softDeleteMailbox(
  * input, so we can't be tricked into rm-ing an arbitrary path. `removeMaildirOnDisk`
  * additionally guards against any path outside /var/vmail/.
  */
-export async function hardDeleteMailbox(
-  serverId: string,
-  email: string,
-): Promise<void> {
+export async function hardDeleteMailbox(serverId: string, email: string): Promise<void> {
   validateEmail(email);
   const username = email.toLowerCase();
   const existing = await getMailbox(serverId, username);
@@ -390,4 +366,3 @@ export class MailboxNotFoundError extends Error {
     super(`Mailbox not found: ${username}`);
   }
 }
-

--- a/apps/api/src/modules/mail/admin/mailboxes.service.ts
+++ b/apps/api/src/modules/mail/admin/mailboxes.service.ts
@@ -34,6 +34,7 @@ import {
 import { recountDomain, validateDomain } from "./domains.service";
 import { buildInsertMailboxSql, buildInsertSelfForwardingSql } from "./platform-mailbox.service";
 import { safeErrorMessage } from "@repo/core";
+import { readState } from "../mail-state";
 
 const EMAIL_RE = /^[a-z0-9._+-]+@[a-z0-9.-]+\.[a-z]{2,}$/;
 const LOCAL_PART_RE = /^[a-z0-9._+-]+$/;
@@ -321,16 +322,19 @@ export async function hardDeleteMailbox(serverId: string, email: string): Promis
   const existing = await getMailbox(serverId, username);
   if (!existing) throw new MailboxNotFoundError(username);
 
-  // Refuse to delete the postmaster account of the install domain. The
-  // install wizard creates it and iRedMail's own scripts expect it to
-  // exist. The UI should not even expose this option, but defence in depth.
-  if (existing.username.startsWith("postmaster@")) {
-    throw new Error(
-      `Refusing to hard-delete the postmaster mailbox (${existing.username}). Use soft delete instead.`,
-    );
-  }
-
   await sshManager.withExecutor(serverId, async (exec) => {
+    // Only the install domain's postmaster is infrastructure. Additional
+    // domains also get a postmaster mailbox, but it must remain removable so
+    // cascade deletion can empty and drop those domains.
+    if (username.startsWith("postmaster@")) {
+      const installDomain = (await readState(exec))?.domain?.toLowerCase();
+      if (!installDomain || username === `postmaster@${installDomain}`) {
+        throw new Error(
+          `Refusing to hard-delete the postmaster mailbox (${existing.username}). Use soft delete instead.`,
+        );
+      }
+    }
+
     await transaction(exec, [
       `DELETE FROM forwardings WHERE address = ${q(username)} OR forwarding = ${q(username)}`,
       `DELETE FROM used_quota WHERE username = ${q(username)}`,

--- a/apps/api/test/modules/mail/mailboxes.service.test.ts
+++ b/apps/api/test/modules/mail/mailboxes.service.test.ts
@@ -1,0 +1,115 @@
+import "./_setup-env";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  queryOne: vi.fn(),
+  transaction: vi.fn(),
+  readState: vi.fn(),
+  removeMaildirOnDisk: vi.fn(),
+  recountDomain: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: {
+    withExecutor: async (_serverId: string, fn: (exec: object) => unknown) => fn({}),
+  },
+}));
+
+vi.mock("../../../src/modules/mail/admin/psql-runner", () => ({
+  execute: vi.fn(),
+  queryOne: mocks.queryOne,
+  queryRows: vi.fn(),
+  q: (value: string) => `'${value}'`,
+  qInt: (value: number) => String(value),
+  transaction: mocks.transaction,
+}));
+
+vi.mock("../../../src/modules/mail/mail-state", () => ({
+  readState: mocks.readState,
+}));
+
+vi.mock("../../../src/modules/mail/admin/maildir", () => ({
+  createMaildirOnDisk: vi.fn(),
+  generateMaildir: vi.fn(),
+  removeMaildirOnDisk: mocks.removeMaildirOnDisk,
+  STORAGE_BASE: "/var/vmail",
+  STORAGE_NODE: "vmail1",
+}));
+
+vi.mock("../../../src/modules/mail/admin/domains.service", () => ({
+  recountDomain: mocks.recountDomain,
+  validateDomain: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/mail/admin/password", () => ({
+  hashPassword: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/mail/admin/platform-mailbox.service", () => ({
+  buildInsertMailboxSql: vi.fn(),
+  buildInsertSelfForwardingSql: vi.fn(),
+}));
+
+import { hardDeleteMailbox } from "../../../src/modules/mail/admin/mailboxes.service";
+
+function mailbox(username: string, domain: string) {
+  return {
+    username,
+    name: "Postmaster",
+    domain,
+    quotaMB: 0,
+    storagebasedirectory: "/var/vmail",
+    storagenode: "vmail1",
+    maildir: `${domain}/p/o/s/postmaster-2026.07.21.00.00.00/`,
+    active: true,
+    isAdmin: false,
+    isGlobalAdmin: false,
+    createdAt: "2026-07-21",
+    passwordLastChange: "2026-07-21",
+  };
+}
+
+describe("hardDeleteMailbox postmaster protection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readState.mockResolvedValue({ domain: "primary.example" });
+    mocks.transaction.mockResolvedValue(undefined);
+    mocks.removeMaildirOnDisk.mockResolvedValue(undefined);
+    mocks.recountDomain.mockResolvedValue(undefined);
+  });
+
+  test("allows hard-deleting the postmaster mailbox of an additional domain", async () => {
+    mocks.queryOne.mockResolvedValue(
+      mailbox("postmaster@additional.example", "additional.example"),
+    );
+
+    await hardDeleteMailbox("srv_test", "postmaster@additional.example");
+
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+    expect(mocks.removeMaildirOnDisk).toHaveBeenCalledOnce();
+    expect(mocks.recountDomain).toHaveBeenCalledWith("srv_test", "additional.example");
+  });
+
+  test("refuses to hard-delete the postmaster mailbox of the install domain", async () => {
+    mocks.queryOne.mockResolvedValue(mailbox("postmaster@primary.example", "primary.example"));
+
+    await expect(hardDeleteMailbox("srv_test", "postmaster@primary.example")).rejects.toThrow(
+      /refusing to hard-delete the postmaster mailbox/i,
+    );
+
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  test("refuses to hard-delete a postmaster mailbox when install state is unavailable", async () => {
+    mocks.queryOne.mockResolvedValue(
+      mailbox("postmaster@additional.example", "additional.example"),
+    );
+    mocks.readState.mockResolvedValue(null);
+
+    await expect(hardDeleteMailbox("srv_test", "postmaster@additional.example")).rejects.toThrow(
+      /refusing to hard-delete the postmaster mailbox/i,
+    );
+
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- scope postmaster hard-delete protection to the primary install domain
- allow automatically-created postmaster mailboxes on additional domains to be removed during cascade deletion
- fail closed when the install domain cannot be read
- add regression coverage for additional, primary, and unavailable-state cases

## Verification

- `bunx vitest run test/modules/mail/mailboxes.service.test.ts test/modules/mail/dns-scan.service.test.ts test/modules/mail/psql-injection.test.ts` (11 tests passed)
- `bun run --cwd apps/api lint`
- Prettier check on both touched files
- `git diff --check`

## Formatting note

`mailboxes.service.ts` was not Prettier-clean on `main`. Per `CONTRIBUTING.md`, the formatting-only changes are isolated in the first commit; the functional change and tests are in the second commit.

Fixes #76