### PR TITLE
fix(core): drop conditional (has/missing) vercel.json header rules

### DIFF
--- a/packages/core/src/metadata/vercel.ts
+++ b/packages/core/src/metadata/vercel.ts
@@ -82,7 +82,10 @@ function parseHeaders(value: unknown): DeploymentHeaderRule[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const rules: DeploymentHeaderRule[] = [];
   for (const entry of value) {
-    if (!entry || typeof entry !== "object") continue;
+    // Like rewrites/redirects, a `has`/`missing` rule can't be reproduced by a
+    // plain nginx location — emitting its headers would apply them to EVERY
+    // request, not just the matching ones — so drop it rather than mis-apply it.
+    if (!entry || typeof entry !== "object" || isConditional(entry)) continue;
     const e = entry as { source?: unknown; headers?: unknown };
     if (typeof e.source !== "string" || !Array.isArray(e.headers)) continue;
     const headers: { key: string; value: string }[] = [];

--- a/packages/core/test/vercel-conditional-headers.test.ts
+++ b/packages/core/test/vercel-conditional-headers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { parseVercelConfig } from "../src/metadata/vercel";
+
+// Vercel's `headers` rules — like `redirects` and `rewrites` — support `has` and
+// `missing` conditions (match only when a header/cookie/host/query is present or
+// absent). openship reproduces routing with plain nginx locations, which can't
+// express those conditions, so a conditional rule must be DROPPED. Applying its
+// headers anyway would set them on EVERY request, not just the matching ones.
+//
+// parseRewrites/parseRedirects already skip conditional entries; parseHeaders did
+// not, so a `has`/`missing` header rule leaked through and was later emitted as an
+// unconditional `add_header … always;`.
+
+describe("vercel.json conditional header rules", () => {
+  it("drops a `has`-conditioned header rule", () => {
+    const cfg = parseVercelConfig(
+      JSON.stringify({
+        headers: [
+          {
+            source: "/(.*)",
+            has: [{ type: "host", value: "admin.example.com" }],
+            headers: [{ key: "X-Admin", value: "1" }],
+          },
+        ],
+      }),
+    );
+    // No unconditional-safe header rules remain → `headers` is absent entirely.
+    expect(cfg?.headers).toBeUndefined();
+  });
+
+  it("drops a `missing`-conditioned header rule", () => {
+    const cfg = parseVercelConfig(
+      JSON.stringify({
+        headers: [
+          {
+            source: "/(.*)",
+            missing: [{ type: "cookie", key: "session" }],
+            headers: [{ key: "X-Anon", value: "1" }],
+          },
+        ],
+      }),
+    );
+    expect(cfg?.headers).toBeUndefined();
+  });
+
+  it("keeps an unconditional header rule and drops the conditional one alongside it", () => {
+    const cfg = parseVercelConfig(
+      JSON.stringify({
+        headers: [
+          {
+            source: "/(.*)",
+            has: [{ type: "query", key: "authorized" }],
+            headers: [{ key: "X-Authorized", value: "true" }],
+          },
+          {
+            source: "/assets/(.*)",
+            headers: [{ key: "Cache-Control", value: "public, max-age=31536000" }],
+          },
+        ],
+      }),
+    );
+    expect(cfg?.headers).toEqual([
+      {
+        source: "/assets/(.*)",
+        headers: [{ key: "Cache-Control", value: "public, max-age=31536000" }],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

A `vercel.json` `headers` rule can carry `has`/`missing` conditions — matching only when a header, cookie, host, or query is present/absent — exactly like `redirects` and `rewrites`. openship reproduces routing with plain nginx `location` blocks, which can't express those conditions, so the parser's own `isConditional` helper (with `parseRewrites`/`parseRedirects`) deliberately **drops** conditional rules rather than mis-apply them.

`parseHeaders` was missing that guard. A conditional header rule leaked through and was later emitted as an **unconditional** `add_header … always;` (via `vercel-routing.ts` → `nginx.ts` / `oblien-routing.ts`), so the header landed on **every** request instead of only the matching ones.

| `vercel.json` headers rule | Expected | Actual (before fix) |
|---|---|---|
| `{ source: "/(.*)", has: [{type:"host", value:"admin.example.com"}], headers: [{key:"X-Admin", value:"1"}] }` | dropped (can't reproduce the host condition) | `X-Admin: 1` added to **all** hosts |
| `{ source: "/(.*)", missing: [{type:"cookie", key:"session"}], headers: [{key:"X-Anon", value:"1"}] }` | dropped | `X-Anon: 1` added to **all** requests, session or not |

For redirects/rewrites the same input is already correctly dropped — headers were the lone inconsistency.

## Cause

```ts
// parseRedirects — guards conditional:
if (!entry || typeof entry !== "object" || isConditional(entry)) continue;
// parseHeaders — did NOT:
if (!entry || typeof entry !== "object") continue;
```

## Fix

One line: skip conditional entries in `parseHeaders` too, mirroring `parseRedirects`.

## Tests

Adds `packages/core/test/vercel-conditional-headers.test.ts`:
- a `has`-conditioned rule is dropped,
- a `missing`-conditioned rule is dropped,
- a mixed list keeps the unconditional rule and drops the conditional one.

Verified all three **fail without** the source change (`git stash` the src file → 3 failed) and **pass with** it.

## Verification

- `bun run test` → all 5 turbo tasks green (729 api passing, 104 core passing).
- `bun run --cwd apps/api lint` (tsc) → clean.
- The touched source file has **pre-existing** prettier drift on `origin/main` (unrelated lines 71-76 / 191-192); left untouched per CONTRIBUTING's no-churn guidance. My added lines are prettier-clean, and the new test file is clean.