### PR TITLE
feat(api/dashboard): add Microsoft Teams as a notification channel

### DIFF
--- a/apps/api/src/lib/notification-workers.ts
+++ b/apps/api/src/lib/notification-workers.ts
@@ -243,6 +243,62 @@ async function sendSlack(
   }
 }
 
+async function sendMSTeams(
+  delivery: NotificationDelivery,
+  channel: NotificationChannel,
+): Promise<void> {
+  const config = channel.config as { webhookUrl?: string };
+  if (!config?.webhookUrl) {
+    throw new Error("Microsoft Teams channel has no webhook URL configured");
+  }
+
+  // Webhook URL is encrypted at storage time.
+  const webhookUrl = decrypt(config.webhookUrl);
+
+  const { title, body } = renderMessage(delivery);
+  // Adaptive Card in the "message" envelope — the shape accepted by both
+  // Power Automate Workflows and legacy Office 365 connectors.
+  const teamsPayload = {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        contentUrl: null,
+        content: {
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          type: "AdaptiveCard",
+          // 1.2 is the highest card version legacy connectors render; the
+          // card only uses 1.0-level elements so nothing is lost.
+          version: "1.2",
+          body: [
+            { type: "TextBlock", text: title, weight: "Bolder", size: "Medium", wrap: true },
+            { type: "TextBlock", text: body, wrap: true },
+          ],
+        },
+      },
+    ],
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(teamsPayload),
+      signal: controller.signal,
+    });
+    // Note: Power Automate Workflows respond 202 even when the flow fails
+    // downstream — a 2xx means "accepted", not "delivered".
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Microsoft Teams webhook returned ${res.status}: ${text.slice(0, 200)}`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /* ─── Worker registry ─────────────────────────────────────────────────────── */
 
 const WORKERS: Record<
@@ -254,6 +310,7 @@ const WORKERS: Record<
   in_app: sendInApp,
   slack: sendSlack,
   discord: sendDiscord,
+  msteams: sendMSTeams,
 };
 
 /* ─── Runner loop ─────────────────────────────────────────────────────────── */

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -23,7 +23,7 @@ import { encrypt } from "../../lib/encryption";
 import { CATEGORIES } from "../../lib/notification-categories";
 import { randomBytes } from "node:crypto";
 
-const VALID_CHANNEL_KINDS = new Set(["email", "webhook", "in_app", "slack", "discord"]);
+const VALID_CHANNEL_KINDS = new Set(["email", "webhook", "in_app", "slack", "discord", "msteams"]);
 
 /* ─── Categories (static, no DB) ─────────────────────────────────────── */
 
@@ -303,8 +303,8 @@ interface ConfigErr {
 
 /**
  * Sanitize + normalize the inbound config per kind. Secrets (webhook
- * URLs, Slack URLs, HMAC keys) are stored encrypted — the dispatcher
- * decrypts at delivery time.
+ * URLs, Slack/Discord/Teams URLs, HMAC keys) are stored encrypted — the
+ * dispatcher decrypts at delivery time.
  *
  * Returns either { ok: true, value } or { ok: false, error }.
  */
@@ -351,6 +351,28 @@ function sanitizeChannelConfig(kind: string, raw: unknown): ConfigOk | ConfigErr
       const out: Record<string, unknown> = { webhookUrl: encrypt(webhookUrl) };
       return { ok: true, value: out };
     }
+    case "msteams": {
+      const webhookUrl = String(cfg.webhookUrl ?? "").trim();
+      if (!webhookUrl) return { ok: false, error: "Invalid Microsoft Teams webhook URL" };
+      // Power Automate Workflows live on *.logic.azure.com; legacy
+      // connectors on *.webhook.office.com. Suffix-match the hostname so
+      // lookalike domains (e.g. evil-logic.azure.com.attacker.io) fail.
+      try {
+        const parsed = new URL(webhookUrl);
+        if (
+          parsed.protocol !== "https:" ||
+          !(
+            parsed.hostname.endsWith(".logic.azure.com") ||
+            parsed.hostname.endsWith(".webhook.office.com")
+          )
+        ) {
+          return { ok: false, error: "Invalid Microsoft Teams webhook URL" };
+        }
+      } catch {
+        return { ok: false, error: "Invalid Microsoft Teams webhook URL" };
+      }
+      return { ok: true, value: { webhookUrl: encrypt(webhookUrl) } };
+    }
     default:
       return { ok: false, error: `Unsupported channel kind: ${kind}` };
   }
@@ -359,8 +381,8 @@ function sanitizeChannelConfig(kind: string, raw: unknown): ConfigOk | ConfigErr
 /**
  * Strip secrets from the channel config before returning to the client.
  * Email address is non-secret; webhook URL is shown but HMAC secret is
- * masked; Slack URL is masked entirely (showing it would let anyone with
- * dashboard access post to the channel).
+ * masked; Slack/Discord/Teams URLs are masked entirely (showing them
+ * would let anyone with dashboard access post to the channel).
  */
 function redactChannelConfig(
   kind: string,
@@ -383,6 +405,10 @@ function redactChannelConfig(
         channelName: cfg.channelName ?? null,
       };
     case "discord":
+      return {
+        webhookUrlConfigured: !!cfg.webhookUrl,
+      };
+    case "msteams":
       return {
         webhookUrlConfigured: !!cfg.webhookUrl,
       };

--- a/apps/dashboard/src/app/(dashboard)/settings/_components/NotificationsTab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/_components/NotificationsTab.tsx
@@ -25,6 +25,7 @@ import {
   Webhook,
   MessageSquare,
   MessageCircle,
+  MessagesSquare,
   Smartphone,
   Plus,
   Trash2,
@@ -52,6 +53,7 @@ const CHANNEL_ICONS: Record<ChannelKind, React.ElementType> = {
   webhook: Webhook,
   slack: MessageSquare,
   discord: MessageCircle,
+  msteams: MessagesSquare,
   in_app: Smartphone,
 };
 
@@ -60,6 +62,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   webhook: "Webhook",
   slack: "Slack",
   discord: "Discord",
+  msteams: "Microsoft Teams",
   in_app: "In-app",
 };
 
@@ -259,7 +262,7 @@ function ChannelsCard({
 
 function describeChannel(
   ch: NotificationChannel,
-  labels: { slackWebhook: string; discordWebhook: string; inApp: string },
+  labels: { slackWebhook: string; discordWebhook: string; msteamsWebhook: string; inApp: string },
 ): string {
   switch (ch.kind) {
     case "email":
@@ -272,6 +275,8 @@ function describeChannel(
       );
     case "discord":
       return labels.discordWebhook;
+    case "msteams":
+      return labels.msteamsWebhook;
     case "in_app":
       return labels.inApp;
     default:
@@ -326,7 +331,8 @@ function NewChannelForm({
     let config: Record<string, unknown> = {};
     if (kind === "email") config = { address: address.trim() };
     else if (kind === "webhook") config = { url: url.trim() };
-    else if (kind === "slack" || kind === "discord") config = { webhookUrl: webhookUrl.trim() };
+    else if (kind === "slack" || kind === "discord" || kind === "msteams")
+      config = { webhookUrl: webhookUrl.trim() };
 
     setBusy(true);
     try {
@@ -356,6 +362,7 @@ function NewChannelForm({
           <option value="webhook">{t.settings.notifications.kinds.webhook}</option>
           <option value="slack">{t.settings.notifications.kinds.slack}</option>
           <option value="discord">{t.settings.notifications.kinds.discord}</option>
+          <option value="msteams">{t.settings.notifications.kinds.msteams}</option>
           <option value="in_app">{t.settings.notifications.kinds.in_app}</option>
         </select>
         <input
@@ -412,6 +419,15 @@ function NewChannelForm({
         <input
           type="url"
           placeholder={t.settings.notifications.form.discordPlaceholder}
+          value={webhookUrl}
+          onChange={(e) => setWebhookUrl(e.target.value)}
+          className="w-full bg-background border border-border/50 rounded-lg px-3 py-2 text-sm"
+        />
+      )}
+      {kind === "msteams" && (
+        <input
+          type="url"
+          placeholder={t.settings.notifications.form.msteamsPlaceholder}
           value={webhookUrl}
           onChange={(e) => setWebhookUrl(e.target.value)}
           className="w-full bg-background border border-border/50 rounded-lg px-3 py-2 text-sm"
@@ -606,6 +622,7 @@ function OrgDefaultsCard({
                 <option value="webhook">{t.settings.notifications.kinds.webhook}</option>
                 <option value="slack">{t.settings.notifications.kinds.slack}</option>
                 <option value="discord">{t.settings.notifications.kinds.discord}</option>
+                <option value="msteams">{t.settings.notifications.kinds.msteams}</option>
                 <option value="in_app">{t.settings.notifications.kinds.in_app}</option>
               </select>
               <Toggle

--- a/apps/dashboard/src/i18n/locales/ar/settings.json
+++ b/apps/dashboard/src/i18n/locales/ar/settings.json
@@ -417,6 +417,7 @@
     "describe": {
       "slackWebhook": "‏Webhook الخاص بـ Slack",
       "discordWebhook": "Discord webhook",
+      "msteamsWebhook": "‏Webhook الخاص بـ Microsoft Teams",
       "inApp": "أيقونة الجرس في لوحة التحكم"
     },
     "kinds": {
@@ -424,6 +425,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "داخل التطبيق"
     },
     "form": {
@@ -432,6 +434,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "جارٍ الإضافة…",
       "addChannel": "إضافة قناة",
       "labelRequired": "التسمية مطلوبة"

--- a/apps/dashboard/src/i18n/locales/de/settings.json
+++ b/apps/dashboard/src/i18n/locales/de/settings.json
@@ -417,6 +417,7 @@
     "describe": {
       "slackWebhook": "Slack-Webhook",
       "discordWebhook": "Discord-Webhook",
+      "msteamsWebhook": "Microsoft Teams-Webhook",
       "inApp": "Glockensymbol im Dashboard"
     },
     "kinds": {
@@ -424,6 +425,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "In-App"
     },
     "form": {
@@ -432,6 +434,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "Wird hinzugefügt…",
       "addChannel": "Kanal hinzufügen",
       "labelRequired": "Bezeichnung ist erforderlich"

--- a/apps/dashboard/src/i18n/locales/en/settings.json
+++ b/apps/dashboard/src/i18n/locales/en/settings.json
@@ -500,6 +500,7 @@
     "describe": {
       "slackWebhook": "Slack webhook",
       "discordWebhook": "Discord webhook",
+      "msteamsWebhook": "Microsoft Teams webhook",
       "inApp": "Dashboard bell icon"
     },
     "kinds": {
@@ -507,6 +508,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "In-app"
     },
     "form": {
@@ -515,6 +517,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "Adding…",
       "addChannel": "Add channel",
       "labelRequired": "Label is required",

--- a/apps/dashboard/src/i18n/locales/es/settings.json
+++ b/apps/dashboard/src/i18n/locales/es/settings.json
@@ -417,6 +417,7 @@
     "describe": {
       "slackWebhook": "Webhook de Slack",
       "discordWebhook": "Webhook de Discord",
+      "msteamsWebhook": "Webhook de Microsoft Teams",
       "inApp": "Icono de campana del panel"
     },
     "kinds": {
@@ -424,6 +425,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "En la app"
     },
     "form": {
@@ -432,6 +434,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "Añadiendo…",
       "addChannel": "Añadir canal",
       "labelRequired": "La etiqueta es obligatoria"

--- a/apps/dashboard/src/i18n/locales/fr/settings.json
+++ b/apps/dashboard/src/i18n/locales/fr/settings.json
@@ -459,6 +459,7 @@
     "describe": {
       "slackWebhook": "Webhook Slack",
       "discordWebhook": "Webhook Discord",
+      "msteamsWebhook": "Webhook Microsoft Teams",
       "inApp": "Icône cloche du tableau de bord"
     },
     "kinds": {
@@ -466,6 +467,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "Dans l'application"
     },
     "form": {
@@ -474,6 +476,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "Ajout…",
       "addChannel": "Ajouter un canal",
       "labelRequired": "Le libellé est requis"

--- a/apps/dashboard/src/i18n/locales/ja/settings.json
+++ b/apps/dashboard/src/i18n/locales/ja/settings.json
@@ -417,6 +417,7 @@
     "describe": {
       "slackWebhook": "Slack Webhook",
       "discordWebhook": "Discord Webhook",
+      "msteamsWebhook": "Microsoft Teams Webhook",
       "inApp": "ダッシュボードのベルアイコン"
     },
     "kinds": {
@@ -424,6 +425,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "アプリ内"
     },
     "form": {
@@ -432,6 +434,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "追加中…",
       "addChannel": "チャンネルを追加",
       "labelRequired": "ラベルは必須です"

--- a/apps/dashboard/src/i18n/locales/pt/settings.json
+++ b/apps/dashboard/src/i18n/locales/pt/settings.json
@@ -417,6 +417,7 @@
     "describe": {
       "slackWebhook": "Webhook do Slack",
       "discordWebhook": "Webhook do Discord",
+      "msteamsWebhook": "Webhook do Microsoft Teams",
       "inApp": "Ícone de sino do painel"
     },
     "kinds": {
@@ -424,6 +425,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "No aplicativo"
     },
     "form": {
@@ -432,6 +434,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "Adicionando…",
       "addChannel": "Adicionar canal",
       "labelRequired": "O rótulo é obrigatório"

--- a/apps/dashboard/src/i18n/locales/zh/settings.json
+++ b/apps/dashboard/src/i18n/locales/zh/settings.json
@@ -417,6 +417,7 @@
     "describe": {
       "slackWebhook": "Slack webhook",
       "discordWebhook": "Discord webhook",
+      "msteamsWebhook": "Microsoft Teams webhook",
       "inApp": "仪表盘铃铛图标"
     },
     "kinds": {
@@ -424,6 +425,7 @@
       "webhook": "Webhook",
       "slack": "Slack",
       "discord": "Discord",
+      "msteams": "Microsoft Teams",
       "in_app": "应用内"
     },
     "form": {
@@ -432,6 +434,7 @@
       "webhookPlaceholder": "https://example.com/openship-hook",
       "slackPlaceholder": "https://hooks.slack.com/services/...",
       "discordPlaceholder": "https://discord.com/api/webhooks/...",
+      "msteamsPlaceholder": "https://prod-00.westus.logic.azure.com/workflows/...",
       "adding": "正在添加…",
       "addChannel": "添加渠道",
       "labelRequired": "标签为必填项"

--- a/apps/dashboard/src/lib/api/notifications.ts
+++ b/apps/dashboard/src/lib/api/notifications.ts
@@ -10,7 +10,7 @@ export interface NotificationCategory {
   defaultEnabled: boolean;
 }
 
-export type ChannelKind = "email" | "webhook" | "in_app" | "slack" | "discord";
+export type ChannelKind = "email" | "webhook" | "in_app" | "slack" | "discord" | "msteams";
 export type DeliveryStatus = "queued" | "sending" | "sent" | "failed" | "seen";
 
 /* ── Channel ─────────────────────────────────────────────────────── */
@@ -25,7 +25,8 @@ export interface NotificationChannel {
    *    webhook → { url, hmacSecretConfigured }
    *    in_app  → {}
    *    slack   → { webhookUrlConfigured, channelName | null }
-   *    discord → { webhookUrlConfigured } */
+   *    discord → { webhookUrlConfigured }
+   *    msteams → { webhookUrlConfigured } */
   config: Record<string, unknown>;
   verified: boolean;
   enabled: boolean;

--- a/apps/web/content/docs/api/notifications.mdx
+++ b/apps/web/content/docs/api/notifications.mdx
@@ -6,7 +6,7 @@ description: Manage delivery channels, per-event subscriptions, org defaults, an
 import { TypeTable } from "fumadocs-ui/components/type-table";
 
 The Notifications API decides who hears about events like a failed deploy or an expiring SSL cert, and how.
-You register **channels** (where alerts go — email, webhook, Slack, Discord, or the in-app bell), toggle
+You register **channels** (where alerts go — email, webhook, Slack, Discord, Microsoft Teams, or the in-app bell), toggle
 **subscriptions** (which event categories reach each channel), set org-wide **defaults** for new members, and
 read **deliveries** (the alert feed behind the bell icon). In the dashboard this is the **Settings →
 Notifications** page. Channels, subscriptions, and deliveries are per-user; defaults are per-org.
@@ -71,7 +71,7 @@ POST /api/notifications/channels
 <TypeTable
   type={{
     kind: {
-      type: '"email" | "webhook" | "in_app" | "slack" | "discord"',
+      type: '"email" | "webhook" | "in_app" | "slack" | "discord" | "msteams"',
       description: "The channel type. Any other value is rejected.",
       required: true,
     },
@@ -114,8 +114,18 @@ The `config` shape depends on `kind`:
       description:
         'A https://discord.com/api/webhooks/... incoming-webhook URL. Required for kind "discord".',
     },
+    "msteams.webhookUrl": {
+      type: "string",
+      description: 'A Microsoft Teams incoming-webhook URL. Required for kind "msteams".',
+    },
   }}
 />
+
+<Callout title="Getting a Teams webhook URL" type="info">
+  In Teams, create a **Workflow** with the **"When a Teams webhook request is received"** trigger
+  and use the URL it generates. Legacy `webhook.office.com` connector URLs are also accepted. The
+  URL is stored encrypted and comes back as `webhookUrlConfigured` in responses, never in full.
+</Callout>
 
 ```bash
 curl -X POST https://your-host/api/notifications/channels \
@@ -209,7 +219,7 @@ PUT /api/notifications/defaults
       required: true,
     },
     defaultChannelKind: {
-      type: '"email" | "webhook" | "in_app" | "slack" | "discord"',
+      type: '"email" | "webhook" | "in_app" | "slack" | "discord" | "msteams"',
       description: "Which channel kind the default routes to.",
       default: '"email"',
     },
@@ -249,11 +259,12 @@ curl "https://your-host/api/notifications/deliveries?unseen=true&limit=20" \
 ## Errors you might see
 
 <Callout title="400 — invalid channel or missing fields" type="warn">
-  The `kind` isn't one of `email`/`webhook`/`in_app`/`slack`/`discord`, `label` is missing, or the
-  `config` failed its per-kind check (a malformed email, a non-`http(s)` webhook URL, a Slack URL
-  that isn't `https://hooks.slack.com/...`, or a Discord URL that isn't
-  `https://discord.com/api/webhooks/...`). Subscriptions need `category`, `channelId`, and a boolean
-  `enabled`; defaults need `category` and a boolean `defaultEnabled`.
+  The `kind` isn't one of `email`/`webhook`/`in_app`/`slack`/`discord`/`msteams`, `label` is
+  missing, or the `config` failed its per-kind check (a malformed email, a non-`http(s)` webhook
+  URL, a Slack URL that isn't `https://hooks.slack.com/...`, a Discord URL that isn't
+  `https://discord.com/api/webhooks/...`, or a Teams URL that isn't an https Workflow or
+  `webhook.office.com` URL). Subscriptions need `category`, `channelId`, and a boolean `enabled`;
+  defaults need `category` and a boolean `defaultEnabled`.
 </Callout>
 
 <Callout title="404 on a per-user route" type="error">

--- a/packages/db/src/repos/notification.repo.ts
+++ b/packages/db/src/repos/notification.repo.ts
@@ -30,7 +30,7 @@ export type NotificationDefault = typeof notificationDefault.$inferSelect;
 export type NotificationDelivery = typeof notificationDelivery.$inferSelect;
 export type NewNotificationDelivery = typeof notificationDelivery.$inferInsert;
 
-export type ChannelKind = "email" | "webhook" | "in_app" | "slack" | "discord";
+export type ChannelKind = "email" | "webhook" | "in_app" | "slack" | "discord" | "msteams";
 export type DeliveryStatus = "queued" | "sending" | "sent" | "failed" | "seen";
 
 // ─── notification_channel repo ───────────────────────────────────────────────

--- a/packages/db/src/schema/notification.ts
+++ b/packages/db/src/schema/notification.ts
@@ -27,6 +27,7 @@
  *   in_app    delivery row read by the dashboard's bell icon
  *   slack     POST to Slack incoming-webhook URL the user pasted
  *   discord   POST to Discord webhook URL with a markdown-aware embed
+ *   msteams   POST Adaptive Card to a Teams Workflows / legacy connector webhook URL
  */
 
 import {
@@ -54,9 +55,10 @@ export const notificationChannel = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
 
-    /** "email" | "webhook" | "in_app" | "slack". Stored as text so we can
-     *  add new channel kinds without a schema migration. The dispatcher's
-     *  channel registry decides which kinds are dispatchable. */
+    /** "email" | "webhook" | "in_app" | "slack" | "discord" | "msteams".
+     *  Stored as text so we can add new channel kinds without a schema
+     *  migration. The dispatcher's channel registry decides which kinds
+     *  are dispatchable. */
     kind: text("kind").notNull(),
 
     /** Display label the user picks ("My personal Slack", "On-call email").
@@ -69,6 +71,8 @@ export const notificationChannel = pgTable(
      *   webhook → { url: string, hmacSecret: string (encrypted) }
      *   in_app  → {} (no config)
      *   slack   → { webhookUrl: string (encrypted), channelName?: string }
+     *   discord → { webhookUrl: string (encrypted) }
+     *   msteams → { webhookUrl: string (encrypted) }
      */
     config: jsonb("config").notNull().default({}),
 


### PR DESCRIPTION
## Problem

OpenShip supports email, webhook, Slack, Discord, and in-app notifications, but teams that coordinate in Microsoft Teams can't receive deployment or system alerts without routing a generic webhook through a separate flow.

## Solution

Add a first-class `msteams` notification channel kind:

- `packages/db`: `ChannelKind` and schema comments now include `msteams` (the config-shape comments also gained the previously missing `discord` entry while being touched).
- `apps/api/lib/notification-workers.ts`: new `sendMSTeams` worker posts an Adaptive Card (title + body TextBlocks) in the `message` envelope accepted by both **Power Automate Workflows** webhooks and **legacy Office 365 connector** webhooks, with the same 10s timeout and encrypted-secret handling as Slack/Discord. The card declares version 1.2 — the highest legacy connectors render — and a comment notes that Workflows return 202 even for downstream failures, so 2xx means "accepted", not "delivered".
- `apps/api/modules/notifications/notifications.controller.ts`: validates Teams webhook URLs by hostname suffix (`*.logic.azure.com` for Workflows, `*.webhook.office.com` for legacy connectors — suffix-matched on the parsed hostname so lookalike domains fail), stores the URL encrypted, and redacts it to `webhookUrlConfigured` on the way back to the client.
- `apps/dashboard`: Microsoft Teams appears in the channel list, creation form, and org-defaults selector, with a dedicated icon and localized strings for all supported locales.
- `apps/web/content/docs/api/notifications.mdx`: documents the new `kind`, the `msteams.webhookUrl` config shape, and how to get a webhook URL from a Teams Workflow.

No schema migration is required; `notification_channel.kind` is stored as free text so the dispatcher registry can add new channel kinds without DDL changes.

## Verification

- `bun run --cwd apps/api lint` — `tsc --noEmit` passes.
- `bun run --cwd apps/api test` — 61 test files / 737 tests pass (3 skipped).
- `bunx tsc --noEmit` inside `apps/dashboard` passes.
- `bun run --cwd apps/dashboard test` — 2 test files / 17 tests pass.
- Prettier run over all changed files; all 8 locale JSON files validated.
- Manually exercised against a local dev stack: invalid and lookalike URLs are rejected with a 400, Workflows and legacy connector URLs are accepted, and responses redact the stored URL.

## Related

- Feature request area: notifications / Microsoft Teams
- No open issue existed for Teams support; this is self-sourced, following the pattern of #164 (Discord).

