### PR TITLE
fix(api): avoid domain route save timeouts

### DIFF
--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -90,7 +90,43 @@ export async function addDomain(ctx: RequestContext, data: TAddDomainBody) {
 
   const existing = await repos.domain.findByHostname(hostname);
   if (existing) {
-    throw new ConflictError(`Domain "${hostname}" is already in use`);
+    if (existing.projectId !== data.projectId) {
+      throw new ConflictError(`Domain "${hostname}" is already in use`);
+    }
+
+    // Connecting a custom domain is a two-step dashboard flow: create the
+    // pending domain row, then attach it to publicEndpoints. If the second
+    // request is interrupted (for example while a remote live-route apply is
+    // still running), retrying must resume from the existing row instead of
+    // trapping the user behind a same-project "already in use" conflict.
+    const patch: Partial<Domain> = {};
+    if (
+      data.externalIngress !== undefined &&
+      existing.externalIngress !== data.externalIngress
+    ) {
+      patch.externalIngress = data.externalIngress;
+    }
+
+    if (Object.keys(patch).length > 0) {
+      await repos.domain.update(existing.id, patch);
+    }
+    if (data.isPrimary && !existing.isPrimary) {
+      await repos.domain.setPrimary(data.projectId, existing.id);
+    }
+
+    const domain = {
+      ...existing,
+      ...patch,
+      ...(data.isPrimary ? { isPrimary: true } : {}),
+    };
+    const token = domain.verificationToken ?? generateToken(hostname);
+    const records = await buildRecords(
+      hostname,
+      token,
+      project,
+      domain.externalIngress,
+    );
+    return { domain, records };
   }
 
   const token = generateToken(hostname);

--- a/apps/api/src/modules/projects/project-crud.service.ts
+++ b/apps/api/src/modules/projects/project-crud.service.ts
@@ -843,10 +843,14 @@ export async function updateProject(
     }
 
     // Re-apply the live route so a domain/port edit takes effect without a
-    // redeploy (best-effort — the DB rows are already committed).
+    // redeploy. Remote routing can take longer than the dashboard's request
+    // timeout (SSH connection + route removal/registration), while the domain
+    // rows above are already canonical. Keep this best-effort work in the
+    // background so the mutation can return success as soon as persistence is
+    // complete instead of surfacing a false client-side timeout.
     const refreshed = await repos.project.findById(projectId);
     if (refreshed) {
-      await reapplyProjectLiveRoutes(refreshed, previousHostnames).catch((err) =>
+      void reapplyProjectLiveRoutes(refreshed, previousHostnames).catch((err) =>
         console.warn(
           `[updateProject] live route re-apply failed (non-fatal): ${safeErrorMessage(err)}`,
         ),
@@ -1358,5 +1362,4 @@ export async function getLatestDeploymentSession(
       : null,
   };
 }
-
 

--- a/apps/api/test/modules/domains/domain-add.test.ts
+++ b/apps/api/test/modules/domains/domain-add.test.ts
@@ -1,0 +1,133 @@
+import "../mail/_setup-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConflictError } from "@repo/core";
+
+const domainRepo = vi.hoisted(() => ({
+  create: vi.fn(),
+  findByHostname: vi.fn(),
+  setPrimary: vi.fn(),
+  update: vi.fn(),
+}));
+
+const projectRepo = vi.hoisted(() => ({
+  findById: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    domain: domainRepo,
+    project: projectRepo,
+  },
+}));
+
+vi.mock("../../../src/lib/controller-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/lib/controller-helpers")>();
+  return {
+    ...actual,
+    platform: () => ({ target: "local", runtime: {} }),
+  };
+});
+
+vi.mock("../../../src/lib/server-target", () => ({
+  resolveProjectServerHost: vi.fn().mockResolvedValue("203.0.113.10"),
+}));
+
+vi.mock("../../../src/lib/domain-ssl", () => ({
+  installDomainCert: vi.fn(),
+  manageDomainSsl: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/dns-resolver", () => ({
+  resolveRecords: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/route-apply.service", () => ({
+  reconcileProjectRoutes: vi.fn(),
+}));
+
+import { addDomain } from "../../../src/modules/domains/domain.service";
+
+const project = {
+  id: "proj_123",
+  organizationId: "org_123",
+};
+
+const context = {
+  organizationId: "org_123",
+  userId: "user_123",
+};
+
+const existingDomain = {
+  id: "dom_existing",
+  projectId: project.id,
+  serviceId: null,
+  hostname: "example.com",
+  verificationToken: "verify-existing",
+  externalIngress: false,
+  isPrimary: false,
+  verified: false,
+  status: "pending",
+};
+
+describe("addDomain retries", () => {
+  beforeEach(() => {
+    domainRepo.create.mockReset();
+    domainRepo.findByHostname.mockReset();
+    domainRepo.setPrimary.mockReset();
+    domainRepo.update.mockReset();
+    projectRepo.findById.mockReset();
+    projectRepo.findById.mockResolvedValue(project);
+  });
+
+  it("reuses a pending domain owned by the same project", async () => {
+    domainRepo.findByHostname.mockResolvedValue(existingDomain);
+
+    const result = await addDomain(context as any, {
+      projectId: project.id,
+      hostname: "example.com",
+      isPrimary: true,
+    });
+
+    expect(domainRepo.create).not.toHaveBeenCalled();
+    expect(domainRepo.setPrimary).toHaveBeenCalledWith(project.id, existingDomain.id);
+    expect(result.domain).toMatchObject({
+      id: existingDomain.id,
+      hostname: existingDomain.hostname,
+      isPrimary: true,
+    });
+    expect(result.records).toEqual({
+      mode: "selfhosted",
+      records: [
+        {
+          type: "A",
+          host: "@",
+          name: "example.com",
+          value: "203.0.113.10",
+        },
+        {
+          type: "TXT",
+          host: "_openship-challenge",
+          name: "_openship-challenge.example.com",
+          value: "verify-existing",
+        },
+      ],
+    });
+  });
+
+  it("still rejects a domain owned by another project", async () => {
+    domainRepo.findByHostname.mockResolvedValue({
+      ...existingDomain,
+      projectId: "proj_other",
+    });
+
+    await expect(
+      addDomain(context as any, {
+        projectId: project.id,
+        hostname: "example.com",
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(domainRepo.create).not.toHaveBeenCalled();
+    expect(domainRepo.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/modules/projects/project-route-update.test.ts
+++ b/apps/api/test/modules/projects/project-route-update.test.ts
@@ -1,0 +1,94 @@
+import "../mail/_setup-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectRepo = vi.hoisted(() => ({
+  findById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const routeState = vi.hoisted(() => ({
+  reapplyProjectLiveRoutes: vi.fn(),
+  resolveProjectRouteState: vi.fn(),
+  syncProjectRouteState: vi.fn(),
+}));
+
+vi.mock("@repo/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/db")>();
+  return {
+    ...actual,
+    repos: {
+      ...actual.repos,
+      project: projectRepo,
+    },
+  };
+});
+
+vi.mock("../../../src/modules/domains/project-route.service", () => ({
+  deriveEnvironmentPublicEndpoints: vi.fn(),
+  deriveNextProjectRouteState: vi.fn(),
+  persistProjectRouteState: vi.fn(),
+  reapplyProjectLiveRoutes: routeState.reapplyProjectLiveRoutes,
+  resolveProjectRouteState: routeState.resolveProjectRouteState,
+  syncProjectRouteState: routeState.syncProjectRouteState,
+}));
+
+vi.mock("../../../src/modules/domains/routing-apply.service", () => ({
+  applyProjectRouting: vi.fn(),
+}));
+
+import { updateProject } from "../../../src/modules/projects/project-crud.service";
+
+const project = {
+  id: "proj_123",
+  organizationId: "org_123",
+  groupId: null,
+  slug: "portfolio",
+  name: "Portfolio",
+  port: 4321,
+  activeDeploymentId: "dep_123",
+  cloudWorkspaceId: null,
+  resources: null,
+  buildResources: null,
+  sleepMode: "auto_sleep",
+};
+
+describe("updateProject route persistence", () => {
+  beforeEach(() => {
+    projectRepo.findById.mockReset();
+    projectRepo.update.mockReset();
+    routeState.reapplyProjectLiveRoutes.mockReset();
+    routeState.resolveProjectRouteState.mockReset();
+    routeState.syncProjectRouteState.mockReset();
+
+    projectRepo.findById.mockResolvedValue(project);
+    routeState.resolveProjectRouteState.mockResolvedValue({
+      projectDomains: [{ hostname: "old.example.com" }],
+    });
+    routeState.syncProjectRouteState.mockResolvedValue(undefined);
+  });
+
+  it("does not hold the response open for best-effort live route re-apply", async () => {
+    routeState.reapplyProjectLiveRoutes.mockReturnValue(new Promise(() => {}));
+
+    const result = await Promise.race([
+      updateProject(
+        project.id,
+        {
+          publicEndpoints: [
+            {
+              customDomain: "new.example.com",
+              domainType: "custom",
+              port: 4321,
+            },
+          ],
+        },
+        project.organizationId,
+      ),
+      new Promise((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+    ]);
+
+    expect(result).not.toBe("timed-out");
+    expect(routeState.syncProjectRouteState).toHaveBeenCalled();
+    expect(routeState.reapplyProjectLiveRoutes).toHaveBeenCalledWith(project, ["old.example.com"]);
+  });
+});


### PR DESCRIPTION
## Summary

- return from project domain updates after the canonical route rows are persisted, while live remote route re-application continues as best-effort background work
- make custom-domain connection retries reuse an existing row owned by the same project
- preserve the existing conflict for domains owned by another project
- add regressions for both the non-blocking route update and same-project retry behavior

## Root cause

Updating a project's `publicEndpoints` awaited live route removal and registration before returning. On a remote self-hosted server, the SSH-backed routing work can take longer than the dashboard client's 15-second timeout. The client then reported `signal is aborted without reason` even though the API continued and eventually persisted/applied the change.

The dashboard's add-domain flow first creates a pending domain row and then attaches it to `publicEndpoints`. Retrying after the false timeout hit the existing same-project row and returned `Domain "<hostname>" is already in use`, leaving the user unable to resume through the normal add flow.

## Impact

Domain add/edit requests return as soon as their canonical database state is saved instead of waiting on best-effort remote routing. If the two-step add flow is interrupted, retrying resumes from the project's existing domain row without weakening cross-project ownership checks.

## Validation

- `bun run --cwd apps/api lint`
- `bun run --cwd apps/api test` — 61 files passed; 737 tests passed, 3 skipped
- `bun run --cwd apps/api build`
- reproduced against the v0.3.0 desktop app with a remote self-hosted deployment
