### PR TITLE
fix(api): honor compose long-form volume `read_only` (:ro)

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -206,7 +206,10 @@ function parseVolumes(vols: unknown, env: Record<string, string>): string[] {
       const vol = v as Record<string, unknown>;
       const src = vol.source ?? vol.name;
       const tgt = vol.target;
-      if (src && tgt) return `${src}:${tgt}`;
+      // Long form carries read-only intent as a separate `read_only: true`
+      // field; fold it back into the ":ro" mode suffix the short form spells.
+      const mode = vol.read_only === true ? ":ro" : "";
+      if (src && tgt) return `${src}:${tgt}${mode}`;
       if (tgt) return String(tgt);
     }
     return String(v);

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -352,6 +352,28 @@ services:
     ]);
   });
 
+  it("folds long-form `read_only: true` into a :ro bind (read-only intent survives)", () => {
+    const parsed = parseComposeFile(`
+services:
+  app:
+    image: nginx
+    volumes:
+      - type: bind
+        source: /host/config
+        target: /etc/nginx/conf.d
+        read_only: true
+      - type: volume
+        source: cache
+        target: /var/cache
+`);
+    // read_only must produce the ":ro" suffix downstream honors — dropping it
+    // would create a writable mount despite the config declaring read-only.
+    expect(parsed.services[0]?.volumes).toEqual([
+      "/host/config:/etc/nginx/conf.d:ro",
+      "cache:/var/cache",
+    ]);
+  });
+
   it("throws on invalid YAML (callers wrap in try/catch)", () => {
     // parseComposeFile is expected to throw on syntax errors. The caller in
     // prepare.service.ts swallows the error and continues without services.


### PR DESCRIPTION
The compose parser reads volumes in both the short-string form (`- ./x:/y:ro`) and the long object form (`type/source/target/read_only`). The long form dropped the `read_only` field, so a service that declared a **read-only** mount was materialized **read-write**.

## Problem

```yaml
services:
  app:
    image: nginx
    volumes:
      - type: bind
        source: /host/config
        target: /etc/nginx/conf.d
        read_only: true
```

| | volume spec produced |
|---|---|
| **Expected** | `/host/config:/etc/nginx/conf.d:ro` |
| **Actual** | `/host/config:/etc/nginx/conf.d` &nbsp;(writable) |

The `:ro` suffix is **not** cosmetic — it is honored end to end. `scopeVolumeBinds` (in `packages/adapters/src/runtime/volume-namespace.ts`) explicitly preserves the trailing `:(ro|rw|z|Z|nocopy)` mode, and the string lands in Docker's `HostConfig.Binds`, where `:ro` makes the bind read-only. The short-form spelling already carries `:ro` verbatim (and there's a test pinning that). So the two spellings of the *same* intent produced different mounts — and for read-only, the long form silently granted write access to a host path the user meant to protect.

## Cause

In `parseVolumes` (`apps/api/src/lib/compose-parser.ts`), the long-form object branch emitted only `` `${src}:${tgt}` `` and never looked at `read_only`.

## Fix

Fold `read_only: true` back into the `:ro` mode suffix — mirroring how the adjacent `parsePorts` already folds the long-form `protocol:` field back into the `/udp` suffix so the string form stays lossless. One line of behavior:

```ts
const mode = vol.read_only === true ? ":ro" : "";
if (src && tgt) return `${src}:${tgt}${mode}`;
```

## Tests

Added a regression case (`folds long-form read_only: true into a :ro bind`) asserting the long-form bind compiles to `…:ro` while a plain long-form volume stays unchanged. I verified it **fails without the source change** (produces the writable `/host/config:/etc/nginx/conf.d`) and passes with it.

- `bun run test` → all 5 turbo tasks successful (api: 720 passed, 3 skipped).
- `bun run --cwd apps/api lint` → clean.
- Touched files: only my added lines checked against `prettier`; the file carries pre-existing drift on `main`, so per CONTRIBUTING I hand-formatted rather than running `--write` over unrelated lines.

Scope note: I only handled `read_only` in the `source`+`target` case, where a bind/named mount can meaningfully be read-only and the string form supports a mode suffix. An anonymous long-form volume (bare `target:` only) is left as-is. Happy to extend if you'd prefer.