### PR TITLE
fix(adapters): shell-form ENTRYPOINT ignores CMD in workspace start command

### DIFF
--- a/packages/adapters/src/dockerfile/compiler.ts
+++ b/packages/adapters/src/dockerfile/compiler.ts
@@ -152,6 +152,11 @@ function combineStartCommand(
     return commandToShell(entrypoint);
   }
 
+  // A shell-form ENTRYPOINT runs via `/bin/sh -c` and takes no CMD arguments.
+  if (entrypoint.form === "shell") {
+    return commandToShell(entrypoint);
+  }
+
   const entrypointShell = commandToShell(entrypoint);
   const cmdShell = commandToShell(cmd);
   return cmdShell ? `${entrypointShell} ${cmdShell}` : entrypointShell;

--- a/packages/adapters/test/dockerfile-entrypoint-cmd.test.ts
+++ b/packages/adapters/test/dockerfile-entrypoint-cmd.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { compileDockerfileToWorkspacePlan } from "../src/dockerfile/compiler";
+
+function startCommand(dockerfile: string): string | undefined {
+  return compileDockerfileToWorkspacePlan(dockerfile).runtime?.startCommand;
+}
+
+// Expectations follow Docker's documented ENTRYPOINT/CMD interaction table.
+// The shell form of ENTRYPOINT runs the image as `/bin/sh -c "<entrypoint>"`,
+// which takes no arguments — so any CMD (and run-time args) is dropped.
+describe("compileDockerfileToWorkspacePlan — ENTRYPOINT/CMD combination", () => {
+  it("drops CMD when ENTRYPOINT is shell form (exec CMD)", () => {
+    expect(startCommand(`FROM node:20\nENTRYPOINT ./start.sh\nCMD ["--flag"]`)).toBe("./start.sh");
+  });
+
+  it("drops CMD when ENTRYPOINT is shell form (shell CMD)", () => {
+    expect(startCommand(`FROM node:20\nENTRYPOINT ./start.sh\nCMD --flag`)).toBe("./start.sh");
+  });
+
+  it("drops CMD regardless of instruction order", () => {
+    expect(startCommand(`FROM node:20\nCMD ["--flag"]\nENTRYPOINT ./start.sh`)).toBe("./start.sh");
+  });
+
+  it("appends CMD as arguments when ENTRYPOINT is exec form", () => {
+    expect(
+      startCommand(`FROM node:20\nENTRYPOINT ["node","server.js"]\nCMD ["--port","3000"]`),
+    ).toBe("node server.js --port 3000");
+  });
+
+  it("uses CMD alone when there is no ENTRYPOINT", () => {
+    expect(startCommand(`FROM node:20\nCMD ["node","server.js"]`)).toBe("node server.js");
+  });
+
+  it("uses a shell-form ENTRYPOINT alone", () => {
+    expect(startCommand(`FROM node:20\nENTRYPOINT ./start.sh`)).toBe("./start.sh");
+  });
+});


### PR DESCRIPTION
## Problem

When compiling a Dockerfile to a workspace runtime plan, a **shell-form** `ENTRYPOINT` combined with a `CMD` produces a start command that runs arguments Docker would never pass.

Docker's [ENTRYPOINT/CMD interaction table](https://docs.docker.com/reference/dockerfile/#understand-how-cmd-and-entrypoint-interact) is explicit: the shell form of `ENTRYPOINT` runs the image as `/bin/sh -c "<entrypoint>"`, and in that form **CMD (and any run-time arguments) is ignored**. `combineStartCommand` appended CMD unconditionally, so:

| Dockerfile | Docker runs | Compiled `startCommand` |
|---|---|---|
| `ENTRYPOINT ./start.sh` + `CMD ["--flag"]` | `./start.sh` | `./start.sh --flag` ❌ |
| `ENTRYPOINT ./start.sh` + `CMD --flag` | `./start.sh` | `./start.sh --flag` ❌ |
| `CMD ["--flag"]` then `ENTRYPOINT ./start.sh` | `./start.sh` | `./start.sh --flag` ❌ |
| `ENTRYPOINT ["node","server.js"]` + `CMD ["--port","3000"]` | `node server.js --port 3000` | `node server.js --port 3000` ✅ |

The exec-form column was already correct — the bug is confined to the shell-form ENTRYPOINT rows, where CMD must be dropped.

## Cause

`combineStartCommand` (packages/adapters/src/dockerfile/compiler.ts), when both an ENTRYPOINT and a CMD are present, always concatenates them. It never checked the ENTRYPOINT's form.

## Fix

When the ENTRYPOINT is shell form, return it alone and ignore CMD. Exec-form ENTRYPOINT keeps folding CMD in as arguments, unchanged.

```diff
+  // A shell-form ENTRYPOINT runs via `/bin/sh -c` and takes no CMD arguments.
+  if (entrypoint.form === "shell") {
+    return commandToShell(entrypoint);
+  }
```

## Tests

Adds `packages/adapters/test/dockerfile-entrypoint-cmd.test.ts` (6 cases): the three shell-form ENTRYPOINT+CMD cases above (incl. reversed instruction order), plus regression guards for exec-form ENTRYPOINT+CMD, CMD-only, and shell-ENTRYPOINT-only. There was previously **no** test exercising `compileDockerfileToWorkspacePlan`'s ENTRYPOINT/CMD combination.

**Verified the test catches the bug:** with the source change reverted, the three shell-form cases fail (`expected './start.sh --flag' to be './start.sh'`); the exec-form guards still pass. With the fix, all 6 pass.

## Verification

- `bun run test` → all 5 turbo tasks successful (`@repo/adapters` 252 passed, +6 new).
- `bun run --cwd apps/api lint` → clean.
- `npx prettier --check` on both touched files → clean. `compiler.ts` had no pre-existing drift, so no unrelated churn.