### PR TITLE
fix(api): report the persisted authMode from /health/env

### DIFF
--- a/apps/api/src/modules/health/health.routes.ts
+++ b/apps/api/src/modules/health/health.routes.ts
@@ -78,10 +78,17 @@ healthRoutes.get("/env", async (c) => {
       authMode = "none";
     }
   } else {
+    // Not desktop-only: zero-auth is valid for any DEPLOY_MODE (see
+    // lib/auth-mode.ts). The operator opts in through the settings endpoint,
+    // which gates it behind OPENSHIP_ALLOW_ZERO_AUTH plus an explicit
+    // `confirm` string. Read the persisted value so this agrees with
+    // getAuthMode() — hardcoding "local" told the dashboard to render a login
+    // screen on an instance whose API requires no login.
     authMode = "local";
     try {
       const { repos } = await import("@repo/db");
       const settings = await repos.instanceSettings.get();
+      authMode = settings?.authMode ?? "local";
       teamMode = settings?.teamMode ?? "single_user";
       migrationTargetUrl = settings?.migrationTargetUrl ?? null;
       migrationInProgress = settings?.migrationInProgress ?? false;

--- a/apps/api/test/modules/health-env-authmode.test.ts
+++ b/apps/api/test/modules/health-env-authmode.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// GET /health/env is what the dashboard reads to decide which login flow to
+// render ("none" → zero-auth, "local" → Better Auth login). The non-desktop
+// branch used to hardcode "local" while still querying instanceSettings for its
+// siblings, so an operator who completed the deliberate zero-auth opt-in
+// (OPENSHIP_ALLOW_ZERO_AUTH + `confirm: "I-understand-no-auth"`, see
+// modules/system/setup.controller.ts) still got a login screen — even though
+// authMiddleware, via lib/auth-mode.ts, had already resolved "none".
+//
+// DEPLOY_MODE defaults to "docker" under vitest (see vitest.config.ts), so
+// these exercise the non-desktop path.
+
+const settings: {
+  authMode?: string | null;
+  teamMode?: string | null;
+  migrationTargetUrl?: string | null;
+  migrationInProgress?: boolean | null;
+} = {};
+
+let getThrows = false;
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    instanceSettings: {
+      get: async () => {
+        if (getThrows) throw new Error("settings table unavailable mid-migration");
+        return settings;
+      },
+    },
+  },
+}));
+
+async function getEnv() {
+  const { healthRoutes } = await import("../../src/modules/health/health.routes");
+  const res = await healthRoutes.request("/env");
+  return { res, body: (await res.json()) as Record<string, unknown> };
+}
+
+afterEach(() => {
+  getThrows = false;
+  delete settings.authMode;
+  delete settings.teamMode;
+});
+
+describe("GET /health/env authMode", () => {
+  it("reports the persisted zero-auth mode instead of hardcoding local", async () => {
+    settings.authMode = "none";
+
+    const { res, body } = await getEnv();
+    expect(res.status).toBe(200);
+    expect(body.deployMode).not.toBe("desktop");
+    expect(body.authMode).toBe("none");
+  });
+
+  it("reports a persisted cloud mode", async () => {
+    settings.authMode = "cloud";
+    expect((await getEnv()).body.authMode).toBe("cloud");
+  });
+
+  it("defaults to local when no authMode has been written", async () => {
+    // Matches getAuthMode()'s non-desktop fallback: require login on a fresh
+    // self-hosted install.
+    expect((await getEnv()).body.authMode).toBe("local");
+  });
+
+  it("falls back to local when the settings lookup fails", async () => {
+    // The settings table may be unavailable mid-migration; failing closed to
+    // "login required" is the safe default.
+    getThrows = true;
+    expect((await getEnv()).body.authMode).toBe("local");
+  });
+
+  it("still reports the other instanceSettings fields", async () => {
+    settings.authMode = "none";
+    settings.teamMode = "multi_user";
+
+    const { body } = await getEnv();
+    expect(body.teamMode).toBe("multi_user");
+    expect(body.migrationInProgress).toBe(false);
+    expect(body.migrationTargetUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

In `apps/api/src/modules/health/health.routes.ts`, the non-desktop branch hardcodes the auth mode:

```ts
} else {
  authMode = "local";
  try {
    const { repos } = await import("@repo/db");
    const settings = await repos.instanceSettings.get();
    teamMode = settings?.teamMode ?? "single_user";
    migrationTargetUrl = settings?.migrationTargetUrl ?? null;
    migrationInProgress = settings?.migrationInProgress ?? false;
  } catch { … }
}
```

It queries `instanceSettings` and reads three fields off the row — but **discards `settings.authMode`**. The desktop branch immediately above does read it (`settings?.authMode ?? "none"`).

## Zero-auth isn't desktop-only

Three places say the persisted value should win regardless of `DEPLOY_MODE`:

- `lib/auth-mode.ts`, verbatim: *"`none` is valid for any DEPLOY_MODE — the operator opts in via the settings endpoint, which is itself gated by `OPENSHIP_ALLOW_ZERO_AUTH=true`."*
- `getAuthMode()` — which `authMiddleware` uses — returns `settings?.authMode ?? fallback`, with the fallback only supplying a default.
- `modules/system/setup.controller.ts` implements a deliberate **two-key gate** for writing `authMode: "none"` on a non-desktop instance: `OPENSHIP_ALLOW_ZERO_AUTH=true` **and** `confirm: "I-understand-no-auth"` in the body.

That gate exists precisely so a self-hoster *can* run zero-auth. Today, completing it leaves the API requiring no login while `/health/env` still answers `"local"`.

## Impact

The route's own comment: *"authMode tells the dashboard which login flow to use: `none` → zero-auth"*.

So the dashboard renders a **login screen for an instance that has no login** — the API and the UI disagree about the instance's auth mode, after the operator jumped through a two-step opt-in specifically designed to enable it.

Observed with `DEPLOY_MODE=docker` and a persisted `authMode: "none"`:

```
{ deployMode: "docker", authMode: "local", teamMode: "single_user" }
```

`teamMode` came from the same settings row and was read correctly — only `authMode` was dropped.

## Fix

Read `settings.authMode` inside the existing `try`, keeping `"local"` as the fallback for both an absent value and a failed lookup. That matches `getAuthMode()`'s non-desktop default and mirrors the desktop branch three lines above.

## Tests

New `apps/api/test/modules/health-env-authmode.test.ts` — 5 cases (`@repo/api` 714 → 719). `DEPLOY_MODE` defaults to `docker` under vitest, so these exercise the non-desktop path; `@repo/db` is mocked since the handler imports it dynamically.

- persisted `"none"` → reported as `"none"` (asserting `deployMode !== "desktop"`, so it can't pass via the desktop branch)
- persisted `"cloud"` → reported as `"cloud"`
- **no persisted value → still `"local"`** (fresh self-hosted install requires login)
- **settings lookup throws → still `"local"`** (fails closed mid-migration)
- the sibling fields (`teamMode`, `migrationInProgress`, `migrationTargetUrl`) are still reported

Verified against the unfixed source: the **2 persisted-value cases fail**, and the 3 fallback/regression guards pass either way.

Full suite: `bun run test` → **5/5 turbo tasks successful** (api 719, adapters 240, core 101, db 25, dashboard 17). `bun run --cwd apps/api lint` clean.

## Alternative

`/health/env` could just call `getAuthMode()` and delete the duplicated resolution entirely — single source of truth, and it would also pick up the `OPENSHIP_REQUIRE_AUTH` / `OPENSHIP_PUBLIC_URL` handling that this route doesn't have. I kept the change minimal since that also alters the desktop branch's default, but I'm happy to switch it if you'd prefer the consolidation.