### PR TITLE
fix(api): keep single-quoted .env values literal (no interpolation)

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -333,6 +333,7 @@ function buildInterpolationEnv(options: ComposeParseOptions): Record<string, str
 
 export function parseComposeEnvFile(content: string): Record<string, string> {
   const result: Record<string, string> = {};
+  const literalKeys = new Set<string>();
 
   for (const rawLine of content.replace(/^\uFEFF/, "").split(/\r?\n/)) {
     let line = rawLine.trim();
@@ -345,35 +346,43 @@ export function parseComposeEnvFile(content: string): Record<string, string> {
     const key = line.slice(0, eqIdx).trim();
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
 
-    result[key] = parseEnvValue(line.slice(eqIdx + 1));
+    const parsed = parseEnvValue(line.slice(eqIdx + 1));
+    result[key] = parsed.value;
+    if (parsed.expand) literalKeys.delete(key);
+    else literalKeys.add(key);
   }
 
   for (const [key, value] of Object.entries(result)) {
+    if (literalKeys.has(key)) continue;
     result[key] = interpolateComposeString(value, result);
   }
 
   return result;
 }
 
-function parseEnvValue(rawValue: string): string {
+function parseEnvValue(rawValue: string): { value: string; expand: boolean } {
   const value = rawValue.trimStart();
-  if (!value) return "";
+  if (!value) return { value: "", expand: true };
 
   if (value.startsWith('"')) {
     const end = findClosingQuote(value, '"');
     const quoted = end >= 0 ? value.slice(1, end) : value.slice(1);
-    return quoted.replace(/\\([nrt"\\])/g, (_m, ch: string) =>
-      ch === "n" ? "\n" : ch === "r" ? "\r" : ch === "t" ? "\t" : ch,
-    );
+    return {
+      value: quoted.replace(/\\([nrt"\\])/g, (_m, ch: string) =>
+        ch === "n" ? "\n" : ch === "r" ? "\r" : ch === "t" ? "\t" : ch,
+      ),
+      expand: true,
+    };
   }
 
   if (value.startsWith("'")) {
     const end = findClosingQuote(value, "'");
-    return end >= 0 ? value.slice(1, end) : value.slice(1);
+    return { value: end >= 0 ? value.slice(1, end) : value.slice(1), expand: false };
   }
 
   const commentMatch = value.match(/\s+#/);
-  return (commentMatch?.index === undefined ? value : value.slice(0, commentMatch.index)).trimEnd();
+  const bare = commentMatch?.index === undefined ? value : value.slice(0, commentMatch.index);
+  return { value: bare.trimEnd(), expand: true };
 }
 
 function findClosingQuote(value: string, quote: '"' | "'"): number {

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -218,6 +218,18 @@ BAZ=qux
     });
   });
 
+  it("does NOT interpolate inside single-quoted values (literal)", () => {
+    expect(parseComposeEnvFile(`BASE=foo\nA='$BASE-bar'\nB='\${BASE}-bar'`)).toEqual({
+      BASE: "foo",
+      A: "$BASE-bar",
+      B: "${BASE}-bar",
+    });
+  });
+
+  it("keeps '$$' literal inside single-quoted values (no un-escaping)", () => {
+    expect(parseComposeEnvFile(`PWD='p@$$w0rd'`)).toEqual({ PWD: "p@$$w0rd" });
+  });
+
   it("handles CRLF line endings", () => {
     expect(parseComposeEnvFile("FOO=bar\r\nBAZ=qux\r\n")).toEqual({ FOO: "bar", BAZ: "qux" });
   });


### PR DESCRIPTION
## Problem

`parseComposeEnvFile` (apps/api/src/lib/compose-parser.ts) applied `interpolateComposeString` to **every** parsed `.env` value, so single-quoted entries were expanded exactly like unquoted ones. Docker Compose treats single-quoted `.env` values as **literal** — no `$VAR`/`${VAR}` substitution and no `$$` un-escaping. The existing tests in this file already codify that single quotes suppress backslash-escape processing and preserve `#`, but the `$` case was missed.

Concrete wrong outputs, with `BASE=foo` earlier in the file:

| `.env` line       | expected (Docker) | before this PR |
|-------------------|-------------------|----------------|
| `A='$BASE-bar'`   | `$BASE-bar`       | `foo-bar`      |
| `B='${BASE}-bar'` | `${BASE}-bar`     | `foo-bar`      |
| `PWD='p@$$w0rd'`  | `p@$$w0rd`        | `p@$w0rd`      |

Impact:
- A single-quoted secret containing `$` — extremely common in passwords — was **silently corrupted** (`p@$$w0rd` → `p@$w0rd`), so the value fed into the services UI / deploy env no longer matched the file.
- A literal `${...}` string was replaced with the (usually empty) value of a non-existent variable.

## Cause

The interpolation pass ran unconditionally:

```ts
result[key] = parseEnvValue(line.slice(eqIdx + 1));
...
for (const [key, value] of Object.entries(result)) {
  result[key] = interpolateComposeString(value, result); // even single-quoted
}
```

`parseEnvValue` returned only the string, discarding the fact that a value was single-quoted (i.e. must not be expanded).

## Fix

`parseEnvValue` now returns `{ value, expand }`, where `expand` is `false` only for single-quoted values. `parseComposeEnvFile` records those keys and skips them in the interpolation pass. Double-quoted and unquoted values are unchanged (still interpolated, still escape-decoded for double quotes). Because single-quoted values now bypass `interpolateComposeString` entirely, `$$` also stays literal — matching Docker's "raw string" semantics.

## Tests

Added two cases to `apps/api/test/lib/compose-parser.test.ts`:
- `does NOT interpolate inside single-quoted values (literal)` — `'$BASE-bar'` / `'${BASE}-bar'` stay literal.
- `keeps '$$' literal inside single-quoted values (no un-escaping)` — `'p@$$w0rd'` stays intact.

I verified both **FAIL without the source change** (they assert the wrong `foo-bar` / `p@$w0rd` outputs) and pass with it:

```
× does NOT interpolate inside single-quoted values (literal)
  expected { …, A: 'foo-bar', … } to deeply equal { …, A: '$BASE-bar', … }
× keeps '$$' literal inside single-quoted values (no un-escaping)
  expected { PWD: 'p@$w0rd' } to deeply equal { PWD: 'p@$$w0rd' }
```

Full verification:
- `bun run test` → **5/5 tasks successful** (compose-parser suite: 39 passed).
- `bun run --cwd apps/api lint` (tsc) → clean.
- Touched only my own new lines for formatting; `compose-parser.ts` has pre-existing Prettier drift on unrelated lines (per CONTRIBUTING) which I deliberately left untouched, and all added lines are within the repo's `printWidth: 100`.