### PR TITLE
fix(api): honor compose long-form port `host_ip` bind interface

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -133,8 +133,19 @@ function parsePorts(ports: unknown, env: Record<string, string>): string[] {
       // fold it back into the "/proto" suffix so the string form is lossless.
       const proto = typeof port.protocol === "string" ? port.protocol.toLowerCase() : undefined;
       const suffix = proto && proto !== "tcp" ? `/${proto}` : "";
+      // Long form carries the bind interface as a separate `host_ip` field;
+      // fold it back into the leading "<ip>:" segment the short form spells.
+      const hostIp =
+        typeof port.host_ip === "string" ? interpolateComposeString(port.host_ip, env) : undefined;
       if (target) {
-        return published ? `${published}:${target}${suffix}` : `${target}${suffix}`;
+        const hostPart = published
+          ? hostIp
+            ? `${hostIp}:${published}:`
+            : `${published}:`
+          : hostIp
+            ? `${hostIp}::`
+            : "";
+        return `${hostPart}${target}${suffix}`;
       }
     }
     return String(p);

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -305,6 +305,47 @@ services:
     expect(parsed.services[0]?.ports).toEqual(["80:80", "443:443"]);
   });
 
+  it("folds long-form `host_ip` into the leading `<ip>:` (loopback publish stays private)", () => {
+    const parsed = parseComposeFile(`
+services:
+  db:
+    image: postgres
+    ports:
+      - target: 5432
+        host_ip: 127.0.0.1
+        published: 5432
+      - target: 80
+        host_ip: 127.0.0.1
+        published: 8080
+        protocol: tcp
+`);
+    // Dropping host_ip would collapse these to "5432:5432" / "8080:80", which
+    // bind 0.0.0.0 — publishing to the whole internet a service the config
+    // pinned to loopback. The ip must survive as the leading short-form segment
+    // that the docker runtime honors ("127.0.0.1:8080:80").
+    expect(parsed.services[0]?.ports).toEqual(["127.0.0.1:5432:5432", "127.0.0.1:8080:80"]);
+  });
+
+  it("keeps host_ip when published is omitted, and omits it when absent", () => {
+    const parsed = parseComposeFile(`
+services:
+  x:
+    image: nginx
+    ports:
+      - target: 80
+        host_ip: 127.0.0.1
+      - target: 443
+        published: 8443
+      - target: 53
+        host_ip: 0.0.0.0
+        published: 53
+        protocol: udp
+`);
+    // host_ip with no published → ip-scoped random host port ("127.0.0.1::80");
+    // published with no host_ip → unchanged; protocol suffix still applies.
+    expect(parsed.services[0]?.ports).toEqual(["127.0.0.1::80", "8443:443", "0.0.0.0:53:53/udp"]);
+  });
+
   it("extracts depends_on as array", () => {
     const parsed = parseComposeFile(`
 services:


### PR DESCRIPTION
## Problem

The Docker Compose long-form port parser (`parsePorts` in `apps/api/src/lib/compose-parser.ts`) reads `published`/`host_port` and `protocol`, but **silently drops `host_ip`**. A port pinned to a specific interface via long form is flattened to a bare `<published>:<target>`, and the docker runtime binds that to `0.0.0.0` — publishing on **every interface** a service the config explicitly meant to keep private.

This is a data-exposure bug: the canonical way to keep a database/admin port on localhost in compose long form is `host_ip: 127.0.0.1`, and the intent is dropped.

| compose long form | parsed (before) | parsed (after) | short form the runtime honors |
|---|---|---|---|
| `target: 5432, host_ip: 127.0.0.1, published: 5432` | `5432:5432` ❌ (0.0.0.0) | `127.0.0.1:5432:5432` ✅ | loopback-only publish |
| `target: 80, host_ip: 127.0.0.1, published: 8080, protocol: tcp` | `8080:80` ❌ | `127.0.0.1:8080:80` ✅ | loopback-only publish |
| `target: 80, host_ip: 127.0.0.1` (no `published`) | `80` ❌ | `127.0.0.1::80` ✅ | IP-scoped random host port |
| `target: 443, published: 8443` (no `host_ip`) | `8443:443` | `8443:443` (unchanged) | — |

Reproduced against the real parser:

```
parsed ports: ["5432:5432","8080:80"]        // before
expected     : ["127.0.0.1:5432:5432","127.0.0.1:8080:80"]
```

## Cause

`parsePorts` only ever looked at `target`/`container_port`, `published`/`host_port`, and `protocol`. The `host_ip` field of the [compose long-form port spec](https://docs.docker.com/reference/compose-file/services/#ports) was never consulted, so it never made it into the emitted short-form string.

## Fix

Fold `host_ip` back into the leading `<ip>:` segment that the short form spells and that the runtime's `parsePortBindings` (in `packages/adapters/src/runtime/docker.ts`) **already** parses — its own comment documents `"127.0.0.1:8080:80"` as "a loopback-only publish". When `published` is omitted, emit the IP-scoped random-host-port form `<ip>::<target>`, which `parsePortBindings` also handles (`HostIp` set, empty `HostPort`). `host_ip` is interpolated like every other string field. Non-`host_ip` specs are byte-for-byte unchanged.

## Tests

Added two regression tests to `apps/api/test/lib/compose-parser.test.ts`:
- `host_ip` + `published` (+ `protocol`) → `127.0.0.1:5432:5432` / `127.0.0.1:8080:80` — proves the loopback pin survives.
- `host_ip` without `published` → `127.0.0.1::80`; `published` without `host_ip` → unchanged; `protocol` suffix preserved.

**Verified they fail without the fix** (with the source change stashed, the new asserts produce `"80"` / `"53:53/udp"` instead of the IP-scoped strings), and pass with it.

## Full-suite result

- `bun run test` → **5 tasks successful** (api 721 passed | 3 skipped; core 103; adapters 243; db 25; dashboard 17).
- `bun run --cwd apps/api lint` (tsc) → clean.
- Touched files respect the pre-existing prettier drift in `compose-parser.ts` — only my added lines were hand-formatted to prettier's style; no unrelated churn.

Note: this is a distinct, non-overlapping hunk from my open #133 (which fixes long-form **volume** `read_only` in the same file's `parseVolumes`); they touch different functions and merge cleanly.