### PR TITLE
fix(api): drop unused @ts-expect-error that breaks CI typecheck

### DIFF
--- a/apps/api/src/lib/startup/self-edge.test.ts
+++ b/apps/api/src/lib/startup/self-edge.test.ts
@@ -39,7 +39,7 @@ const origGetuid = process.getuid;
 beforeEach(() => {
   vi.clearAllMocks();
   Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-  // @ts-expect-error — stub root so the not-root guard passes
+  // stub root so the not-root guard passes
   process.getuid = () => 0;
   h.canProceedClean = false;
   h.probeEdge.mockImplementation(async () => ({


### PR DESCRIPTION
## Problem

CI's **Typecheck** job is failing on `main` (and therefore on every open PR branched from it):

```
src/lib/startup/self-edge.test.ts(42,3): error TS2578: Unused '@ts-expect-error' directive.
```

This started with `3381e54` (#114), which introduced `apps/api/src/lib/startup/self-edge.test.ts`. The three most recent CI runs on `main` are red — the `Typecheck apps/api` step exits 2, which also short-circuits the `Typecheck apps/dashboard` step so it never runs.

## Cause

`process.getuid` is typed `(() => number) | undefined` in `@types/node` 22 (`^22.13.0`, resolving to 22.19.15), so:

```ts
process.getuid = () => 0;
```

is already valid TypeScript — nothing to suppress. `tsc` treats a `@ts-expect-error` that suppresses no error as an error in its own right (TS2578).

The teardown a few lines below already assigns to the same property with no directive, which confirms the assignment type-checks on its own:

```ts
afterEach(() => {
  ...
  process.getuid = origGetuid;
});
```

## Fix

Remove the directive, keep the explanatory comment. One line.

## Verification

Run against this branch:

- `bun run --cwd apps/api lint` → clean, exit 0 (was: TS2578, exit 2)
- `apps/dashboard` `tsc --noEmit` (the CI filter step) → passes
- `bun run test` → **5/5 turbo tasks successful**, matching CI's counts exactly:
  - `@repo/api` 695 passed / 3 skipped
  - `@repo/adapters` 222 passed
  - `@repo/core` 89 passed
  - `@repo/db` 25 passed
  - `@repo/dashboard` 17 passed
- The three `ensureSelfEdgeInfra` tests in the touched file pass unchanged (`vitest run src/lib/startup/self-edge.test.ts` → 3 passed).

No behavior change — this only unblocks the typecheck gate.