### PR TITLE
fix(adapters): pair MySQL backup credentials with the right account

### DIFF
--- a/packages/adapters/src/backup/producers/mysql-dump.test.ts
+++ b/packages/adapters/src/backup/producers/mysql-dump.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { Readable } from "node:stream";
+import { MysqlDumpProducer, mysqlCredentials } from "./mysql-dump";
+import type { BackupExecutor, ExecExitInfo, ServiceHandle } from "../types";
+
+function serviceWith(env: Record<string, string>): ServiceHandle {
+  return {
+    id: "svc-1",
+    projectId: "proj-1",
+    name: "db",
+    image: "mysql:8.0",
+    env,
+    volumes: [],
+    containerId: "c1",
+    projectSlug: "app",
+    namespaceVolumes: true,
+  };
+}
+
+/** Records the argv of the first execStream/pipeIntoCommand call. */
+function captureExecutor(): { executor: BackupExecutor; lastCmd: () => string[] } {
+  let captured: string[] = [];
+  const exit: ExecExitInfo = { code: 0, stderr: "" };
+  const executor = {
+    runtimeName: "docker",
+    async execStream(_service: ServiceHandle, cmd: string[]) {
+      captured = cmd;
+      return { stdout: Readable.from([]), awaitExit: Promise.resolve(exit) };
+    },
+    async pipeIntoCommand(_service: ServiceHandle, cmd: string[]) {
+      captured = cmd;
+      return exit;
+    },
+  } as unknown as BackupExecutor;
+  return { executor, lastCmd: () => captured };
+}
+
+describe("mysqlCredentials", () => {
+  it("pairs root with MYSQL_ROOT_PASSWORD when a non-root MYSQL_USER is also set", () => {
+    const creds = mysqlCredentials({
+      MYSQL_ROOT_PASSWORD: "rootpw",
+      MYSQL_DATABASE: "wordpress",
+      MYSQL_USER: "wordpress",
+      MYSQL_PASSWORD: "wppw",
+    });
+    expect(creds).toEqual({ user: "root", password: "rootpw" });
+  });
+
+  it("uses root with MYSQL_ROOT_PASSWORD when no MYSQL_USER is set", () => {
+    expect(mysqlCredentials({ MYSQL_ROOT_PASSWORD: "rootpw" })).toEqual({
+      user: "root",
+      password: "rootpw",
+    });
+  });
+
+  it("pairs MYSQL_USER with MYSQL_PASSWORD when no root password is present", () => {
+    expect(mysqlCredentials({ MYSQL_USER: "app", MYSQL_PASSWORD: "apppw" })).toEqual({
+      user: "app",
+      password: "apppw",
+    });
+  });
+
+  it("falls back to root with an empty password when nothing is set", () => {
+    expect(mysqlCredentials({})).toEqual({ user: "root", password: "" });
+  });
+});
+
+describe("MysqlDumpProducer command construction", () => {
+  const env = {
+    MYSQL_ROOT_PASSWORD: "rootpw",
+    MYSQL_DATABASE: "wordpress",
+    MYSQL_USER: "wordpress",
+    MYSQL_PASSWORD: "wppw",
+  };
+
+  it("authenticates the dump as root using the root password", async () => {
+    const { executor, lastCmd } = captureExecutor();
+    // Drain the async generator so produce() issues the exec call.
+    for await (const _artifact of MysqlDumpProducer.produce(serviceWith(env), executor, {})) {
+      // no-op
+    }
+    const script = lastCmd()[2] ?? "";
+    expect(script).toContain("MYSQL_PWD='rootpw'");
+    expect(script).toContain("-u 'root'");
+    expect(script).not.toContain("-u 'wordpress'");
+  });
+
+  it("restores as root using the root password", async () => {
+    const { executor, lastCmd } = captureExecutor();
+    await MysqlDumpProducer.restore(
+      serviceWith(env),
+      executor,
+      {
+        metadata: {},
+        open: async () => Readable.from([]),
+      } as never,
+      {},
+    );
+    const script = lastCmd()[2] ?? "";
+    expect(script).toContain("MYSQL_PWD='rootpw'");
+    expect(script).toContain("-u 'root'");
+    expect(script).not.toContain("-u 'wordpress'");
+  });
+});

--- a/packages/adapters/src/backup/producers/mysql-dump.ts
+++ b/packages/adapters/src/backup/producers/mysql-dump.ts
@@ -29,6 +29,13 @@ function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
+export function mysqlCredentials(env: Record<string, string>): { user: string; password: string } {
+  if (env.MYSQL_ROOT_PASSWORD) {
+    return { user: "root", password: env.MYSQL_ROOT_PASSWORD };
+  }
+  return { user: env.MYSQL_USER ?? "root", password: env.MYSQL_PASSWORD ?? "" };
+}
+
 class MysqlDumpProducerImpl implements BackupProducer {
   readonly kind = "mysql_dump" as const;
 
@@ -42,9 +49,7 @@ class MysqlDumpProducerImpl implements BackupProducer {
     executor: BackupExecutor,
     _opts: ProducerOpts,
   ): AsyncIterable<Artifact> {
-    const password =
-      service.env.MYSQL_ROOT_PASSWORD ?? service.env.MYSQL_PASSWORD ?? "";
-    const user = service.env.MYSQL_USER ?? "root";
+    const { user, password } = mysqlCredentials(service.env);
     // If a specific DB isn't named, dump all-databases.
     const db = service.env.MYSQL_DATABASE ?? "";
     const dbArg = db ? `--databases ${shellEscape(db)}` : "--all-databases";
@@ -79,9 +84,7 @@ class MysqlDumpProducerImpl implements BackupProducer {
     artifact: ArtifactRef,
     _opts: RestoreOpts,
   ): Promise<void> {
-    const password =
-      service.env.MYSQL_ROOT_PASSWORD ?? service.env.MYSQL_PASSWORD ?? "";
-    const user = service.env.MYSQL_USER ?? "root";
+    const { user, password } = mysqlCredentials(service.env);
 
     // Collapsed to a SINGLE `sh -c` level. `export` so MYSQL_PWD
     // reaches mysql (the second process in the pipeline) — the


### PR DESCRIPTION
## Problem

The MySQL/MariaDB backup producer picks its username and password from **independent** env lookups:

```ts
const password = service.env.MYSQL_ROOT_PASSWORD ?? service.env.MYSQL_PASSWORD ?? "";
const user     = service.env.MYSQL_USER ?? "root";
```

These don't come from the same account. For the canonical WordPress / Nextcloud / self-host `docker-compose` shape:

```yaml
db:
  image: mysql:8
  environment:
    MYSQL_ROOT_PASSWORD: rootpw
    MYSQL_DATABASE: wordpress
    MYSQL_USER: wordpress
    MYSQL_PASSWORD: wppw
```

| env in | `user` | `password` | result |
|---|---|---|---|
| root pw **+** `MYSQL_USER` (the common case) | `wordpress` | `rootpw` | ❌ `Access denied for user 'wordpress'` — backup **and** restore fail |
| only `MYSQL_ROOT_PASSWORD` (e.g. the built-in Ghost template) | `root` | `rootpw` | ✅ works |
| only `MYSQL_USER` + `MYSQL_PASSWORD` | `wordpress` | `wppw` | ✅ works |

The broken row is the one most self-hosters hit: the official MySQL image **forbids `MYSQL_USER=root`**, so `MYSQL_USER` is always a non-root account whose password is `MYSQL_PASSWORD` — never `MYSQL_ROOT_PASSWORD`. Pairing that username with the root password can never authenticate.

Actual dump command produced today for the table's first row:

```
MYSQL_PWD='rootpw' mysqldump --single-transaction --routines --triggers -u 'wordpress' --databases 'wordpress' | zstd -c -3
```

## Fix

Pair each password with the account it actually authenticates, via one shared helper used by both `produce` and `restore`:

```ts
export function mysqlCredentials(env) {
  if (env.MYSQL_ROOT_PASSWORD) return { user: "root", password: env.MYSQL_ROOT_PASSWORD };
  return { user: env.MYSQL_USER ?? "root", password: env.MYSQL_PASSWORD ?? "" };
}
```

Preferring root when a root password is present is also correct on privileges: `--single-transaction --routines --triggers` and `--all-databases` need SUPER/global grants a scoped app user typically lacks. The two previously-working rows above are unchanged; only the broken pairing changes (`wordpress`/`rootpw` → `root`/`rootpw`).

## Tests

New `packages/adapters/src/backup/producers/mysql-dump.test.ts`:
- `mysqlCredentials` unit cases for all four env shapes (both set / root-only / user-only / empty).
- Integration: drive `produce` and `restore` through a fake executor and assert the emitted `sh -c` script authenticates as `-u 'root'` with `MYSQL_PWD='rootpw'` and never `-u 'wordpress'`.

Verified they **fail without the fix** — against unpatched source the command tests assert-fail with the buggy `mysql -u 'wordpress'` (root password) command captured verbatim.

## Verification

- `bun run test` → all 5 turbo tasks successful (adapters 258 tests, +6).
- `bun run --cwd apps/api lint` → clean.
- Both touched files pass `npx prettier --check`; source had no pre-existing drift, so no unrelated churn.

### Alternative considered
Keep `MYSQL_USER` when set and instead pair it with `MYSQL_PASSWORD` (dumping as the app user). Rejected as the default because a scoped app user usually can't perform `--routines`/`--all-databases`; happy to switch if you'd rather back up as the app account.