### PR TITLE
fix(core): correctly close TOML strings ending with escaped backslash

### DIFF
--- a/packages/core/src/workspaces/toml-helpers.ts
+++ b/packages/core/src/workspaces/toml-helpers.ts
@@ -66,7 +66,15 @@ function findClosingBracket(body: string, start: number): number {
     const ch = body[i];
     const prev = body[i - 1];
     if (inDouble) {
-      if (ch === '"' && prev !== "\\") inDouble = false;
+      if (ch === '"') {
+        // A closing double quote is escaped only when it is preceded by an
+        // odd number of consecutive backslashes (standard TOML basic-string rule).
+        let backslashRun = 0;
+        for (let j = i - 1; j >= 0 && body[j] === "\\"; j--) {
+          backslashRun++;
+        }
+        if (backslashRun % 2 === 0) inDouble = false;
+      }
       continue;
     }
     if (inSingle) {

--- a/packages/core/test/toml-helpers.test.ts
+++ b/packages/core/test/toml-helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { extractStringArrayFromSection } from "../src/workspaces/toml-helpers";
+
+describe("extractStringArrayFromSection", () => {
+  it("extracts workspace members", () => {
+    const toml = `
+[workspace]
+members = ["pkg-a", "pkg-b"]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual([
+      "pkg-a",
+      "pkg-b",
+    ]);
+  });
+
+  it("ignores values in later sections", () => {
+    const toml = `
+[workspace]
+members = ["pkg-a"]
+
+[dependencies]
+members = ["should-not-appear"]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg-a"]);
+  });
+
+  it("handles strings that end with an escaped backslash", () => {
+    const toml = `
+[workspace]
+members = ["pkg\\\\"]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg\\\\"]);
+  });
+
+  it("handles strings with an escaped backslash followed by a closing bracket", () => {
+    const toml = `
+[workspace]
+members = ["pkg\\\\]name"]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual([
+      "pkg\\\\]name",
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

`findClosingBracket` in `packages/core/src/workspaces/toml-helpers.ts` mishandled double-quoted TOML strings that end with an escaped backslash. It treated any single backslash before a closing quote as an escape, so a string like `\"pkg\\\\\"` kept the scanner in string mode and the matching `]` was never found, causing `extractStringArrayFromSection` to return `[]`.

The fix counts consecutive backslashes before the quote and only treats the quote as escaped when the run length is odd, matching TOML basic-string escaping rules.

## Changes

- `packages/core/src/workspaces/toml-helpers.ts`: count backslash run before deciding whether a double quote is escaped.
- `packages/core/test/toml-helpers.test.ts`: regression tests for strings ending with `\\\\` and for `\\\\]` inside a string.

## Verification

- `bun test` in `packages/core` — 89 pass
- `bun run lint` (`tsc --noEmit`) — clean