### PR TITLE
fix(adapters): normalize Docker container status and handle health states (#127)

### DIFF
--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -1540,15 +1540,18 @@ export class DockerRuntime implements RuntimeAdapter {
     });
     const stateMap: Record<string, ContainerStatus> = {
       running: "running",
+      healthy: "running",
+      starting: "running",
       restarting: "running",
       exited: "stopped",
       paused: "stopped",
       created: "stopped",
       dead: "failed",
+      unhealthy: "failed",
     };
     return containers.map((c) => ({
       containerId: c.Id,
-      status: stateMap[c.State] ?? "stopped",
+      status: stateMap[(c.State ?? "").toLowerCase().trim()] ?? "stopped",
       serviceName: c.Labels?.["openship.service"],
     }));
   }
@@ -1684,7 +1687,7 @@ export class DockerRuntime implements RuntimeAdapter {
         names: (c.Names ?? []).map((n) => n.replace(/^\//, "")),
         image: c.Image,
         imageId: c.ImageID,
-        state: c.State,
+        state: (c.State ?? "").toLowerCase().trim(),
         status: c.Status,
         labels,
         ports: (c.Ports ?? []).map((p) => ({
@@ -1718,7 +1721,7 @@ export class DockerRuntime implements RuntimeAdapter {
       name: (data.Name ?? "").replace(/^\//, ""),
       image: data.Config?.Image ?? data.Image,
       imageId: data.Image,
-      state: data.State?.Status ?? "unknown",
+      state: (data.State?.Status ?? "").toLowerCase().trim() || "unknown",
       command: toStringArray(data.Config?.Cmd),
       entrypoint: toStringArray(data.Config?.Entrypoint),
       env: data.Config?.Env ?? [],
@@ -1850,11 +1853,14 @@ export class DockerRuntime implements RuntimeAdapter {
 
     const statusMap: Record<string, ContainerInfo["status"]> = {
       running: "running",
+      healthy: "running",
+      starting: "running",
+      restarting: "running",
       exited: "stopped",
       paused: "stopped",
-      restarting: "running",
-      dead: "failed",
       created: "stopped",
+      dead: "failed",
+      unhealthy: "failed",
     };
 
     const startedAt = data.State.StartedAt;
@@ -1864,9 +1870,19 @@ export class DockerRuntime implements RuntimeAdapter {
 
     const { ip, hostPort } = extractNetworkInfo(data);
 
+    let status: ContainerInfo["status"];
+    if (data.State.Running) {
+      status = "running";
+    } else if (data.State.Paused) {
+      status = "stopped";
+    } else {
+      const rawStatus = (data.State.Status ?? "").toLowerCase().trim();
+      status = statusMap[rawStatus] ?? "stopped";
+    }
+
     return {
       containerId,
-      status: statusMap[data.State.Status] ?? "stopped",
+      status,
       ip,
       hostPort,
       uptimeSeconds: uptimeSeconds && uptimeSeconds > 0 ? uptimeSeconds : undefined,

--- a/packages/adapters/test/docker-container-status.test.ts
+++ b/packages/adapters/test/docker-container-status.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { DockerRuntime } from "../src/runtime/docker";
+
+describe("DockerRuntime container status normalization", () => {
+  it("correctly identifies running status when State.Running is true regardless of State.Status casing", async () => {
+    const runtime = await DockerRuntime.create();
+    
+    // Mock container inspect response
+    const mockInspectInfo: any = {
+      Id: "container-12345",
+      State: {
+        Status: "Running",
+        Running: true,
+        Paused: false,
+        StartedAt: new Date(Date.now() - 60000).toISOString(),
+      },
+      NetworkSettings: { Networks: {}, Ports: {} },
+    };
+
+    // Override internal docker container inspect
+    runtime.docker.getContainer = (() => ({
+      inspect: async () => mockInspectInfo,
+    })) as any;
+
+    const info = await runtime.getContainerInfo("container-12345");
+    expect(info.status).toBe("running");
+    expect(info.uptimeSeconds).toBeGreaterThan(0);
+  });
+
+  it("handles health check status strings like 'healthy' and 'starting'", async () => {
+    const runtime = await DockerRuntime.create();
+
+    const mockInspectInfo: any = {
+      Id: "container-67890",
+      State: {
+        Status: "healthy",
+        Running: false, // In case Running flag is false or not set
+        Paused: false,
+        StartedAt: new Date(Date.now() - 30000).toISOString(),
+      },
+      NetworkSettings: { Networks: {}, Ports: {} },
+    };
+
+    runtime.docker.getContainer = (() => ({
+      inspect: async () => mockInspectInfo,
+    })) as any;
+
+    const info = await runtime.getContainerInfo("container-67890");
+    expect(info.status).toBe("running");
+  });
+
+  it("normalizes listDeploymentContainers state string in case-insensitive manner", async () => {
+    const runtime = await DockerRuntime.create();
+
+    runtime.docker.listContainers = (async () => [
+      {
+        Id: "c1",
+        State: "Running",
+        Labels: { "openship.deployment": "dep1", "openship.service": "web" },
+      },
+      {
+        Id: "c2",
+        State: "HEALTHY",
+        Labels: { "openship.deployment": "dep1", "openship.service": "db" },
+      },
+      {
+        Id: "c3",
+        State: "Exited",
+        Labels: { "openship.deployment": "dep1", "openship.service": "cache" },
+      },
+    ]) as any;
+
+    const results = await runtime.listDeploymentContainers("dep1");
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ containerId: "c1", status: "running", serviceName: "web" });
+    expect(results[1]).toEqual({ containerId: "c2", status: "running", serviceName: "db" });
+    expect(results[2]).toEqual({ containerId: "c3", status: "stopped", serviceName: "cache" });
+  });
+});


### PR DESCRIPTION
Fixes #127

### Summary & Context
When deploying applications using Docker (e.g. Webmail, or custom apps) on modern environments such as Ubuntu 26.04 LTS running Docker 29.6.2+, the build completes successfully, but OpenShip fails to detect the container as running, leading to status reconciliation failures where the deployment is incorrectly marked as `failed` or `missing`.

### Root Cause
1. `DockerRuntime.getContainerInfo()` and `listDeploymentContainers()` used direct case-sensitive lookups (`statusMap[data.State.Status]` and `stateMap[c.State]`) without string normalization (`.toLowerCase().trim()`).
2. `getContainerInfo()` did not prioritize the authoritative Docker Engine API boolean flag `data.State.Running === true` before falling back to string mapping.
3. Containers with healthchecks or variant status strings (such as `"healthy"`, `"starting"`, or `"Running"`) returned `undefined` from `statusMap`/`stateMap`, defaulting to `"stopped"`.
4. Downstream, `reconcileDeployment()` and `reconcileWebmailInstalled()` received status `"stopped"`/`"down"`, marking valid deployments as `failed` and reporting that OpenShip could not detect the application.

### Proposed Changes
- **`packages/adapters/src/runtime/docker.ts`**:
  - Prioritized `data.State.Running === true` $\rightarrow$ `"running"` and `data.State.Paused === true` $\rightarrow$ `"stopped"`.
  - Normalized state strings (`.toLowerCase().trim()`) before mapping.
  - Added support for Docker healthcheck states (`"healthy"`, `"starting"`, `"unhealthy"`).
  - Normalized state string handling in `listAllContainers()` and `inspectContainer()`.

### How It Was Verified
Ran the unit test suite with `bun test`:

```bash
bun test packages/adapters/test/docker-container-status.test.ts packages/adapters/test/docker-build-plan.test.ts