### PR TITLE
fix(adapters): confine cloud Pages static output path (#66)

### DIFF
--- a/packages/adapters/src/runtime/bare.ts
+++ b/packages/adapters/src/runtime/bare.ts
@@ -43,11 +43,10 @@ import type {
 import { BuildLogger, detectBuildKillHint, runBuildPipeline, sq, type BuildEnvironment } from "./build-pipeline";
 import { runLocalBuild } from "./local-build";
 import { transferLocalDirectory } from "./transfer";
-import { prepareStackOutput, resolveProjectDir } from "./stack-output";
+import { prepareStackOutput, resolveProjectDir, resolveStaticOutputPath } from "./stack-output";
 import type { ProcessSupervisor } from "./supervisor/types";
 import { detectSupervisor } from "./supervisor/detect";
 import { probeListeningPort } from "./port-conflict";
-import { posix as pathPosix } from "node:path";
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -600,28 +599,7 @@ export class BareRuntime implements RuntimeAdapter {
   }
 
   resolveStaticRoot(containerId: string, outputDirectory: string): string {
-    if (!outputDirectory || outputDirectory === ".") {
-      return containerId;
-    }
-
-    // SECURITY: the return value becomes OpenResty's `root <dir>;`. It MUST stay
-    // inside the deployment's own workDir — an absolute path (e.g. "/", "/etc")
-    // or a `../`-traversal would point the document root at the host filesystem,
-    // serving /etc/passwd, other tenants' builds, TLS keys, etc. over the app's
-    // public domain (arbitrary file disclosure). Reject absolute, confine relative.
-    if (outputDirectory.startsWith("/")) {
-      throw new Error(
-        `Invalid outputDirectory "${outputDirectory}": must be relative to the project (absolute paths are not allowed).`,
-      );
-    }
-    const base = containerId.replace(/\/+$/, "");
-    const resolved = pathPosix.normalize(pathPosix.join(base, outputDirectory));
-    if (resolved !== base && !resolved.startsWith(`${base}/`)) {
-      throw new Error(
-        `Invalid outputDirectory "${outputDirectory}": escapes the deployment directory.`,
-      );
-    }
-    return resolved;
+    return resolveStaticOutputPath(containerId, outputDirectory);
   }
 
   async stop(containerId: string): Promise<void> {

--- a/packages/adapters/src/runtime/cloud-deploy-static.test.ts
+++ b/packages/adapters/src/runtime/cloud-deploy-static.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { STACKS } from "@repo/core";
+import { CloudRuntime } from "./cloud";
+import { DEFAULT_RESOURCE_CONFIG } from "../types";
+import type { DeployConfig } from "../types";
+
+// #66 — a bare static site (root index.html, no framework) is detected as the
+// "static" stack, whose outputDirectory is ".". The Pages deploy path used to
+// hand Oblien `/app/.` (an unnormalized join), which the Pages API rejects with
+// a "path not found" error — surfaced to the user as the misleading
+// "Couldn't find the build output directory '.' after the build finished".
+// The path exported to the edge must be a clean `/app`.
+describe("CloudRuntime.deployStatic output path (regression #66)", () => {
+  function fakeClientRecording(created: Array<{ path: string }>) {
+    return {
+      pages: {
+        get: async () => null,
+        create: async (input: { path: string; slug: string }) => {
+          created.push(input);
+          return { page: { slug: input.slug, url: null } };
+        },
+      },
+      workspace: () => ({ delete: async () => {} }),
+    };
+  }
+
+  const baseConfig: DeployConfig = {
+    deploymentId: "dep_123456",
+    projectId: "proj_profilcard",
+    buildSessionId: "bs_1",
+    imageRef: "ws_123",
+    environment: "production",
+    port: 3000,
+    envVars: {},
+    resources: DEFAULT_RESOURCE_CONFIG,
+    publicEndpoints: [{ domain: "profilcard", domainType: "free" }],
+  };
+
+  test("static stack ('.') exports a clean /app, not /app/.", async () => {
+    const created: Array<{ path: string }> = [];
+    const rt = new CloudRuntime(fakeClientRecording(created) as never);
+
+    const result = await rt.deployStatic({
+      ...baseConfig,
+      outputDirectory: STACKS.static.outputDirectory, // "."
+    });
+
+    expect(created).toHaveLength(1);
+    expect(created[0].path).toBe("/app");
+    expect(result.status).toBe("running");
+  });
+
+  test("a real subdirectory ('dist') is joined under /app", async () => {
+    const created: Array<{ path: string }> = [];
+    const rt = new CloudRuntime(fakeClientRecording(created) as never);
+
+    await rt.deployStatic({ ...baseConfig, outputDirectory: "dist" });
+
+    expect(created[0].path).toBe("/app/dist");
+  });
+
+  test("a ../ traversal that escapes /app is rejected", async () => {
+    const created: Array<{ path: string }> = [];
+    const rt = new CloudRuntime(fakeClientRecording(created) as never);
+
+    await expect(
+      rt.deployStatic({ ...baseConfig, outputDirectory: "../../etc" }),
+    ).rejects.toThrow(/escapes/);
+    expect(created).toHaveLength(0);
+  });
+});

--- a/packages/adapters/src/runtime/cloud.ts
+++ b/packages/adapters/src/runtime/cloud.ts
@@ -64,7 +64,7 @@ import { createDockerBuildContext } from "./docker-build-context";
 import { normalizeDockerRelativePath, resolveDockerfileCandidates } from "./docker-paths";
 import { runLocalBuild } from "./local-build";
 import { transferLocalDirectory } from "./transfer";
-import { prepareStackOutput, resolveProjectDir } from "./stack-output";
+import { prepareStackOutput, resolveProjectDir, resolveStaticOutputPath } from "./stack-output";
 import { checkGit } from "../system/checks";
 import { installGit } from "../system/installer";
 import { isRuntimeNotFoundError } from "../system/errors";
@@ -1713,14 +1713,6 @@ fi`;
     }
 
     // 1. Create page via Pages API - export build output from workspace
-    const outputPath = config.outputDirectory.startsWith("/")
-      ? config.outputDirectory
-      : `/app/${config.outputDirectory}`;
-
-    console.log(
-      `Deploying static site from workspace ${workspaceId}, output path ${outputPath}...`,
-    );
-
     const primaryEndpoint = primaryPublicEndpoint(config);
     const primarySlug = endpointSlug(primaryEndpoint);
     const primaryCustomDomain = endpointCustomDomain(primaryEndpoint);
@@ -1749,6 +1741,12 @@ fi`;
     if (!trimmedOutput || trimmedOutput === "/") {
       throw outputDirError();
     }
+
+    // Confine under /app; "." → "/app", not the "/app/." the Pages API rejects (#66).
+    const outputPath = resolveStaticOutputPath("/app", config.outputDirectory);
+    console.log(
+      `Deploying static site from workspace ${workspaceId}, output path ${outputPath}...`,
+    );
 
     // Create a brand-new page bound the way this deploy wants. Free subdomains
     // live on the shared `.opsh.io` zone (an account-level op): a namespace

--- a/packages/adapters/src/runtime/stack-output.test.ts
+++ b/packages/adapters/src/runtime/stack-output.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { resolveStaticOutputPath } from "./stack-output";
+
+// The result is served / exported as a document root, so it MUST stay inside
+// `base`. Covers both callers: bare (base = workDir) and cloud Pages (base = /app).
+describe("resolveStaticOutputPath", () => {
+  const WORK = "/opt/openship/releases/dep_123";
+
+  test("empty / '.' → base itself", () => {
+    expect(resolveStaticOutputPath(WORK, "")).toBe(WORK);
+    expect(resolveStaticOutputPath(WORK, ".")).toBe(WORK);
+    expect(resolveStaticOutputPath("/app", ".")).toBe("/app"); // #66: not "/app/."
+  });
+
+  test("relative subdir → joined under base", () => {
+    expect(resolveStaticOutputPath(WORK, "dist")).toBe(`${WORK}/dist`);
+    expect(resolveStaticOutputPath("/app", "apps/web/dist")).toBe("/app/apps/web/dist");
+  });
+
+  test("trailing slash on base does not double up", () => {
+    expect(resolveStaticOutputPath("/app/", "dist")).toBe("/app/dist");
+    expect(resolveStaticOutputPath("/app/", ".")).toBe("/app");
+  });
+
+  test("absolute outputDirectory is rejected", () => {
+    expect(() => resolveStaticOutputPath("/app", "/")).toThrow(/absolute paths are not allowed/);
+    expect(() => resolveStaticOutputPath("/app", "/etc")).toThrow(/absolute/);
+  });
+
+  test("../ traversal that escapes base is rejected", () => {
+    expect(() => resolveStaticOutputPath("/app", "../../etc")).toThrow(/escapes/);
+    expect(() => resolveStaticOutputPath(WORK, "dist/../../../root")).toThrow(/escapes/);
+  });
+
+  test("../ that stays inside is allowed", () => {
+    expect(resolveStaticOutputPath("/app", "build/../dist")).toBe("/app/dist");
+  });
+});

--- a/packages/adapters/src/runtime/stack-output.ts
+++ b/packages/adapters/src/runtime/stack-output.ts
@@ -10,7 +10,7 @@
  * lives in its own module; this is just the registry + generic entry points.
  */
 
-import { join } from "node:path";
+import { join, posix as pathPosix } from "node:path";
 import type { StackId } from "@repo/core";
 import { prepareNextStandalone, type NextStandalonePlan } from "./nextjs-standalone";
 
@@ -47,4 +47,36 @@ export async function prepareStackOutput(
 export function resolveProjectDir(buildDir: string, rootDirectory?: string): string {
   const normalized = rootDirectory?.trim().replace(/^\/+|\/+$/g, "");
   return normalized ? join(buildDir, normalized) : buildDir;
+}
+
+/**
+ * Resolve a static deploy's output directory to a concrete path under `base`.
+ *
+ * Shared by both static-deploy paths so their "." / traversal / absolute rules
+ * never drift: self-hosted (the result becomes OpenResty's `root <dir>;`) and
+ * cloud Pages (the result becomes the export `path` inside the build VM).
+ *
+ * Unlike {@link resolveProjectDir}, this CONFINES the result — the value is
+ * served / exported as a document root, so an absolute path (e.g. "/etc") or a
+ * `../`-traversal would point it at the host/VM filesystem (TLS keys, other
+ * tenants, /etc/passwd): arbitrary file disclosure over the app's public
+ * domain. Reject absolute, confine relative. "." and "" mean "serve `base`".
+ */
+export function resolveStaticOutputPath(base: string, outputDirectory: string): string {
+  const normalizedBase = base.replace(/\/+$/, "");
+  if (!outputDirectory || outputDirectory === ".") {
+    return normalizedBase;
+  }
+  if (outputDirectory.startsWith("/")) {
+    throw new Error(
+      `Invalid outputDirectory "${outputDirectory}": must be relative to the project (absolute paths are not allowed).`,
+    );
+  }
+  const resolved = pathPosix.normalize(pathPosix.join(normalizedBase, outputDirectory));
+  if (resolved !== normalizedBase && !resolved.startsWith(`${normalizedBase}/`)) {
+    throw new Error(
+      `Invalid outputDirectory "${outputDirectory}": escapes the deployment directory.`,
+    );
+  }
+  return resolved;
 }


### PR DESCRIPTION
## Summary

- extract `resolveStaticOutputPath(base, outputDirectory)` into `stack-output.ts` — normalize an output dir and confine it under a base
- `bare.ts` `resolveStaticRoot` now delegates to it (behavior unchanged)
- cloud Pages deploy builds its export path via the same helper: `"."` → `/app` (was `/app/.`)
- reject `../` / absolute output dirs on the cloud path too — they'd otherwise export outside the build root
- tests: helper unit + a `CloudRuntime.deployStatic` regression asserting `"."` → `/app`

## Why

A bare static site (root `index.html`, no framework) detects as the `static` stack, whose `outputDirectory` is `"."`. The cloud path built the export path as `` `/app/${outputDirectory}` `` → `/app/.`, an unnormalized join the Pages API rejects — surfaced to the user as the misleading *"Couldn't find the build output directory '.' after the build finished"*. The self-hosted path already normalized and confined this in `bare.ts`; the cloud path never got the same treatment. One shared helper closes the gap.

Fixes #66
