### PR TITLE
fix(docker): create the first admin declaratively on compose deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,17 @@ BETTER_AUTH_URL=http://localhost:4000
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 INTERNAL_TOKEN=change-me-32-byte-random-hex
 
+# ─── First admin (Docker Compose only, optional) ──────────
+# On the CLI (`openship`) the setup wizard creates the first admin. Docker has no
+# wizard, so set these to have the one-shot `init-admin` service create the first
+# admin on `docker compose up` (issue #138). Leave unset to create it another way
+# (CLI, or a first sign-in you enable manually). Public sign-up stays disabled —
+# this calls the same internal-token-gated bootstrap endpoint the CLI uses, and
+# is idempotent (it won't touch an admin that already exists). Password: 8-128 chars.
+# OPENSHIP_ADMIN_NAME=Admin
+# OPENSHIP_ADMIN_EMAIL=admin@example.com
+# OPENSHIP_ADMIN_PASSWORD=
+
 # ─── OAuth login (optional) ───────────────────────────────
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,26 @@ services:
       api:
         condition: service_healthy
 
+  # ─── First-admin bootstrap (one-shot, optional) ───────
+  # Creates the first administrator declaratively so a fresh `docker compose up`
+  # is usable without the CLI wizard (issue #138). No-op unless OPENSHIP_ADMIN_*
+  # is set in .env; idempotent (bootstrap-admin is one-shot — 409 once an admin
+  # exists). Does NOT enable public sign-up — it calls the same internal-token-
+  # gated endpoint the CLI uses. Runs after the API is healthy, then exits.
+  init-admin:
+    image: curlimages/curl:8.11.1
+    restart: "no"
+    env_file:
+      - .env
+    environment:
+      OPENSHIP_API_URL: http://api:4000
+    volumes:
+      - ./scripts/docker-init-admin.sh:/docker-init-admin.sh:ro
+    entrypoint: ["sh", "/docker-init-admin.sh"]
+    depends_on:
+      api:
+        condition: service_healthy
+
   # ─── Web / Landing ────────────────────────────────────
   web:
     build:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,11 +64,24 @@ cp .env.example .env
 docker compose up -d
 ```
 
+**Create the first admin.** Docker has no interactive setup wizard, so declare the
+first administrator in `.env` before starting — the one-shot `init-admin` service
+creates it once the API is healthy (public sign-up stays disabled):
+
+```bash
+OPENSHIP_ADMIN_NAME=Admin
+OPENSHIP_ADMIN_EMAIL=admin@example.com
+OPENSHIP_ADMIN_PASSWORD=a-strong-password   # 8-128 chars
+```
+
+It's idempotent — re-running `docker compose up` never changes an existing admin.
+Leaving these unset skips the step; you can still create the admin another way.
+
 ---
 
 ## Users & access (self-hosted)
 
-- **Public signup is disabled.** The first admin is created by `openship up`'s setup wizard.
+- **Public signup is disabled.** On the CLI the first admin is created by `openship up`'s setup wizard; on Docker, set `OPENSHIP_ADMIN_*` in `.env` (see [Docker](#docker) above).
 - **Invite teammates** from **Settings → Team**. They get an accept link at your instance's URL (so the instance needs to be reachable — a public URL or your LAN).
 - **Lost the admin password?** Run `openship reset-admin-password` on the box (no sign-in needed; uses the local internal token).
 

--- a/scripts/docker-init-admin.sh
+++ b/scripts/docker-init-admin.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# ─────────────────────────────────────────────────────────────────────────────
+# Declarative first-admin bootstrap for the Docker Compose stack.
+#
+# Compose has no equivalent of `openship up`'s interactive setup wizard, so a
+# fresh `docker compose up` used to leave the instance with no way to create the
+# first administrator through the web flow (public sign-up is disabled, and the
+# loopback bootstrap shortcut never fires because the request reaches the API
+# from a Docker-bridge IP, not 127.0.0.1). See issue #138.
+#
+# This one-shot service closes that gap WITHOUT enabling public sign-up: it
+# calls the existing internal-token-gated `POST /api/system/bootstrap-admin`
+# endpoint — the same endpoint the CLI wizard uses — with the credentials the
+# operator declared in `.env`.
+#
+# It is a no-op unless OPENSHIP_ADMIN_EMAIL and OPENSHIP_ADMIN_PASSWORD are set,
+# and it is idempotent: bootstrap-admin refuses (409) once an admin exists, so
+# re-running `docker compose up` never changes an existing admin. Operators who
+# prefer the CLI or a manual first sign-in can simply leave the vars unset.
+# ─────────────────────────────────────────────────────────────────────────────
+set -eu
+
+API_URL="${OPENSHIP_API_URL:-http://api:4000}"
+ADMIN_NAME="${OPENSHIP_ADMIN_NAME:-Admin}"
+
+if [ -z "${OPENSHIP_ADMIN_EMAIL:-}" ] || [ -z "${OPENSHIP_ADMIN_PASSWORD:-}" ]; then
+  echo "[init-admin] OPENSHIP_ADMIN_EMAIL / OPENSHIP_ADMIN_PASSWORD not set — skipping declarative admin bootstrap."
+  echo "[init-admin] Create the first admin with the CLI, or set those vars in .env and re-run \`docker compose up\`."
+  exit 0
+fi
+
+if [ -z "${INTERNAL_TOKEN:-}" ]; then
+  echo "[init-admin] INTERNAL_TOKEN is not set. The API requires it and so does this bootstrap. Aborting." >&2
+  exit 1
+fi
+
+# Build the JSON body with a tiny Python helper if available; otherwise fall back
+# to a manual escape. curl images ship neither jq nor python, so escape inline.
+escape() {
+  # Escape backslash, double-quote and control chars for a JSON string value.
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+body="{\"name\":\"$(escape "$ADMIN_NAME")\",\"email\":\"$(escape "$OPENSHIP_ADMIN_EMAIL")\",\"password\":\"$(escape "$OPENSHIP_ADMIN_PASSWORD")\"}"
+
+echo "[init-admin] Bootstrapping first admin for ${OPENSHIP_ADMIN_EMAIL} via ${API_URL} …"
+
+status="$(
+  curl -sS -o /tmp/init-admin-response -w '%{http_code}' \
+    -X POST "${API_URL}/api/system/bootstrap-admin" \
+    -H 'Content-Type: application/json' \
+    -H "X-Internal-Token: ${INTERNAL_TOKEN}" \
+    --data "${body}"
+)" || {
+  echo "[init-admin] Could not reach the API at ${API_URL}. Is the api service healthy?" >&2
+  exit 1
+}
+
+case "${status}" in
+  200)
+    echo "[init-admin] First admin created for ${OPENSHIP_ADMIN_EMAIL}. Sign in at the dashboard."
+    ;;
+  409)
+    echo "[init-admin] An admin already exists — nothing to do (bootstrap is one-shot)."
+    ;;
+  401)
+    echo "[init-admin] API rejected the internal token (401). Ensure INTERNAL_TOKEN matches the api service." >&2
+    exit 1
+    ;;
+  *)
+    echo "[init-admin] bootstrap-admin failed (HTTP ${status}):" >&2
+    cat /tmp/init-admin-response >&2 2>/dev/null || true
+    echo >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Problem

On a fresh Docker Compose deployment there's no supported way to create the first admin through the web flow. Public sign-up is disabled on self-hosted instances, and the loopback bootstrap shortcut in the sign-up guard never fires because the request reaches the API from a Docker-bridge IP (e.g. `172.18.x.x`) rather than `127.0.0.1`, so it always returns `SIGNUP_DISABLED`. `openship up`'s interactive wizard has no Compose equivalent.

Fixes #138.

## Approach

This follows the direction discussed in #138 (declarative credentials at start, endorsed by @Hydralerne) and reuses the exact mechanism the CLI already relies on — the internal-token-gated, one-shot `POST /api/system/bootstrap-admin` endpoint. **Public sign-up is not touched.**

An optional one-shot `init-admin` Compose service runs once the API is healthy and creates the first admin from credentials the operator declares in `.env`:

```env
OPENSHIP_ADMIN_NAME=Admin
OPENSHIP_ADMIN_EMAIL=admin@example.com
OPENSHIP_ADMIN_PASSWORD=a-strong-password   # 8-128 chars
```

Properties:

- **Opt-in / no-op by default** — if the admin vars are unset the service prints a hint and exits `0`, so nothing changes for operators who create the admin another way. `depends_on` is one-directional; no other service waits on it.
- **No new public surface** — it POSTs to the same invite-only bootstrap endpoint the CLI wizard uses, authenticated with the existing `INTERNAL_TOKEN`. It does not enable public registration.
- **Idempotent** — `bootstrap-admin` returns `409` once an admin exists, which the script treats as success, so re-running `docker compose up` never mutates an existing admin.

## Changes

- `scripts/docker-init-admin.sh` — the bootstrap script (POSIX `sh`; JSON body is escaped for embedded quotes/backslashes).
- `docker-compose.yml` — the `init-admin` service (pinned `curlimages/curl`, mounts the script read-only, waits for `api` health, then exits).
- `.env.example` — documents the optional `OPENSHIP_ADMIN_*` vars.
- `docs/installation.md` — a "Create the first admin" note in the Docker section.

## Testing

- `docker compose config` renders cleanly; `init-admin` receives `INTERNAL_TOKEN` and `OPENSHIP_API_URL`.
- `sh -n` / `bash -n` syntax-check pass.
- Ran the script against a mock of the `bootstrap-admin` contract covering every branch: vars-unset skip, successful create (incl. a password with embedded `"` and `\` to confirm JSON escaping), idempotent `409` re-run, `401` wrong-token, missing-`INTERNAL_TOKEN` abort, and unreachable-API. Success/skip paths exit `0`; error paths exit non-zero without blocking the rest of the stack.

## Notes for reviewers

- The service is intentionally non-blocking for the rest of the stack (`restart: "no"`, nothing depends on it), so an error state surfaces as an `Exited (1)` container without affecting the API/dashboard.
- No application/TypeScript code changes — this only wires up an existing endpoint for the Compose path.
