### PR TITLE
fix(api): decode compose .env double-quoted escapes in a single pass

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -362,12 +362,9 @@ function parseEnvValue(rawValue: string): string {
   if (value.startsWith('"')) {
     const end = findClosingQuote(value, '"');
     const quoted = end >= 0 ? value.slice(1, end) : value.slice(1);
-    return quoted
-      .replace(/\\n/g, "\n")
-      .replace(/\\r/g, "\r")
-      .replace(/\\t/g, "\t")
-      .replace(/\\"/g, '"')
-      .replace(/\\\\/g, "\\");
+    return quoted.replace(/\\([nrt"\\])/g, (_m, ch: string) =>
+      ch === "n" ? "\n" : ch === "r" ? "\r" : ch === "t" ? "\t" : ch,
+    );
   }
 
   if (value.startsWith("'")) {

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -169,6 +169,14 @@ BAZ=qux
     expect(parseComposeEnvFile(`MSG='line1\\nline2'`)).toEqual({ MSG: "line1\\nline2" });
   });
 
+  it("treats an escaped backslash as a literal `\\` before the next char", () => {
+    expect(parseComposeEnvFile(String.raw`WINPATH="C:\\nginx\\conf"`)).toEqual({
+      WINPATH: "C:\\nginx\\conf",
+    });
+    expect(parseComposeEnvFile(String.raw`X="a\\nb"`)).toEqual({ X: "a\\nb" });
+    expect(parseComposeEnvFile(String.raw`Y="a\nb"`)).toEqual({ Y: "a\nb" });
+  });
+
   it("accepts 'export' prefix (POSIX shell convention)", () => {
     expect(parseComposeEnvFile(`export FOO=bar\nexport BAZ="qux qux"`)).toEqual({
       FOO: "bar",


### PR DESCRIPTION
## Problem

`parseEnvValue` in `apps/api/src/lib/compose-parser.ts` decodes escape sequences inside **double-quoted** `.env` values with a chained sequence of `.replace()` calls:

```ts
return quoted
  .replace(/\\n/g, "\n")
  .replace(/\\r/g, "\r")
  .replace(/\\t/g, "\t")
  .replace(/\\"/g, '"')
  .replace(/\\\\/g, "\\");   // ← runs LAST
```

Because `\n`→newline runs **before** `\\`→`\`, an escaped backslash immediately followed by `n`/`r`/`t` is mis-decoded: the second backslash of a `\\` pair is greedily consumed as the start of a `\n`/`\r`/`\t` escape. The correct rule (matching docker-compose / dotenv) is that `\\` is one literal backslash and the following character is plain text.

A Windows path in a compose `.env` file corrupts silently:

| `.env` line | expected | actual (before) |
|---|---|---|
| `WINPATH="C:\\nginx\\conf"` | `C:\nginx\conf` | `C:\`⏎`ginx\conf` (a real **newline** is injected, and the `n` is eaten) |
| `X="a\\nb"` | `a\nb` (backslash + `n`) | `a\`⏎`b` |

Reproduced directly against `parseComposeEnvFile`:

```
winpath     "C:\\\nginx\\conf"     ← JSON: backslash + NEWLINE + ginx…
  expected  "C:\\nginx\\conf"
```

## Cause

Sequential, order-dependent replacements. The last-listed `\\`→`\` can never protect the backslashes the earlier `\n`/`\r`/`\t` passes have already rewritten.

## Fix

Decode in a **single left-to-right pass** with one regex, so an escaped backslash is consumed as a literal `\` before the next character is examined:

```ts
return quoted.replace(/\\([nrt"\\])/g, (_m, ch) =>
  ch === "n" ? "\n" : ch === "r" ? "\r" : ch === "t" ? "\t" : ch,
);
```

Genuine single-backslash `\n`/`\r`/`\t`/`\"` still decode to their control characters, and unknown escapes (`\x`) are left untouched — identical to the previous behavior for every input except the mis-handled `\\`+char case. The existing `decodes common escape sequences` test is unchanged and still passes.

Scope note: this only touches the escape decoding. The separate naïve `findClosingQuote` edge (a value ending in `\\"`) is out of scope and deliberately not changed.

## Tests

Added a regression test in `apps/api/test/lib/compose-parser.test.ts`:
- `WINPATH="C:\\nginx\\conf"` → `C:\nginx\conf` (literal backslashes preserved, no newline)
- `X="a\\nb"` → `a\nb` (literal backslash + `n`)
- `Y="a\nb"` → `a`⏎`b` (a genuine single-backslash `\n` still becomes a newline — proves the fix doesn't over-correct)

**Verified the test fails without the source change** (actual `C:\`⏎`ginx\conf`) and passes with it.

## Verification

- `bun run test` → all 5 turbo tasks successful.
- `bun run --cwd apps/api lint` (tsc) → clean.
- Touched files introduce **no new** prettier drift (the file has pre-existing drift on `main`; only my added lines were hand-formatted and confirmed prettier-clean, per CONTRIBUTING).