### PR TITLE
fix(adapters): clamp untrusted vercel.json redirect status codes on the self-hosted path

### DIFF
--- a/packages/adapters/src/infra/vercel-routing.ts
+++ b/packages/adapters/src/infra/vercel-routing.ts
@@ -73,6 +73,19 @@ function isSafeHeaderValue(value: string): boolean {
   return !/["\\\n\r]/.test(value); // emitted double-quoted
 }
 
+/** A vercel.json redirect status: an HTTP 3xx integer, else the permanent/temporary default. */
+function redirectStatus(statusCode: number | undefined, permanent: boolean | undefined): number {
+  if (
+    statusCode !== undefined &&
+    Number.isInteger(statusCode) &&
+    statusCode >= 300 &&
+    statusCode <= 399
+  ) {
+    return statusCode;
+  }
+  return permanent ? 308 : 307;
+}
+
 function isFullUrl(destination: string): boolean {
   return /^https?:\/\//i.test(destination.trim());
 }
@@ -137,7 +150,7 @@ export function compileVercelRouting(
     out.redirects.push({
       path: loc.path,
       exact: loc.exact,
-      statusCode: redirect.statusCode ?? (redirect.permanent ? 308 : 307),
+      statusCode: redirectStatus(redirect.statusCode, redirect.permanent),
       destination: redirect.destination,
     });
   }

--- a/packages/adapters/test/vercel-routing.test.ts
+++ b/packages/adapters/test/vercel-routing.test.ts
@@ -54,6 +54,23 @@ describe("compileVercelRouting", () => {
     ]);
   });
 
+  it("normalizes a non-3xx or out-of-range redirect status to a safe default", () => {
+    const out = compileVercelRouting({
+      redirects: [
+        { source: "/a", destination: "/x", statusCode: 200 },
+        { source: "/b", destination: "/y", statusCode: 999 },
+        { source: "/c", destination: "/z", statusCode: 302.5 },
+        { source: "/d", destination: "/w", statusCode: 404, permanent: true },
+      ],
+    });
+    expect(out.redirects).toEqual([
+      { path: "/a", exact: true, statusCode: 307, destination: "/x" },
+      { path: "/b", exact: true, statusCode: 307, destination: "/y" },
+      { path: "/c", exact: true, statusCode: 307, destination: "/z" },
+      { path: "/d", exact: true, statusCode: 308, destination: "/w" },
+    ]);
+  });
+
   it("compiles header rules and passes through cleanUrls/trailingSlash", () => {
     const out = compileVercelRouting({
       headers: [{ source: "/(.*)", headers: [{ key: "X-Frame-Options", value: "DENY" }] }],


### PR DESCRIPTION
## Problem

`compileVercelRouting` (the shared compiler that both the self-hosted OpenResty emitter and the cloud Oblien emitter share) passes a repo's `vercel.json` `redirect.statusCode` **straight through** into the nginx `return <code> <dest>;` directive. The only filling-in is for a *missing* code — `redirect.statusCode ?? (redirect.permanent ? 308 : 307)` — so any code that *is* present is emitted verbatim, no matter how wrong.

`vercel.json` is untrusted repo input. A non-3xx, out-of-range, or non-integer status therefore reaches nginx unmodified:

| `vercel.json` statusCode | emitted nginx     | result |
|--------------------------|-------------------|--------|
| `200`                    | `return 200 /x;`  | not a redirect — nginx returns `/x` as a 200 body |
| `999`                    | `return 999 /y;`  | `nginx -t` rejects it (invalid return code) |
| `302.5`                  | `return 302.5 /z;`| `nginx -t` rejects it |
| `404` + `permanent:true` | `return 404 /w;`  | `permanent` ignored (should be 308) |

The `999` / `302.5` cases fail `nginx -t`, which takes down the **whole server block**, so the deploy / route-apply fails for a self-hoster whose repo happens to carry a malformed redirect.

### Why only self-hosted is affected

- The **cloud** path (`oblien-routing.ts`) already normalizes every code via `toOblienRedirectStatus` → `{301,302,307,308}`.
- The **openship.json** parser (`packages/core/.../openship-config/parse.ts`) already range-checks `statusCode` to `300–399`.
- The **self-hosted** path, fed the same untrusted config, had **no** guard. The `oblien-routing.ts` docstring even states both emitters are meant to share "one set of safety guards" — this one was missing from the shared compiler.

## Reproduction

```ts
compileVercelRouting({ redirects: [{ source: "/b", destination: "/y", statusCode: 999 }] })
// → { path: "/b", exact: true, statusCode: 999, destination: "/y" }
// renders: return 999 /y;   →  nginx -t fails
```

## Fix

Normalize in the **shared** compiler (`compileVercelRouting`) so both emitters inherit the guard: a `statusCode` is honored only when it is an HTTP **3xx integer** — matching the openship.json parser's own `300–399` range — otherwise it falls back to the documented `permanent ? 308 : 307` default. Valid 3xx codes (301/302/303/307/308) are unchanged, so no existing behavior shifts (incl. the cloud path's `303 → 307` narrowing).

Surgical: one small helper + one call-site change.

## Tests

Added `normalizes a non-3xx or out-of-range redirect status to a safe default` to `packages/adapters/test/vercel-routing.test.ts`, asserting the four inputs above normalize to `307/307/307/308`.

**Verified it fails without the fix:** with `src/infra/vercel-routing.ts` stashed, the new test fails (`received 200`, `999`, …); restored, it passes.

- `bun run test` → all 5 turbo tasks successful (`@repo/adapters` 259 passed, +1).
- `bun run --cwd apps/api lint` → clean.
- Touched `src` file passes `prettier --check`. The test file has pre-existing prettier drift on `main`; per CONTRIBUTING I did **not** run `--write` over it — my added lines are already prettier-clean (confirmed they don't appear in a `prettier` diff), so the diff carries no unrelated churn.

### Alternative

The guard could instead live in each parser (`metadata/vercel.ts` `parseRedirects`), dropping a bad `statusCode` at parse time. I put it in the shared compiler because that's the single point both emitters and every config source (vercel.json, netlify, openship.json routing) funnel through — matching the stated "one source of truth / one set of safety guards" intent. Happy to move it if you'd prefer parse-time rejection.