### PR TITLE
fix(api): honor compose long-form volume `selinux`/`nocopy` mode

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -217,9 +217,22 @@ function parseVolumes(vols: unknown, env: Record<string, string>): string[] {
       const vol = v as Record<string, unknown>;
       const src = vol.source ?? vol.name;
       const tgt = vol.target;
-      // Long form carries read-only intent as a separate `read_only: true`
-      // field; fold it back into the ":ro" mode suffix the short form spells.
-      const mode = vol.read_only === true ? ":ro" : "";
+      // Long form carries read-only/selinux/nocopy intent as separate nested
+      // fields; fold them back into the single mode suffix the short-form
+      // string spells (the downstream MODE_SUFFIX regex in volume-namespace.ts
+      // only matches ONE flag, no combining — so read_only wins when more than
+      // one is set, since silently granting write access is the worse miss).
+      const bindOpts = vol.bind as Record<string, unknown> | undefined;
+      const volumeOpts = vol.volume as Record<string, unknown> | undefined;
+      const selinux = typeof bindOpts?.selinux === "string" ? bindOpts.selinux : undefined;
+      const mode =
+        vol.read_only === true
+          ? ":ro"
+          : volumeOpts?.nocopy === true
+            ? ":nocopy"
+            : selinux === "z" || selinux === "Z"
+              ? `:${selinux}`
+              : "";
       if (src && tgt) return `${src}:${tgt}${mode}`;
       if (tgt) return String(tgt);
     }

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -415,6 +415,29 @@ services:
     ]);
   });
 
+  it("folds long-form `bind.selinux` and `volume.nocopy` into their mode suffix", () => {
+    const parsed = parseComposeFile(`
+services:
+  app:
+    image: nginx
+    volumes:
+      - type: bind
+        source: /host/data
+        target: /data
+        bind:
+          selinux: Z
+      - type: volume
+        source: cache
+        target: /cache
+        volume:
+          nocopy: true
+`);
+    // Dropping these would collapse both to their bare "source:target" — the
+    // MODE_SUFFIX regex downstream (volume-namespace.ts) already recognizes
+    // z/Z/nocopy, same as :ro; the long form just never emitted them.
+    expect(parsed.services[0]?.volumes).toEqual(["/host/data:/data:Z", "cache:/cache:nocopy"]);
+  });
+
   it("throws on invalid YAML (callers wrap in try/catch)", () => {
     // parseComposeFile is expected to throw on syntax errors. The caller in
     // prepare.service.ts swallows the error and continues without services.


### PR DESCRIPTION
## Problem

The compose parser reads volumes in both the short-string form (`- ./x:/y:Z`) and the long object form (`type/source/target/...`). #133 taught `parseVolumes` the long-form `read_only` field, but the two other mode-bearing long-form fields are still dropped:

- `bind.selinux: z | Z` — the SELinux relabel flag
- `volume.nocopy: true` — skip copying the image's existing content into a fresh named volume

```yaml
services:
  app:
    image: nginx
    volumes:
      - type: bind
        source: /host/data
        target: /data
        bind:
          selinux: Z          # relabel so the container can access it
      - type: volume
        source: cache
        target: /cache
        volume:
          nocopy: true        # don't seed the volume from the image
```

| compose long form | parsed (before) | parsed (after) |
|---|---|---|
| `bind.selinux: Z` | `/host/data:/data` ❌ | `/host/data:/data:Z` ✅ |
| `volume.nocopy: true` | `cache:/cache` ❌ | `cache:/cache:nocopy` ✅ |

Same class of bug #133/#135 fixed: the long form silently loses intent the short form carries. Without the relabel a bind mount can be inaccessible to the container under SELinux; without `nocopy` a fresh named volume is seeded from the image instead of staying empty.

## Cause

In `parseVolumes` (`apps/api/src/lib/compose-parser.ts`) the long-form object branch only folded `read_only` into the mode suffix. `bind.selinux` and `volume.nocopy` — both nested one level under the volume entry — were never read, so they never reached the emitted `source:target[:mode]` string.

## Fix

Fold `bind.selinux` (`z`/`Z`) and `volume.nocopy: true` into the same single mode suffix that `read_only` already targets. The `:mode` suffix is honored end to end: `scopeVolumeBinds` (`packages/adapters/src/runtime/volume-namespace.ts`) already preserves the trailing `:(ro|rw|z|Z|nocopy)` when scoping named volumes, and the string lands in Docker's `HostConfig.Binds`, which recognizes all of those flags.

```ts
const bindOpts = vol.bind as Record<string, unknown> | undefined;
const volumeOpts = vol.volume as Record<string, unknown> | undefined;
const selinux = typeof bindOpts?.selinux === "string" ? bindOpts.selinux : undefined;
const mode =
  vol.read_only === true
    ? ":ro"
    : volumeOpts?.nocopy === true
      ? ":nocopy"
      : selinux === "z" || selinux === "Z"
        ? `:${selinux}`
        : "";
```

`MODE_SUFFIX` matches exactly one flag (no combining), so when more than one is set `read_only` wins — silently granting write access is the worse miss.

## Tests

Added one regression case (`folds long-form bind.selinux and volume.nocopy into their mode suffix`) asserting a `selinux: Z` bind compiles to `…:Z` and a `nocopy: true` volume to `…:nocopy`. **Verified it fails without the source change** (produces the bare `/host/data:/data` / `cache:/cache`) and passes with it.

- `npx vitest run` in `apps/api` → **58 files, 730 passed | 3 skipped** (two separate clean runs).
- `tsc --noEmit` → no `compose-parser` type errors.
- Touched-file scope only; no unrelated churn.

## Scope

Third in the long-form volume-mode series, on top of merged #133 (`read_only`) and #135 (`host_ip`); non-overlapping hunk in the same `parseVolumes` branch. Only the `source`+`target` case gets a mode suffix — an anonymous long-form volume (bare `target:`) is left as-is, matching #133.
