### PR TITLE
fix: align cloud-session-auth docs with CLOUD_SESSION_PINNING default warn

### DIFF
--- a/apps/api/src/modules/cloud/cloud-session-auth.ts
+++ b/apps/api/src/modules/cloud/cloud-session-auth.ts
@@ -13,8 +13,9 @@ import { env } from "../../config/env";
  * verify the request's IP and User-Agent against the values recorded
  * when the session was created. This catches exfiltrated tokens being
  * used from a different network/client, at the cost of breaking legit
- * users that switch carriers / VPN. Default is "off" — the standard
- * Better-Auth posture — with "warn" / "strict" available for hardening.
+ * users that switch carriers / VPN. Default is "warn" — matching
+ * env.ts — with "off" (permissive Better-Auth posture) and "strict"
+ * available as options.
  */
 export async function cloudSessionAuth(c: Context, next: Next) {
   const header = c.req.header("authorization");
@@ -36,9 +37,9 @@ export async function cloudSessionAuth(c: Context, next: Next) {
 
   // IP / User-Agent fingerprint check.
   //
-  // env.CLOUD_SESSION_PINNING:
-  //   off    → permissive (default Better-Auth posture)
-  //   warn   → log mismatches but allow
+  // env.CLOUD_SESSION_PINNING (env default: "warn"):
+  //   off    → permissive — skip fingerprint check (Better-Auth posture)
+  //   warn   → log mismatches but allow (runtime default from env.ts)
   //   strict → 401 on mismatch
   //
   // We compare against the session row's stored ipAddress / userAgent
@@ -78,11 +79,7 @@ export async function cloudSessionAuth(c: Context, next: Next) {
     }
   }
 
-  const [user] = await db
-    .select()
-    .from(schema.user)
-    .where(eq(schema.user.id, row.userId))
-    .limit(1);
+  const [user] = await db.select().from(schema.user).where(eq(schema.user.id, row.userId)).limit(1);
 
   if (!user) {
     return c.json({ error: "Unauthorized" }, 401);


### PR DESCRIPTION
## Summary

- `apps/api/src/config/env.ts` defines `CLOUD_SESSION_PINNING` with `.default("warn")`.
- `apps/api/src/modules/cloud/cloud-session-auth.ts` still said the default is `"off"` in the module comment, and the inline mode list called `"off"` the default Better-Auth posture in a way that reads like the runtime default.
- Updated those comments only so they match the env schema: env default is `"warn"`; `"off"` remains the permissive (skip fingerprint check) option.

Related: #67 fixed the stale default wording in `env.ts` but left this middleware file unchanged.

## Test plan

- [x] Re-read `env.ts`: `CLOUD_SESSION_PINNING` uses `.default("warn")`.
- [x] Confirm no remaining `Default is "off"` in `cloud-session-auth.ts`.
- [x] `git diff --check` clean; Prettier run on the touched file.
- [ ] No runtime/behavior change — comments only; no `env.ts` edits.


Made with [Cursor](https://cursor.com)