### PR TITLE
fix(cli): add openship up --host for dashboard bind address

### DIFF
--- a/apps/cli/src/commands/up-host.test.ts
+++ b/apps/cli/src/commands/up-host.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for resolveDashboardHost — run with:
+ *   bun test apps/cli/src/commands/up-host.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+import { resolveDashboardHost } from "./up-host";
+
+describe("resolveDashboardHost", () => {
+  test("defaults to loopback when private", () => {
+    expect(resolveDashboardHost({})).toBe("127.0.0.1");
+  });
+
+  test("binds all interfaces with --public-url (no managed edge)", () => {
+    expect(
+      resolveDashboardHost({ publicUrl: "https://ops.example.com" }),
+    ).toBe("0.0.0.0");
+  });
+
+  test("stays on loopback under managed edge (OpenResty fronts it)", () => {
+    expect(
+      resolveDashboardHost({
+        publicUrl: "https://ops.example.com",
+        managedEdge: true,
+      }),
+    ).toBe("127.0.0.1");
+  });
+
+  test("--host overrides public-url / managed-edge defaults", () => {
+    expect(resolveDashboardHost({ host: "0.0.0.0" })).toBe("0.0.0.0");
+    expect(
+      resolveDashboardHost({
+        host: "10.0.0.5",
+        publicUrl: "https://ops.example.com",
+        managedEdge: true,
+      }),
+    ).toBe("10.0.0.5");
+  });
+
+  test("trims explicit host", () => {
+    expect(resolveDashboardHost({ host: "  0.0.0.0  " })).toBe("0.0.0.0");
+  });
+});

--- a/apps/cli/src/commands/up-host.ts
+++ b/apps/cli/src/commands/up-host.ts
@@ -1,0 +1,19 @@
+/**
+ * Resolve the dashboard listen address for Next.js `HOSTNAME`.
+ *
+ * Homelab reverse proxies need an explicit bind when there is no public URL —
+ * default remains loopback; `--public-url` without managed edge still defaults
+ * to all interfaces unless `--host` overrides.
+ */
+export function resolveDashboardHost(opts: {
+  host?: string;
+  publicUrl?: string;
+  managedEdge?: boolean;
+}): string {
+  const explicit = opts.host?.trim();
+  if (explicit) return explicit;
+  // Reachable remotely when public; loopback-only otherwise. Under managed
+  // edge the local OpenResty fronts the dashboard, so it stays on loopback
+  // even though there's a public URL.
+  return opts.publicUrl && !opts.managedEdge ? "0.0.0.0" : "127.0.0.1";
+}

--- a/apps/cli/src/commands/up.ts
+++ b/apps/cli/src/commands/up.ts
@@ -12,11 +12,20 @@ import { ensureDashboard } from "../lib/dashboard";
 import { installAndStart, preview } from "../lib/service";
 import { resolvePorts } from "../lib/ports";
 import { prepareFromSource, type FromSourceRun } from "../lib/from-source";
+import { resolveDashboardHost } from "./up-host";
+
+export { resolveDashboardHost } from "./up-host";
 
 interface UpOpts {
   port?: string;
   dataDir?: string;
   dashboardPort?: string;
+  /**
+   * Dashboard bind address. Homelab reverse proxies need this when there is no
+   * public URL — default remains loopback; `--public-url` without managed edge
+   * still defaults to all interfaces unless `--host` overrides.
+   */
+  host?: string;
   ui?: boolean;
   uiVersion?: string;
   foreground?: boolean;
@@ -102,6 +111,10 @@ export const upCommand = new Command("up")
   .option("--port <port>", "API port to listen on", "4000")
   .option("--data-dir <dir>", "Directory for the embedded database")
   .option("--dashboard-port <port>", "Dashboard port", "3001")
+  .option(
+    "--host <addr>",
+    "Dashboard bind address (default: 127.0.0.1; 0.0.0.0 with --public-url unless --managed-edge). Use 0.0.0.0 or a LAN IP so a reverse proxy on another host can reach the dashboard without --public-url",
+  )
   .option("--no-ui", "Run the API only — don't download/serve the dashboard")
   .option("--ui-version <tag>", "Dashboard release tag to run (default: this CLI's version)")
   .option("-f, --foreground", "Run attached in this terminal instead of as a background service")
@@ -171,6 +184,7 @@ export async function startService(
       port: opts.port,
       dataDir: opts.dataDir,
       dashboardPort: opts.dashboardPort,
+      host: opts.host,
       ui: opts.ui,
       uiVersion: opts.uiVersion,
       publicUrl,
@@ -201,6 +215,7 @@ export async function startService(
     port,
     dataDir: opts.dataDir,
     dashboardPort: dashPort,
+    host: opts.host,
     ui: opts.ui,
     uiVersion: opts.uiVersion,
     publicUrl,
@@ -452,10 +467,13 @@ async function runForeground(opts: UpOpts, source?: FromSourceRun): Promise<void
             NODE_ENV: "production",
             OPENSHIP_TARGET: "local",
             PORT: dashPort,
-            // Reachable remotely when public; loopback-only otherwise. Under
-            // managed edge the local OpenResty fronts the dashboard, so it stays
-            // on loopback even though there's a public URL.
-            HOSTNAME: publicUrl && !managedEdge ? "0.0.0.0" : "127.0.0.1",
+            // Homelab / LAN reverse proxies: `--host 0.0.0.0` (or a private IP)
+            // without requiring `--public-url`. See resolveDashboardHost.
+            HOSTNAME: resolveDashboardHost({
+              host: opts.host,
+              publicUrl,
+              managedEdge,
+            }),
             // The dashboard's same-origin proxy (NEXT_PUBLIC_API_PROXY, baked
             // into the release build) forwards /api/proxy/* to this address, so
             // the browser never needs to know where the API lives. Set in every

--- a/apps/cli/src/lib/service.ts
+++ b/apps/cli/src/lib/service.ts
@@ -29,6 +29,8 @@ export interface UpFlags {
   port?: string;
   dataDir?: string;
   dashboardPort?: string;
+  /** Dashboard bind address (`openship up --host`). */
+  host?: string;
   /** false → pass --no-ui */
   ui?: boolean;
   uiVersion?: string;
@@ -54,6 +56,7 @@ function upArgs(flags: UpFlags): string[] {
   if (flags.port) a.push("--port", flags.port);
   if (flags.dataDir) a.push("--data-dir", flags.dataDir);
   if (flags.dashboardPort) a.push("--dashboard-port", flags.dashboardPort);
+  if (flags.host) a.push("--host", flags.host);
   if (flags.ui === false) a.push("--no-ui");
   if (flags.uiVersion) a.push("--ui-version", flags.uiVersion);
   if (flags.publicUrl) a.push("--public-url", flags.publicUrl);

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/apps/web/content/docs/cli/run.mdx
+++ b/apps/web/content/docs/cli/run.mdx
@@ -87,6 +87,7 @@ openship up --dry-run
 | `--port <port>` | API port to listen on. | `4000` |
 | `--data-dir <dir>` | Directory for the embedded database. | `~/.openship/data` |
 | `--dashboard-port <port>` | Dashboard port. | `3001` |
+| `--host <addr>` | Dashboard bind address. Use `0.0.0.0` or a LAN IP so another host (homelab reverse proxy) can reach the dashboard **without** `--public-url`. The API stays on loopback. | `127.0.0.1` (or `0.0.0.0` with `--public-url` unless `--managed-edge`) |
 | `--no-ui` | Run the API only — don't download or serve the dashboard. | — |
 | `--ui-version <tag>` | Dashboard release tag to run. | this CLI's version |
 | `-f`, `--foreground` | Run attached in this terminal instead of as a background service. | — |
@@ -95,6 +96,11 @@ openship up --dry-run
 | `--trust-proxy` | Trust the `X-Real-IP` set by a reverse proxy in front (the proxy MUST overwrite it with the real client IP, e.g. `proxy_set_header X-Real-IP $remote_addr`) — enables per-client rate limiting. | — |
 | `--managed-edge` | Install OpenResty + a free Let's Encrypt cert on this box and route `--public-url`'s domain to the dashboard — no separate reverse proxy needed. | — |
 | `--acme-email <email>` | Contact email for the Let's Encrypt certificates (managed edge). | — |
+
+```bash
+# Homelab: listen on all interfaces so your ingress VM can reverse-proxy here
+openship up --host 0.0.0.0 --trust-proxy
+```
 
 <Callout title="The dashboard is downloaded on first run">
 Unless you pass `--no-ui`, the dashboard bundle is lazy-downloaded from GitHub releases the first time you run


### PR DESCRIPTION
## Summary
- Fixes #113: homelab users need the dashboard reachable by a LAN reverse proxy without requiring `--public-url`.
- Adds `openship up --host <addr>` (also persisted into the installed service unit).
- API remains on loopback (`OPENSHIP_API_HOST=127.0.0.1`); only the dashboard bind changes.
- Documents the flag in `apps/web/content/docs/cli/run.mdx`.

## Verification
```bash
bun test ./apps/cli/src/commands/up-host.test.ts
# 5 pass
bunx tsc --noEmit -p apps/cli
```

## Test plan
- [x] `openship up --foreground --host 0.0.0.0` — dashboard listens on all interfaces; API still on 127.0.0.1
- [x] Without `--host`, private mode still binds dashboard to 127.0.0.1
- [x] `--public-url` without `--host` still defaults dashboard to `0.0.0.0` (unless `--managed-edge`)
- [x] `--host` wins over the public-url default