### PR TITLE
fix(api,dashboard): unlock Docker Compose first-admin signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,8 @@ BETTER_AUTH_URL=http://localhost:4000
 # Internal-auth token fronting trusted endpoints. REQUIRED for any non-desktop
 # deploy — the API REFUSES to boot without it. Generate:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# On Docker Compose the dashboard also reads this value: it injects the token
+# only for the empty-DB first-admin signup proxied through /api/proxy (see #138).
 INTERNAL_TOKEN=change-me-32-byte-random-hex
 
 # ─── OAuth login (optional) ───────────────────────────────

--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -1,5 +1,5 @@
 export { authMiddleware } from "./auth";
-export { internalAuth } from "./internal-auth";
+export { hasValidInternalToken, internalAuth } from "./internal-auth";
 export { localOnly } from "./local-only";
 export { rateLimiter } from "./rate-limiter";
 export { betterAuthShield } from "./better-auth-shield";

--- a/apps/api/src/middleware/internal-auth.ts
+++ b/apps/api/src/middleware/internal-auth.ts
@@ -4,6 +4,22 @@ import { env } from "../config";
 import { isLoopbackRequest, peerAddress } from "./loopback-peer";
 
 /**
+ * True when `X-Internal-Token` matches `INTERNAL_TOKEN` (timing-safe).
+ * Used by `internalAuth` and by the empty-DB first-signup gate so the
+ * dashboard same-origin proxy can vouch for Docker-compose signup without
+ * widening `isLoopbackRequest` to RFC1918 peers.
+ */
+export function hasValidInternalToken(c: Context): boolean {
+  if (!env.INTERNAL_TOKEN) return false;
+  const token = c.req.header("X-Internal-Token");
+  if (!token) return false;
+
+  const expected = Buffer.from(env.INTERNAL_TOKEN, "utf-8");
+  const received = Buffer.from(token, "utf-8");
+  return expected.length === received.length && timingSafeEqual(expected, received);
+}
+
+/**
  * Middleware that validates the internal token for Electron → API calls.
  *
  * The desktop app generates a shared secret on first run and passes it
@@ -48,16 +64,7 @@ export async function internalAuth(c: Context, next: Next) {
     return;
   }
 
-  const token = c.req.header("X-Internal-Token");
-  if (!token) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
-
-  // Timing-safe comparison - prevents response-time side-channel attacks.
-  const expected = Buffer.from(env.INTERNAL_TOKEN, "utf-8");
-  const received = Buffer.from(token, "utf-8");
-
-  if (expected.length !== received.length || !timingSafeEqual(expected, received)) {
+  if (!hasValidInternalToken(c)) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 

--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -15,7 +15,7 @@ import { Hono } from "hono";
 import { db, schema } from "@repo/db";
 import { env } from "../../config/env";
 import { auth, isSaasDeployment } from "../../lib/auth";
-import { internalAuth } from "../../middleware/internal-auth";
+import { hasValidInternalToken, internalAuth } from "../../middleware/internal-auth";
 import { isLoopbackRequest } from "../../middleware/loopback-peer";
 import * as ctrl from "./auth.controller";
 
@@ -32,14 +32,18 @@ if (env.DEPLOY_MODE === "desktop") {
 
 // Invite-only sign-up guard (runs BEFORE the Better Auth catch-all). SaaS keeps
 // open public signup. On self-host the ONLY Better Auth signup allowed is the
-// FIRST account and only from loopback (CLI bootstrap / local dev) — this closes
-// the remote first-admin race and public invite-hijack signup. Every other new
-// account is created via the token-bound POST /api/system/invite-signup, so a
-// remote peer can never create an account through /sign-up here.
+// FIRST account, and only from a trusted local path:
+//   - loopback (CLI bootstrap / local dev), OR
+//   - valid X-Internal-Token (dashboard same-origin proxy on Docker Compose —
+//     the API peer is the dashboard container's bridge IP, not 127.0.0.1).
+// This closes the remote first-admin race for direct hits on a published API
+// port (no token → refused) while still letting `docker compose up` → open
+// dashboard → create first admin work. Every other new account is created via
+// the token-bound POST /api/system/invite-signup.
 authRoutes.on("POST", "/sign-up/*", async (c, next) => {
   if (isSaasDeployment) return next();
   const [anyUser] = await db.select({ id: schema.user.id }).from(schema.user).limit(1);
-  if (!anyUser && isLoopbackRequest(c)) return next();
+  if (!anyUser && (isLoopbackRequest(c) || hasValidInternalToken(c))) return next();
   return c.json(
     {
       error: "Public sign-up is disabled on this instance. Use your invitation link to join.",

--- a/apps/api/src/modules/health/health.routes.ts
+++ b/apps/api/src/modules/health/health.routes.ts
@@ -64,16 +64,21 @@ healthRoutes.get("/env", async (c) => {
   let teamMode: string = "single_user";
   let migrationTargetUrl: string | null = null;
   let migrationInProgress: boolean = false;
+  // Empty user table → Docker / self-host first-admin signup is still open
+  // (see auth.routes.ts + dashboard proxy token injection, #138).
+  let bootstrapRequired = false;
 
   if (env.DEPLOY_MODE === "desktop") {
     // Desktop: authMode is set during onboarding (none or cloud)
     try {
-      const { repos } = await import("@repo/db");
+      const { repos, db, schema } = await import("@repo/db");
       const settings = await repos.instanceSettings.get();
       authMode = settings?.authMode ?? "none";
       teamMode = settings?.teamMode ?? "single_user";
       migrationTargetUrl = settings?.migrationTargetUrl ?? null;
       migrationInProgress = settings?.migrationInProgress ?? false;
+      const [anyUser] = await db.select({ id: schema.user.id }).from(schema.user).limit(1);
+      bootstrapRequired = !anyUser;
     } catch {
       authMode = "none";
     }
@@ -86,12 +91,16 @@ healthRoutes.get("/env", async (c) => {
     // screen on an instance whose API requires no login.
     authMode = "local";
     try {
-      const { repos } = await import("@repo/db");
+      const { repos, db, schema } = await import("@repo/db");
       const settings = await repos.instanceSettings.get();
       authMode = settings?.authMode ?? "local";
       teamMode = settings?.teamMode ?? "single_user";
       migrationTargetUrl = settings?.migrationTargetUrl ?? null;
       migrationInProgress = settings?.migrationInProgress ?? false;
+      if (!env.CLOUD_MODE) {
+        const [anyUser] = await db.select({ id: schema.user.id }).from(schema.user).limit(1);
+        bootstrapRequired = !anyUser;
+      }
     } catch {
       // settings table may be unavailable mid-migration; defaults are safe.
     }
@@ -105,6 +114,7 @@ healthRoutes.get("/env", async (c) => {
     teamMode,
     migrationTargetUrl,
     migrationInProgress,
+    bootstrapRequired,
     // Both respect OPENSHIP_CLOUD_TARGET (cloudRuntimeTarget). The dashboard
     // must use these, not its static table, to reach the right cloud.
     cloudAuthUrl: cloudRuntimeTarget.dashboard,

--- a/apps/api/test/middleware/internal-token.test.ts
+++ b/apps/api/test/middleware/internal-token.test.ts
@@ -1,0 +1,53 @@
+/**
+ * INTERNAL_TOKEN helper used by internalAuth and the empty-DB first-signup gate.
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/config", () => ({
+  env: {
+    INTERNAL_TOKEN: "test-internal-token-32bytes-ok!!",
+    DEPLOY_MODE: "docker",
+  },
+}));
+
+import { env } from "@/config";
+import { hasValidInternalToken } from "@/middleware/internal-auth";
+
+const e = env as unknown as { INTERNAL_TOKEN?: string };
+
+function ctxWithToken(token: string | undefined) {
+  return {
+    req: {
+      header: (name: string) =>
+        name.toLowerCase() === "x-internal-token" ? token : undefined,
+    },
+  } as never;
+}
+
+beforeEach(() => {
+  e.INTERNAL_TOKEN = "test-internal-token-32bytes-ok!!";
+});
+
+describe("hasValidInternalToken", () => {
+  test("accepts an exact match", () => {
+    expect(hasValidInternalToken(ctxWithToken("test-internal-token-32bytes-ok!!"))).toBe(true);
+  });
+
+  test("rejects missing header", () => {
+    expect(hasValidInternalToken(ctxWithToken(undefined))).toBe(false);
+  });
+
+  test("rejects wrong token", () => {
+    expect(hasValidInternalToken(ctxWithToken("wrong-token"))).toBe(false);
+  });
+
+  test("rejects length-mismatched token (timing-safe path)", () => {
+    expect(hasValidInternalToken(ctxWithToken("short"))).toBe(false);
+  });
+
+  test("rejects when INTERNAL_TOKEN is unset", () => {
+    e.INTERNAL_TOKEN = undefined;
+    expect(hasValidInternalToken(ctxWithToken("test-internal-token-32bytes-ok!!"))).toBe(false);
+  });
+});

--- a/apps/api/test/middleware/signup-proxy-path.test.ts
+++ b/apps/api/test/middleware/signup-proxy-path.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure path check mirroring the dashboard proxy's first-admin token injection
+ * (#138). Kept as a unit so we don't need a Next.js request fixture.
+ */
+
+import { describe, expect, test } from "vitest";
+
+/** Same predicate as apps/dashboard/.../proxy/[...path]/route.ts */
+function isProxiedSignUp(method: string, pathSegments: string[]): boolean {
+  return (
+    method === "POST" &&
+    pathSegments.length >= 3 &&
+    pathSegments[0] === "api" &&
+    pathSegments[1] === "auth" &&
+    pathSegments[2] === "sign-up"
+  );
+}
+
+describe("dashboard proxy sign-up injection path", () => {
+  test("matches Better Auth email sign-up", () => {
+    expect(isProxiedSignUp("POST", ["api", "auth", "sign-up", "email"])).toBe(true);
+  });
+
+  test("matches bare sign-up prefix", () => {
+    expect(isProxiedSignUp("POST", ["api", "auth", "sign-up"])).toBe(true);
+  });
+
+  test("does not match GET or other auth routes", () => {
+    expect(isProxiedSignUp("GET", ["api", "auth", "sign-up", "email"])).toBe(false);
+    expect(isProxiedSignUp("POST", ["api", "auth", "sign-in", "email"])).toBe(false);
+    expect(isProxiedSignUp("POST", ["api", "system", "bootstrap-admin"])).toBe(false);
+  });
+});

--- a/apps/dashboard/src/app/(auth)/layout.tsx
+++ b/apps/dashboard/src/app/(auth)/layout.tsx
@@ -100,7 +100,12 @@ export default async function AuthLayout({
   if (!deploymentInfo) return <ApiUnavailable />;
 
   return (
-    <AuthProviders authMode={deploymentInfo.authMode} cloudAuthUrl={deploymentInfo.cloudAuthUrl} selfHosted={deploymentInfo.selfHosted}>
+    <AuthProviders
+      authMode={deploymentInfo.authMode}
+      cloudAuthUrl={deploymentInfo.cloudAuthUrl}
+      selfHosted={deploymentInfo.selfHosted}
+      bootstrapRequired={Boolean(deploymentInfo.bootstrapRequired)}
+    >
       <div className="th-page">{children}</div>
     </AuthProviders>
   );

--- a/apps/dashboard/src/app/(auth)/login/page.tsx
+++ b/apps/dashboard/src/app/(auth)/login/page.tsx
@@ -40,7 +40,7 @@ function LoginPageInner() {
   const searchParams = useSearchParams();
   const { toast } = useToast();
   const { t } = useI18n();
-  const { authMode, cloudAuthUrl, selfHosted } = useAuthContext();
+  const { authMode, cloudAuthUrl, selfHosted, bootstrapRequired } = useAuthContext();
 
   const isDesktop = typeof window !== "undefined" && !!window.desktop?.isDesktop;
   const handleBack = isDesktop ? () => { void window.desktop?.reset?.(); } : undefined;
@@ -245,11 +245,10 @@ function LoginPageInner() {
       {/* OAuth only for SaaS (cloud-hosted) - hidden on self-hosted */}
       {!selfHosted && <OAuthButtons callbackURL={postLoginUrl ?? "/"} />}
 
-      {/* Public sign-up is a SaaS-only front door. On a self-hosted instance the
-          only account is the CLI-created admin; everyone else joins via an
-          invitation link (server also enforces invite-only signup), so there's
-          no public "create account" entry here. */}
-      {!selfHosted && (
+      {/* SaaS: always offer public sign-up. Self-host: only while the user
+          table is empty (Docker Compose first-admin / #138). After that,
+          accounts come from invitation links. */}
+      {(!selfHosted || bootstrapRequired) && (
         <p className="mt-8 text-center text-sm text-muted-foreground">
           {t.auth.login.noAccount}{" "}
           <Link

--- a/apps/dashboard/src/app/(auth)/providers.tsx
+++ b/apps/dashboard/src/app/(auth)/providers.tsx
@@ -7,12 +7,15 @@ interface AuthContextValue {
   authMode: "cloud" | "local" | "none";
   cloudAuthUrl: string;
   selfHosted: boolean;
+  /** Empty user table — show first-admin register link on self-host (#138). */
+  bootstrapRequired: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   authMode: "local",
   cloudAuthUrl: CLOUD_DASHBOARD_URL,
   selfHosted: true,
+  bootstrapRequired: false,
 });
 
 export function useAuthContext() {
@@ -24,11 +27,18 @@ interface AuthProvidersProps {
   authMode: "cloud" | "local" | "none";
   cloudAuthUrl: string;
   selfHosted: boolean;
+  bootstrapRequired?: boolean;
 }
 
-export function AuthProviders({ children, authMode, cloudAuthUrl, selfHosted }: AuthProvidersProps) {
+export function AuthProviders({
+  children,
+  authMode,
+  cloudAuthUrl,
+  selfHosted,
+  bootstrapRequired = false,
+}: AuthProvidersProps) {
   return (
-    <AuthContext.Provider value={{ authMode, cloudAuthUrl, selfHosted }}>
+    <AuthContext.Provider value={{ authMode, cloudAuthUrl, selfHosted, bootstrapRequired }}>
       {children}
     </AuthContext.Provider>
   );

--- a/apps/dashboard/src/app/(auth)/register/page.tsx
+++ b/apps/dashboard/src/app/(auth)/register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signUp } from "@/lib/auth-client";
@@ -33,7 +33,7 @@ function RegisterPageInner() {
   const searchParams = useSearchParams();
   const { toast } = useToast();
   const { t } = useI18n();
-  const { selfHosted } = useAuthContext();
+  const { selfHosted, bootstrapRequired } = useAuthContext();
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -42,6 +42,24 @@ function RegisterPageInner() {
   const [loading, setLoading] = useState(false);
 
   const postLoginUrl = getPostAuthRedirect(searchParams);
+  const blockSelfHostRegister = selfHosted && !bootstrapRequired;
+
+  // Self-host after first admin: register is invite-only — bounce to login.
+  useEffect(() => {
+    if (blockSelfHostRegister) {
+      router.replace(buildAuthPageHref("/login", searchParams));
+    }
+  }, [blockSelfHostRegister, router, searchParams]);
+
+  if (blockSelfHostRegister) {
+    return (
+      <AuthShell>
+        <div className="flex justify-center py-8">
+          <div className="size-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+        </div>
+      </AuthShell>
+    );
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/apps/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -127,6 +127,21 @@ async function proxy(req: NextRequest, pathSegments: string[]): Promise<Response
   const upstream = buildUpstreamUrl(req, pathSegments);
   const headers = buildForwardedHeaders(req, upstream);
 
+  // Docker Compose first-admin (#138): browser signup is rewritten here, so the
+  // API's TCP peer is the dashboard container (bridge IP), not loopback. Inject
+  // INTERNAL_TOKEN only for Better Auth sign-up so the API's empty-DB gate can
+  // accept it — never for other routes (that would mint god-mode for the browser).
+  const internalToken = process.env.INTERNAL_TOKEN?.trim();
+  const isSignUp =
+    req.method === "POST" &&
+    pathSegments.length >= 3 &&
+    pathSegments[0] === "api" &&
+    pathSegments[1] === "auth" &&
+    pathSegments[2] === "sign-up";
+  if (internalToken && isSignUp && !headers.has("x-internal-token")) {
+    headers.set("x-internal-token", internalToken);
+  }
+
   // Body: pass through directly. fetch accepts a ReadableStream and
   // won't double-buffer it.  duplex:'half' lets the body stream upstream
   // while we wait for the response (required by undici when body is a

--- a/apps/dashboard/src/lib/server/session.ts
+++ b/apps/dashboard/src/lib/server/session.ts
@@ -114,6 +114,12 @@ export type DeploymentInfo = {
   machineName?: string;
   hostDomain?: string;
   /**
+   * True when the user table is empty on a self-hosted instance — the login
+   * page may offer first-admin signup (Docker Compose / #138). Absent on
+   * older API builds; treat as false.
+   */
+  bootstrapRequired?: boolean;
+  /**
    * Multi-user migration state. When non-default, the dashboard
    * should render a launcher screen pointing at migrationTargetUrl
    * instead of the normal UI — this instance no longer owns the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,14 +61,36 @@ Once it's up, **Openship registers itself as an app** (dashboard → Apps → *O
 ```bash
 git clone https://github.com/oblien/openship.git && cd openship
 cp .env.example .env
-docker compose up -d
+# Set INTERNAL_TOKEN + BETTER_AUTH_SECRET to long random values before starting
+docker compose up -d --build
+```
+
+Open the dashboard at `http://localhost:3001` and create the **first admin** account
+there. The dashboard proxies signup to the API with the compose `INTERNAL_TOKEN`, which
+is what unlocks empty-DB first signup on Docker (the API peer is the dashboard container,
+not loopback). After that account exists, public signup stays disabled — invite teammates
+from **Settings → Team**.
+
+If you prefer not to use the web form, you can also mint the first admin with the same
+token the CLI uses:
+
+```bash
+docker compose exec api bun -e '
+  const token = process.env.INTERNAL_TOKEN;
+  const res = await fetch("http://127.0.0.1:4000/api/system/bootstrap-admin", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-internal-token": token },
+    body: JSON.stringify({ name: "Admin", email: "admin@example.com", password: "changeme-please" }),
+  });
+  console.log(await res.json());
+'
 ```
 
 ---
 
 ## Users & access (self-hosted)
 
-- **Public signup is disabled.** The first admin is created by `openship up`'s setup wizard.
+- **Public signup is disabled.** The first admin is created by the `openship` setup wizard, the Docker dashboard signup on a fresh install, or `POST /api/system/bootstrap-admin` with `INTERNAL_TOKEN`.
 - **Invite teammates** from **Settings → Team**. They get an accept link at your instance's URL (so the instance needs to be reachable — a public URL or your LAN).
 - **Lost the admin password?** Run `openship reset-admin-password` on the box (no sign-in needed; uses the local internal token).
 


### PR DESCRIPTION
## Summary
- Fixes #138: fresh Docker Compose installs hit `SIGNUP_DISABLED` because the dashboard proxy peers as a bridge IP (`172.18.x.x`), not loopback.
- **Does not** widen `isLoopbackRequest()` to RFC1918 (that would open a remote first-admin race on published `:4000`).
- Empty-DB signup is allowed when the request is loopback **or** carries a valid `X-Internal-Token`.
- Dashboard `/api/proxy` injects `INTERNAL_TOKEN` **only** for `POST …/api/auth/sign-up/*`.
- `/health/env` reports `bootstrapRequired` so the login page can offer “Create account” on a fresh self-host install.
- Docs + `.env.example` updated for the Docker first-admin path.

## Verification
```bash
bun run --cwd apps/api test -- test/middleware/internal-token.test.ts test/middleware/signup-proxy-path.test.ts
# 8 pass
```

## Test plan
- [x] Fresh `docker compose up` with real `INTERNAL_TOKEN` → open dashboard → Create account → first admin succeeds
- [x] Direct `POST` to published `:4000/api/auth/sign-up/email` without token still returns `SIGNUP_DISABLED`
- [x] After first user exists, register link disappears and signup stays invite-only
- [x] `isLoopbackRequest` consumers (zero-auth / internal-auth desktop fallback / rate-limit) unchanged