### PR TITLE
fix(api): let the self-app route its own domain past the reserved loopback guard

### DIFF
--- a/apps/api/src/lib/startup/self-deploy.ts
+++ b/apps/api/src/lib/startup/self-deploy.ts
@@ -206,7 +206,7 @@ export async function provisionSelfAppEdge(
     return { verified: false, reason: "no_project" };
   }
   try {
-    await reapplyProjectLiveRoutes(project, []);
+    await reapplyProjectLiveRoutes(project, [], { isSelfApp: true });
   } catch (err) {
     log?.(safeErrorMessage(err), "error");
     progress.onStep?.("route", "failed");
@@ -311,7 +311,7 @@ export function registerSelfAdoptReconcile(): void {
         const fresh = await repos.project.findById(project.id);
         if (fresh) {
           try {
-            await reapplyProjectLiveRoutes(fresh, []);
+            await reapplyProjectLiveRoutes(fresh, [], { isSelfApp: true });
           } catch (err) {
             console.warn(`[self-deploy] route reapply failed: ${safeErrorMessage(err)}`);
           }

--- a/apps/api/src/modules/domains/project-route.service.ts
+++ b/apps/api/src/modules/domains/project-route.service.ts
@@ -231,6 +231,33 @@ export async function syncProjectRouteState(
  * Static-path routes (served straight from the web root) are left to the next
  * deploy — they have no live upstream to point at here.
  */
+export interface ReapplyProjectLiveRoutesOptions {
+  /**
+   * The self-app (control plane) project legitimately routes its public
+   * hostname to its OWN dashboard port on loopback — that's the whole point
+   * of self-deploy.ts. Only self-deploy.ts's own call sites may pass this;
+   * it must never be derived from `project.appTemplateId`, which is
+   * client-writable via the ordinary create/update project APIs and would
+   * let any project forge its way past the reserved-port guard.
+   */
+  isSelfApp?: boolean;
+}
+
+/**
+ * True when a resolved upstream must NOT be used for a public route: a
+ * loopback host pointed at a reserved control-plane/mgmt port (the admin
+ * API, the dashboard, or the unauthenticated OpenResty mgmt port) would
+ * expose an internal service to the internet. `isSelfApp` is the one
+ * exception — the control-plane project's own route to itself.
+ */
+export function shouldRefuseLoopbackRoute(
+  host: string,
+  port: number,
+  opts: ReapplyProjectLiveRoutesOptions = {},
+): boolean {
+  return isLoopbackHost(host) && isReservedLoopbackPort(port) && !opts.isSelfApp;
+}
+
 export async function reapplyProjectLiveRoutes(
   project: Pick<
     Project,
@@ -243,6 +270,7 @@ export async function reapplyProjectLiveRoutes(
     | "webhookDomain"
   >,
   previousHostnames: string[],
+  opts: ReapplyProjectLiveRoutesOptions = {},
 ): Promise<void> {
   const isCloud = !!project.cloudWorkspaceId;
   if (!isCloud && !project.activeDeploymentId) return;
@@ -315,8 +343,9 @@ export async function reapplyProjectLiveRoutes(
     // Never proxy a public route at a reserved control-plane/mgmt port on the
     // host loopback — that would expose the admin API (env.PORT) or the
     // unauthenticated OpenResty mgmt port (9145) to the internet. Only guards
-    // loopback: a container's own IP:<port> is the app's, not ours.
-    if (isLoopbackHost(host) && isReservedLoopbackPort(port)) {
+    // loopback: a container's own IP:<port> is the app's, not ours. The
+    // self-app is exempt (see ReapplyProjectLiveRoutesOptions.isSelfApp).
+    if (shouldRefuseLoopbackRoute(host, port, opts)) {
       console.warn(
         `[project-route] ${project.slug}: refusing reserved loopback upstream port ${port} for a public route`,
       );

--- a/apps/api/test/modules/domains/project-route.service.test.ts
+++ b/apps/api/test/modules/domains/project-route.service.test.ts
@@ -1,14 +1,58 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listByProject, findDeployment, resolveRuntime, reconcile } = vi.hoisted(() => ({
+  listByProject: vi.fn(),
+  findDeployment: vi.fn(),
+  resolveRuntime: vi.fn(),
+  reconcile: vi.fn(),
+}));
 
 vi.mock("@repo/db", () => ({
   repos: {
-    domain: {
-      listByProject: vi.fn(),
-    },
+    domain: { listByProject },
+    deployment: { findById: findDeployment },
   },
 }));
 
-import { deriveEnvironmentPublicEndpoints } from "../../../src/modules/domains/project-route.service";
+vi.mock("../../../src/lib/deployment-runtime", () => ({
+  resolveDeploymentRuntime: resolveRuntime,
+}));
+
+vi.mock("../../../src/lib/route-apply.service", () => ({
+  reconcileProjectRoutes: reconcile,
+}));
+
+vi.mock("../../../src/modules/route-rules/route-rule.service", () => ({
+  pushProjectRules: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  deriveEnvironmentPublicEndpoints,
+  reapplyProjectLiveRoutes,
+  shouldRefuseLoopbackRoute,
+} from "../../../src/modules/domains/project-route.service";
+
+describe("shouldRefuseLoopbackRoute", () => {
+  it("refuses a tenant project's public route to the dashboard port on loopback", () => {
+    expect(shouldRefuseLoopbackRoute("127.0.0.1", 3001, { isSelfApp: false })).toBe(true);
+  });
+
+  it("refuses a tenant project's public route to the admin API port on loopback", () => {
+    expect(shouldRefuseLoopbackRoute("127.0.0.1", 4000, { isSelfApp: false })).toBe(true);
+  });
+
+  it("allows the self-app's own public route to the dashboard port on loopback", () => {
+    expect(shouldRefuseLoopbackRoute("127.0.0.1", 3001, { isSelfApp: true })).toBe(false);
+  });
+
+  it("allows a non-reserved port on loopback regardless of self-app status", () => {
+    expect(shouldRefuseLoopbackRoute("127.0.0.1", 8080, { isSelfApp: false })).toBe(false);
+  });
+
+  it("allows any port on a non-loopback host (container IP)", () => {
+    expect(shouldRefuseLoopbackRoute("172.17.0.5", 3001, { isSelfApp: false })).toBe(false);
+  });
+});
 
 describe("deriveEnvironmentPublicEndpoints", () => {
   it("clones an explicit proxy target without inventing a fallback port", () => {
@@ -35,5 +79,74 @@ describe("deriveEnvironmentPublicEndpoints", () => {
 
   it("returns no endpoints when the base project has no explicit destination", () => {
     expect(deriveEnvironmentPublicEndpoints([], "preview-app")).toEqual([]);
+  });
+});
+
+// Behavioral regression for issue #129: the self-app's own boot route to its
+// dashboard port on loopback was refused, so OpenResty never bound 443 and the
+// domain was unreachable. Drives the ACTUAL failing branch (bare adopt runtime,
+// resolveTargetUrl) rather than just the shouldRefuseLoopbackRoute predicate.
+describe("reapplyProjectLiveRoutes self-app loopback route (issue #129)", () => {
+  // Mirrors the real self-app adopt deployment: meta { runtimeMode: "bare" } →
+  // the app runs on the host, so the runtime resolves the upstream to
+  // 127.0.0.1:<dashboard port> rather than a container IP.
+  const project = {
+    id: "proj-openship",
+    slug: "openship",
+    port: 3001,
+    cloudWorkspaceId: null,
+    activeDeploymentId: "dep-1",
+    organizationId: "org-1",
+    webhookDomain: null,
+  };
+
+  beforeEach(() => {
+    reconcile.mockReset().mockResolvedValue(undefined);
+    resolveRuntime.mockReset();
+    findDeployment.mockReset();
+    listByProject.mockReset();
+
+    // One public hostname → the dashboard port, no static path.
+    listByProject.mockResolvedValue([
+      {
+        id: "dom-1",
+        hostname: "panel.example.com",
+        isPrimary: true,
+        serviceId: null,
+        targetPort: 3001,
+        targetPath: null,
+        domainType: "free",
+      },
+    ]);
+    // Bare adopt deployment: truthy containerId (so we reach resolveTargetUrl),
+    // runtime does NOT support containerIp → host resolves to 127.0.0.1.
+    findDeployment.mockResolvedValue({
+      id: "dep-1",
+      containerId: "dep-1",
+      meta: { runtimeMode: "bare" },
+      organizationId: "org-1",
+    });
+    resolveRuntime.mockResolvedValue({
+      routing: { provider: "bare" },
+      runtime: { supports: () => false },
+      effectiveTarget: "local",
+      serverId: null,
+    });
+  });
+
+  it("registers the self-app's own loopback dashboard route when isSelfApp is set", async () => {
+    await reapplyProjectLiveRoutes(project, [], { isSelfApp: true });
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0][1].registers).toEqual([
+      { hostname: "panel.example.com", targetUrl: "http://127.0.0.1:3001", isCustomDomain: false },
+    ]);
+  });
+
+  it("still refuses the same loopback dashboard route for an ordinary tenant project", async () => {
+    await reapplyProjectLiveRoutes(project, []);
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0][1].registers).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Exempt the self-app (control plane) from the reserved-loopback-port route guard in `reapplyProjectLiveRoutes`, so its own domain can route to its dashboard port on `127.0.0.1`.
- Add an opt-in `isSelfApp` option plus a pure `shouldRefuseLoopbackRoute` predicate that reuses the existing `isLoopbackHost` / `isReservedLoopbackPort` helpers.
- Wire the two authoritative self-deploy call sites (`provisionSelfAppEdge` and the adopt-reconcile timer) to pass `{ isSelfApp: true }`; no other caller does.
- Add regression coverage that drives the real bare-adopt `resolveTargetUrl` branch, not just the predicate.

Fixes #129

## Root cause

`reapplyProjectLiveRoutes` refuses any public route whose resolved upstream is a reserved control-plane port on loopback — the admin API (`env.PORT`), the dashboard (`3001`), or the unauthenticated OpenResty mgmt port (`9145`) — so an internal service is never exposed to the internet. That guard is correct for tenant projects, but the self-app legitimately routes its own hostname to its dashboard port on `127.0.0.1`. Every self-app boot and reconcile hit the guard, logged `refusing reserved loopback upstream port 3001 for a public route`, and never registered the route — so OpenResty never created the vhost/ACME-challenge location, the cert never issued, and 443 never bound. The domain was unreachable regardless of its name.

The exemption is deliberately **not** derived from `project.appTemplateId`: that field is client-writable through the ordinary create/update project APIs, so keying off it would let any project forge past the guard. The flag is opt-in per call site and only self-deploy.ts sets it.

## Tests

- `bun run --cwd apps/api test test/modules/domains/project-route.service.test.ts` — 10 passed (RED without the fix: the self-app case registers `[]`; GREEN with it: registers `http://127.0.0.1:3001`, tenant case still refused).
- `bun run --cwd apps/api lint` (`tsc --noEmit`) — clean.
- Both run twice, clean.

## Note on live reproduction

`provisionSelfAppEdge` (the 80/443 takeover + ACME issuance) is `isLinuxRoot()`-gated, so the live cert/443 surface can't run on macOS on any arch. The added behavioral test is the faithful offline proxy — it exercises the same `resolveTargetUrl` branch that failed on the reporter's Linux host. The Redis `ECONNREFUSED` line in the report is a separate concern (cache/jobs/rate-limit, all with fallbacks) and is out of scope here.
