### PR TITLE
fix(mail): prevent concurrent setup runs

### DIFF
--- a/apps/api/src/modules/mail/mail-setup-lease.ts
+++ b/apps/api/src/modules/mail/mail-setup-lease.ts
@@ -1,0 +1,18 @@
+import { repos, tryAcquireAdvisoryLock, type AdvisoryLockHandle } from "@repo/db";
+
+/** Acquire a cross-replica lock and record the mail setup start. */
+export async function reserveMailSetup(
+  serverId: string,
+  domain: string,
+): Promise<AdvisoryLockHandle | null> {
+  const lock = await tryAcquireAdvisoryLock(`mail-setup:${serverId}`);
+  if (!lock) return null;
+
+  try {
+    await repos.mailServer.upsert({ serverId, domain, installedAt: null });
+    return lock;
+  } catch (err) {
+    await lock.release();
+    throw err;
+  }
+}

--- a/apps/api/src/modules/mail/mail.controller.ts
+++ b/apps/api/src/modules/mail/mail.controller.ts
@@ -25,6 +25,7 @@
  */
 
 import type { Context } from "hono";
+import type { SSEStreamingApi } from "hono/streaming";
 import crypto from "node:crypto";
 import { lookup as dnsLookup } from "node:dns/promises";
 import { buildMailBackupPayload } from "./admin/backup-plan";
@@ -55,6 +56,7 @@ import {
 } from "./mail.service";
 import { checkMailHealth, MAIL_COMPONENTS } from "./mail-health.service";
 import { updatePostmasterPassword } from "./mail-credentials.service";
+import { reserveMailSetup } from "./mail-setup-lease";
 import {
   readState,
   writeState,
@@ -650,35 +652,32 @@ export async function startSetup(c: Context) {
     return c.json({ error: "Setup already running" }, 409);
   }
 
-  // Cross-replica lock: the mail_servers row IS the lock. INSERT with
-  // installedAt=null + atomic conflict detection — if another replica
-  // already started an install for this server within the last hour
-  // (row exists with installedAt=null AND createdAt is recent), we
-  // refuse. After 1h we assume the install crashed and let the next
-  // attempt take over.
-  const existing = await repos.mailServer.get(serverId).catch(() => null);
-  if (existing && !existing.installedAt) {
-    const ageMs = Date.now() - new Date(existing.createdAt).getTime();
-    if (ageMs < 60 * 60 * 1000) {
-      return c.json(
-        { error: "Setup already running on another replica or recently crashed" },
-        409,
-      );
-    }
-  }
+  // Reserve the process-local slot before the first database await so two
+  // requests cannot both pass the in-memory check in the same event-loop turn.
+  const session: ActiveSession = { serverId, domain, cancelled: false };
+  active = session;
 
-  active = { serverId, domain, cancelled: false };
-
+  let reservation;
   try {
-    await repos.mailServer.upsert({ serverId, domain, installedAt: null });
+    reservation = await reserveMailSetup(serverId, domain);
   } catch (err) {
-    console.warn(
-      "[mail] failed to record mail-server install start:",
+    if (active === session) active = null;
+    console.error(
+      "[mail] failed to reserve mail-server setup:",
       safeErrorMessage(err),
+    );
+    return c.json(
+      { error: "Could not reserve mail setup. Please try again." },
+      503,
     );
   }
 
-  return streamSSE(c, async (stream) => {
+  if (!reservation) {
+    if (active === session) active = null;
+    return c.json({ error: "Setup already running on another replica" }, 409);
+  }
+
+  const runSetup = async (stream: SSEStreamingApi) => {
     // Resolve initial state from the server. New install → fresh state.
     // Existing install on same domain → merge so secrets/completedSteps
     // survive across retries. Different domain on same server → wipe and
@@ -991,7 +990,25 @@ export async function startSetup(c: Context) {
         active = null;
       }
     }
-  });
+  };
+
+  const releaseSession = async () => {
+    if (active === session) active = null;
+    await reservation.release();
+  };
+
+  try {
+    return streamSSE(c, async (stream) => {
+      try {
+        await runSetup(stream);
+      } finally {
+        await releaseSession();
+      }
+    });
+  } catch (err) {
+    await releaseSession();
+    throw err;
+  }
 }
 
 /** POST /mail/setup/cancel - cancel the running setup */

--- a/apps/api/test/modules/mail/mail-setup-concurrency.test.ts
+++ b/apps/api/test/modules/mail/mail-setup-concurrency.test.ts
@@ -1,0 +1,105 @@
+import "./_setup-env";
+import type { Context } from "hono";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(async () => undefined),
+  sshWithExecutor: vi.fn(),
+  upsertMailServer: vi.fn(),
+  streamSSE: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    mailServer: {
+      upsert: mocks.upsertMailServer,
+    },
+  },
+  tryAcquireAdvisoryLock: mocks.acquireLock,
+}));
+
+vi.mock("../../../src/lib/permission", () => ({
+  permission: { assert: vi.fn(async () => undefined) },
+}));
+
+vi.mock("../../../src/lib/request-context", () => ({
+  getRequestContext: () => ({ organizationId: "org-1" }),
+}));
+
+vi.mock("../../../src/lib/controller-helpers", () => ({
+  isServerInOrg: vi.fn(async () => true),
+}));
+
+vi.mock("../../../src/lib/sse", () => ({
+  streamSSE: mocks.streamSSE,
+}));
+
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: { withExecutor: mocks.sshWithExecutor },
+}));
+
+import { startSetup } from "../../../src/modules/mail/mail.controller";
+
+function setupContext() {
+  return {
+    req: {
+      json: vi.fn(async () => ({
+        serverId: "server-1",
+        domain: "example.com",
+      })),
+    },
+    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
+  } as unknown as Context;
+}
+
+describe("startSetup concurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.acquireLock.mockResolvedValue({ release: mocks.releaseLock });
+    mocks.sshWithExecutor.mockRejectedValue(new Error("ssh unavailable"));
+    mocks.upsertMailServer.mockResolvedValue({});
+    mocks.streamSSE.mockReturnValue({ stream: true });
+  });
+
+  test("releases failed reservations and allows only one concurrent setup", async () => {
+    mocks.acquireLock.mockRejectedValueOnce(new Error("database unavailable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(startSetup(setupContext())).resolves.toEqual({
+      body: { error: "Could not reserve mail setup. Please try again." },
+      status: 503,
+    });
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+
+    let releaseLookup!: () => void;
+    const lookupPending = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    mocks.acquireLock.mockImplementation(async () => {
+      await lookupPending;
+      return { release: mocks.releaseLock };
+    });
+
+    const first = startSetup(setupContext());
+    await vi.waitFor(() => expect(mocks.acquireLock).toHaveBeenCalledTimes(1));
+
+    const second = startSetup(setupContext());
+    await Promise.resolve();
+    releaseLookup();
+
+    const responses = await Promise.all([first, second]);
+
+    expect(mocks.streamSSE).toHaveBeenCalledTimes(1);
+    expect(responses).toContainEqual({
+      body: { error: "Setup already running" },
+      status: 409,
+    });
+
+    expect(mocks.releaseLock).not.toHaveBeenCalled();
+    const setupCallback = mocks.streamSSE.mock.calls[0]?.[1];
+    await setupCallback({ writeSSE: vi.fn(async () => undefined) });
+    expect(mocks.releaseLock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/test/modules/mail/mail-setup-lease.test.ts
+++ b/apps/api/test/modules/mail/mail-setup-lease.test.ts
@@ -1,0 +1,56 @@
+import "./_setup-env";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getLock: vi.fn(),
+  upsertMailServer: vi.fn(),
+  release: vi.fn(async () => undefined),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    mailServer: {
+      upsert: mocks.upsertMailServer,
+    },
+  },
+  tryAcquireAdvisoryLock: mocks.getLock,
+}));
+
+import { reserveMailSetup } from "../../../src/modules/mail/mail-setup-lease";
+
+describe("reserveMailSetup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getLock.mockResolvedValue({ release: mocks.release });
+    mocks.upsertMailServer.mockResolvedValue({});
+  });
+
+  test("returns a held advisory lock after recording setup start", async () => {
+    const reservation = await reserveMailSetup("server-1", "example.com");
+
+    expect(mocks.getLock).toHaveBeenCalledWith("mail-setup:server-1");
+    expect(mocks.upsertMailServer).toHaveBeenCalledWith({
+      serverId: "server-1",
+      domain: "example.com",
+      installedAt: null,
+    });
+    expect(reservation).toEqual({ release: mocks.release });
+    expect(mocks.release).not.toHaveBeenCalled();
+  });
+
+  test("returns null without writing when another replica holds the lock", async () => {
+    mocks.getLock.mockResolvedValue(null);
+
+    await expect(reserveMailSetup("server-2", "example.com")).resolves.toBeNull();
+    expect(mocks.upsertMailServer).not.toHaveBeenCalled();
+  });
+
+  test("releases the advisory lock when recording setup start fails", async () => {
+    mocks.upsertMailServer.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(reserveMailSetup("server-3", "example.com")).rejects.toThrow(
+      "database unavailable",
+    );
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/db/src/advisory-lock.test.ts
+++ b/packages/db/src/advisory-lock.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getDriver: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  getDriver: mocks.getDriver,
+  getPgPool: () => ({ connect: mocks.connect }),
+}));
+
+import { tryAcquireAdvisoryLock } from "./advisory-lock";
+
+describe("tryAcquireAdvisoryLock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDriver.mockReturnValue("postgres");
+  });
+
+  test("returns null and releases the connection when the lock is busy", async () => {
+    const client = {
+      query: vi.fn(async () => ({ rows: [{ acquired: false }] })),
+      release: vi.fn(),
+    };
+    mocks.connect.mockResolvedValue(client);
+
+    await expect(tryAcquireAdvisoryLock("mail-setup:server-1")).resolves.toBeNull();
+    expect(client.query).toHaveBeenCalledWith("SELECT pg_try_advisory_lock($1) AS acquired", [
+      expect.any(Number),
+    ]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("holds the connection until the acquired lock is released", async () => {
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockResolvedValueOnce({ rows: [{ pg_advisory_unlock: true }] }),
+      release: vi.fn(),
+    };
+    mocks.connect.mockResolvedValue(client);
+
+    const lock = await tryAcquireAdvisoryLock("mail-setup:server-2");
+    expect(lock).not.toBeNull();
+    expect(client.release).not.toHaveBeenCalled();
+
+    await lock?.release();
+    await lock?.release();
+
+    expect(client.query).toHaveBeenLastCalledWith("SELECT pg_advisory_unlock($1)", [
+      expect.any(Number),
+    ]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses a no-op handle for the single-process PGlite driver", async () => {
+    mocks.getDriver.mockReturnValue("pglite");
+
+    const lock = await tryAcquireAdvisoryLock("mail-setup:server-3");
+    await lock?.release();
+
+    expect(lock).not.toBeNull();
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  test("destroys the pooled connection when unlocking fails", async () => {
+    const unlockError = new Error("connection lost");
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockRejectedValueOnce(unlockError),
+      release: vi.fn(),
+    };
+    mocks.connect.mockResolvedValue(client);
+
+    const lock = await tryAcquireAdvisoryLock("mail-setup:server-4");
+
+    await expect(lock?.release()).rejects.toThrow("connection lost");
+    expect(client.release).toHaveBeenCalledWith(unlockError);
+  });
+});

--- a/packages/db/src/advisory-lock.ts
+++ b/packages/db/src/advisory-lock.ts
@@ -1,5 +1,9 @@
 import { getDriver, getPgPool } from "./client";
 
+export interface AdvisoryLockHandle {
+  release(): Promise<void>;
+}
+
 /**
  * 31-bit signed-positive int hash of a string identity, for Postgres advisory
  * lock keys. `pg_advisory_lock` takes a bigint; hashing a string identity down
@@ -46,4 +50,46 @@ export async function withAdvisoryLock<T>(scopeKey: string, fn: () => Promise<T>
   } finally {
     client.release();
   }
+}
+
+/**
+ * Try to acquire a session-level advisory lock without waiting. The returned
+ * handle owns its pooled connection until release, so callers can hold the lock
+ * across lifecycles that outlive a single awaited function (for example SSE).
+ */
+export async function tryAcquireAdvisoryLock(scopeKey: string): Promise<AdvisoryLockHandle | null> {
+  if (getDriver() === "pglite") {
+    return { release: async () => {} };
+  }
+
+  const key = hashStringToInt(scopeKey);
+  const client = await getPgPool().connect();
+  try {
+    const result = await client.query<{ acquired: boolean }>(
+      "SELECT pg_try_advisory_lock($1) AS acquired",
+      [key],
+    );
+    if (result.rows[0]?.acquired !== true) {
+      client.release();
+      return null;
+    }
+  } catch (err) {
+    client.release();
+    throw err;
+  }
+
+  let released = false;
+  return {
+    release: async () => {
+      if (released) return;
+      released = true;
+      try {
+        await client.query("SELECT pg_advisory_unlock($1)", [key]);
+      } catch (err) {
+        client.release(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
+      client.release();
+    },
+  };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,7 +2,12 @@
 export { db, getDriver, getPgPool, closeDb, type Database, type Driver } from "./client";
 
 // ─── Advisory locking (cross-process serialization) ──────────────────────────
-export { withAdvisoryLock, hashStringToInt } from "./advisory-lock";
+export {
+  withAdvisoryLock,
+  tryAcquireAdvisoryLock,
+  hashStringToInt,
+  type AdvisoryLockHandle,
+} from "./advisory-lock";
 
 // ─── Schema (table definitions) ──────────────────────────────────────────────
 export * as schema from "./schema";


### PR DESCRIPTION
## Summary

- reserve the process-local setup slot before the first database await
- add a non-blocking Postgres advisory-lock handle for cross-replica coordination
- hold the advisory lock for the complete SSE setup lifecycle
- release the lock on completion, pause, failure, disconnect, and setup-start errors
- return `409` immediately when another replica owns the server lock
- return `503` instead of running unlocked when reservation persistence fails

## Why

The previous `active` check and assignment were separated by an awaited database lookup, so two requests could both pass the check. The `mail_servers` fallback was also not an atomic lock because `upsert()` updates on conflict.

The former one-hour row heuristic also blocked intentional DNS/PTR resumes and could expire while a valid long-running install was still active. A session-level advisory lock follows the actual SSE lifecycle instead of relying on elapsed time.

## Tests

- focused mail suite: 24 passed
- advisory-lock tests: 4 passed
- `bun run --cwd apps/api lint`
- `bun run --cwd packages/db lint`
- Prettier check on all new and directly formatted files
- independent code review: green, no remaining blockers

`bun format` was run per CONTRIBUTING.md. Its repository-wide Windows line-ending churn and unrelated formatting changes were excluded; the pre-existing `mail.controller.ts` file is not fully Prettier-clean on `main`.

Fixes #79