### PR TITLE
fix(api): allow the documented /etc/openship/ssh-keys default root

### DIFF
--- a/apps/api/src/lib/ssh-key-path.ts
+++ b/apps/api/src/lib/ssh-key-path.ts
@@ -15,9 +15,11 @@
  *   - absolute path, no `..` segments, no null bytes
  *   - must sit under an allowed root (operator-controlled directories
  *     OR an env-configured override)
- *   - deny common system paths even when nested under an allowed root
+ *   - deny common system paths even when nested under an env-configured or
+ *     caller-supplied root (the built-in DEFAULT_ROOTS are exempt — one of
+ *     them, /etc/openship/ssh-keys, deliberately sits under /etc)
  *
- * Tests live alongside in __tests__/ssh-key-path.test.ts.
+ * Tests live in test/lib/ssh-key-path.test.ts.
  */
 
 import { isAbsolute, resolve, sep } from "node:path";
@@ -72,11 +74,23 @@ export function resolveSafeSshKeyPath(
 
   const resolved = resolve(trimmed);
 
-  for (const denied of SYSTEM_DENY) {
-    if (resolved === denied || resolved.startsWith(denied + sep)) {
-      throw new Error(
-        `sshKeyPath is inside a protected system directory (${denied}): ${trimmed}`,
-      );
+  // SYSTEM_DENY is deliberately broad (`/etc`), and one of the built-in
+  // DEFAULT_ROOTS sits inside it (`/etc/openship/ssh-keys`). Those roots are
+  // hardcoded here — not operator- or caller-supplied — so a path under one is
+  // an explicit carve-out and skips the denylist. Env-configured and caller
+  // supplied roots deliberately do NOT get this exemption, so an `extraRoots`
+  // of `/` (or a `$HOME` of `/`) still can't unlock `/etc/shadow`.
+  const underDefaultRoot = DEFAULT_ROOTS.map((r) => resolve(r)).some(
+    (root) => resolved === root || resolved.startsWith(root + sep),
+  );
+
+  if (!underDefaultRoot) {
+    for (const denied of SYSTEM_DENY) {
+      if (resolved === denied || resolved.startsWith(denied + sep)) {
+        throw new Error(
+          `sshKeyPath is inside a protected system directory (${denied}): ${trimmed}`,
+        );
+      }
     }
   }
 

--- a/apps/api/test/lib/ssh-key-path.test.ts
+++ b/apps/api/test/lib/ssh-key-path.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSafeSshKeyPath } from "../../src/lib/ssh-key-path";
+
+// This guard exists so an attacker who can write the servers row can't point
+// sshKeyPath at /etc/shadow and have the bytes exfiltrated through the SFTP
+// private-key field. The cases below pin BOTH halves: the documented default
+// roots must work, and the denylist must still hold everywhere else.
+
+describe("resolveSafeSshKeyPath", () => {
+  describe("allowed roots", () => {
+    it("accepts a key under /var/lib/openship/ssh-keys", () => {
+      expect(resolveSafeSshKeyPath("/var/lib/openship/ssh-keys/id_ed25519")).toBe(
+        "/var/lib/openship/ssh-keys/id_ed25519",
+      );
+    });
+
+    it("accepts a key under /etc/openship/ssh-keys", () => {
+      // A documented DEFAULT_ROOT that sits under the broad `/etc` denylist
+      // entry. config/env.ts advertises it too ("The default allowlist already
+      // includes /var/lib/openship/ssh-keys and /etc/openship/ssh-keys").
+      expect(resolveSafeSshKeyPath("/etc/openship/ssh-keys/id_ed25519")).toBe(
+        "/etc/openship/ssh-keys/id_ed25519",
+      );
+    });
+
+    it("accepts a key under a caller-supplied extra root", () => {
+      expect(resolveSafeSshKeyPath("/home/op/.ssh/id_rsa", { extraRoots: ["/home/op"] })).toBe(
+        "/home/op/.ssh/id_rsa",
+      );
+    });
+  });
+
+  describe("system denylist", () => {
+    it("rejects /etc/shadow", () => {
+      expect(() => resolveSafeSshKeyPath("/etc/shadow")).toThrow(
+        /protected system directory \(\/etc\)/,
+      );
+    });
+
+    it("rejects a sibling of the allowed root that is still under /etc", () => {
+      expect(() => resolveSafeSshKeyPath("/etc/openship-secrets/key")).toThrow(
+        /protected system directory \(\/etc\)/,
+      );
+    });
+
+    it.each([
+      ["/proc/self/environ", "/proc"],
+      ["/sys/kernel/notes", "/sys"],
+      ["/dev/mem", "/dev"],
+      ["/boot/vmlinuz", "/boot"],
+      ["/root/.ssh/id_rsa", "/root/.ssh"],
+      ["/var/lib/docker/volumes/x", "/var/lib/docker"],
+      ["/var/lib/postgresql/data/x", "/var/lib/postgresql"],
+    ])("rejects %s", (path, denied) => {
+      expect(() => resolveSafeSshKeyPath(path)).toThrow(
+        `sshKeyPath is inside a protected system directory (${denied})`,
+      );
+    });
+
+    it("still denies a system path reached through a permissive extra root", () => {
+      // The exemption is scoped to the hardcoded DEFAULT_ROOTS only — a caller
+      // passing "/" as $HOME must not unlock the denylist.
+      expect(() => resolveSafeSshKeyPath("/etc/shadow", { extraRoots: ["/"] })).toThrow(
+        /protected system directory/,
+      );
+    });
+  });
+
+  describe("path shape", () => {
+    it("rejects an empty or whitespace-only path", () => {
+      expect(() => resolveSafeSshKeyPath("   ")).toThrow(/is empty/);
+    });
+
+    it("rejects a null byte", () => {
+      expect(() => resolveSafeSshKeyPath("/var/lib/openship/ssh-keys/id\0")).toThrow(/null byte/);
+    });
+
+    it("rejects a relative path", () => {
+      expect(() => resolveSafeSshKeyPath("ssh-keys/id_ed25519")).toThrow(/must be absolute/);
+    });
+
+    it("rejects a traversal segment", () => {
+      expect(() => resolveSafeSshKeyPath("/var/lib/openship/ssh-keys/../../../etc/shadow")).toThrow(
+        /traversal segment/,
+      );
+    });
+
+    it("rejects a path outside every allowed root", () => {
+      expect(() => resolveSafeSshKeyPath("/opt/somewhere/id_rsa")).toThrow(/must sit under one of/);
+    });
+
+    it("trims surrounding whitespace", () => {
+      expect(resolveSafeSshKeyPath("  /var/lib/openship/ssh-keys/id_ed25519  ")).toBe(
+        "/var/lib/openship/ssh-keys/id_ed25519",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

In `apps/api/src/lib/ssh-key-path.ts`, `SYSTEM_DENY` contains `/etc` and is checked **before** the allowed-roots test — but `DEFAULT_ROOTS` advertises `/etc/openship/ssh-keys`. Every path under that root is unconditionally rejected, so the root is dead config:

```
resolveSafeSshKeyPath("/etc/openship/ssh-keys/id_ed25519")
  -> Error: sshKeyPath is inside a protected system directory (/etc): …

resolveSafeSshKeyPath("/var/lib/openship/ssh-keys/id_ed25519")
  -> /var/lib/openship/ssh-keys/id_ed25519          (the other default root works)
```

`config/env.ts` documents the same root as working, in the `SSH_KEY_PATH_ROOTS` comment:

> The default allowlist already includes /var/lib/openship/ssh-keys and /etc/openship/ssh-keys — set this for installs that keep their SSH keys somewhere else.

So two independent places state the root is supported, and it never is.

## Impact

Callers are `lib/ssh-manager.ts` and `modules/backup-destinations/hydrate-server.ts`. An operator who follows the documented layout gets SSH connections and SFTP backup destinations failing with a *misleading* "protected system directory" error, and has to discover the undocumented `/var/lib/...` alternative to get unstuck.

This fails **closed**, so it's a broken documented feature rather than a security hole — hence a public PR rather than an advisory.

## Fix

Exempt only the hardcoded `DEFAULT_ROOTS` from the denylist.

That list is fixed in this file — not operator- or caller-supplied — so the carve-out can't be widened from outside. Env-configured roots (`SSH_KEY_PATH_ROOTS`) and `extraRoots` (which carry the operator's `$HOME`) still run the full `SYSTEM_DENY` check, so the original threat model is intact: an `extraRoots` of `/` still cannot reach `/etc/shadow`.

I also corrected the docblock: it described the policy as "deny common system paths even when nested under an allowed root", and pointed at `__tests__/ssh-key-path.test.ts` — a file that does not exist.

## Tests

This file had **no tests**. `apps/api/test/lib/ssh-key-path.test.ts` adds 19 (`@repo/api` 695 → 714), deliberately pinning *both* halves of the policy so the carve-out can't silently widen later:

**Allowed** — `/var/lib/openship/ssh-keys`, `/etc/openship/ssh-keys`, a caller-supplied extra root.

**Still denied** — `/etc/shadow`; `/etc/openship-secrets/key` (a sibling of the allowed root, still under `/etc`); `/proc`, `/sys`, `/dev`, `/boot`, `/root/.ssh`, `/var/lib/docker`, `/var/lib/postgresql`; and **`/etc/shadow` with `extraRoots: ["/"]`** — the case that proves the exemption is scoped to the built-in roots only.

**Path shape** — empty, null byte, relative, `..` traversal, outside every root, whitespace trimming.

Verified against the unfixed source: **exactly one of the 19 fails** (the documented root), and all ten denial cases pass identically before and after — i.e. this change provably doesn't weaken the denylist.

Full suite: `bun run test` → **5/5 turbo tasks successful** (api 714, adapters 222, core 89, db 25, dashboard 17).

## Alternative

If `/etc/openship/ssh-keys` was never meant to be supported, the other valid fix is to drop it from `DEFAULT_ROOTS` and correct the `env.ts` comment instead. I went with honoring the documentation since two places advertise it, but I'm happy to flip this to the removal if that matches your intent better.

## Note

`bun run --cwd apps/api lint` currently fails on `main` for an unrelated reason (`self-edge.test.ts` TS2578, from #114), which will surface on this PR's Typecheck job. #115 fixes it; typecheck reports no errors from the files in this PR.