### PR TITLE
fix(api): don't re-interpolate a '$' carried in by a resolved compose value

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -396,12 +396,14 @@ function interpolateComposeString(input: string, env: Record<string, string>): s
   const escapedDollar = "\0COMPOSE_ESCAPED_DOLLAR\0";
   const protectedInput = input.replace(/\$\$/g, escapedDollar);
 
-  const withBraced = protectedInput.replace(/\$\{([^}]+)\}/g, (_match, expression: string) =>
-    resolveInterpolationExpression(expression, env).value,
-  );
-
-  return withBraced
-    .replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, key: string) => env[key] ?? "")
+  return protectedInput
+    .replace(
+      /\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+      (_match, braced: string | undefined, bare: string | undefined) =>
+        braced !== undefined
+          ? resolveInterpolationExpression(braced, env).value
+          : (env[bare!] ?? ""),
+    )
     .replaceAll(escapedDollar, "$");
 }
 

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -126,6 +126,24 @@ services:
     expect(parsed.services[0]?.command).toBe("echo $BETTER_AUTH_SECRET");
     expect(parsed.services[0]?.environment.LITERAL).toBe("$BETTER_AUTH_SECRET");
   });
+
+  it("does not re-interpolate a '$' inside a resolved value embedded in a larger string", () => {
+    const parsed = parseComposeFile(
+      `
+services:
+  app:
+    environment:
+      DIRECT: \${DB_PASS}
+      EMBEDDED: postgres://user:\${DB_PASS}@db:5432/app
+`,
+      { envFileContent: `DB_PASS='p$ss'\n` },
+    );
+
+    expect(parsed.services[0]?.environment).toEqual({
+      DIRECT: "p$ss",
+      EMBEDDED: "postgres://user:p$ss@db:5432/app",
+    });
+  });
 });
 
 // ─── parseComposeEnvFile - direct .env content scenarios ─────────────────────
@@ -223,6 +241,13 @@ BAZ=qux
       BASE: "foo",
       A: "$BASE-bar",
       B: "${BASE}-bar",
+    });
+  });
+
+  it("does not re-interpolate a literal '$' carried in by an interpolated entry", () => {
+    expect(parseComposeEnvFile(`PW='a$bc'\nURL=x\${PW}y`)).toEqual({
+      PW: "a$bc",
+      URL: "xa$bcy",
     });
   });
 


### PR DESCRIPTION
## Problem

`interpolateComposeString` in `apps/api/src/lib/compose-parser.ts` interpolated in **two sequential passes**: first `${...}` expressions, then bare `$VAR` references. The second pass ran over the **entire** string — including the text the first pass had just substituted in — so a `$`-sequence that arrived as part of a *resolved* value got interpolated a second time and (usually) blanked out.

Docker Compose interpolation is single-pass and non-recursive: a value pulled from the environment is inserted verbatim, never re-scanned. The parser already honoured this for a value that is **exactly** `${VAR}` (the `resolveComposeValue` `directBraced` fast-path), but any value that merely **embedded** the reference (`x${VAR}y`) fell through to the two-pass path and was corrupted.

### Realistic failure

A secret / connection string whose interpolated variable holds a literal `$` — e.g. a single-quoted `.env` password that legitimately contains `$`:

```yaml
# .env
DB_PASS='p$ss'

# docker-compose.yml
services:
  app:
    environment:
      DIRECT:   ${DB_PASS}
      EMBEDDED: postgres://user:${DB_PASS}@db:5432/app
```

| field | resolved value | before | after |
|-------|----------------|--------|-------|
| `DIRECT` (exact `${VAR}`) | `p$ss` | `p$ss` ✓ | `p$ss` ✓ |
| `EMBEDDED` (embedded) | — | `postgres://user:p@db:5432/app` ✗ | `postgres://user:p$ss@db:5432/app` ✓ |

The `$ss` in the substituted password is re-read by the second pass, `$ss` resolves to an undefined var → `""`, and the rest of the password silently vanishes. The same double pass also fires inside `.env` self-interpolation: `URL=x${PW}y` with `PW='a$bc'` yielded `xa` instead of `xa$bcy`.

The asymmetry — `PASSWORD: ${SECRET}` safe but `PASSWORD: x${SECRET}` corrupt — is what makes this easy to miss.

## Cause

Two `.replace()` calls in sequence. `String.prototype.replace` does not re-scan its *replacement* text, but a second, separate `.replace()` over the already-substituted string does.

## Fix

Collapse the two passes into **one combined scan** whose regex matches either `${...}` or `$VAR` and replaces each token exactly once. Substituted values are never re-scanned.

- `${VAR:-$OTHER}` default interpolation still resolves recursively via `resolveInterpolationExpression` (the default *word* is meant to be interpolated — that path is unchanged).
- `$$` escaping is unchanged (`$$` → literal `$`).
- All previously-correct cases (e.g. `postgres://${USER}:${PASS}@db` where the resolved values contain no `$`) produce identical output.

## Tests

Added two regression tests in `apps/api/test/lib/compose-parser.test.ts`:
1. embedded `${DB_PASS}` in a compose env value where `DB_PASS` holds a literal `$`;
2. `.env` self-interpolation `URL=x${PW}y` where `PW` holds a literal `$`.

Both **fail without the source change** (the values come back as `postgres://user:p@db:5432/app` and `xa` respectively) and pass with it — verified by stashing the source file and re-running.

- `bun run test` → all 5 turbo tasks successful (748 api tests pass, 3 pre-existing skips).
- `bun run --cwd apps/api lint` → clean.
- Touched files respect the repo's pre-existing prettier drift (no `--write` churn; new lines confirmed prettier-clean).