### PR TITLE
fix(cli): let `openship logs` run without a deployment ID

### DIFF
--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -1,8 +1,11 @@
 /**
- * `openship logs <deploymentId>` — deployment logs.
+ * `openship logs [deploymentId]` — deployment logs.
  *
  *   default:   GET /api/deployments/:id/logs  → { data: LogEntry[] } (snapshot)
  *   --follow:  GET /api/deployments/:id/stream → SSE build-session stream
+ *
+ * With no deploymentId, resolve the latest deployment of the linked project so
+ * the command the CLI suggests after a failed deploy works without an ID.
  *
  * (deployment.controller.ts:logs / stream)
  */
@@ -10,6 +13,7 @@ import { Command } from "commander";
 import { apiRequest, ApiError } from "../lib/api-client";
 import { streamDeploymentLogs } from "../lib/deploy-stream";
 import { isJsonMode, printJson, err } from "../lib/output";
+import { readProjectLink } from "../lib/project-link";
 
 interface LogEntry {
   message?: string;
@@ -17,12 +21,43 @@ interface LogEntry {
   timestamp?: string;
 }
 
+/**
+ * Latest deployment ID for the linked project, or null if the directory isn't
+ * linked or the project has no deployments. The list endpoint returns rows
+ * newest-first, so the first row is the most recent deployment.
+ */
+async function resolveLatestDeploymentId(): Promise<string | null> {
+  const projectId = readProjectLink()?.projectId;
+  if (!projectId) return null;
+  const res = await apiRequest<{ data?: { id: string }[] }>(
+    `/deployments?projectId=${encodeURIComponent(projectId)}&perPage=1`,
+  );
+  return res.data?.[0]?.id ?? null;
+}
+
 export const logsCommand = new Command("logs")
   .description("View or stream a deployment's logs")
-  .argument("<deploymentId>", "Deployment ID")
+  .argument("[deploymentId]", "Deployment ID (defaults to the latest deployment of the linked project)")
   .option("-f, --follow", "Stream live logs via SSE until the deployment finishes")
   .option("--tail <n>", "Show only the last N log lines (snapshot mode)")
-  .action(async (deploymentId: string, opts) => {
+  .action(async (deploymentIdArg: string | undefined, opts) => {
+    let deploymentId = deploymentIdArg;
+    if (!deploymentId) {
+      try {
+        deploymentId = (await resolveLatestDeploymentId()) ?? undefined;
+      } catch (e) {
+        err(e instanceof ApiError ? e.message : String(e));
+        process.exit(1);
+      }
+      if (!deploymentId) {
+        err(
+          "No deployment ID given and none could be resolved. Pass one explicitly " +
+            "(openship logs <deploymentId>), or run inside a linked project directory.",
+        );
+        process.exit(1);
+      }
+    }
+
     if (opts.follow) {
       try {
         const result = await streamDeploymentLogs(deploymentId);

--- a/apps/cli/src/commands/wizard.ts
+++ b/apps/cli/src/commands/wizard.ts
@@ -602,7 +602,7 @@ export async function runWizard(): Promise<void> {
     if (reason && /lock/i.test(reason)) {
       log.info("The database is locked by another instance — run `openship stop`, then re-run `openship`.");
     } else {
-      log.info("Check logs: `openship logs` (or `openship up --foreground`).");
+      log.info("Run `openship up --foreground` to run it attached and see the error.");
     }
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

- Make `openship logs`'s `deploymentId` optional; when it is omitted, resolve the latest deployment of the linked project via the existing `GET /deployments?projectId=…&perPage=1` (rows come back newest-first).
- When the directory isn't linked or the project has no deployments, print one clear, actionable line instead of commander's cryptic `missing required argument` error.
- Stop the setup wizard from pointing service-startup failures at `openship logs` — a deployment-logs command that needs an ID and a reachable API, neither of which exists when the service itself never came up.

Fixes #126

## Root cause

**`openship logs` (issue 1).** The command declared a required positional argument (`.argument("<deploymentId>")`), so running it bare exited with `error: missing required argument 'deploymentId'`. That is the exact command the CLI hands users after a failed deploy, and after a service-health timeout the wizard printed `Check logs: openship logs` — pointing straight at a command that can't run without an ID. Two defects fed one dead-end: the command had no default, and the wizard suggested it for a failure it can't diagnose (a *deployment*-logs fetch against an API that is down, for a deployment that doesn't exist).

The fix addresses both remedies the issue lists: `openship logs` now works without a manual ID (resolving the most recent deployment), and the wizard's service-health hint now recommends `openship up --foreground` — matching the sibling failure path a few lines up, which already tells users to run the service attached to surface the error.

**OAuth callback 404 (issue 2) — already resolved.** This was the pre-`mode=device` connect flow: the CLI spun up a loopback callback server on the box and had the browser navigate back to it after authorizing. On a headless server reached over SSH, the laptop browser can't reach that callback, so the redirect 404s. The connect flow was rewritten to device/poll in v0.2.3 (`aba463e`): no browser→box redirect, the CLI polls the SaaS for the PKCE-locked code, and `/cloud-authorize` confirms in place when `mode=device`. No change needed here; called out for completeness so the issue can close.

## Tests

The CLI has no automated test suite (adding a framework is out of scope for this fix), so this is verified by building the CLI and reproducing the reported failure against the committed change:

- Before: `openship logs` → `error: missing required argument 'deploymentId'`.
- After: `openship logs` (no linked project) → `No deployment ID given and none could be resolved. Pass one explicitly (openship logs <deploymentId>), or run inside a linked project directory.`; `openship logs --help` shows `[deploymentId]` as optional.
- `bun run --cwd apps/cli lint` (`tsc --noEmit`) — clean, run twice.

## Commits

- `fix(cli): resolve the latest deployment when openship logs gets no ID` — the command fix (`apps/cli/src/commands/logs.ts`).
- `fix(cli): stop pointing service-health failures at openship logs` — the wizard hint (`apps/cli/src/commands/wizard.ts`).
