### PR TITLE
fix(core): reject custom hostnames with an over-long DNS label

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -47,9 +47,9 @@ export function normalizeCustomHostname(raw: string): string {
  * True when `host` (already run through normalizeCustomHostname) is a plausible
  * public DNS hostname. Rejects the shapes a bare hostname must never contain —
  * embedded path / port / scheme leftovers / whitespace, IPv4 literals,
- * localhost, and single-label names. The same shape gate the single-app custom
- * domain flow enforces, so service custom domains can't store a bogus host that
- * later becomes an unservable vhost.
+ * localhost, single-label names, and labels longer than the 63-octet DNS limit.
+ * The same shape gate the single-app custom domain flow enforces, so service
+ * custom domains can't store a bogus host that later becomes an unservable vhost.
  */
 export function isValidCustomHostname(host: string): boolean {
   if (!host || host.length > 253) return false;
@@ -59,7 +59,9 @@ export function isValidCustomHostname(host: string): boolean {
   if (host.startsWith(".") || host.endsWith(".") || host.includes("..")) return false;
   const labels = host.split(".");
   if (labels.length < 2) return false; // must be multi-label (has a dot)
-  return labels.every((label) => /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(label));
+  return labels.every(
+    (label) => label.length <= 63 && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(label),
+  );
 }
 
 /** Generate a prefixed unique ID (e.g. "proj_abc123...") */

--- a/packages/core/test/normalize-custom-hostname.test.ts
+++ b/packages/core/test/normalize-custom-hostname.test.ts
@@ -52,8 +52,13 @@ describe("isValidCustomHostname", () => {
       "example.com.", // trailing dot
       "a..b.com", // empty label
       "exa mple.com", // whitespace
+      `${"a".repeat(64)}.example.com`, // label over the 63-octet DNS limit
     ]) {
       expect(isValidCustomHostname(h)).toBe(false);
     }
+  });
+
+  it("accepts a label at exactly the 63-octet DNS limit", () => {
+    expect(isValidCustomHostname(`${"a".repeat(63)}.example.com`)).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`isValidCustomHostname` (packages/core/src/utils.ts) is the shape gate for custom domains — a host it accepts gets stored and turned into a served vhost. It caps the **total** name at 253 octets but never caps an **individual label** at the 63-octet limit RFC 1035 §2.3.4 sets. So an over-long label slips through as long as the whole string stays under 253:

| Input | `isValidCustomHostname` | Correct |
|---|---|---|
| `app.example.com` | `true` | `true` |
| `<63×'a'>.example.com` (valid max label) | `true` | `true` |
| `<64×'a'>.example.com` (76 chars total) | **`true`** ❌ | `false` |

A 64-octet label is unresolvable — no DNS server answers for it and Let's Encrypt rejects it at issuance. Accepting it is exactly the *"bogus host that later becomes an unservable vhost"* the function's own docstring says it exists to prevent: the domain is stored, a vhost is registered, and SSL/DNS then silently never work.

Reproduced before the fix:

```
63-char label accepted (want true): true
64-char label accepted (BUG if true): true   len: 76   (<= 253, so the length gate passes)
```

## Cause

The per-label predicate validated only the character shape:

```ts
return labels.every((label) => /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(label));
```

The regex has no upper bound on label length, and the only length check in the function is the whole-name `> 253` guard.

## Fix

Add the 63-octet per-label cap to the predicate:

```ts
return labels.every(
  (label) => label.length <= 63 && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(label),
);
```

## Tests

`packages/core/test/normalize-custom-hostname.test.ts`:
- adds `<64×'a'>.example.com` to the "rejects the shapes a bare host must never contain" set;
- adds a case asserting a label at exactly 63 octets is still **accepted** (pins the boundary both ways).

Verified the reject case **fails without the source change** (stash the src edit, keep the test → 1 failed) and passes with it.

## Verification
- `bun run test` → all 5 turbo tasks successful (`@repo/core` 107 tests pass).
- `bun run --cwd apps/api lint` → clean.
- Touched source line is prettier-clean; I did **not** run `prettier --write` over `utils.ts` / the test file because both carry pre-existing drift on `main` unrelated to this change (CONTRIBUTING warns against churning it) — my added lines match prettier output on their own.

Scope is deliberately minimal — one predicate clause. Happy to adjust the message/boundary handling if you'd prefer.