### PR TITLE
fix(desktop): package OpenResty Lua assets

### DIFF
--- a/apps/desktop/build/stage.ts
+++ b/apps/desktop/build/stage.ts
@@ -7,6 +7,7 @@
  *   resources/dashboard/              the dashboard's own Next standalone output
  *   resources/migrations/             drizzle .sql  → OPENSHIP_MIGRATIONS_DIR
  *   resources/pglite/                 pglite.wasm + pglite.data → OPENSHIP_PGLITE_ASSETS_DIR
+ *   resources/lua/                    OpenResty scripts → OPENSHIP_LUA_DIR
  *
  * Invoked by electron-forge's `generateAssets` hook (forge.config.js) and also
  * runnable standalone with `bun run build/stage.ts`. Must run under bun — it
@@ -26,6 +27,7 @@ const RESOURCES = join(DESKTOP_DIR, "resources");
 const API_DIR = join(REPO_ROOT, "apps/api");
 const DASHBOARD_DIR = join(REPO_ROOT, "apps/dashboard");
 const DB_DRIZZLE_DIR = join(REPO_ROOT, "packages/db/drizzle");
+const ADAPTERS_LUA_DIR = join(REPO_ROOT, "packages/adapters/src/infra/lua");
 
 const isWin = process.platform === "win32";
 const API_BIN = isWin ? "openship-api.exe" : "openship-api";
@@ -163,6 +165,12 @@ function main(): void {
       }
       cpSync(src, join(dest, file));
     }
+  });
+
+  // 5. OpenResty Lua scripts — data files bun --compile can't embed. The API
+  //    reads them via OPENSHIP_LUA_DIR (set by the desktop at spawn).
+  step("copying OpenResty scripts → resources/lua/", () => {
+    cpSync(ADAPTERS_LUA_DIR, join(RESOURCES, "lua"), { recursive: true });
   });
 
   process.stdout.write(

--- a/apps/desktop/forge.config.js
+++ b/apps/desktop/forge.config.js
@@ -60,6 +60,7 @@ module.exports = {
       path.join(RESOURCES, "dashboard"),
       path.join(RESOURCES, "migrations"),
       path.join(RESOURCES, "pglite"),
+      path.join(RESOURCES, "lua"),
     ],
     ...osxSigning,
   },

--- a/apps/desktop/src/main/services.ts
+++ b/apps/desktop/src/main/services.ts
@@ -96,6 +96,7 @@ function resourcePaths() {
     apiBin: join(root, "bin", API_BIN),
     migrationsDir: join(root, "migrations"),
     pgliteDir: join(root, "pglite"),
+    luaDir: join(root, "lua"),
     dashboardDir: join(root, "dashboard", "apps", "dashboard"),
   };
 }
@@ -213,7 +214,7 @@ export async function startLocalServices(internalToken: string): Promise<void> {
   if (started) return;
   started = true;
 
-  const { apiBin, migrationsDir, pgliteDir, dashboardDir } = resourcePaths();
+  const { apiBin, migrationsDir, pgliteDir, luaDir, dashboardDir } = resourcePaths();
   const userData = app.getPath("userData");
   const dataDir = join(userData, "data");
   mkdirSync(dataDir, { recursive: true });
@@ -279,6 +280,7 @@ export async function startLocalServices(internalToken: string): Promise<void> {
       PGLITE_DATA_DIR: dataDir,
       OPENSHIP_MIGRATIONS_DIR: migrationsDir,
       OPENSHIP_PGLITE_ASSETS_DIR: pgliteDir,
+      OPENSHIP_LUA_DIR: luaDir,
       // The dashboard runs on a dynamic port not in the API's static origin
       // table — trust it explicitly so CORS / origin-guard / auth accept it.
       OPENSHIP_EXTRA_TRUSTED_ORIGINS: `${dashOrigin},http://127.0.0.1:${dashPort}`,

--- a/packages/adapters/src/infra/openresty-lua.ts
+++ b/packages/adapters/src/infra/openresty-lua.ts
@@ -239,7 +239,8 @@ const GEOIP_DB_URL =
 
 // ── Local Lua source directory ───────────────────────────────────────────────
 
-const LUA_SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), "lua");
+const LUA_SRC_DIR =
+  process.env.OPENSHIP_LUA_DIR ?? join(dirname(fileURLToPath(import.meta.url)), "lua");
 
 /** Read a .lua file from the local lua/ directory. */
 function readLua(filename: string): string {

--- a/packages/adapters/test/fixtures/compiled-openresty-lua.ts
+++ b/packages/adapters/test/fixtures/compiled-openresty-lua.ts
@@ -1,0 +1,21 @@
+import {
+  deployLuaScripts,
+  OPENRESTY_DEFAULT_PATHS,
+  OPENRESTY_LUA_DIR,
+} from "../../src/infra/openresty-lua";
+import type { CommandExecutor } from "../../src/types";
+
+const writtenFiles: string[] = [];
+const executor = {
+  exec: async () => "",
+  writeFile: async (path: string) => {
+    if (path.startsWith(`${OPENRESTY_LUA_DIR}/`)) {
+      writtenFiles.push(path.slice(OPENRESTY_LUA_DIR.length + 1));
+    }
+  },
+  exists: async () => true,
+  mkdir: async () => {},
+} as CommandExecutor;
+
+await deployLuaScripts(executor, OPENRESTY_DEFAULT_PATHS);
+process.stdout.write(JSON.stringify(writtenFiles));

--- a/packages/adapters/test/openresty-lua-assets.test.ts
+++ b/packages/adapters/test/openresty-lua-assets.test.ts
@@ -1,0 +1,44 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const FIXTURE = join(PACKAGE_DIR, "test/fixtures/compiled-openresty-lua.ts");
+const LUA_DIR = join(PACKAGE_DIR, "src/infra/lua");
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("compiled OpenResty Lua deployment", () => {
+  it("reads every deployed script from the packaged Lua directory", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "openship-lua-"));
+    const executable = join(tempDir, "deploy-lua");
+
+    execFileSync("bun", ["build", FIXTURE, "--compile", "--outfile", executable], {
+      cwd: PACKAGE_DIR,
+      stdio: "pipe",
+    });
+
+    const output = execFileSync(executable, {
+      encoding: "utf8",
+      env: { ...process.env, OPENSHIP_LUA_DIR: LUA_DIR },
+    });
+
+    expect(JSON.parse(output)).toEqual([
+      "site_logger.lua",
+      "pipe_log.lua",
+      "pipe_stream.lua",
+      "mgmt_api.lua",
+      "geo_country.lua",
+      "rules_lib.lua",
+      "rules_guard.lua",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #82

## Bug

Installing OpenResty from the packaged macOS arm64 desktop app fails while reading `site_logger.lua`:

```text
ENOENT: no such file or directory, open '/$bunfs/root/lua/site_logger.lua'
```

## Root cause

The compiled API resolves the Lua scripts inside the Bun virtual filesystem, but `bun build --compile` does not embed files read at runtime. The CLI packaging path already stages these assets for #47; the desktop packaging path did not.

## Fix

- allow the adapter to read Lua scripts from `OPENSHIP_LUA_DIR`, preserving the existing source-relative fallback
- stage the existing OpenResty Lua directory as a desktop resource
- pass the packaged resource path to the compiled API process
- add a regression test that compiles and executes the public Lua deployment path

## Verification

- compiled-executable regression test passed in two independent pre-commit runs and one post-commit run
- adapters suite passed: 33 tests
- adapter and desktop TypeScript checks passed
- macOS arm64 Forge package completed; packaged Lua files exactly match the source directory
- `git diff --check` passed