### PR TITLE
fix(adapters): quote systemd Environment= values

### DIFF
--- a/packages/adapters/src/runtime/supervisor/systemd.ts
+++ b/packages/adapters/src/runtime/supervisor/systemd.ts
@@ -23,6 +23,27 @@ import { DeployError } from "@repo/core";
 /** Prefix for all openship systemd units */
 const UNIT_PREFIX = "openship";
 
+/**
+ * Escape an env value for a double-quoted systemd `Environment=` assignment.
+ *
+ * `Environment=` takes a SPACE-SEPARATED list of assignments, so an unquoted
+ * value is cut at its first space. Quoting fixes that, and inside the quotes
+ * systemd applies C-style escapes plus `%` specifier expansion — so `"`, `\`
+ * and `%` have to be escaped, and a literal newline (which would otherwise
+ * inject raw lines into the unit) is encoded as `\n`.
+ *
+ * Backslash is replaced first so the escapes introduced below aren't re-escaped.
+ */
+export function escapeSystemdEnvValue(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/%/g, "%%")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
 export class SystemdSupervisor implements ProcessSupervisor {
   readonly name = "systemd";
 
@@ -67,13 +88,14 @@ export class SystemdSupervisor implements ProcessSupervisor {
    * Build a systemd unit file contents string.
    *
    * Uses Type=exec so systemd tracks the actual process (not the shell wrapper).
-   * Environment vars are set via Environment= directives (one per line)
-   * which avoids any shell quoting issues.
+   * Environment vars are set via Environment= directives (one per line), which
+   * avoids any SHELL quoting issues - but systemd does its own parsing, so each
+   * assignment is double-quoted and escaped (see escapeSystemdEnvValue).
    */
   private buildUnitFile(opts: SupervisorDeployOpts): string {
     const envLines = Object.entries(opts.env)
       .filter(([key]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
-      .map(([k, v]) => `Environment=${k}=${v}`)
+      .map(([k, v]) => `Environment="${k}=${escapeSystemdEnvValue(v)}"`)
       .join("\n");
 
     return `[Unit]

--- a/packages/adapters/test/systemd-env-quoting.test.ts
+++ b/packages/adapters/test/systemd-env-quoting.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeSystemdEnvValue } from "../src/runtime/supervisor/systemd";
+
+// systemd's `Environment=` takes a SPACE-SEPARATED list of assignments, so an
+// unquoted value is cut at its first space. Every expectation below was checked
+// against real systemd (252) by starting a unit and dumping the environment the
+// process actually received - the comments record that observed behaviour.
+
+/** Render an assignment the way buildUnitFile does. */
+const line = (k: string, v: string) => `Environment="${k}=${escapeSystemdEnvValue(v)}"`;
+
+describe("escapeSystemdEnvValue", () => {
+  it("leaves a simple value untouched", () => {
+    expect(escapeSystemdEnvValue("3000")).toBe("3000");
+    expect(line("PORT", "3000")).toBe('Environment="PORT=3000"');
+  });
+
+  it("keeps a value containing spaces in one assignment", () => {
+    // Unquoted this became SITE_TITLE=My, and systemd logged
+    // "Invalid environment assignment, ignoring: Cool" / ": App".
+    expect(line("SITE_TITLE", "My Cool App")).toBe('Environment="SITE_TITLE=My Cool App"');
+  });
+
+  it("keeps a connection string whose tail looks like another assignment", () => {
+    // The nastiest case: unquoted, systemd silently truncated DATABASE_URL at
+    // `-c` AND created a stray `search_path=app` variable. No warning at all.
+    const url = "postgres://u:p@h/db?options=-c search_path=app";
+    expect(line("DATABASE_URL", url)).toBe(
+      'Environment="DATABASE_URL=postgres://u:p@h/db?options=-c search_path=app"',
+    );
+  });
+
+  it("escapes double quotes so they don't close the assignment", () => {
+    // Verified: the process receives  say "hi" now
+    expect(escapeSystemdEnvValue('say "hi" now')).toBe('say \\"hi\\" now');
+  });
+
+  it("escapes backslashes, and does so before the escapes it introduces", () => {
+    // Verified: the process receives  C:\new\table
+    // (a naive implementation that escaped quotes first would double-escape).
+    expect(escapeSystemdEnvValue("C:\\new\\table")).toBe("C:\\\\new\\\\table");
+    expect(escapeSystemdEnvValue('a\\"b')).toBe('a\\\\\\"b');
+  });
+
+  it("escapes % so systemd does not expand it as a specifier", () => {
+    // Verified: the process receives  100% done
+    expect(escapeSystemdEnvValue("100% done")).toBe("100%% done");
+  });
+
+  it("encodes newlines instead of injecting raw lines into the unit", () => {
+    // A PEM key is the real-world case. Unescaped, the second line lands in the
+    // [Service] section as a bogus directive and breaks daemon-reload.
+    const pem = "-----BEGIN KEY-----\nabc\n-----END KEY-----";
+    const escaped = escapeSystemdEnvValue(pem);
+
+    expect(escaped).not.toContain("\n");
+    expect(escaped).toBe("-----BEGIN KEY-----\\nabc\\n-----END KEY-----");
+    // Verified: systemd decodes \n back to a real newline for the process.
+  });
+
+  it("encodes carriage returns and tabs", () => {
+    expect(escapeSystemdEnvValue("a\tb")).toBe("a\\tb");
+    expect(escapeSystemdEnvValue("a\r\nb")).toBe("a\\r\\nb");
+  });
+
+  it("never emits an unescaped quote that would terminate the assignment", () => {
+    for (const value of [
+      'plain "quoted" text',
+      'trailing quote"',
+      '"leading quote',
+      'C:\\path\\"weird"',
+      "%%already%%",
+    ]) {
+      const rendered = line("V", value);
+      // Strip the escaped pairs, then nothing quote-ish may remain inside.
+      const body = rendered.slice('Environment="'.length, -1).replace(/\\\\|\\"/g, "");
+      expect(body).not.toContain('"');
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`SystemdSupervisor.buildUnitFile` emits env vars unquoted:

```ts
.map(([k, v]) => `Environment=${k}=${v}`)
```

systemd's `Environment=` takes a **space-separated list of assignments**, so any value containing a space is cut at the first one.

I verified this against **real systemd 252** — started a unit and dumped the environment the process actually received:

| Written by Openship today | What the process gets |
| --- | --- |
| `Environment=SITE_TITLE=My Cool App` | `SITE_TITLE=My` |
| `Environment=DATABASE_URL=postgres://u:p@h/db?options=-c search_path=app` | `DATABASE_URL=postgres://u:p@h/db?options=-c` **plus a phantom `search_path=app`** |
| `Environment=PORT=3000` | `PORT=3000` ✅ |

The `SITE_TITLE` case at least logs `Invalid environment assignment, ignoring: Cool` / `: App`.

**The `DATABASE_URL` case is completely silent** — its tail happens to parse as another valid assignment, so systemd accepts it without a word. The app boots with a truncated connection string and fails at runtime with nothing pointing back at Openship.

A value containing a **newline** (a PEM private key, a multi-line config) is worse: it injects raw lines into the `[Service]` section and breaks `systemctl daemon-reload`.

## Why this is an oversight, not intent

The sibling `NohupSupervisor` already quotes correctly — `export ${k}=${sq(v)}` (`nohup.ts`). systemd is the only supervisor that doesn't.

Its doc comment says `Environment=` "avoids any shell quoting issues" — true of the *shell*, but systemd does its own parsing on top.

Values reach here unfiltered: `BareRuntime.deploy` passes `config.envVars` straight through, and the existing filter only validates **keys**.

## Fix

Double-quote each assignment and escape what systemd treats specially inside quotes. Each rule was confirmed empirically (unit started, env dumped):

| Escape emitted | Value the process receives |
| --- | --- |
| `\"` | `"` |
| `\\` | `\` |
| `%%` | `%` (otherwise `%` starts a specifier) |
| `\n` | a real newline |
| `\t` | a real tab |

Backslash is replaced **first** so the escapes introduced afterwards aren't re-escaped.

## Round-trip verification

Fed this branch's actual generated output to real systemd and dumped the received environment:

```
SITE_TITLE=My Cool App
DATABASE_URL=postgres://u:p@h/db?options=-c search_path=app
QUOTED=say "hi" now
WINPATH=C:\new\table
PCT=100% done
TABBED=a	b
PEM=-----BEGIN KEY-----
abc
def
-----END KEY-----
```

All intact, including the multi-line PEM key.

## Tests

New `packages/adapters/test/systemd-env-quoting.test.ts` — 9 cases (`@repo/adapters` 222 → 231). Each assertion is pinned to the systemd behaviour observed above, and the comments record it, so the intent survives if someone revisits the escaping later.

Covers: spaces; the silent `DATABASE_URL` truncation; embedded quotes; backslash ordering (a naive quote-first implementation double-escapes — asserted explicitly); `%`; newline encoding; CR/tab; and a sweep asserting no unescaped quote can ever terminate an assignment.

Full suite: `bun run test` → **5/5 turbo tasks successful** (api 695, adapters 231, core 89, db 25, dashboard 17).

## Note

`escapeSystemdEnvValue` is exported for the tests. I left `buildUnitFile` private and didn't reformat the rest of the file (it has some pre-existing prettier drift, and running `--write` over it would bury this diff in unrelated hunks).