### PR TITLE
fix: ignore outbound sockets in edge port preflight

### DIFF
--- a/packages/adapters/src/runtime/port-conflict.test.ts
+++ b/packages/adapters/src/runtime/port-conflict.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import type { CommandExecutor } from "../types";
+import { probeListeningPort } from "./port-conflict";
+
+describe("probeListeningPort", () => {
+  test("does not treat an outbound socket as a listener in the lsof fallback", async () => {
+    const commands: string[] = [];
+    const executor = {
+      exec: async (command: string) => {
+        commands.push(command);
+        if (command.startsWith("ss ")) return "";
+        if (command.includes("-sTCP:LISTEN")) return "";
+        if (command.startsWith("lsof ")) return "4242";
+        throw new Error(`unexpected command: ${command}`);
+      },
+    } as unknown as CommandExecutor;
+
+    expect(await probeListeningPort(executor, 443)).toBeNull();
+    expect(commands.some((command) => command.includes("-sTCP:LISTEN"))).toBe(true);
+  });
+});

--- a/packages/adapters/src/runtime/port-conflict.ts
+++ b/packages/adapters/src/runtime/port-conflict.ts
@@ -81,7 +81,7 @@ export async function probeListeningPort(
 ): Promise<PortOccupant | null> {
   try {
     const out = await executor.exec(
-      `ss -tlnp sport = :${port} 2>/dev/null | grep LISTEN || lsof -ti tcp:${port} 2>/dev/null || true`,
+      `ss -tlnp sport = :${port} 2>/dev/null | grep LISTEN || lsof -ti tcp:${port} -sTCP:LISTEN 2>/dev/null || true`,
     );
 
     const ssMatch = out.match(/pid=(\d+)/);


### PR DESCRIPTION
## Summary

Fixes #85. The edge port probe used `lsof -ti tcp:${port}` as a fallback when `ss` found no LISTEN socket. Because that fallback matched any TCP socket touching the port, an unrelated outbound HTTPS connection could make port 443 appear occupied and abort OpenResty installation.

The fallback now uses `lsof -ti tcp:${port} -sTCP:LISTEN`, so only listening sockets are treated as port occupants.

## Testing

- `bun run --cwd packages/adapters lint`
- `bunx vitest run src/runtime/port-conflict.test.ts` from `packages/adapters`
- Prettier check and `git diff --check`

The focused test simulates an empty `ss` result and an outbound-only lsof result, and verifies that no occupant is reported. The full adapter suite also ran: 100 tests passed and 11 unrelated tests failed because this local sandbox denies binding `127.0.0.1` with `EPERM` in the existing reverse-tunnel/reachability tests.

No existing test assertions were changed.