### PR TITLE
return 400 not 500 for malformed JSON request bodies

### DIFF
--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -8,7 +8,8 @@ import { AppError } from "@repo/core";
  * Order of precedence:
  * 1. ZodError → 400 with field-level details
  * 2. AppError subclass → statusCode + message + code
- * 3. Unknown → 500
+ * 3. SyntaxError → 400 (malformed JSON request body)
+ * 4. Unknown → 500
  *
  * Registered via `app.onError(handleApiError)`. Hono's compose() wraps
  * each dispatch level in try/catch and routes thrown errors to
@@ -35,6 +36,14 @@ export function handleApiError(err: unknown, c: Context) {
       { error: message, code },
       statusCode as 400 | 401 | 403 | 404 | 409 | 500,
     );
+  }
+
+  // `c.req.json()` / `JSON.parse` throw a native SyntaxError on a malformed
+  // request body. Routes without a `tbValidator("json", …)` (most mutation
+  // routes) would otherwise fall through to the 500 branch below, mislabeling
+  // a client input error as a server fault. Map it to 400 centrally.
+  if (err instanceof SyntaxError) {
+    return c.json({ error: "Invalid JSON body", code: "INVALID_JSON" }, 400);
   }
 
   console.error("[UNHANDLED ERROR]", err);

--- a/apps/api/test/middleware/json-error-handler.test.ts
+++ b/apps/api/test/middleware/json-error-handler.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Malformed JSON request bodies must return 400, not 500.
+ *
+ * Many controllers call `c.req.json()` on routes that have no `tbValidator`
+ * (~124 call sites). Hono's `c.req.json()` throws a `SyntaxError` on an
+ * invalid body; if `handleApiError` doesn't recognize it, the request falls
+ * through to the unknown-error branch and returns a 500 with a logged stack —
+ * a client input error mislabeled as a server fault.
+ */
+
+import { describe, test, expect } from "vitest";
+import { Hono } from "hono";
+import { handleApiError } from "@/middleware/error-handler";
+
+function makeApp() {
+  const app = new Hono();
+  app.onError(handleApiError);
+  // Mirrors an unvalidated mutation route, e.g. POST /api/tokens/mcp-authorize.
+  app.post("/echo", async (c) => {
+    const body = await c.req.json<{ ok?: boolean }>();
+    return c.json({ received: body });
+  });
+  return app;
+}
+
+describe("handleApiError — malformed JSON body", () => {
+  test("returns 400 (not 500) for a syntactically invalid body", async () => {
+    const app = makeApp();
+    const res = await app.request("/echo", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{", // malformed
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toMatch(/json/i);
+  });
+
+  test("still parses a valid JSON body", async () => {
+    const app = makeApp();
+    const res = await app.request("/echo", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: { ok: true } });
+  });
+});


### PR DESCRIPTION
Controllers call c.req.json() on ~124 sites, most on routes without a tbValidator("json", …). Hono's c.req.json() throws a native SyntaxError on an invalid body, which handleApiError did not recognize — the request fell through to the unknown-error branch and returned 500 with a logged stack, mislabeling a client input error as a server fault.

Map SyntaxError to 400 centrally in the error handler so every route that parses a JSON body is covered at once, without touching individual routes.