### PR TITLE
fix(core): guard JSON manifests that parse to a bare null

### DIFF
--- a/packages/core/src/languages/javascript.ts
+++ b/packages/core/src/languages/javascript.ts
@@ -17,6 +17,9 @@ function parsePackageJsonDeps(content: string): Record<string, string> {
   } catch {
     return {};
   }
+  // `JSON.parse("null")` succeeds → guard before property access, or a stray
+  // `null` file would throw and crash detection (cf. metadata/railway.ts).
+  if (typeof parsed !== "object" || parsed === null) return {};
 
   const deps = (parsed.dependencies as Record<string, string> | undefined) ?? {};
   const devDeps = (parsed.devDependencies as Record<string, string> | undefined) ?? {};

--- a/packages/core/src/languages/php.ts
+++ b/packages/core/src/languages/php.ts
@@ -11,6 +11,9 @@ function parseComposerJson(content: string): Record<string, string> {
   } catch {
     return {};
   }
+  // `JSON.parse("null")` succeeds → guard before property access, or a stray
+  // `null` file would throw and crash detection (cf. metadata/railway.ts).
+  if (typeof parsed !== "object" || parsed === null) return {};
   return { ...(parsed.require ?? {}), ...(parsed["require-dev"] ?? {}) };
 }
 

--- a/packages/core/src/metadata/vercel.ts
+++ b/packages/core/src/metadata/vercel.ts
@@ -122,6 +122,9 @@ export function parseVercelConfig(raw: string): VercelConfig | null {
   } catch {
     return null;
   }
+  // `JSON.parse("null")` succeeds → guard before property access, or a stray
+  // `null` file would throw and crash the metadata pipeline (cf. railway.ts).
+  if (typeof parsed !== "object" || parsed === null) return null;
   const cfg: VercelConfig = {};
   const installCommand = trimmed(parsed.installCommand);
   const buildCommand = trimmed(parsed.buildCommand);

--- a/packages/core/test/null-json-manifest.test.ts
+++ b/packages/core/test/null-json-manifest.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { parseVercelConfig } from "../src/metadata/vercel";
+import { parseDeploymentMetadata } from "../src/metadata";
+import { javascriptLanguageDetector } from "../src/languages/javascript";
+import { phpLanguageDetector } from "../src/languages/php";
+
+// `JSON.parse("null")` SUCCEEDS and yields null, so a `catch` around the parse
+// doesn't cover the property access that follows. metadata/railway.ts already
+// guards for exactly this ("would throw and crash the metadata pipeline"); the
+// parsers below did not, so one degenerate file aborted detection for the whole
+// project instead of being ignored.
+//
+// Note a bare primitive (`42`, `"str"`) never threw - JS boxes those on
+// property access. `null` is the only JSON literal that does.
+
+describe("JSON manifests containing a bare null", () => {
+  it("parseVercelConfig returns null instead of throwing", () => {
+    expect(parseVercelConfig("null")).toBeNull();
+  });
+
+  it("parseDeploymentMetadata survives a null vercel.json", () => {
+    expect(() => parseDeploymentMetadata({ "vercel.json": "null" })).not.toThrow();
+    expect(parseDeploymentMetadata({ "vercel.json": "null" })).toEqual([]);
+  });
+
+  it("the javascript detector returns no deps for a null package.json", () => {
+    expect(javascriptLanguageDetector.parseManifest?.("package.json", "null")).toEqual({});
+  });
+
+  it("the php detector returns no deps for a null composer.json", () => {
+    expect(phpLanguageDetector.parseManifest?.("composer.json", "null")).toEqual({});
+  });
+
+  it("still parses ordinary manifests", () => {
+    expect(parseVercelConfig('{"framework":"nextjs"}')).toEqual({ framework: "nextjs" });
+    expect(
+      javascriptLanguageDetector.parseManifest?.(
+        "package.json",
+        '{"dependencies":{"next":"15.0.0"},"devDependencies":{"vitest":"4.0.0"}}',
+      ),
+    ).toEqual({ next: "15.0.0", vitest: "4.0.0" });
+    expect(
+      phpLanguageDetector.parseManifest?.(
+        "composer.json",
+        '{"require":{"laravel/framework":"^11"}}',
+      ),
+    ).toEqual({ "laravel/framework": "^11" });
+  });
+
+  it("still returns empty for malformed JSON", () => {
+    expect(parseVercelConfig("{not json")).toBeNull();
+    expect(javascriptLanguageDetector.parseManifest?.("package.json", "{not json")).toEqual({});
+    expect(phpLanguageDetector.parseManifest?.("composer.json", "{not json")).toEqual({});
+  });
+});


### PR DESCRIPTION
## Problem

`JSON.parse("null")` **succeeds** and returns `null`, so a `try/catch` around the parse doesn't cover the property access that comes after it. Three parsers read a property straight off the result:

| Parser | File | Access |
| --- | --- | --- |
| `parseVercelConfig` | `metadata/vercel.ts` | `parsed.installCommand` |
| `parsePackageJsonDeps` | `languages/javascript.ts` | `parsed.dependencies` |
| `parseComposerJson` | `languages/php.ts` | `parsed.require` |

Executed on `main`:

```
vercel.json   = null  -> THREW: null is not an object (evaluating 'parsed.installCommand')
package.json  = null  -> THREW: null is not an object (evaluating 'parsed.dependencies')
composer.json = null  -> THREW: null is not an object (evaluating 'parsed.require')

parseDeploymentMetadata({"vercel.json": "null"})
                      -> THREW: null is not an object (evaluating 'parsed.installCommand')
```

The TypeError escapes `parseDeploymentMetadata` and the language detectors, so **one degenerate file aborts detection for the whole project** instead of being ignored like every other unusable manifest.

## This was already recognised once

`metadata/railway.ts` carries exactly this guard, with a comment naming the failure:

```ts
// `JSON.parse("null")` succeeds → guard before property access, or a stray
// `null`/primitive file would throw and crash the metadata pipeline.
if (typeof parsed !== "object" || parsed === null) return null;
```

Its three siblings never got it. This PR applies the same check, worded consistently and cross-referencing `railway.ts`.

## Fix

Three lines, one per parser — `return null` for the vercel config, `return {}` for the two dependency maps, matching each function's existing "unusable input" path.

## Scope note

A bare **primitive** (`42`, `"str"`) never threw — JS boxes those on property access, so they already fell through to an empty result. `null` is the only JSON literal affected, which is why the guard is `typeof !== "object" || === null` rather than a broader shape check.

## Tests

New `packages/core/test/null-json-manifest.test.ts` — 6 cases (`@repo/core` 89 → 95):

- each of the three parsers returns its empty value for `null`
- `parseDeploymentMetadata` doesn't throw and returns `[]`
- **ordinary manifests still parse** (vercel `framework`, npm deps + devDeps merged, composer `require`)
- **malformed JSON still returns empty** — the existing `catch` path is untouched

Verified against the unfixed source: the **4 null cases fail**, and the 2 regression guards pass either way.

Full suite: `bun run test` → **5/5 turbo tasks successful** (api 714, adapters 235, core 95, db 25, dashboard 17).