### PR TITLE
fix(core): skip # comments when scanning a TOML string array

### DIFF
--- a/packages/core/src/workspaces/toml-helpers.ts
+++ b/packages/core/src/workspaces/toml-helpers.ts
@@ -39,10 +39,7 @@ export function extractStringArrayFromSection(
   // Locate `key = [` inside the body, then scan forward to the matching `]`,
   // tracking bracket depth and quote state so values like "foo[1]" don't
   // truncate the array early.
-  const keyStart = new RegExp(
-    `(?:^|\\n)\\s*${escapeRegex(key)}\\s*=\\s*\\[`,
-    "i",
-  );
+  const keyStart = new RegExp(`(?:^|\\n)\\s*${escapeRegex(key)}\\s*=\\s*\\[`, "i");
   const keyMatch = keyStart.exec(body);
   if (!keyMatch) return [];
 
@@ -56,7 +53,8 @@ export function extractStringArrayFromSection(
 /**
  * Walk `body` forward from `start` and return the index of the `]` that closes
  * the array opened just before `start`. Respects string literals (single and
- * double quoted) and nested `[`. Returns -1 if no closing bracket is found.
+ * double quoted), `#` comments, and nested `[`. Returns -1 if no closing
+ * bracket is found.
  */
 function findClosingBracket(body: string, start: number): number {
   let depth = 1; // we're already past the opening `[`
@@ -79,6 +77,15 @@ function findClosingBracket(body: string, start: number): number {
     }
     if (inSingle) {
       if (ch === "'") inSingle = false;
+      continue;
+    }
+    if (ch === "#") {
+      // Comment: everything to end of line is not TOML syntax. Skipping it
+      // keeps an apostrophe ("don't") from opening a phantom string literal
+      // and a `]` from closing the array early.
+      const newline = body.indexOf("\n", i);
+      if (newline === -1) return -1; // unterminated array - comment runs to EOF
+      i = newline;
       continue;
     }
     if (ch === '"') {
@@ -105,7 +112,10 @@ function findClosingBracket(body: string, start: number): number {
 function parseTomlStringArray(arrayBody: string): string[] {
   const items: string[] = [];
   // Match either "double-quoted" or 'single-quoted' strings, ignoring commas/whitespace/comments.
-  const itemPattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^']*)'/g;
+  // The trailing `#[^\n]*` alternative consumes comments so quoted-looking text
+  // inside one (`# use "quotes" here`) isn't collected as a member. Strings are
+  // matched first at any given position, so a `#` inside a value stays part of it.
+  const itemPattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^']*)'|#[^\n]*/g;
   let match: RegExpExecArray | null;
   while ((match = itemPattern.exec(arrayBody)) !== null) {
     const value = (match[1] ?? match[2] ?? "").trim();

--- a/packages/core/test/toml-helpers.test.ts
+++ b/packages/core/test/toml-helpers.test.ts
@@ -8,10 +8,7 @@ describe("extractStringArrayFromSection", () => {
 [workspace]
 members = ["pkg-a", "pkg-b"]
 `;
-    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual([
-      "pkg-a",
-      "pkg-b",
-    ]);
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg-a", "pkg-b"]);
   });
 
   it("ignores values in later sections", () => {
@@ -38,8 +35,69 @@ members = ["pkg\\\\"]
 [workspace]
 members = ["pkg\\\\]name"]
 `;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg\\\\]name"]);
+  });
+
+  it("ignores an apostrophe inside a comment", () => {
+    const toml = `
+[workspace]
+members = [
+  "pkg-a",  # don't put binaries here
+  "pkg-b",
+]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg-a", "pkg-b"]);
+  });
+
+  it("ignores a closing bracket inside a comment", () => {
+    const toml = `
+[workspace]
+members = [
+  "pkg-a", # see docs] for details
+  "pkg-b",
+]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg-a", "pkg-b"]);
+  });
+
+  it("does not collect quoted text inside a comment as a member", () => {
+    const toml = `
+[workspace]
+members = [
+  "pkg-a", # use "pkg-c" instead
+  "pkg-b",
+]
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg-a", "pkg-b"]);
+  });
+
+  it("keeps a # that is part of a string value", () => {
+    const toml = `
+[workspace]
+members = ["pkg-a#1", "pkg[extra]#2"]
+`;
     expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual([
-      "pkg\\\\]name",
+      "pkg-a#1",
+      "pkg[extra]#2",
     ]);
+  });
+
+  it("handles a comment-only line and a trailing comment", () => {
+    const toml = `
+[workspace]
+members = [
+  # "pkg-disabled" is commented out
+  "pkg-a",
+] # trailing
+`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual(["pkg-a"]);
+  });
+
+  it("returns [] when a comment runs to EOF with the array unterminated", () => {
+    const toml = `
+[workspace]
+members = [
+  "pkg-a", # oops`;
+    expect(extractStringArrayFromSection(toml, "workspace", "members")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`extractStringArrayFromSection` (`packages/core/src/workspaces/toml-helpers.ts`) tracks quote state and bracket depth, but has no notion of TOML `#` comments — so anything inside a comment is parsed as syntax.

Its own docblock already claims the opposite ("Robust to multi-line arrays and **inline comments**"), as does the comment on `parseTomlStringArray` ("ignoring commas/whitespace/**comments**"). This PR makes that true.

Three distinct failures, all from ordinary manifests:

| `members` comment | Expected | Actual on `main` |
| --- | --- | --- |
| `# don't put binaries here` | `["crates/core", "crates/cli"]` | `[]` |
| `# see docs] for details` | `["crates/core", "crates/cli"]` | `["crates/core"]` |
| `# use "pkg-c" instead` | `["crates/core", "crates/cli"]` | `["crates/core", "pkg-c", "crates/cli"]` |

1. **Apostrophe** — `don't` opens a single-quoted string that never closes, `findClosingBracket` returns `-1`, and the entire array parses as `[]`.
2. **`]` in a comment** — closes the array early, silently dropping every member after it.
3. **Quoted text in a comment** — collected as a phantom member that doesn't exist on disk.

Case 1 is the common one: `don't`, `doesn't`, `won't` are completely ordinary in a hand-written manifest.

## Impact

Both callers are workspace detectors — `workspaces/cargo.ts` (`[workspace] members`) and `workspaces/python-uv.ts` (`[tool.uv.workspace] members`). Executed end-to-end against `parseWorkspaceManifest`:

```
                 before fix     after fix
Cargo.toml    -> []             [{ detector: cargo, patterns: ["crates/core","crates/cli"] }]
pyproject.toml-> []             [{ detector: uv,    patterns: ["packages/api","packages/web"] }]
```

A Cargo or uv monorepo is silently demoted to a single-package project — no error, no warning. Sub-projects are never discovered and the monorepo build path never runs, because of a comment style that is entirely valid TOML.

## Fix

Two small changes, both scoped to comment handling:

- `findClosingBracket` — when a `#` is seen **outside** string state, skip to end of line. If the comment runs to EOF the array is unterminated, so it keeps returning `-1`.
- `parseTomlStringArray` — add a trailing `#[^\n]*` alternative so quoted-looking text inside a comment isn't collected. Strings are matched first at any given position, so a `#` inside a value stays part of the value.

## Tests

Six cases added to `packages/core/test/toml-helpers.test.ts` (`89 → 95` tests in `@repo/core`), covering all three failures plus the guards against over-correcting:

- apostrophe in a comment
- `]` in a comment
- quoted text in a comment
- **`#` that is part of a string value** (`"pkg-a#1"`, `"pkg[extra]#2"`) — must be preserved
- comment-only line and trailing comment after the `]`
- comment running to EOF with the array unterminated — still `[]`

Verified the new tests actually catch the bug: with the source change reverted, **4 of the 6 fail**; with it, all pass. The 4 pre-existing tests (including the escaped-backslash cases from #112) pass both ways.

Full suite on this branch: `bun run test` → **5/5 turbo tasks successful** (api 695, adapters 222, core 95, db 25, dashboard 17).

## Note on the diff

`bun format` (the documented pre-commit step) also collapsed one pre-existing unrelated line in this file — the `keyStart` regex — because the file had formatting drift on `main` already. Happy to drop that hunk if you'd rather keep the diff to the comment logic alone.