### PR TITLE
fix(dashboard): point self-hosting tutorial links at a live docs page

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/servers/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/servers/page.tsx
@@ -413,7 +413,7 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
           {t.servers.list.addFirstServer}
         </button>
         <a
-          href="https://openship.io/docs/self-hosting"
+          href="https://openship.io/docs/guides/custom-servers"
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 rounded-xl bg-muted/50 px-6 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"

--- a/apps/dashboard/src/app/(onboarding)/onboarding/_components/ssh-step.tsx
+++ b/apps/dashboard/src/app/(onboarding)/onboarding/_components/ssh-step.tsx
@@ -361,7 +361,7 @@ export function SshStep({ state, onUpdate, onNext, onBack }: StepProps) {
 
         <a
           className="ob-tutorial-link"
-          href="https://openship.io/docs/self-hosting"
+          href="https://openship.io/docs/guides/custom-servers"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## Summary
- Fixes #19: `https://openship.io/docs/self-hosting` still 404s (path never existed).
- Updates onboarding SSH step + empty Servers state to `https://openship.io/docs/guides/custom-servers` (verified **200**).

## Verification
```bash
curl -s -o /dev/null -w '%{http_code}\n' -L https://openship.io/docs/self-hosting          # 404
curl -s -o /dev/null -w '%{http_code}\n' -L https://openship.io/docs/guides/custom-servers # 200
```

## Test plan
- [x] Open Self Hosted → Another Server onboarding; “Step-by-step setup tutorial” opens a live docs page
- [x] Empty Servers page “See docs” link opens the same live page