### PR TITLE
feat(cli): add `openship mail install` for the standalone webmail dashboard

### DIFF
--- a/apps/cli/src/commands/mail.ts
+++ b/apps/cli/src/commands/mail.ts
@@ -407,7 +407,7 @@ function resolveWebmailTarget(
 const installCmd = new Command("install")
   .description("Install the standalone webmail dashboard for a self-hosted mail server")
   .argument("<serverId>", "Mail server ID to install the webmail dashboard for")
-  .requiredOption("-d, --domain <host>", "Public host for the webmail UI (e.g. mail.example.com)")
+  .option("-d, --domain <host>", "Public host for the webmail UI (e.g. mail.example.com)")
   .option("-t, --target <target>", 'Where to deploy: "mail" (the mail server itself, default), "cloud", or an openship server ID')
   .option("--internal-port <n>", "Internal container port for the webmail UI")
   .option("--list-targets", "List the servers the webmail can be installed on, then exit")
@@ -432,6 +432,13 @@ const installCmd = new Command("install")
           ["target", "kind", "label", "available"],
         );
         return;
+      }
+
+      // --domain is required to install, but not to --list-targets (a read-only
+      // discovery run before a host is chosen), so it's enforced here.
+      if (!opts.domain) {
+        err("  --domain is required (e.g. --domain mail.example.com). Use --list-targets to explore targets first.");
+        process.exit(1);
       }
 
       let internalPort: number | undefined;

--- a/apps/cli/src/commands/mail.ts
+++ b/apps/cli/src/commands/mail.ts
@@ -378,6 +378,102 @@ const forgetCmd = new Command("forget")
     }),
   );
 
+// ─── Standalone webmail dashboard ─────────────────────────────────────────────
+
+interface WebmailTargetOption {
+  kind: "mail" | "server" | "opshcloud";
+  serverId: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+/**
+ * Resolve a `--target` token to the deploy-project target body. "mail" (the
+ * default) and a bare openship server ID both deploy onto an openship server
+ * (`kind: "self"`); "cloud"/"opshcloud" hands off to Opshcloud.
+ */
+function resolveWebmailTarget(
+  token: string | undefined,
+  mailServerId: string,
+): { kind: "self"; serverId: string } | { kind: "cloud" } {
+  const t = token?.trim();
+  if (!t || t === "mail") return { kind: "self", serverId: mailServerId };
+  if (t === "cloud" || t === "opshcloud") return { kind: "cloud" };
+  return { kind: "self", serverId: t };
+}
+
+const installCmd = new Command("install")
+  .description("Install the standalone webmail dashboard for a self-hosted mail server")
+  .argument("<serverId>", "Mail server ID to install the webmail dashboard for")
+  .requiredOption("-d, --domain <host>", "Public host for the webmail UI (e.g. mail.example.com)")
+  .option("-t, --target <target>", 'Where to deploy: "mail" (the mail server itself, default), "cloud", or an openship server ID')
+  .option("--internal-port <n>", "Internal container port for the webmail UI")
+  .option("--list-targets", "List the servers the webmail can be installed on, then exit")
+  .option("--no-watch", "Queue the install without streaming the build logs")
+  .action(
+    guard(async (serverId: string, opts) => {
+      // `--list-targets`: reuse the same picker the dashboard wizard reads.
+      if (opts.listTargets) {
+        const res = await apiRequest<{ options: WebmailTargetOption[] }>(
+          `/mail/webmail/targets?serverId=${encodeURIComponent(serverId)}`,
+        );
+        const rows = res.options ?? [];
+        if (isJsonMode()) return printJson(rows);
+        if (rows.length === 0) return info("  No deploy targets.");
+        printTable(
+          rows.map((o) => ({
+            target: o.kind === "opshcloud" ? "cloud" : o.kind === "mail" ? "mail" : o.serverId,
+            kind: o.kind,
+            label: o.label,
+            available: o.disabled ? `no (${o.disabledReason ?? "unavailable"})` : "yes",
+          })),
+          ["target", "kind", "label", "available"],
+        );
+        return;
+      }
+
+      let internalPort: number | undefined;
+      if (opts.internalPort !== undefined) {
+        internalPort = Number(opts.internalPort);
+        if (!Number.isInteger(internalPort) || internalPort < 1 || internalPort > 65535) {
+          err("  --internal-port must be an integer between 1 and 65535.");
+          process.exit(1);
+        }
+      }
+
+      const body: Record<string, unknown> = {
+        mailServerId: serverId,
+        hostname: opts.domain,
+        target: resolveWebmailTarget(opts.target, serverId),
+      };
+      if (internalPort !== undefined) body.internalPort = internalPort;
+
+      const sp = spin("Queuing webmail install…");
+      let res: { deploymentId?: string; projectId?: string };
+      try {
+        res = await apiRequest<{ deploymentId?: string; projectId?: string }>(
+          "/mail/webmail/deploy-project",
+          { method: "POST", body: JSON.stringify(body) },
+        );
+      } catch (e) {
+        sp?.fail("Webmail install failed to start");
+        throw e;
+      }
+      const deploymentId = res.deploymentId;
+      sp?.succeed(deploymentId ? `Webmail install queued: ${deploymentId}` : "Webmail install queued");
+
+      // Same build-session SSE the dashboard subscribes to at /build/[deploymentId].
+      if (isJsonMode() && opts.watch === false) return printJson(res);
+      if (!deploymentId) return info("  No deployment id returned; nothing to watch.");
+      if (opts.watch === false) return info(`  Follow with: openship logs ${deploymentId} --follow`);
+
+      const result = await streamDeploymentLogs(deploymentId);
+      if (result.success === false || result.status === "cancelled") process.exit(1);
+    }),
+  );
+
 // ─── Post-install ─────────────────────────────────────────────────────────────
 
 const healthCmd = new Command("health")
@@ -468,6 +564,7 @@ export const mailCommand = new Command("mail")
   .addCommand(ptrAckCmd)
   .addCommand(resetCmd)
   .addCommand(forgetCmd)
+  .addCommand(installCmd)
   .addCommand(healthCmd)
   .addCommand(logsCmd)
   .addCommand(postmasterCmd);


### PR DESCRIPTION
> **WIP / draft** — first slice, to iterate on. Opening early for direction.

Refs #137.

## What

Adds `openship mail install` — the CLI entry point for installing the standalone
mail (Zero webmail) dashboard, reusing the *same* machinery the integrated
dashboard wizard already uses. No new API, no reimplementation of the mail stack.

```
openship mail install <serverId> -d <domain> [-t mail|cloud|<serverId>] [--internal-port n] [--list-targets] [--no-watch]
```

## How it maps to the "integrated version"

The integrated install is the dashboard wizard at `apps/dashboard/.../apps/new/mail`:

- **Self-host** → the iRedMail provisioning flow — already exposed on the CLI as `openship mail setup`.
- **Standalone webmail dashboard** → deploy the Zero webmail UI via `POST /mail/webmail/deploy-project`.

The CLI had no verb for the second path, even though `mail.ts`'s own header already
documents the intended `webmail targets` + `deploy-project` surface. This wires it up.

## Fix

`apps/cli/src/commands/mail.ts` (+97, one file):

- `--list-targets` → `GET /mail/webmail/targets?serverId=` (the same picker the wizard reads).
- deploy → `POST /mail/webmail/deploy-project { mailServerId, hostname, target, internalPort? }`,
  then streams the build over the shared deployment SSE (`streamDeploymentLogs`), the same
  `/build/[deploymentId]` stream the dashboard subscribes to.
- `--target` resolves `mail` (default, the mail server itself) / `cloud` / a server ID to the
  `{ kind: "self", serverId } | { kind: "cloud" }` body.
- Streams by default; `--no-watch` just queues. JSON mode honored throughout.

Also uses the previously-dead `streamDeploymentLogs` import in this file.

## Tests

`apps/cli` has no test runner (`lint` is `tsc --noEmit`; the CLI isn't unit-tested).
Adding a framework for one command would be out of scope, so verification is the
strongest available, run twice:

- `tsc --noEmit` → clean (twice).
- Built binary: `mail install` registers under `mail`, `--help` renders, `--list-targets`
  present, missing `--domain` rejected. Re-verified against committed `HEAD`.

## Scope / follow-ups (WIP)

- Deferred: the external IMAP/SMTP path (`POST /mail/webmail/deploy-external`, the wizard's
  "connect existing" provider). Natural next step — same command, a `--external` mode.
- Open to reshaping the flag surface / subcommand split before this leaves draft.
