### PR TITLE
fix(deployments): pass service mode into trigger preflight

### DIFF
--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -1457,9 +1457,16 @@ export async function triggerDeployment(
     );
   }
 
+  const { useServicePipeline, servicePreflightServices } = await resolveServicePipelineMode(
+    project,
+    snapshot,
+  );
+
   // ── Preflight: validate config before creating any resources ────
   await runDeploymentPreflight(snapshot, routeState, {
     ctx,
+    composeServices: servicePreflightServices,
+    multiService: useServicePipeline,
     gitOwner: project.gitOwner,
     projectId: project.id,
   });

--- a/apps/api/test/modules/deployments/build.service.test.ts
+++ b/apps/api/test/modules/deployments/build.service.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  assertGitHubRepoAccess,
+  kickoffBuild,
+  repos,
+  resolveProjectRouteState,
+  resolveServicePipelineMode,
+  resolveSmartRoute,
+  resolveStrategy,
+  runPreflightChecks,
+} = vi.hoisted(() => ({
+  assertGitHubRepoAccess: vi.fn(),
+  kickoffBuild: vi.fn(),
+  repos: {
+    project: {
+      findById: vi.fn(),
+      getEnvMap: vi.fn(),
+    },
+    deployment: {
+      listByProject: vi.fn(),
+      getLatestSuccessfulForBranch: vi.fn(),
+      create: vi.fn(),
+      createBuildSession: vi.fn(),
+      supersedeReconciling: vi.fn(),
+      supersedePendingDecisions: vi.fn(),
+    },
+  },
+  resolveProjectRouteState: vi.fn(),
+  resolveServicePipelineMode: vi.fn(),
+  resolveSmartRoute: vi.fn(),
+  resolveStrategy: vi.fn(),
+  runPreflightChecks: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos,
+}));
+
+vi.mock("../../../src/modules/deployments/preflight", () => ({
+  runPreflightChecks,
+}));
+
+vi.mock("../../../src/modules/deployments/build-pipeline", () => ({
+  kickoffBuild,
+  resolveServicePipelineMode,
+}));
+
+vi.mock("../../../src/modules/domains/project-route.service", () => ({
+  listProjectRouteRows: vi.fn(),
+  resolveProjectRouteState,
+  syncProjectRouteState: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/github/github-access", () => ({
+  assertGitHubRepoAccess,
+}));
+
+vi.mock("../../../src/modules/github/github.service", () => ({
+  getLatestCommit: vi.fn(),
+  getRepository: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/settings/settings.service", () => ({
+  resolveStrategy,
+}));
+
+vi.mock("../../../src/modules/deployments/smart-route", () => ({
+  resolveSmartRoute,
+}));
+
+import {
+  triggerDeployment,
+  type DeploymentConfigSnapshot,
+} from "../../../src/modules/deployments/build.service";
+
+const ctx = { userId: "user-1", organizationId: "org-1" } as any;
+
+function baseProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "project-1",
+    organizationId: "org-1",
+    appTemplateId: null,
+    activeDeploymentId: null,
+    gitUrl: null,
+    localPath: "/srv/my-stack",
+    gitProvider: "local",
+    gitOwner: null,
+    gitRepo: null,
+    gitBranch: "main",
+    slug: "my-stack",
+    framework: "docker-compose",
+    packageManager: "npm",
+    installCommand: null,
+    buildCommand: null,
+    outputDirectory: null,
+    productionPaths: null,
+    rootDirectory: null,
+    startCommand: null,
+    buildImage: null,
+    productionMode: "host",
+    port: 3000,
+    hasServer: true,
+    hasBuild: true,
+    resources: null,
+    buildResources: null,
+    cloudWorkspaceId: null,
+    runtimeMode: "docker",
+    defaultRollbackStrategy: "git",
+    ...overrides,
+  };
+}
+
+const composeServices = [
+  {
+    id: "svc-web",
+    kind: "compose",
+    enabled: true,
+    name: "web",
+    image: undefined,
+    build: ".",
+    dockerfile: "Dockerfile",
+    ports: ["3000:3000"],
+    dependsOn: [],
+    environment: {},
+    volumes: [],
+    exposed: true,
+    exposedPort: "3000",
+    domainType: "free",
+  },
+];
+
+function baseSnapshot(): DeploymentConfigSnapshot {
+  return {
+    organizationId: "org-1",
+    repoUrl: "",
+    branch: "main",
+    framework: "docker-compose",
+    buildImage: null as unknown as string,
+    runtimeImage: "docker:latest",
+    packageManager: "npm",
+    installCommand: null as unknown as string,
+    buildCommand: null as unknown as string,
+    outputDirectory: null as unknown as string,
+    productionPaths: [],
+    rootDirectory: "",
+    port: 3000,
+    startCommand: null as unknown as string,
+    resources: null,
+    buildResources: null,
+    hasServer: true,
+    hasBuild: true,
+    localPath: "/srv/my-stack",
+    deployTarget: "server",
+    runtimeMode: "docker",
+    composeServices: composeServices as any,
+  };
+}
+
+describe("triggerDeployment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    repos.project.findById.mockResolvedValue(baseProject());
+    repos.project.getEnvMap.mockResolvedValue({});
+    repos.deployment.listByProject.mockResolvedValue({ rows: [] });
+    repos.deployment.getLatestSuccessfulForBranch.mockResolvedValue(null);
+    repos.deployment.create.mockResolvedValue({ id: "dep-1", projectId: "project-1" });
+    repos.deployment.createBuildSession.mockResolvedValue(undefined);
+    repos.deployment.supersedeReconciling.mockResolvedValue(undefined);
+    repos.deployment.supersedePendingDecisions.mockResolvedValue(undefined);
+
+    assertGitHubRepoAccess.mockResolvedValue(undefined);
+    resolveProjectRouteState.mockResolvedValue({
+      primaryCustomDomain: undefined,
+      primaryDomainType: undefined,
+      primarySlug: undefined,
+      publicEndpoints: [],
+    });
+    resolveServicePipelineMode.mockResolvedValue({
+      useServicePipeline: true,
+      servicePreflightServices: composeServices,
+      useSingleAppPipeline: false,
+    });
+    resolveStrategy.mockResolvedValue("local");
+    resolveSmartRoute.mockResolvedValue({
+      forceAll: undefined,
+      serviceIds: undefined,
+      changedPaths: undefined,
+    });
+    runPreflightChecks.mockResolvedValue({ ok: true, checks: [] });
+    kickoffBuild.mockResolvedValue("session-1");
+  });
+
+  it("passes compose service mode into preflight for manual services deploys", async () => {
+    await triggerDeployment(ctx, {
+      projectId: "project-1",
+      branch: "main",
+      commitSha: "abc123",
+    });
+
+    expect(resolveServicePipelineMode).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "project-1" }),
+      expect.objectContaining({ framework: "docker-compose" }),
+    );
+    expect(runPreflightChecks).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        multiService: true,
+        composeServices,
+      }),
+    );
+  });
+
+  it("resolves service mode before preflight for reused snapshots", async () => {
+    await triggerDeployment(ctx, {
+      projectId: "project-1",
+      branch: "main",
+      commitSha: "abc123",
+      reuseSnapshot: {
+        meta: baseSnapshot(),
+        envVars: null,
+      },
+    });
+
+    expect(resolveServicePipelineMode).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "project-1" }),
+      expect.objectContaining({ composeServices }),
+    );
+    expect(runPreflightChecks).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        multiService: true,
+        composeServices,
+      }),
+    );
+  });
+});

--- a/apps/api/test/modules/deployments/preflight.test.ts
+++ b/apps/api/test/modules/deployments/preflight.test.ts
@@ -125,4 +125,56 @@ describe("runPreflightChecks", () => {
     expect(result.ok).toBe(true);
     expect(result.checks.some((check) => check.status === "fail")).toBe(false);
   });
+
+  it("does not require framework build fields for compose service deploys", async () => {
+    const result = await runPreflightChecks(
+      {
+        repoUrl: "",
+        localPath: "/srv/my-stack",
+        branch: "main",
+        framework: "docker-compose",
+        buildImage: null,
+        installCommand: null,
+        buildCommand: null,
+        startCommand: null,
+        port: 3000,
+        hasBuild: true,
+        hasServer: true,
+        deployTarget: "server",
+        organizationId: "org-1",
+      } as any,
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" } as any,
+        buildStrategy: "local",
+        multiService: true,
+        composeServices: [
+          {
+            kind: "compose",
+            name: "web",
+            build: ".",
+            dockerfile: "Dockerfile",
+            ports: ["3000:3000"],
+            dependsOn: [],
+            environment: {},
+            volumes: [],
+            exposed: false,
+          },
+        ],
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "config",
+          label: "Service configuration",
+          status: "pass",
+        }),
+      ]),
+    );
+    expect(result.checks.some((check) => check.message?.includes("build image"))).toBe(false);
+    expect(result.checks.some((check) => check.message?.includes("install command"))).toBe(false);
+    expect(result.checks.some((check) => check.message?.includes("start command"))).toBe(false);
+  });
 });

--- a/packages/db/src/repos/personal-access-token-grant.repo.test.ts
+++ b/packages/db/src/repos/personal-access-token-grant.repo.test.ts
@@ -26,7 +26,7 @@ describe("personalAccessTokenGrant repo", () => {
   let repo: Awaited<ReturnType<typeof freshRepo>>;
   beforeEach(async () => {
     repo = await freshRepo();
-  });
+  }, 30_000);
 
   it("createMany + listByToken round-trips grants for a token", async () => {
     await repo.createMany("tok_1", [

--- a/packages/db/src/repos/project-env.repo.test.ts
+++ b/packages/db/src/repos/project-env.repo.test.ts
@@ -51,7 +51,7 @@ describe("project.repo env writes (PGlite)", () => {
   beforeEach(async () => {
     ctx = await freshRepo();
     await seed(ctx.db);
-  });
+  }, 30_000);
 
   it("mergeEnvVars touches ONLY the named keys — untouched secret + other scopes survive", async () => {
     await ctx.repo.mergeEnvVars(


### PR DESCRIPTION
## Summary
- Resolve service-pipeline mode before `triggerDeployment` runs preflight.
- Pass compose services and `multiService` into preflight so services projects skip single-app framework field validation.
- Add regression coverage for manual compose deploys, reused snapshots, and the compose preflight contract.

Fixes #105

## CI note
- Includes two `test(db):` commits that bump PGlite `beforeEach` hook timeouts in `packages/db`; these were failing in CI independently of this deployments change due to pre-existing cold-start/migration hook flakiness. Happy to split them into a separate PR if preferred.

## Test Plan
- `bun format`
- `bun run --cwd apps/api test test/modules/deployments/build.service.test.ts test/modules/deployments/preflight.test.ts`
- `bun run --cwd apps/api lint`
- `bun run --cwd apps/api test`
- `bun run --cwd packages/db test`
- `bun run --cwd packages/db lint`