### PR TITLE
fix(api): clamp Slack/Discord notifications to webhook payload limits

### DIFF
--- a/apps/api/src/lib/notification-workers.ts
+++ b/apps/api/src/lib/notification-workers.ts
@@ -72,6 +72,71 @@ function renderMessage(delivery: NotificationDelivery): RenderedMessage {
   };
 }
 
+/* ─── Chat-webhook payload builders ───────────────────────────────────────── */
+
+// Slack Block Kit caps a `section` text object at 3000 characters and a
+// `header` plain_text at 150; a Discord embed caps `title` at 256 and
+// `description` at 4096.
+const SLACK_HEADER_LIMIT = 150;
+const SLACK_SECTION_LIMIT = 3000;
+const DISCORD_TITLE_LIMIT = 256;
+const DISCORD_DESCRIPTION_LIMIT = 4096;
+
+// The Slack section body is wrapped in a ```…``` code fence — reserve its width
+// so the wrapped text still fits SLACK_SECTION_LIMIT.
+const SLACK_CODE_FENCE_OVERHEAD = "```\n".length + "\n```".length;
+
+/** Clamp `text` to `max` characters, marking a cut with a trailing ellipsis. */
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+interface SlackMessage {
+  text: string;
+  blocks: Array<Record<string, unknown>>;
+}
+
+/** Slack incoming-webhook payload for a rendered message, clamped to Slack's
+ *  block-text limits. */
+export function buildSlackMessage(input: { title: string; body: string }): SlackMessage {
+  const title = truncate(input.title, SLACK_HEADER_LIMIT);
+  const body = truncate(input.body, SLACK_SECTION_LIMIT - SLACK_CODE_FENCE_OVERHEAD);
+  return {
+    text: title,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: title } },
+      { type: "section", text: { type: "mrkdwn", text: "```\n" + body + "\n```" } },
+    ],
+  };
+}
+
+interface DiscordMessage {
+  username: string;
+  avatar_url: string;
+  embeds: Array<Record<string, unknown>>;
+}
+
+/** Discord webhook payload (single embed) for a rendered message, clamped to
+ *  Discord's embed title/description limits. */
+export function buildDiscordMessage(input: {
+  title: string;
+  body: string;
+  timestamp: string;
+}): DiscordMessage {
+  return {
+    username: "Openship",
+    avatar_url: "https://openship.io/favicon.ico",
+    embeds: [
+      {
+        title: truncate(input.title, DISCORD_TITLE_LIMIT),
+        description: truncate(input.body, DISCORD_DESCRIPTION_LIMIT),
+        color: 0x3b82f6,
+        timestamp: input.timestamp,
+      },
+    ],
+  };
+}
+
 /* ─── Channel workers ─────────────────────────────────────────────────────── */
 
 async function sendEmail(
@@ -166,18 +231,11 @@ async function sendDiscord(
   const webhookUrl = decrypt(config.webhookUrl);
 
   const { title, body } = renderMessage(delivery);
-  const discordPayload = {
-    username: "Openship",
-    avatar_url: "https://openship.io/favicon.ico",
-    embeds: [
-      {
-        title,
-        description: body,
-        color: 0x3b82f6,
-        timestamp: new Date(delivery.createdAt).toISOString(),
-      },
-    ],
-  };
+  const discordPayload = buildDiscordMessage({
+    title,
+    body,
+    timestamp: new Date(delivery.createdAt).toISOString(),
+  });
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10_000);
@@ -211,19 +269,7 @@ async function sendSlack(
   const webhookUrl = decrypt(config.webhookUrl);
 
   const { title, body } = renderMessage(delivery);
-  const slackPayload = {
-    text: title,
-    blocks: [
-      {
-        type: "header",
-        text: { type: "plain_text", text: title },
-      },
-      {
-        type: "section",
-        text: { type: "mrkdwn", text: "```\n" + body + "\n```" },
-      },
-    ],
-  };
+  const slackPayload = buildSlackMessage({ title, body });
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10_000);

--- a/apps/api/test/lib/notification-message-limits.test.ts
+++ b/apps/api/test/lib/notification-message-limits.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDiscordMessage, buildSlackMessage } from "../../src/lib/notification-workers";
+
+describe("notification chat-webhook payload limits", () => {
+  it("clamps a long Slack section body to Slack's 3000-char limit", () => {
+    const msg = buildSlackMessage({ title: "Deployment failed", body: "x".repeat(5000) });
+    const section = msg.blocks[1] as { text: { text: string } };
+    expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    expect(section.text.text.startsWith("```\n")).toBe(true);
+    expect(section.text.text.endsWith("\n```")).toBe(true);
+  });
+
+  it("clamps a long Slack header to Slack's 150-char limit", () => {
+    const msg = buildSlackMessage({ title: "T".repeat(400), body: "body" });
+    const header = msg.blocks[0] as { text: { text: string } };
+    expect(header.text.text.length).toBeLessThanOrEqual(150);
+  });
+
+  it("clamps a long Discord embed to Discord's 256/4096-char limits", () => {
+    const msg = buildDiscordMessage({
+      title: "D".repeat(400),
+      body: "y".repeat(9000),
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    const embed = msg.embeds[0] as { title: string; description: string; timestamp: string };
+    expect(embed.title.length).toBeLessThanOrEqual(256);
+    expect(embed.description.length).toBeLessThanOrEqual(4096);
+    expect(embed.timestamp).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("leaves a short message untouched", () => {
+    const msg = buildSlackMessage({ title: "Deploy OK", body: "All good" });
+    const section = msg.blocks[1] as { text: { text: string } };
+    expect(section.text.text).toBe("```\nAll good\n```");
+  });
+});


### PR DESCRIPTION
## Problem

The Slack and Discord notification workers wrap the rendered message into a Block Kit block / embed with **no length bound**. Both platforms enforce hard caps on those fields:

| Platform | Field | Limit | Over-limit result |
|---|---|---|---|
| Slack | `section` text | 3000 | webhook rejects with `invalid_blocks` |
| Slack | `header` plain_text | 150 | webhook rejects with `invalid_blocks` |
| Discord | embed `description` | 4096 | webhook returns HTTP 400 |
| Discord | embed `title` | 256 | webhook returns HTTP 400 |

When a payload exceeds any of these, the worker's `fetch` gets a non-OK response and **throws**. The runner then retries up to `MAX_ATTEMPTS` and finally marks the delivery **failed permanently** — the notification is silently dropped.

### Realistic trigger

This bites the alert you least want to lose. `deployment-lifecycle.ts` emits `deployment.failed` with the build's `errorMessage` in the payload:

```ts
notification.emit({
  eventType: "deployment.failed",
  payload: { projectName, branch, commitSha, errorMessage: errorMessage ?? "Unknown error", logsTail, durationMs },
});
```

`renderMessage` folds `errorMessage` into the body (`Error: ${payload.errorMessage}`). A compiler / Docker build-log tail routinely runs past 3000 chars, so the Slack `section` blows the 3000 cap and the whole delivery fails after retries. The user never finds out their deploy failed.

**Concrete case:** body of 5000 chars → Slack section text = `` ```\n `` + 5000 + `` \n``` `` = 5008 > 3000 → `invalid_blocks` → permanent failure. Same shape on Discord at 4096.

## Fix

Extract the payload construction into pure, exported `buildSlackMessage` / `buildDiscordMessage` builders that truncate title/body to each platform's documented limit (a trailing `…` marks the cut). For Slack, the code-fence overhead is reserved so the *wrapped* section text still fits 3000. The workers now call the builders instead of building inline — behavior for short messages is unchanged (byte-identical payload).

A truncated notification is delivered; the prior behavior dropped it entirely.

## Tests

`apps/api/test/lib/notification-message-limits.test.ts`:
- a 5000-char body stays ≤ 3000 in the Slack section (and the fence wrapper survives)
- a 400-char title stays ≤ 150 in the Slack header
- a 9000-char body / 400-char title stay ≤ 4096 / 256 in the Discord embed (timestamp preserved)
- a short message passes through unchanged

**Proved the test catches the bug:** with the `truncate(...)` calls removed from the builders (mirroring today's unclamped behavior), the length assertions FAIL (`expected 400 to be less than or equal to 256`); restored, they pass.

## Verification

- `bun run test` → 5/5 turbo tasks successful; `@repo/api` 743 passed / 3 skipped (was 739, +4 new).
- `bun run --cwd apps/api lint` → clean (`tsc --noEmit`).
- `npx prettier --check` clean on both touched files; the source file has no pre-existing drift on `main`, so no unrelated churn.

## Alternative considered

Splitting an over-limit body across multiple Slack blocks / Discord embeds instead of truncating. Truncation is simpler and clearly correct for a notification; happy to switch to splitting if you'd prefer the full text preserved.