### PR TITLE
fix(adapters): make the empty-transfer guard actually detect an empty target

### DIFF
--- a/packages/adapters/src/runtime/transfer.ts
+++ b/packages/adapters/src/runtime/transfer.ts
@@ -67,16 +67,21 @@ export async function transferLocalDirectory(
  * Verify that a transfer via CommandExecutor actually produced files.
  * Checks for non-empty directory and the presence of at least one
  * expected marker file (package.json, index.html, etc.).
+ *
+ * Exported for testing.
  */
-async function verifyExecutorTransfer(
+export async function verifyExecutorTransfer(
   executor: CommandExecutor,
   targetPath: string,
   logger: BuildLogger,
 ): Promise<void> {
   // Quick check: is the target directory non-empty?
   try {
+    // `-mindepth 1` excludes the target directory itself. `-not -name '.'`
+    // only filters a literal `.`, which an absolute targetPath never is, so
+    // find always listed the directory and the count never reached 0.
     const countOutput = await executor.exec(
-      `find ${sq(targetPath)} -maxdepth 1 -not -name '.' | head -5 | wc -l`,
+      `find ${sq(targetPath)} -mindepth 1 -maxdepth 1 | head -5 | wc -l`,
     );
     const fileCount = parseInt(countOutput.trim(), 10);
     if (fileCount === 0) {

--- a/packages/adapters/test/transfer-verify.test.ts
+++ b/packages/adapters/test/transfer-verify.test.ts
@@ -1,0 +1,92 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { verifyExecutorTransfer } from "../src/runtime/transfer";
+import { BuildLogger } from "../src/runtime/build-pipeline";
+import type { CommandExecutor } from "../src/types";
+
+const execFileAsync = promisify(execFile);
+
+// `verifyExecutorTransfer` is the only guard between a silently-failed source
+// transfer and the build. It shells out to `find`, so the assertions below run
+// the real command against real directories - a mocked exec would happily
+// return whatever count the test wanted and prove nothing about find's
+// semantics, which is exactly where the bug lived.
+
+/** Minimal executor that runs the command locally through a shell. */
+function shellExecutor(): CommandExecutor {
+  return {
+    exec: async (command: string) => {
+      const { stdout } = await execFileAsync("/bin/sh", ["-c", command]);
+      return stdout;
+    },
+  } as unknown as CommandExecutor;
+}
+
+const logs: string[] = [];
+const logger = new BuildLogger((entry) => {
+  logs.push(entry.message);
+});
+
+let root: string;
+let emptyDir: string;
+let populatedDir: string;
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "openship-transfer-"));
+  emptyDir = join(root, "empty");
+  populatedDir = join(root, "populated");
+  await mkdir(emptyDir);
+  await mkdir(populatedDir);
+  await writeFile(join(populatedDir, "package.json"), "{}");
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("verifyExecutorTransfer", () => {
+  it("throws when the target directory is empty", async () => {
+    // Previously `find <dir> -maxdepth 1 -not -name '.'` listed the directory
+    // itself, so the count was 1 and this guard could never fire.
+    await expect(verifyExecutorTransfer(shellExecutor(), emptyDir, logger)).rejects.toThrow(
+      /is empty - files were not copied/,
+    );
+  });
+
+  it("passes when the target directory has content, and counts only its entries", async () => {
+    logs.length = 0;
+    await expect(
+      verifyExecutorTransfer(shellExecutor(), populatedDir, logger),
+    ).resolves.toBeUndefined();
+
+    // One file in the directory => "1+", not "2+" (the directory itself used
+    // to be counted alongside its contents).
+    expect(logs.join("\n")).toContain("Transfer verified (1+ entries in target).");
+  });
+
+  it("still rejects when the target does not exist", async () => {
+    // find's failure doesn't fail the pipeline (`wc -l` supplies the exit
+    // code), so this lands on the same count-of-zero branch rather than the
+    // "count command itself failed" one.
+    await expect(
+      verifyExecutorTransfer(shellExecutor(), join(root, "does-not-exist"), logger),
+    ).rejects.toThrow(/files were not copied/);
+  });
+
+  it("handles a target path containing spaces and quotes", async () => {
+    const odd = join(root, "we're here");
+    await mkdir(odd);
+    await expect(verifyExecutorTransfer(shellExecutor(), odd, logger)).rejects.toThrow(
+      /is empty - files were not copied/,
+    );
+
+    await writeFile(join(odd, "index.html"), "<!doctype html>");
+    await expect(verifyExecutorTransfer(shellExecutor(), odd, logger)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`verifyExecutorTransfer` in `packages/adapters/src/runtime/transfer.ts` is the only check between a silently-failed source transfer and the build. It counts entries with:

```sh
find <target> -maxdepth 1 -not -name '.' | head -5 | wc -l
```

`find <dir> -maxdepth 1` emits **the directory itself** as its first result. `-not -name '.'` only excludes a literal `.`, which is never the case here — `targetPath` is absolute (e.g. `/opt/openship/proj_x`). So the count is always ≥ 1 for a directory that exists, and:

```ts
if (fileCount === 0) {
  throw new Error(`Transfer target ${targetPath} is empty - files were not copied`);
}
```

is **unreachable**. The guard can never fire for the case it was written for.

Observed against real directories:

| Target | Current | With `-mindepth 1` |
| --- | --- | --- |
| empty dir | `1` (the dir itself) → guard silently passes | `0` → guard fires ✅ |
| dir with 1 file | `2` → logs `2+ entries` | `1` ✅ |

So the log line is also off by one for every transfer.

## Impact

An empty target means the transfer produced nothing. Today that sails past verification and surfaces much later as an inscrutable `no package.json` / `command not found` inside the build step on the user's server, with nothing pointing back at the transfer.

## Fix

```diff
-      `find ${sq(targetPath)} -maxdepth 1 -not -name '.' | head -5 | wc -l`,
+      `find ${sq(targetPath)} -mindepth 1 -maxdepth 1 | head -5 | wc -l`,
```

`-mindepth 1` excludes the starting point itself, which is exactly what `-not -name '.'` was reaching for.

## Tests

New `packages/adapters/test/transfer-verify.test.ts` (4 cases, `@repo/adapters` 222 → 226).

These run the **real `find` command against real temp directories** rather than mocking `exec`. A mocked executor would return whatever count the test asked for and prove nothing — `find`'s semantics are precisely what was wrong here.

- empty directory → rejects with "files were not copied"
- populated directory → resolves, and logs `1+ entries` (not `2+`)
- non-existent target → still rejects
- target path containing a space and an apostrophe → both empty and populated cases behave (covers the `sq()` quoting)

Verified the tests catch the bug: with the original `find` restored, **3 of the 4 fail**.

Full suite on this branch: `bun run test` → **5/5 turbo tasks successful** (api 695, adapters 226, core 89, db 25, dashboard 17).

## One behavior note

I initially expected a non-existent target to hit the `catch` branch ("If the count command itself fails … that's a transfer failure"). It doesn't: `find`'s non-zero exit is swallowed by the pipeline, whose status comes from `wc -l`, so a missing directory lands on the same count-of-zero branch and reports "is empty". That's unchanged by this PR and still rejects, so I left it alone rather than widen the diff — happy to follow up if you'd like the two cases distinguished.