### PR TITLE
feat(api/dashboard): add Discord as a notification channel

### DIFF
--- a/apps/api/src/lib/notification-workers.ts
+++ b/apps/api/src/lib/notification-workers.ts
@@ -153,6 +153,50 @@ async function sendInApp(_delivery: NotificationDelivery): Promise<void> {
   // inbox. The runner will mark this as sent immediately on return.
 }
 
+async function sendDiscord(
+  delivery: NotificationDelivery,
+  channel: NotificationChannel,
+): Promise<void> {
+  const config = channel.config as { webhookUrl?: string };
+  if (!config?.webhookUrl) {
+    throw new Error("Discord channel has no webhook URL configured");
+  }
+
+  // Webhook URL is encrypted at storage time.
+  const webhookUrl = decrypt(config.webhookUrl);
+
+  const { title, body } = renderMessage(delivery);
+  const discordPayload = {
+    username: "Openship",
+    avatar_url: "https://openship.io/favicon.ico",
+    embeds: [
+      {
+        title,
+        description: body,
+        color: 0x3b82f6,
+        timestamp: new Date(delivery.createdAt).toISOString(),
+      },
+    ],
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(discordPayload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Discord webhook returned ${res.status}: ${text.slice(0, 200)}`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function sendSlack(
   delivery: NotificationDelivery,
   channel: NotificationChannel,
@@ -209,6 +253,7 @@ const WORKERS: Record<
   webhook: sendWebhook,
   in_app: sendInApp,
   slack: sendSlack,
+  discord: sendDiscord,
 };
 
 /* ─── Runner loop ─────────────────────────────────────────────────────────── */
@@ -238,22 +283,14 @@ export async function processQueuedNotifications(): Promise<void> {
       // Resolve channel — null channelId means the subscription pointed
       // at a now-deleted channel. Mark failed permanently.
       if (!delivery.channelId) {
-        await repos.notificationDelivery.markFailed(
-          delivery.id,
-          "Channel deleted",
-          false,
-        );
+        await repos.notificationDelivery.markFailed(delivery.id, "Channel deleted", false);
         return;
       }
       const channel = await repos.notificationChannel
         .findById(delivery.channelId)
         .catch(() => undefined);
       if (!channel) {
-        await repos.notificationDelivery.markFailed(
-          delivery.id,
-          "Channel not found",
-          false,
-        );
+        await repos.notificationDelivery.markFailed(delivery.id, "Channel not found", false);
         return;
       }
 

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -23,7 +23,7 @@ import { encrypt } from "../../lib/encryption";
 import { CATEGORIES } from "../../lib/notification-categories";
 import { randomBytes } from "node:crypto";
 
-const VALID_CHANNEL_KINDS = new Set(["email", "webhook", "in_app", "slack"]);
+const VALID_CHANNEL_KINDS = new Set(["email", "webhook", "in_app", "slack", "discord"]);
 
 /* ─── Categories (static, no DB) ─────────────────────────────────────── */
 
@@ -81,7 +81,10 @@ export async function createChannel(c: Context) {
   });
 
   return c.json({
-    channel: { ...channel, config: redactChannelConfig(channel.kind, channel.config as Record<string, unknown>) },
+    channel: {
+      ...channel,
+      config: redactChannelConfig(channel.kind, channel.config as Record<string, unknown>),
+    },
   });
 }
 
@@ -124,7 +127,10 @@ export async function updateChannel(c: Context) {
 
   return c.json({
     channel: channel
-      ? { ...channel, config: redactChannelConfig(channel.kind, channel.config as Record<string, unknown>) }
+      ? {
+          ...channel,
+          config: redactChannelConfig(channel.kind, channel.config as Record<string, unknown>),
+        }
       : null,
   });
 }
@@ -157,7 +163,10 @@ export async function deleteChannel(c: Context) {
 /** GET /subscriptions — list calling user's subscriptions for the active org. */
 export async function listSubscriptions(c: Context) {
   const ctx = getRequestContext(c);
-  const subs = await repos.notificationSubscription.listForUserInOrg(ctx.userId, ctx.organizationId);
+  const subs = await repos.notificationSubscription.listForUserInOrg(
+    ctx.userId,
+    ctx.organizationId,
+  );
   return c.json({ subscriptions: subs });
 }
 
@@ -241,7 +250,11 @@ export async function upsertDefault(c: Context) {
     eventType: "notification_default.updated",
     resourceType: "notifications",
     resourceId: `${ctx.organizationId}:${body.category}`,
-    after: { category: def.category, defaultEnabled: def.defaultEnabled, defaultChannelKind: def.defaultChannelKind },
+    after: {
+      category: def.category,
+      defaultEnabled: def.defaultEnabled,
+      defaultChannelKind: def.defaultChannelKind,
+    },
   });
 
   return c.json({ default: def });
@@ -254,11 +267,10 @@ export async function listDeliveries(c: Context) {
   const ctx = getRequestContext(c);
   const unseenOnly = c.req.query("unseen") === "true";
   const limit = Math.min(parseInt(c.req.query("limit") ?? "100", 10) || 100, 500);
-  const deliveries = await repos.notificationDelivery.listForUser(
-    ctx.userId,
-    ctx.organizationId,
-    { unseenOnly, limit },
-  );
+  const deliveries = await repos.notificationDelivery.listForUser(ctx.userId, ctx.organizationId, {
+    unseenOnly,
+    limit,
+  });
   return c.json({ deliveries });
 }
 
@@ -280,8 +292,14 @@ export async function markSeen(c: Context) {
 
 /* ─── Helpers ────────────────────────────────────────────────────────── */
 
-interface ConfigOk { ok: true; value: Record<string, unknown> }
-interface ConfigErr { ok: false; error: string }
+interface ConfigOk {
+  ok: true;
+  value: Record<string, unknown>;
+}
+interface ConfigErr {
+  ok: false;
+  error: string;
+}
 
 /**
  * Sanitize + normalize the inbound config per kind. Secrets (webhook
@@ -290,10 +308,7 @@ interface ConfigErr { ok: false; error: string }
  *
  * Returns either { ok: true, value } or { ok: false, error }.
  */
-function sanitizeChannelConfig(
-  kind: string,
-  raw: unknown,
-): ConfigOk | ConfigErr {
+function sanitizeChannelConfig(kind: string, raw: unknown): ConfigOk | ConfigErr {
   const cfg = (raw ?? {}) as Record<string, unknown>;
   switch (kind) {
     case "email": {
@@ -308,9 +323,10 @@ function sanitizeChannelConfig(
       if (!/^https?:\/\//.test(url)) return { ok: false, error: "Invalid webhook URL" };
       // Auto-generate a signing secret if the user didn't supply one —
       // we'll show it back via the verification flow so they can save it.
-      const rawSecret = typeof cfg.hmacSecret === "string" && cfg.hmacSecret.length > 0
-        ? cfg.hmacSecret
-        : randomBytes(32).toString("base64url");
+      const rawSecret =
+        typeof cfg.hmacSecret === "string" && cfg.hmacSecret.length > 0
+          ? cfg.hmacSecret
+          : randomBytes(32).toString("base64url");
       return { ok: true, value: { url, hmacSecret: encrypt(rawSecret) } };
     }
     case "in_app":
@@ -322,6 +338,17 @@ function sanitizeChannelConfig(
       }
       const out: Record<string, unknown> = { webhookUrl: encrypt(webhookUrl) };
       if (typeof cfg.channelName === "string") out.channelName = cfg.channelName;
+      return { ok: true, value: out };
+    }
+    case "discord": {
+      const webhookUrl = String(cfg.webhookUrl ?? "").trim();
+      if (
+        !webhookUrl.startsWith("https://discord.com/api/webhooks/") &&
+        !webhookUrl.startsWith("https://discordapp.com/api/webhooks/")
+      ) {
+        return { ok: false, error: "Invalid Discord webhook URL" };
+      }
+      const out: Record<string, unknown> = { webhookUrl: encrypt(webhookUrl) };
       return { ok: true, value: out };
     }
     default:
@@ -354,6 +381,10 @@ function redactChannelConfig(
       return {
         webhookUrlConfigured: !!cfg.webhookUrl,
         channelName: cfg.channelName ?? null,
+      };
+    case "discord":
+      return {
+        webhookUrlConfigured: !!cfg.webhookUrl,
       };
     default:
       return {};

--- a/apps/dashboard/src/app/(dashboard)/settings/_components/NotificationsTab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/_components/NotificationsTab.tsx
@@ -19,7 +19,18 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Bell, Mail, Webhook, MessageSquare, Smartphone, Plus, Trash2, Loader2, AlertTriangle } from "lucide-react";
+import {
+  Bell,
+  Mail,
+  Webhook,
+  MessageSquare,
+  MessageCircle,
+  Smartphone,
+  Plus,
+  Trash2,
+  Loader2,
+  AlertTriangle,
+} from "lucide-react";
 import { systemApi } from "@/lib/api/system";
 import { useToast } from "@/context/ToastContext";
 import { SettingsSection } from "./SettingsSection";
@@ -40,6 +51,7 @@ const CHANNEL_ICONS: Record<ChannelKind, React.ElementType> = {
   email: Mail,
   webhook: Webhook,
   slack: MessageSquare,
+  discord: MessageCircle,
   in_app: Smartphone,
 };
 
@@ -47,6 +59,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   email: "Email",
   webhook: "Webhook",
   slack: "Slack",
+  discord: "Discord",
   in_app: "In-app",
 };
 
@@ -65,26 +78,29 @@ export function NotificationsTab() {
   // a toggle/mutation so only the clicked control shows its pending state (its
   // own busy flag) instead of the whole tab collapsing to a centered spinner.
   // The global spinner is reserved for the very first load.
-  const refresh = useCallback(async (opts?: { silent?: boolean }) => {
-    const silent = opts?.silent ?? false;
-    if (!silent) setLoading(true);
-    try {
-      const [cats, ch, subs, defs] = await Promise.all([
-        notificationsApi.listCategories(),
-        notificationsApi.listChannels(),
-        notificationsApi.listSubscriptions(),
-        notificationsApi.listDefaults().catch(() => ({ defaults: [] })),
-      ]);
-      setCategories(cats.categories);
-      setChannels(ch.channels);
-      setSubscriptions(subs.subscriptions);
-      setDefaults(defs.defaults);
-    } catch (err) {
-      showToast(getApiErrorMessage(err), "error", "Notifications");
-    } finally {
-      if (!silent) setLoading(false);
-    }
-  }, [showToast]);
+  const refresh = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      const silent = opts?.silent ?? false;
+      if (!silent) setLoading(true);
+      try {
+        const [cats, ch, subs, defs] = await Promise.all([
+          notificationsApi.listCategories(),
+          notificationsApi.listChannels(),
+          notificationsApi.listSubscriptions(),
+          notificationsApi.listDefaults().catch(() => ({ defaults: [] })),
+        ]);
+        setCategories(cats.categories);
+        setChannels(ch.channels);
+        setSubscriptions(subs.subscriptions);
+        setDefaults(defs.defaults);
+      } catch (err) {
+        showToast(getApiErrorMessage(err), "error", "Notifications");
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    [showToast],
+  );
 
   useEffect(() => {
     void refresh();
@@ -94,13 +110,15 @@ export function NotificationsTab() {
   useEffect(() => {
     (async () => {
       try {
-        const result = await (authClient as unknown as {
-          organization: {
-            getFullOrganization: () => Promise<{
-              data?: { members?: Array<{ userId: string; role: string }>; id: string } | null;
-            }>;
-          };
-        }).organization.getFullOrganization();
+        const result = await (
+          authClient as unknown as {
+            organization: {
+              getFullOrganization: () => Promise<{
+                data?: { members?: Array<{ userId: string; role: string }>; id: string } | null;
+              }>;
+            };
+          }
+        ).organization.getFullOrganization();
         const session = await authClient.getSession();
         const userId = session.data?.user?.id;
         const me = result.data?.members?.find((m) => m.userId === userId);
@@ -156,7 +174,11 @@ function ChannelsCard({
     if (!confirm(t.settings.notifications.channels.confirmDelete)) return;
     try {
       await notificationsApi.deleteChannel(id);
-      showToast(t.settings.notifications.channels.channelRemoved, "success", t.settings.common.toast.notifications);
+      showToast(
+        t.settings.notifications.channels.channelRemoved,
+        "success",
+        t.settings.common.toast.notifications,
+      );
       await onChange();
     } catch (err) {
       showToast(getApiErrorMessage(err), "error", t.settings.common.toast.notifications);
@@ -182,13 +204,19 @@ function ChannelsCard({
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium text-foreground truncate">{ch.label}</p>
-                  <p className="text-xs text-muted-foreground truncate">{describeChannel(ch, t.settings.notifications.describe)}</p>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {describeChannel(ch, t.settings.notifications.describe)}
+                  </p>
                 </div>
                 <div className="flex items-center gap-2">
                   {ch.verified ? (
-                    <span className="text-[11px] uppercase tracking-wide text-success">{t.settings.notifications.channels.verified}</span>
+                    <span className="text-[11px] uppercase tracking-wide text-success">
+                      {t.settings.notifications.channels.verified}
+                    </span>
                   ) : ch.kind !== "in_app" ? (
-                    <span className="text-[11px] uppercase tracking-wide text-warning">{t.settings.notifications.channels.unverified}</span>
+                    <span className="text-[11px] uppercase tracking-wide text-warning">
+                      {t.settings.notifications.channels.unverified}
+                    </span>
                   ) : null}
                   <button
                     type="button"
@@ -231,7 +259,7 @@ function ChannelsCard({
 
 function describeChannel(
   ch: NotificationChannel,
-  labels: { slackWebhook: string; inApp: string },
+  labels: { slackWebhook: string; discordWebhook: string; inApp: string },
 ): string {
   switch (ch.kind) {
     case "email":
@@ -239,7 +267,11 @@ function describeChannel(
     case "webhook":
       return String((ch.config as { url?: string }).url ?? "");
     case "slack":
-      return String((ch.config as { channelName?: string | null }).channelName ?? labels.slackWebhook);
+      return String(
+        (ch.config as { channelName?: string | null }).channelName ?? labels.slackWebhook,
+      );
+    case "discord":
+      return labels.discordWebhook;
     case "in_app":
       return labels.inApp;
     default:
@@ -284,18 +316,26 @@ function NewChannelForm({
 
   const submit = async () => {
     if (!label.trim()) {
-      showToast(t.settings.notifications.form.labelRequired, "error", t.settings.common.toast.notifications);
+      showToast(
+        t.settings.notifications.form.labelRequired,
+        "error",
+        t.settings.common.toast.notifications,
+      );
       return;
     }
     let config: Record<string, unknown> = {};
     if (kind === "email") config = { address: address.trim() };
     else if (kind === "webhook") config = { url: url.trim() };
-    else if (kind === "slack") config = { webhookUrl: webhookUrl.trim() };
+    else if (kind === "slack" || kind === "discord") config = { webhookUrl: webhookUrl.trim() };
 
     setBusy(true);
     try {
       await notificationsApi.createChannel({ kind, label: label.trim(), config });
-      showToast(t.settings.notifications.channels.channelAdded, "success", t.settings.common.toast.notifications);
+      showToast(
+        t.settings.notifications.channels.channelAdded,
+        "success",
+        t.settings.common.toast.notifications,
+      );
       await onSaved();
     } catch (err) {
       showToast(getApiErrorMessage(err), "error", t.settings.common.toast.notifications);
@@ -315,6 +355,7 @@ function NewChannelForm({
           <option value="email">{t.settings.notifications.kinds.email}</option>
           <option value="webhook">{t.settings.notifications.kinds.webhook}</option>
           <option value="slack">{t.settings.notifications.kinds.slack}</option>
+          <option value="discord">{t.settings.notifications.kinds.discord}</option>
           <option value="in_app">{t.settings.notifications.kinds.in_app}</option>
         </select>
         <input
@@ -362,6 +403,15 @@ function NewChannelForm({
         <input
           type="url"
           placeholder={t.settings.notifications.form.slackPlaceholder}
+          value={webhookUrl}
+          onChange={(e) => setWebhookUrl(e.target.value)}
+          className="w-full bg-background border border-border/50 rounded-lg px-3 py-2 text-sm"
+        />
+      )}
+      {kind === "discord" && (
+        <input
+          type="url"
+          placeholder={t.settings.notifications.form.discordPlaceholder}
           value={webhookUrl}
           onChange={(e) => setWebhookUrl(e.target.value)}
           className="w-full bg-background border border-border/50 rounded-lg px-3 py-2 text-sm"
@@ -433,13 +483,17 @@ function SubscriptionsCard({
       description={t.settings.notifications.subscriptions.description}
     >
       {channels.length === 0 ? (
-        <p className="text-sm text-muted-foreground">{t.settings.notifications.subscriptions.empty}</p>
+        <p className="text-sm text-muted-foreground">
+          {t.settings.notifications.subscriptions.empty}
+        </p>
       ) : (
         <div className="overflow-x-auto -mx-5">
           <table className="w-full text-sm">
             <thead>
               <tr className="text-start text-xs uppercase tracking-wide text-muted-foreground">
-                <th className="px-5 py-2 font-medium">{t.settings.notifications.subscriptions.eventHeader}</th>
+                <th className="px-5 py-2 font-medium">
+                  {t.settings.notifications.subscriptions.eventHeader}
+                </th>
                 {channels.map((ch) => (
                   <th key={ch.id} className="px-3 py-2 font-medium text-center min-w-[100px]">
                     {ch.label}
@@ -466,7 +520,10 @@ function SubscriptionsCard({
                           checked={enabled}
                           onChange={(e) => toggle(cat.id, ch.id, e.target.checked)}
                           className="size-4 rounded border-border/50 cursor-pointer accent-foreground"
-                          aria-label={interpolate(t.settings.notifications.subscriptions.cellAria, { category: cat.label, channel: ch.label })}
+                          aria-label={interpolate(t.settings.notifications.subscriptions.cellAria, {
+                            category: cat.label,
+                            channel: ch.label,
+                          })}
                         />
                       </td>
                     );
@@ -548,13 +605,16 @@ function OrgDefaultsCard({
                 <option value="email">{t.settings.notifications.kinds.email}</option>
                 <option value="webhook">{t.settings.notifications.kinds.webhook}</option>
                 <option value="slack">{t.settings.notifications.kinds.slack}</option>
+                <option value="discord">{t.settings.notifications.kinds.discord}</option>
                 <option value="in_app">{t.settings.notifications.kinds.in_app}</option>
               </select>
               <Toggle
                 checked={enabled}
                 disabled={isBusy}
                 onChange={(v: boolean) => set(cat.id, v, kind)}
-                aria-label={interpolate(t.settings.notifications.orgDefaults.notifyAria, { category: cat.label })}
+                aria-label={interpolate(t.settings.notifications.orgDefaults.notifyAria, {
+                  category: cat.label,
+                })}
               />
             </div>
           );

--- a/apps/dashboard/src/i18n/locales/ar/settings.json
+++ b/apps/dashboard/src/i18n/locales/ar/settings.json
@@ -416,12 +416,14 @@
     },
     "describe": {
       "slackWebhook": "‏Webhook الخاص بـ Slack",
+      "discordWebhook": "Discord webhook",
       "inApp": "أيقونة الجرس في لوحة التحكم"
     },
     "kinds": {
       "email": "البريد الإلكتروني",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "داخل التطبيق"
     },
     "form": {
@@ -429,6 +431,7 @@
       "emailPlaceholder": "you@example.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "جارٍ الإضافة…",
       "addChannel": "إضافة قناة",
       "labelRequired": "التسمية مطلوبة"

--- a/apps/dashboard/src/i18n/locales/de/settings.json
+++ b/apps/dashboard/src/i18n/locales/de/settings.json
@@ -416,12 +416,14 @@
     },
     "describe": {
       "slackWebhook": "Slack-Webhook",
+      "discordWebhook": "Discord-Webhook",
       "inApp": "Glockensymbol im Dashboard"
     },
     "kinds": {
       "email": "E-Mail",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "In-App"
     },
     "form": {
@@ -429,6 +431,7 @@
       "emailPlaceholder": "du@example.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "Wird hinzugefügt…",
       "addChannel": "Kanal hinzufügen",
       "labelRequired": "Bezeichnung ist erforderlich"

--- a/apps/dashboard/src/i18n/locales/en/settings.json
+++ b/apps/dashboard/src/i18n/locales/en/settings.json
@@ -499,12 +499,14 @@
     },
     "describe": {
       "slackWebhook": "Slack webhook",
+      "discordWebhook": "Discord webhook",
       "inApp": "Dashboard bell icon"
     },
     "kinds": {
       "email": "Email",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "In-app"
     },
     "form": {
@@ -512,6 +514,7 @@
       "emailPlaceholder": "you@example.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "Adding…",
       "addChannel": "Add channel",
       "labelRequired": "Label is required",

--- a/apps/dashboard/src/i18n/locales/es/settings.json
+++ b/apps/dashboard/src/i18n/locales/es/settings.json
@@ -416,12 +416,14 @@
     },
     "describe": {
       "slackWebhook": "Webhook de Slack",
+      "discordWebhook": "Webhook de Discord",
       "inApp": "Icono de campana del panel"
     },
     "kinds": {
       "email": "Correo electrónico",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "En la app"
     },
     "form": {
@@ -429,6 +431,7 @@
       "emailPlaceholder": "tu@ejemplo.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "Añadiendo…",
       "addChannel": "Añadir canal",
       "labelRequired": "La etiqueta es obligatoria"

--- a/apps/dashboard/src/i18n/locales/fr/settings.json
+++ b/apps/dashboard/src/i18n/locales/fr/settings.json
@@ -458,12 +458,14 @@
     },
     "describe": {
       "slackWebhook": "Webhook Slack",
+      "discordWebhook": "Webhook Discord",
       "inApp": "Icône cloche du tableau de bord"
     },
     "kinds": {
       "email": "E-mail",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "Dans l'application"
     },
     "form": {
@@ -471,6 +473,7 @@
       "emailPlaceholder": "vous@exemple.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "Ajout…",
       "addChannel": "Ajouter un canal",
       "labelRequired": "Le libellé est requis"

--- a/apps/dashboard/src/i18n/locales/ja/settings.json
+++ b/apps/dashboard/src/i18n/locales/ja/settings.json
@@ -416,12 +416,14 @@
     },
     "describe": {
       "slackWebhook": "Slack Webhook",
+      "discordWebhook": "Discord Webhook",
       "inApp": "ダッシュボードのベルアイコン"
     },
     "kinds": {
       "email": "メール",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "アプリ内"
     },
     "form": {
@@ -429,6 +431,7 @@
       "emailPlaceholder": "you@example.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "追加中…",
       "addChannel": "チャンネルを追加",
       "labelRequired": "ラベルは必須です"

--- a/apps/dashboard/src/i18n/locales/pt/settings.json
+++ b/apps/dashboard/src/i18n/locales/pt/settings.json
@@ -416,12 +416,14 @@
     },
     "describe": {
       "slackWebhook": "Webhook do Slack",
+      "discordWebhook": "Webhook do Discord",
       "inApp": "Ícone de sino do painel"
     },
     "kinds": {
       "email": "E-mail",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "No aplicativo"
     },
     "form": {
@@ -429,6 +431,7 @@
       "emailPlaceholder": "voce@example.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "Adicionando…",
       "addChannel": "Adicionar canal",
       "labelRequired": "O rótulo é obrigatório"

--- a/apps/dashboard/src/i18n/locales/zh/settings.json
+++ b/apps/dashboard/src/i18n/locales/zh/settings.json
@@ -416,12 +416,14 @@
     },
     "describe": {
       "slackWebhook": "Slack webhook",
+      "discordWebhook": "Discord webhook",
       "inApp": "仪表盘铃铛图标"
     },
     "kinds": {
       "email": "电子邮件",
       "webhook": "Webhook",
       "slack": "Slack",
+      "discord": "Discord",
       "in_app": "应用内"
     },
     "form": {
@@ -429,6 +431,7 @@
       "emailPlaceholder": "you@example.com",
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
+      "discordPlaceholder": "https://discord.com/api/webhooks/...",
       "adding": "正在添加…",
       "addChannel": "添加渠道",
       "labelRequired": "标签为必填项"

--- a/apps/dashboard/src/lib/api/notifications.ts
+++ b/apps/dashboard/src/lib/api/notifications.ts
@@ -10,7 +10,7 @@ export interface NotificationCategory {
   defaultEnabled: boolean;
 }
 
-export type ChannelKind = "email" | "webhook" | "in_app" | "slack";
+export type ChannelKind = "email" | "webhook" | "in_app" | "slack" | "discord";
 export type DeliveryStatus = "queued" | "sending" | "sent" | "failed" | "seen";
 
 /* ── Channel ─────────────────────────────────────────────────────── */
@@ -24,7 +24,8 @@ export interface NotificationChannel {
    *    email   → { address }
    *    webhook → { url, hmacSecretConfigured }
    *    in_app  → {}
-   *    slack   → { webhookUrlConfigured, channelName | null } */
+   *    slack   → { webhookUrlConfigured, channelName | null }
+   *    discord → { webhookUrlConfigured } */
   config: Record<string, unknown>;
   verified: boolean;
   enabled: boolean;
@@ -80,11 +81,7 @@ export const notificationsApi = {
   listChannels: () =>
     api.get<{ channels: NotificationChannel[] }>(endpoints.notifications.channels),
 
-  createChannel: (data: {
-    kind: ChannelKind;
-    label: string;
-    config: Record<string, unknown>;
-  }) =>
+  createChannel: (data: { kind: ChannelKind; label: string; config: Record<string, unknown> }) =>
     api.post<{ channel: NotificationChannel }>(endpoints.notifications.channels, data),
 
   updateChannel: (
@@ -97,20 +94,13 @@ export const notificationsApi = {
     }>,
   ) => api.patch<{ channel: NotificationChannel }>(endpoints.notifications.channel(id), data),
 
-  deleteChannel: (id: string) =>
-    api.delete<{ ok: true }>(endpoints.notifications.channel(id)),
+  deleteChannel: (id: string) => api.delete<{ ok: true }>(endpoints.notifications.channel(id)),
 
   // ── Subscriptions
   listSubscriptions: () =>
-    api.get<{ subscriptions: NotificationSubscription[] }>(
-      endpoints.notifications.subscriptions,
-    ),
+    api.get<{ subscriptions: NotificationSubscription[] }>(endpoints.notifications.subscriptions),
 
-  upsertSubscription: (data: {
-    category: string;
-    channelId: string;
-    enabled: boolean;
-  }) =>
+  upsertSubscription: (data: { category: string; channelId: string; enabled: boolean }) =>
     api.put<{ subscription: NotificationSubscription }>(
       endpoints.notifications.subscriptions,
       data,
@@ -127,8 +117,7 @@ export const notificationsApi = {
     category: string;
     defaultEnabled: boolean;
     defaultChannelKind: ChannelKind;
-  }) =>
-    api.put<{ default: NotificationDefault }>(endpoints.notifications.defaults, data),
+  }) => api.put<{ default: NotificationDefault }>(endpoints.notifications.defaults, data),
 
   // ── Deliveries (in-app inbox)
   listDeliveries: (opts?: { unseen?: boolean; limit?: number }) => {
@@ -142,9 +131,7 @@ export const notificationsApi = {
     return api.get<{ deliveries: NotificationDelivery[] }>(url);
   },
 
-  unseenCount: () =>
-    api.get<{ count: number }>(endpoints.notifications.unseenCount),
+  unseenCount: () => api.get<{ count: number }>(endpoints.notifications.unseenCount),
 
-  markSeen: (id: string) =>
-    api.post<{ ok: true }>(endpoints.notifications.markSeen(id), {}),
+  markSeen: (id: string) => api.post<{ ok: true }>(endpoints.notifications.markSeen(id), {}),
 };

--- a/apps/web/content/docs/api/notifications.mdx
+++ b/apps/web/content/docs/api/notifications.mdx
@@ -3,10 +3,10 @@ title: Notifications API
 description: Manage delivery channels, per-event subscriptions, org defaults, and the in-app alert feed.
 ---
 
-import { TypeTable } from 'fumadocs-ui/components/type-table';
+import { TypeTable } from "fumadocs-ui/components/type-table";
 
 The Notifications API decides who hears about events like a failed deploy or an expiring SSL cert, and how.
-You register **channels** (where alerts go — email, webhook, Slack, or the in-app bell), toggle
+You register **channels** (where alerts go — email, webhook, Slack, Discord, or the in-app bell), toggle
 **subscriptions** (which event categories reach each channel), set org-wide **defaults** for new members, and
 read **deliveries** (the alert feed behind the bell icon). In the dashboard this is the **Settings →
 Notifications** page. Channels, subscriptions, and deliveries are per-user; defaults are per-org.
@@ -19,32 +19,32 @@ Send a personal access token as a bearer header (`Authorization: Bearer <token>`
 </Callout>
 
 <Callout title="Available on every instance" type="info">
-This module ships on both self-hosted and cloud instances. There is no dedicated `openship` CLI command —
-manage notifications from the dashboard or these endpoints directly.
+  This module ships on both self-hosted and cloud instances. There is no dedicated `openship` CLI
+  command — manage notifications from the dashboard or these endpoints directly.
 </Callout>
 
 ## Endpoints
 
-| Method & path | Permission | What it does |
-|---|---|---|
-| `GET /api/notifications/categories` | `notifications:read` | List notification categories (the registry of event types). |
-| `GET /api/notifications/channels` | `notifications:read` | List the caller's notification channels (email, webhook, etc.). |
-| `POST /api/notifications/channels` | `notifications:write` | Create a notification channel. |
-| `PATCH /api/notifications/channels/:id` | `notifications:write` | Update a notification channel. |
-| `DELETE /api/notifications/channels/:id` | `notifications:write` | Delete a notification channel. |
-| `GET /api/notifications/subscriptions` | `notifications:read` | List the caller's notification subscriptions. |
-| `PUT /api/notifications/subscriptions` | `notifications:write` | Create or update a notification subscription. |
-| `DELETE /api/notifications/subscriptions/:id` | `notifications:write` | Delete a notification subscription. |
-| `GET /api/notifications/defaults` | `notifications:read` | List org default notification settings. |
-| `PUT /api/notifications/defaults` | `notifications:admin` | Upsert one org default. |
-| `GET /api/notifications/deliveries` | `notifications:read` | List notification deliveries (the in-app alert feed). |
-| `GET /api/notifications/deliveries/unseen-count` | `notifications:read` | Count unseen notifications (for the bell badge). |
-| `POST /api/notifications/deliveries/:id/seen` | `notifications:write` | Mark one delivery as seen. |
+| Method & path                                    | Permission            | What it does                                                    |
+| ------------------------------------------------ | --------------------- | --------------------------------------------------------------- |
+| `GET /api/notifications/categories`              | `notifications:read`  | List notification categories (the registry of event types).     |
+| `GET /api/notifications/channels`                | `notifications:read`  | List the caller's notification channels (email, webhook, etc.). |
+| `POST /api/notifications/channels`               | `notifications:write` | Create a notification channel.                                  |
+| `PATCH /api/notifications/channels/:id`          | `notifications:write` | Update a notification channel.                                  |
+| `DELETE /api/notifications/channels/:id`         | `notifications:write` | Delete a notification channel.                                  |
+| `GET /api/notifications/subscriptions`           | `notifications:read`  | List the caller's notification subscriptions.                   |
+| `PUT /api/notifications/subscriptions`           | `notifications:write` | Create or update a notification subscription.                   |
+| `DELETE /api/notifications/subscriptions/:id`    | `notifications:write` | Delete a notification subscription.                             |
+| `GET /api/notifications/defaults`                | `notifications:read`  | List org default notification settings.                         |
+| `PUT /api/notifications/defaults`                | `notifications:admin` | Upsert one org default.                                         |
+| `GET /api/notifications/deliveries`              | `notifications:read`  | List notification deliveries (the in-app alert feed).           |
+| `GET /api/notifications/deliveries/unseen-count` | `notifications:read`  | Count unseen notifications (for the bell badge).                |
+| `POST /api/notifications/deliveries/:id/seen`    | `notifications:write` | Mark one delivery as seen.                                      |
 
 <Callout title="Ownership is enforced inside the handlers" type="info">
-The `notifications:*` tags only check that you're a member of the active org. Beyond that, channels,
-subscriptions, and deliveries are scoped to **your** user — you can't read or modify another member's. A
-per-user route for an id you don't own returns `404`.
+  The `notifications:*` tags only check that you're a member of the active org. Beyond that,
+  channels, subscriptions, and deliveries are scoped to **your** user — you can't read or modify
+  another member's. A per-user route for an id you don't own returns `404`.
 </Callout>
 
 ## Categories
@@ -70,9 +70,17 @@ POST /api/notifications/channels
 
 <TypeTable
   type={{
-    kind: { type: '"email" | "webhook" | "in_app" | "slack"', description: 'The channel type. Any other value is rejected.', required: true },
-    label: { type: 'string', description: 'Human-readable name for the channel.', required: true },
-    config: { type: 'object', description: 'Kind-specific settings — see below. in_app takes an empty object.', required: true },
+    kind: {
+      type: '"email" | "webhook" | "in_app" | "slack" | "discord"',
+      description: "The channel type. Any other value is rejected.",
+      required: true,
+    },
+    label: { type: "string", description: "Human-readable name for the channel.", required: true },
+    config: {
+      type: "object",
+      description: "Kind-specific settings — see below. in_app takes an empty object.",
+      required: true,
+    },
   }}
 />
 
@@ -80,11 +88,32 @@ The `config` shape depends on `kind`:
 
 <TypeTable
   type={{
-    'email.address': { type: 'string', description: 'A valid email address. Required for kind "email".' },
-    'webhook.url': { type: 'string', description: 'An http(s) URL to POST alerts to. Required for kind "webhook".' },
-    'webhook.hmacSecret': { type: 'string', description: 'Signing secret for the payload HMAC. Auto-generated if omitted, then surfaced via the verification flow.' },
-    'slack.webhookUrl': { type: 'string', description: 'A https://hooks.slack.com/... incoming-webhook URL. Required for kind "slack".' },
-    'slack.channelName': { type: 'string', description: 'Optional display label for the Slack channel.' },
+    "email.address": {
+      type: "string",
+      description: 'A valid email address. Required for kind "email".',
+    },
+    "webhook.url": {
+      type: "string",
+      description: 'An http(s) URL to POST alerts to. Required for kind "webhook".',
+    },
+    "webhook.hmacSecret": {
+      type: "string",
+      description:
+        "Signing secret for the payload HMAC. Auto-generated if omitted, then surfaced via the verification flow.",
+    },
+    "slack.webhookUrl": {
+      type: "string",
+      description: 'A https://hooks.slack.com/... incoming-webhook URL. Required for kind "slack".',
+    },
+    "slack.channelName": {
+      type: "string",
+      description: "Optional display label for the Slack channel.",
+    },
+    "discord.webhookUrl": {
+      type: "string",
+      description:
+        'A https://discord.com/api/webhooks/... incoming-webhook URL. Required for kind "discord".',
+    },
   }}
 />
 
@@ -109,10 +138,16 @@ PATCH /api/notifications/channels/:id
 
 <TypeTable
   type={{
-    label: { type: 'string', description: 'Rename the channel.' },
-    enabled: { type: 'boolean', description: 'Turn the channel on or off.' },
-    verified: { type: 'boolean', description: 'Mark the channel verified (e.g. after a successful test send).' },
-    config: { type: 'object', description: 'Replace the kind-specific config. Re-validated against the existing kind.' },
+    label: { type: "string", description: "Rename the channel." },
+    enabled: { type: "boolean", description: "Turn the channel on or off." },
+    verified: {
+      type: "boolean",
+      description: "Mark the channel verified (e.g. after a successful test send).",
+    },
+    config: {
+      type: "object",
+      description: "Replace the kind-specific config. Re-validated against the existing kind.",
+    },
   }}
 />
 
@@ -127,9 +162,21 @@ PUT /api/notifications/subscriptions
 
 <TypeTable
   type={{
-    category: { type: 'string', description: 'A category id from GET /categories (e.g. "deploy.failed").', required: true },
-    channelId: { type: 'string', description: 'The channel to route this category to. Must belong to you.', required: true },
-    enabled: { type: 'boolean', description: 'Whether this category delivers to this channel.', required: true },
+    category: {
+      type: "string",
+      description: 'A category id from GET /categories (e.g. "deploy.failed").',
+      required: true,
+    },
+    channelId: {
+      type: "string",
+      description: "The channel to route this category to. Must belong to you.",
+      required: true,
+    },
+    enabled: {
+      type: "boolean",
+      description: "Whether this category delivers to this channel.",
+      required: true,
+    },
   }}
 />
 
@@ -151,9 +198,21 @@ PUT /api/notifications/defaults
 
 <TypeTable
   type={{
-    category: { type: 'string', description: 'A category id from GET /categories.', required: true },
-    defaultEnabled: { type: 'boolean', description: 'Whether new members get this category enabled by default.', required: true },
-    defaultChannelKind: { type: '"email" | "webhook" | "in_app" | "slack"', description: 'Which channel kind the default routes to.', default: '"email"' },
+    category: {
+      type: "string",
+      description: "A category id from GET /categories.",
+      required: true,
+    },
+    defaultEnabled: {
+      type: "boolean",
+      description: "Whether new members get this category enabled by default.",
+      required: true,
+    },
+    defaultChannelKind: {
+      type: '"email" | "webhook" | "in_app" | "slack" | "discord"',
+      description: "Which channel kind the default routes to.",
+      default: '"email"',
+    },
   }}
 />
 
@@ -169,8 +228,16 @@ GET /api/notifications/deliveries
 
 <TypeTable
   type={{
-    unseen: { type: 'boolean', description: 'Pass ?unseen=true to return only unseen deliveries.', default: 'false' },
-    limit: { type: 'integer', description: 'Max deliveries to return. Capped at 500.', default: '100' },
+    unseen: {
+      type: "boolean",
+      description: "Pass ?unseen=true to return only unseen deliveries.",
+      default: "false",
+    },
+    limit: {
+      type: "integer",
+      description: "Max deliveries to return. Capped at 500.",
+      default: "100",
+    },
   }}
 />
 
@@ -182,13 +249,14 @@ curl "https://your-host/api/notifications/deliveries?unseen=true&limit=20" \
 ## Errors you might see
 
 <Callout title="400 — invalid channel or missing fields" type="warn">
-The `kind` isn't one of `email`/`webhook`/`in_app`/`slack`, `label` is missing, or the `config` failed its
-per-kind check (a malformed email, a non-`http(s)` webhook URL, or a Slack URL that isn't
-`https://hooks.slack.com/...`). Subscriptions need `category`, `channelId`, and a boolean `enabled`; defaults
-need `category` and a boolean `defaultEnabled`.
+  The `kind` isn't one of `email`/`webhook`/`in_app`/`slack`/`discord`, `label` is missing, or the
+  `config` failed its per-kind check (a malformed email, a non-`http(s)` webhook URL, a Slack URL
+  that isn't `https://hooks.slack.com/...`, or a Discord URL that isn't
+  `https://discord.com/api/webhooks/...`). Subscriptions need `category`, `channelId`, and a boolean
+  `enabled`; defaults need `category` and a boolean `defaultEnabled`.
 </Callout>
 
 <Callout title="404 on a per-user route" type="error">
-The channel, subscription, or delivery `:id` doesn't belong to you (or was deleted). List your own with the
-matching `GET` route to get valid ids.
+  The channel, subscription, or delivery `:id` doesn't belong to you (or was deleted). List your own
+  with the matching `GET` route to get valid ids.
 </Callout>

--- a/packages/db/src/repos/notification.repo.ts
+++ b/packages/db/src/repos/notification.repo.ts
@@ -30,7 +30,7 @@ export type NotificationDefault = typeof notificationDefault.$inferSelect;
 export type NotificationDelivery = typeof notificationDelivery.$inferSelect;
 export type NewNotificationDelivery = typeof notificationDelivery.$inferInsert;
 
-export type ChannelKind = "email" | "webhook" | "in_app" | "slack";
+export type ChannelKind = "email" | "webhook" | "in_app" | "slack" | "discord";
 export type DeliveryStatus = "queued" | "sending" | "sent" | "failed" | "seen";
 
 // ─── notification_channel repo ───────────────────────────────────────────────

--- a/packages/db/src/schema/notification.ts
+++ b/packages/db/src/schema/notification.ts
@@ -26,6 +26,7 @@
  *   webhook   POST to user-configured URL, signed with HMAC
  *   in_app    delivery row read by the dashboard's bell icon
  *   slack     POST to Slack incoming-webhook URL the user pasted
+ *   discord   POST to Discord webhook URL with a markdown-aware embed
  */
 
 import {
@@ -86,9 +87,7 @@ export const notificationChannel = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
-  (table) => [
-    index("idx_notification_channel_user").on(table.userId),
-  ],
+  (table) => [index("idx_notification_channel_user").on(table.userId)],
 );
 
 // ─── notification_subscription ───────────────────────────────────────────────
@@ -164,10 +163,7 @@ export const notificationDefault = pgTable(
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("uq_notification_default_org_category").on(
-      table.organizationId,
-      table.category,
-    ),
+    uniqueIndex("uq_notification_default_org_category").on(table.organizationId, table.category),
   ],
 );
 
@@ -233,16 +229,10 @@ export const notificationDelivery = pgTable(
   },
   (table) => [
     // Dashboard inbox: list a user's deliveries newest-first.
-    index("idx_notification_delivery_user_created").on(
-      table.userId,
-      table.createdAt,
-    ),
+    index("idx_notification_delivery_user_created").on(table.userId, table.createdAt),
     // Worker queue scan: pick up queued rows in FIFO order.
     index("idx_notification_delivery_queued").on(table.status, table.createdAt),
     // Org-level "what notifications did this org send today" reports.
-    index("idx_notification_delivery_org_created").on(
-      table.organizationId,
-      table.createdAt,
-    ),
+    index("idx_notification_delivery_org_created").on(table.organizationId, table.createdAt),
   ],
 );


### PR DESCRIPTION
## Problem

OpenShip already supports email, webhook, Slack, and in-app notifications, but teams that coordinate in Discord can't receive deployment or system alerts without routing a generic webhook through a separate bot.

## Solution

Add a first-class `discord` notification channel kind:

- `packages/db`: `ChannelKind` and schema comments now include `discord`.
- `apps/api/lib/notification-workers.ts`: new `sendDiscord` worker posts a rich embed (title, body, timestamp, blue accent) to `https://discord.com/api/webhooks/...` URLs, with the same 10s timeout and encrypted-secret handling as Slack.
- `apps/api/modules/notifications/notifications.controller.ts`: validates Discord webhook URLs, stores the URL encrypted, and redacts it on the way back to the client.
- `apps/dashboard`: Discord appears in the channel list, creation form, and org-defaults selector, with a dedicated icon and localized strings for all supported locales.
- `apps/web/content/docs/api/notifications.mdx`: documents the new `kind` and `discord.webhookUrl` config shape.

No schema migration is required; `notification_channel.kind` is stored as free text so the dispatcher registry can add new channel kinds without DDL changes.

## Verification

- `bun run --cwd apps/api lint` — `tsc --noEmit` passes.
- `bun run --cwd apps/api test` — 53 test files / 683 tests pass.
- `bunx tsc --noEmit` inside `apps/dashboard` passes.
- `bun run --cwd apps/dashboard test` — 2 test files / 17 tests pass.
- Prettier run over all changed files.

## Related

- Feature request area: notifications / Discord
- No open issue existed for Discord support; this is self-sourced.
