### PR TITLE
fix(web): correct self-host button URL path in landing page hero

### DIFF
--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -95,7 +95,7 @@ export function Hero() {
               </svg>
             </a>
             <a
-              href="/docs/quickstart"
+              href="/docs/getting-started/quickstart"
               className="th-btn-ghost group rounded-full px-7 py-3 text-[15px] font-medium"
             >
               Self host


### PR DESCRIPTION
## Summary

Fix broken "Self host" button URL on the landing page hero section.

## Changes

- Updated the href for the "Self host" button from `/docs/quickstart` to `/docs/getting-started/quickstart` in `apps/web/src/components/landing/hero.tsx`

## Why

The "Self host" button in the landing page hero was linking to `/docs/quickstart`, which doesn't exist. The correct path is `/docs/getting-started/quickstart`, resulting in users hitting a 404 when clicking the button.

## Verification & Testing

- [ ] Navigate to the landing page
- [ ] Click the "Self host" button in the hero section
- [ ] Confirm it loads the quickstart documentation at `/docs/getting-started/quickstart` without a 404
