### PR TITLE
fix(adapters): map compose `on-failure:<n>` restart policy to on-failure, not always

### DIFF
--- a/packages/adapters/src/runtime/cloud/compose.ts
+++ b/packages/adapters/src/runtime/cloud/compose.ts
@@ -73,9 +73,10 @@ function firstContainerPort(portSpecs: string[]): number | undefined {
   return undefined;
 }
 
-function restartPolicyForWorkload(policy?: string): "always" | "on-failure" | "never" {
-  if (policy === "no" || policy === "never") return "never";
-  if (policy === "on-failure") return "on-failure";
+export function restartPolicyForWorkload(policy?: string): "always" | "on-failure" | "never" {
+  const base = policy?.split(":")[0];
+  if (base === "no" || base === "never") return "never";
+  if (base === "on-failure") return "on-failure";
   return "always";
 }
 

--- a/packages/adapters/test/cloud-restart-policy.test.ts
+++ b/packages/adapters/test/cloud-restart-policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { restartPolicyForWorkload } from "../src/runtime/cloud/compose";
+
+describe("restartPolicyForWorkload", () => {
+  it("maps the plain compose restart values", () => {
+    expect(restartPolicyForWorkload("no")).toBe("never");
+    expect(restartPolicyForWorkload("never")).toBe("never");
+    expect(restartPolicyForWorkload("on-failure")).toBe("on-failure");
+    expect(restartPolicyForWorkload("always")).toBe("always");
+    expect(restartPolicyForWorkload("unless-stopped")).toBe("always");
+  });
+
+  it("maps `on-failure:<max-retries>` to on-failure, not always", () => {
+    expect(restartPolicyForWorkload("on-failure:5")).toBe("on-failure");
+    expect(restartPolicyForWorkload("on-failure:1")).toBe("on-failure");
+  });
+
+  it("defaults to always for an unset or unknown policy", () => {
+    expect(restartPolicyForWorkload(undefined)).toBe("always");
+    expect(restartPolicyForWorkload("")).toBe("always");
+  });
+});


### PR DESCRIPTION
A compose service that declares `restart: on-failure:5` was being deployed to the cloud with `restart_policy: always` — the opposite of what the user asked for.

## Problem

`restart: on-failure:<max-retries>` is valid Docker Compose short-form syntax (it maps to Docker's `--restart=on-failure:max-retries`). `restartPolicyForWorkload` in `runtime/cloud/compose.ts` compared the **whole** restart string against the literal `"on-failure"`, so any policy carrying a retry count missed and fell through to the `always` default:

| compose `restart` | expected     | actual (before) |
| ----------------- | ------------ | --------------- |
| `on-failure`      | `on-failure` | `on-failure` ✅  |
| `on-failure:5`    | `on-failure` | `always` ❌      |
| `on-failure:1`    | `on-failure` | `always` ❌      |
| `no` / `never`    | `never`      | `never` ✅       |
| `always`          | `always`     | `always` ✅      |
| `unless-stopped`  | `always`     | `always` ✅      |

The resolved `restart_policy` is passed straight to the cloud workloads API (`ws.workloads.create({ restart_policy, … })`). With `always`, the container restarts even on a **clean exit (code 0)** — a batch/one-shot workload that a user deliberately capped with `on-failure:5` would instead loop forever.

## Cause

```ts
if (policy === "on-failure") return "on-failure"; // never true for "on-failure:5"
return "always";
```

## Fix

Compare the base word before the `:` so `on-failure:<n>` resolves to `on-failure`. Plain `no`/`never`/`always`/`unless-stopped` carry no colon and are unaffected.

```ts
const base = policy?.split(":")[0];
if (base === "no" || base === "never") return "never";
if (base === "on-failure") return "on-failure";
return "always";
```

The function is exported so the mapping is unit-testable (precedent: `cloudCpus`, `renderProxyOptions`, `escapeSystemdEnvValue`).

## Tests

Added `packages/adapters/test/cloud-restart-policy.test.ts` covering the plain values, `on-failure:<max-retries>`, and the unset/unknown default.

**Verified it catches the bug:** with the pre-fix body kept but exported, only the `on-failure:<max-retries>` case fails (`expected 'always' to be 'on-failure'`); the other cases pass. With the fix, all pass.

## Verification

- `bun run test` → all 5 turbo tasks successful.
- `tsc --noEmit` clean for both `packages/adapters` and `apps/api`.
- Touched files pass `npx prettier --check` (no pre-existing-drift churn — the edited function is prettier-clean; the new test file is formatted normally).

Note: `restart_policy` is a cloud-only field, so self-hosted deploys are unaffected. I kept `unless-stopped → always` as-is (a reasonable approximation for a cloud workload with no manual `docker stop`); happy to revisit if you’d prefer it mapped differently.