### PR TITLE
fix(dashboard): keep clone token visible after save and default toggle

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/settings/_components/CloneCredentials.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/_components/CloneCredentials.tsx
@@ -69,7 +69,7 @@ export function CloneCredentials() {
         // They can toggle off afterward.
         asDefault: state?.asDefault ?? true,
       });
-      setState({ hasToken: next.hasToken, setAt: next.setAt, asDefault: next.asDefault });
+      setState(next.cloneToken);
       setTokenInput("");
       setEditing(false);
       showToast(t.settings.cloneCredentials.toast.saved, "success", t.settings.common.toast.cloneCredentials);
@@ -84,7 +84,7 @@ export function CloneCredentials() {
     setSaving(true);
     try {
       const next = await settingsApi.updateCloneCredentials({ token: null });
-      setState({ hasToken: next.hasToken, setAt: next.setAt, asDefault: next.asDefault });
+      setState(next.cloneToken);
       setTokenInput("");
       setEditing(false);
       showToast(t.settings.cloneCredentials.toast.cleared, "success", t.settings.common.toast.cloneCredentials);
@@ -99,7 +99,7 @@ export function CloneCredentials() {
     setTogglingDefault(true);
     try {
       const updated = await settingsApi.updateCloneCredentials({ asDefault: next });
-      setState({ hasToken: updated.hasToken, setAt: updated.setAt, asDefault: updated.asDefault });
+      setState(updated.cloneToken);
     } catch (err) {
       showToast(getApiErrorMessage(err, t.settings.cloneCredentials.toast.updateDefaultFailed), "error", t.settings.common.toast.cloneCredentials);
     } finally {

--- a/apps/dashboard/src/lib/api/settings.ts
+++ b/apps/dashboard/src/lib/api/settings.ts
@@ -56,10 +56,10 @@ export const settingsApi = {
    *   - asDefault         → whether `resolveCloneToken` should use it
    */
   updateCloneCredentials: (data: { token?: string | null; asDefault?: boolean }) =>
-    api.patch<CloneCredentialsState & { cloneStrategyPreference: CloneStrategyPreference }>(
-      endpoints.settings.cloneCredentials,
-      data,
-    ),
+    api.patch<{
+      cloneToken: CloneCredentialsState;
+      cloneStrategyPreference: CloneStrategyPreference;
+    }>(endpoints.settings.cloneCredentials, data),
 
   /** Save the first-time-deploy nudge choice. */
   updateCloneStrategyPreference: (preference: CloneStrategyPreference) =>


### PR DESCRIPTION
## Summary
Saving or toggling the GitHub clone token in Settings made the saved-token UI disappear until you switched tabs (token was still persisted).

PATCH `/settings/clone-credentials` returns nested `{ cloneToken }`, but the client set state from flat `hasToken` / `setAt` / `asDefault` (always `undefined`).

## Changes
- `CloneCredentials.tsx`: after save / clear / default toggle, `setState(next.cloneToken)`
- `settings.ts`: type `updateCloneCredentials` as the nested response shape

## Test plan
- [x] Settings → Tokens → save a clone token → saved panel stays visible (no tab switch)
- [x] Toggle “Use as default clone token” → panel stays visible
- [x] Switch away from Tokens and back → token still shown