### PR TITLE
fix(domains): prevent DNS verification timeouts

### DIFF
--- a/apps/api/src/modules/domains/domain.controller.ts
+++ b/apps/api/src/modules/domains/domain.controller.ts
@@ -81,6 +81,7 @@ export async function verify(c: Context) {
     resourceId: id,
     after: {
       verified: result.verified,
+      recordVerified: result.recordVerified,
       cnameVerified: result.cnameVerified,
       txtVerified: result.txtVerified,
     },
@@ -88,7 +89,8 @@ export async function verify(c: Context) {
 
   // Failed verification returns 422 so the dashboard's React Query / fetch
   // wrapper can use the standard error path while still reading
-  // message/cnameVerified/txtVerified from the body. 200 on success.
+  // message/recordVerified/txtVerified from the body. cnameVerified remains a
+  // compatibility alias for older dashboard builds. 200 on success.
   return c.json(result, result.verified ? 200 : 422);
 }
 

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -233,6 +233,7 @@ export async function verifyDomain(ctx: RequestContext, domainId: string) {
   if (domain.verified) {
     return {
       verified: true,
+      recordVerified: true,
       cnameVerified: true,
       txtVerified: true,
       message: "Already verified",
@@ -244,18 +245,24 @@ export async function verifyDomain(ctx: RequestContext, domainId: string) {
   const token = domain.verificationToken ?? generateToken(domain.hostname);
   const external = domain.externalIngress;
 
-  // 1. Routing record — cloud: CNAME via Oblien; self-hosted: A record. With
-  //    externally-managed ingress the hostname points at the user's own edge
-  //    (Cloudflare/LB), not this box — so there's nothing to check here;
-  //    ownership (TXT) alone gates activation.
-  const routeOk = external
-    ? true
+  // Check routing and ownership concurrently. Each DNS lookup can spend up to
+  // 5s on DoH and another 5s on the local-resolver fallback; running these
+  // sequentially can therefore exceed the dashboard's 15s request timeout.
+  //
+  // Routing record — cloud: CNAME via Oblien; self-hosted: A record. With
+  // externally-managed ingress the hostname points at the user's own edge
+  // (Cloudflare/LB), not this box — so there's nothing to check here;
+  // ownership (TXT) alone gates activation.
+  const routeCheck = external
+    ? Promise.resolve(true)
     : target === "cloud"
-      ? await verifyCname(domain.hostname)
-      : await verifyARecord(domain.hostname, project);
+      ? verifyCname(domain.hostname)
+      : verifyARecord(domain.hostname, project);
 
-  // 2. Ownership - TXT record with verification hash
-  const txtOk = await verifyTxt(domain.hostname, token);
+  const [routeOk, txtOk] = await Promise.all([
+    routeCheck,
+    verifyTxt(domain.hostname, token),
+  ]);
 
   if (routeOk && txtOk) {
     await repos.domain.markVerified(domainId);
@@ -280,6 +287,7 @@ export async function verifyDomain(ctx: RequestContext, domainId: string) {
       await repos.domain.updateSsl(domainId, { sslStatus: "external" });
       return {
         verified: true,
+        recordVerified: true,
         cnameVerified: true,
         txtVerified: true,
         message: "Domain verified — TLS is handled by your external ingress; no certificate is issued here.",
@@ -304,6 +312,7 @@ export async function verifyDomain(ctx: RequestContext, domainId: string) {
 
     return {
       verified: true,
+      recordVerified: true,
       cnameVerified: true,
       txtVerified: true,
       message: "Domain verified — SSL provisioning started",

--- a/apps/api/test/modules/domains/domain-verification.test.ts
+++ b/apps/api/test/modules/domains/domain-verification.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  findDomain,
+  findProject,
+  listDomains,
+  markVerified,
+  setPrimary,
+  recordVerifyFailure,
+  resolveRecords,
+  resolveProjectServerHost,
+  manageDomainSsl,
+} = vi.hoisted(() => ({
+  findDomain: vi.fn(),
+  findProject: vi.fn(),
+  listDomains: vi.fn(),
+  markVerified: vi.fn(),
+  setPrimary: vi.fn(),
+  recordVerifyFailure: vi.fn(),
+  resolveRecords: vi.fn(),
+  resolveProjectServerHost: vi.fn(),
+  manageDomainSsl: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    domain: {
+      findById: findDomain,
+      listByProject: listDomains,
+      markVerified,
+      setPrimary,
+      recordVerifyFailure,
+    },
+    project: {
+      findById: findProject,
+    },
+  },
+}));
+
+vi.mock("../../../src/lib/controller-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/lib/controller-helpers")>();
+  return {
+    ...actual,
+    platform: () => ({ target: "desktop" }),
+  };
+});
+
+vi.mock("../../../src/lib/dns-resolver", () => ({
+  resolveRecords,
+}));
+
+vi.mock("../../../src/lib/server-target", () => ({
+  resolveProjectServerHost,
+}));
+
+vi.mock("../../../src/lib/domain-ssl", () => ({
+  manageDomainSsl,
+  installDomainCert: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/route-apply.service", () => ({
+  reconcileProjectRoutes: vi.fn(),
+}));
+
+import { verifyDomain } from "../../../src/modules/domains/domain.service";
+
+const ctx = {
+  organizationId: "org-1",
+} as any;
+
+const domain = {
+  id: "dom-1",
+  projectId: "proj-1",
+  hostname: "example.com",
+  domainType: "custom",
+  externalIngress: false,
+  verificationToken: "challenge-token",
+  verified: false,
+  sslStatus: "inactive",
+};
+
+const project = {
+  id: "proj-1",
+  organizationId: "org-1",
+  activeDeploymentId: null,
+};
+
+describe("verifyDomain", () => {
+  beforeEach(() => {
+    findDomain.mockReset().mockResolvedValue(domain);
+    findProject.mockReset().mockResolvedValue(project);
+    listDomains.mockReset().mockResolvedValue([domain]);
+    markVerified.mockReset().mockResolvedValue(undefined);
+    setPrimary.mockReset().mockResolvedValue(undefined);
+    recordVerifyFailure.mockReset().mockResolvedValue(1);
+    resolveRecords.mockReset();
+    resolveProjectServerHost.mockReset().mockResolvedValue("203.0.113.10");
+    manageDomainSsl.mockReset().mockResolvedValue({});
+  });
+
+  it("checks the routing and TXT records concurrently", async () => {
+    let releaseRouteLookup!: (records: string[]) => void;
+    const routeLookup = new Promise<string[]>((resolve) => {
+      releaseRouteLookup = resolve;
+    });
+
+    resolveRecords.mockImplementation(async (name: string, type: "A" | "TXT") => {
+      if (type === "A") return routeLookup;
+      if (type === "TXT" && name === "_openship-challenge.example.com") {
+        return ["challenge-token"];
+      }
+      return [];
+    });
+
+    const verification = verifyDomain(ctx, domain.id);
+
+    // The A lookup deliberately stays pending. A sequential implementation
+    // cannot reach TXT here and reproduces the dashboard's request timeout.
+    await vi.waitFor(() => {
+      expect(resolveRecords).toHaveBeenCalledWith("_openship-challenge.example.com", "TXT");
+    });
+
+    releaseRouteLookup(["203.0.113.10"]);
+
+    await expect(verification).resolves.toEqual(
+      expect.objectContaining({
+        verified: true,
+        recordVerified: true,
+        txtVerified: true,
+      }),
+    );
+  });
+});

--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
@@ -308,7 +308,7 @@ export const DomainSettings = () => {
   // After a failed verify, remember which record(s) still aren't resolving so
   // the pending card can name them and auto-open its DNS records. Keyed by row.
   const [verifyFailure, setVerifyFailure] = useState<
-    { domainId: string; cnameVerified: boolean; txtVerified: boolean } | null
+    { domainId: string; recordVerified: boolean; txtVerified: boolean } | null
   >(null);
   // Live port reachability of the active deployment (advisory) — drives the
   // per-card "nothing responded on port X" hint. [] = no signal → no hint.
@@ -654,11 +654,12 @@ export const DomainSettings = () => {
           t.projectSettings.domains.toast.verifiedTitle,
         );
       } else {
-        // 422 path. cnameVerified/txtVerified pinpoint what's still missing —
+        // 422 path. recordVerified/txtVerified pinpoint what's still missing —
         // stash it so the pending card names the record + opens its DNS panel.
         setVerifyFailure({
           domainId,
-          cnameVerified: !!result.cnameVerified,
+          // cnameVerified is the compatibility field returned by older APIs.
+          recordVerified: !!(result.recordVerified ?? result.cnameVerified),
           txtVerified: !!result.txtVerified,
         });
         showToast(
@@ -684,8 +685,8 @@ export const DomainSettings = () => {
   const verifyHintFor = (domainId?: string): string | null => {
     if (!domainId || verifyFailure?.domainId !== domainId) return null;
     const vm = t.projectSettings.domains.verifyMissing;
-    if (!verifyFailure.cnameVerified && !verifyFailure.txtVerified) return vm.both;
-    if (!verifyFailure.cnameVerified) return vm.cname;
+    if (!verifyFailure.recordVerified && !verifyFailure.txtVerified) return vm.both;
+    if (!verifyFailure.recordVerified) return selfHosted ? vm.a : vm.cname;
     if (!verifyFailure.txtVerified) return vm.txt;
     return null;
   };
@@ -2258,4 +2259,3 @@ function DnsRecordRow({
     </div>
   );
 }
-

--- a/apps/dashboard/src/i18n/locales/en/projectSettings.json
+++ b/apps/dashboard/src/i18n/locales/en/projectSettings.json
@@ -665,7 +665,8 @@
       "none": "No records to add for this domain."
     },
     "verifyMissing": {
-      "both": "Neither the CNAME nor the TXT record is resolving yet — add the records below, wait for DNS to propagate, then Verify.",
+      "both": "Neither the routing nor the TXT record is resolving yet — add the records below, wait for DNS to propagate, then Verify.",
+      "a": "The A record isn't resolving yet — add it below, wait for DNS to propagate, then Verify.",
       "cname": "The CNAME record isn't resolving yet — add it below, wait for DNS to propagate, then Verify.",
       "txt": "The TXT verification record isn't resolving yet — add it below, wait for DNS to propagate, then Verify."
     },

--- a/apps/dashboard/src/i18n/locales/fr/projectSettings.json
+++ b/apps/dashboard/src/i18n/locales/fr/projectSettings.json
@@ -652,8 +652,9 @@
       "none": "Aucun enregistrement à ajouter pour ce domaine."
     },
     "verifyMissing": {
-      "both": "Ni le CNAME ni le TXT ne sont encore résolus — ajoutez les enregistrements ci-dessous, attendez la propagation DNS, puis Vérifiez.",
-      "cname": "L'enregistrement CNAME n'est pas encore résolu — ajoutez-le ci-dessous, attendez la propagation DNS, puis Vérifiez.",
+      "both": "Ni l'enregistrement de routage ni le TXT ne sont encore résolus — ajoutez les enregistrements ci-dessous, attendez la propagation DNS, puis vérifiez.",
+      "a": "L'enregistrement A n'est pas encore résolu — ajoutez-le ci-dessous, attendez la propagation DNS, puis vérifiez.",
+      "cname": "L'enregistrement CNAME n'est pas encore résolu — ajoutez-le ci-dessous, attendez la propagation DNS, puis vérifiez.",
       "txt": "L'enregistrement TXT de vérification n'est pas encore résolu — ajoutez-le ci-dessous, attendez la propagation DNS, puis Vérifiez."
     },
     "portHint": {

--- a/apps/dashboard/src/i18n/locales/tr/projectSettings.json
+++ b/apps/dashboard/src/i18n/locales/tr/projectSettings.json
@@ -665,7 +665,8 @@
       "none": "Bu alan adı için eklenecek kayıt yok."
     },
     "verifyMissing": {
-      "both": "Ne CNAME ne de TXT kaydı henüz çözümlenmiyor — aşağıdaki kayıtları ekleyin, DNS yayılmasını bekleyin ve ardından Doğrula'ya basın.",
+      "both": "Ne yönlendirme ne de TXT kaydı henüz çözümlenmiyor — aşağıdaki kayıtları ekleyin, DNS yayılmasını bekleyin ve ardından Doğrula'ya basın.",
+      "a": "A kaydı henüz çözümlenmiyor — aşağıdan ekleyin, DNS yayılmasını bekleyin ve ardından Doğrula'ya basın.",
       "cname": "CNAME kaydı henüz çözümlenmiyor — aşağıdan ekleyin, DNS yayılmasını bekleyin ve ardından Doğrula'ya basın.",
       "txt": "TXT doğrulama kaydı henüz çözümlenmiyor — aşağıdan ekleyin, DNS yayılmasını bekleyin ve ardından Doğrula'ya basın."
     },

--- a/apps/dashboard/src/lib/api/domains.ts
+++ b/apps/dashboard/src/lib/api/domains.ts
@@ -3,6 +3,8 @@ import { endpoints } from "./endpoints";
 
 export interface DomainVerifyResult {
   verified: boolean;
+  recordVerified?: boolean;
+  /** @deprecated Compatibility alias for API versions before recordVerified. */
   cnameVerified?: boolean;
   txtVerified?: boolean;
   message?: string;
@@ -42,7 +44,7 @@ export const domainsApi = {
    *
    * Returns the verify result on BOTH success and failure — the backend
    * returns 422 with the same shape when verification fails so the UI
-   * can surface cnameVerified/txtVerified/message inline without a
+   * can surface recordVerified/txtVerified/message inline without a
    * second request. Any error other than 422 (network, 4xx, 5xx) is
    * re-thrown so callers can show a generic failure toast.
    */


### PR DESCRIPTION
## Summary

- run routing and TXT ownership DNS checks concurrently so their bounded resolver fallbacks stay within the dashboard request timeout
- expose the route-agnostic `recordVerified` result while retaining `cnameVerified` as a compatibility alias
- show self-hosted users the correct missing A-record hint instead of always calling it a CNAME
- add a regression test that keeps the A lookup pending and proves the TXT lookup starts concurrently

## Root cause

Each DNS record lookup can spend up to 5 seconds on Google DoH and another 5 seconds on the local resolver fallback. The verifier checked the routing record and TXT record sequentially, so an unreachable resolver could take about 20 seconds while the dashboard aborts requests after 15 seconds.

The dashboard also interpreted the historical `cnameVerified` field literally even though self-hosted installations verify an A record.

## Validation

- `bun run --cwd apps/api test` — 735 passed, 3 skipped
- `bun run --cwd apps/api lint`
- `bunx tsc --noEmit -p apps/dashboard/tsconfig.json`
- `bun run --cwd apps/api build`
- `bun run --cwd apps/dashboard build`
- `git diff --check`

## Note

`bun run --cwd apps/dashboard lint` is currently unusable on upstream main because its `next lint` script is interpreted as a project directory by Next.js 16. This PR does not change that script.