### PR TITLE
docs: correct published rate limits, route groups, MCP tools, and logs usage

### DIFF
--- a/apps/web/content/docs/api/index.mdx
+++ b/apps/web/content/docs/api/index.mdx
@@ -62,15 +62,17 @@ are per rolling minute.
 
 | Policy | Limit | Keyed by | Applies to |
 |---|---|---|---|
-| `default-anon` | 100 / min | IP | Any unauthenticated route |
-| `default-authed` | 600 / min | user | Any authenticated route |
-| `auth-tight` | 10 / min | IP | `POST /api/auth/*` (login, signup, reset) |
+| `default-anon` | 300 / min | IP | Any unauthenticated route |
+| `default-authed` | 3000 / min | user | Any authenticated route |
+| `auth-tight` | 10 / min | IP | `POST /api/auth/*` (login, signup, reset) and self-host invite signup |
 | `mcp` | 300 / min | IP | `/api/mcp` (tool-call bursts) |
 | `webhook-ingress` | 120 / min | source IP | Inbound webhook deliveries |
 | `billing-portal` | 20 / min | org | Stripe portal / checkout creation |
 
 Every response carries `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`. `/api/health` is
-never limited (load balancers and SSR poll it).
+never limited (load balancers and SSR poll it). On a self-hosted instance with neither `TRUST_PROXY` nor
+`OPENSHIP_PUBLIC_URL` set, requests arriving over loopback skip the ordinary limits — the `auth-tight` login
+gate always enforces.
 
 <Callout title="429 — Too many requests" type="warn">
 When a bucket is exhausted the request gets a `429` with body `{"error":"Too many requests"}` plus a
@@ -118,6 +120,9 @@ route set by mode.
 | `/api/backup-destinations` | Backup targets, policies, schedules | Both |
 | `/api/notifications` | Channels, subscriptions, deliveries | Both |
 | `/api/audit` | Organization audit log | Both |
+| `/api/apps` | One-click app catalog and installer | Both |
+| `/api/updates` | Update status for apps, projects, self-app, webmail | Both |
+| `/api/notices` | Platform status notices (public read, operator push) | Both |
 | `/api/settings` | Workspace / deploy defaults | Both |
 | `/api/tokens` | Personal access tokens | Both |
 | `/api/permissions` | Roles and resource grants | Both |
@@ -126,6 +131,7 @@ route set by mode.
 | `/api/images` | Container image helpers | Both |
 | `/api/services/terminal` | Interactive service terminal (WebSocket) | Both |
 | `/api/cloud` | Cloud account link / gateway | Both (SaaS vs local route set) |
+| `/api/jobs` | Scheduled jobs, runs, triggers | Self-hosted only |
 | `/api/system` | Filesystem browse, instance setup, provisioning | Self-hosted only |
 | `/api/mail` | Self-hosted mail server wizard | Self-hosted only |
 | `/api/migration` | Adopt an existing Docker host | Self-hosted only |

--- a/apps/web/content/docs/cli/deploy.mdx
+++ b/apps/web/content/docs/cli/deploy.mdx
@@ -146,9 +146,13 @@ For attaching and verifying domains themselves, see [Custom domains](/docs/guide
 
 ## `openship logs`
 
-View or stream a deployment's logs.
+View or stream a deployment's logs. The deployment ID is optional — leave it out and the CLI resolves the
+latest deployment of the linked project.
 
 ```bash
+# Latest deployment of the linked project
+openship logs
+
 # Print the last 100 lines and exit
 openship logs dep_123 --tail 100
 

--- a/apps/web/content/docs/dashboard/settings.mdx
+++ b/apps/web/content/docs/dashboard/settings.mdx
@@ -125,8 +125,8 @@ team organization.
 
 Decide what you get told about and where it goes.
 
-- **Delivery channels** — where notifications are sent. Add an **Email**, **Webhook**, **Slack**, or
-  **In-app** (dashboard bell) channel. Unverified channels are skipped until verified.
+- **Delivery channels** — where notifications are sent. Add an **Email**, **Webhook**, **Slack**, **Discord**,
+  or **In-app** (dashboard bell) channel. Unverified channels are skipped until verified.
 - **What to be notified about** — a grid of events × channels; each cell you switch on is one subscription.
 - **Organization defaults** — the subscriptions applied when a new member joins. Members can override their
   own per-channel.

--- a/apps/web/content/docs/mcp.mdx
+++ b/apps/web/content/docs/mcp.mdx
@@ -157,6 +157,12 @@ UI can flag a destructive call before it runs.
 | `get_github_repos` | `/api/github` | [GitHub API](/docs/api/github) |
 | `get_analytics` | `/api/analytics` | [Analytics API](/docs/api/analytics) |
 | `get_notifications_channels` | `/api/notifications` | [Notifications API](/docs/api/notifications) |
+| `get_settings`, `patch_settings_build_mode` | `/api/settings` | [Settings API](/docs/api/settings) |
+| `get_projects_by_projectId_backup_policies`, `post_backup_policies_by_policyId_run` | `/api/backups` | [Backups API](/docs/api/backups) |
+| `get_cloud_status`, `get_cloud_workspaces` | `/api/cloud` | [Cloud API](/docs/api/cloud) |
+| `get_jobs`, `post_jobs_by_key_run` | `/api/jobs` | [Jobs guide](/docs/guides/jobs) |
+| `get_apps_catalog`, `post_apps` | `/api/apps` | *(REST reference pending)* |
+| `get_updates`, `post_updates_scan` | `/api/updates` | [Updating Openship](/docs/guides/updating) |
 
 <Callout title="Credentials and auth are never exposed" type="info">
 The `tokens`, `auth`, and `mcp` modules are hard-blocked from ever becoming tools — a full-access MCP token


### PR DESCRIPTION
Four places where the docs no longer match the shipped code. Each was checked against source rather than inferred.

### Rate limits were wrong by 3–5×

`docs/api/index.mdx` published `default-anon` at 100/min and `default-authed` at 600/min. `apps/api/src/lib/rate-limit/policies.ts:39,50` sets them to **300** and **3000**. Anyone sizing a script or CI job against the docs was throttling themselves far harder than necessary.

Also in that section:
- `auth-tight` covers the self-host invite-signup route (`apps/api/src/modules/system/system.routes.ts:47`), not just `POST /api/auth/*`.
- Documented the loopback exemption in `apps/api/src/middleware/rate-limiter.ts:75` — with neither `TRUST_PROXY` nor `OPENSHIP_PUBLIC_URL` set, loopback requests skip the ordinary limits while the login gate still enforces. This materially changes what a self-hoster should expect.

I deliberately left `auth-loose`, `read-authed`, and `write-authed` out of the table. They exist in `policies.ts` but no route opts into them — only `billing-portal`, `mcp`, and `webhook-ingress` do. Listing them would imply enforcement that isn't there.

### Route-groups table was missing four mounted modules

Added `/api/apps`, `/api/updates`, `/api/notices` (both modes) and `/api/jobs` (self-hosted only). Worth noting `app.ts:141` mounts jobs unconditionally — the gate is `localOnly` applied inside `job.routes.ts`, which is easy to misread.

### MCP tool table listed 7 of 14 modules

`docs/mcp.mdx` showed 7 route families; the API exposes MCP-annotated routes across 14 modules. Added rows for settings, backups, cloud, jobs, apps, and updates. Tool names are derived from `toolName()` in `apps/api/src/modules/mcp/mcp-tools.ts:79`, so they match what `tools/list` actually returns. `apps` has no REST reference page to link, so that cell says so plainly rather than pointing somewhere wrong.

### Two smaller corrections

- `docs/dashboard/settings.mdx` omitted **Discord** from the delivery channels. It shipped as a first-class channel; the API page was updated at the time, this one was not.
- `docs/cli/deploy.mdx` required a deployment ID for `openship logs`. `apps/cli/src/commands/logs.ts:40` made it optional, falling back to the linked project's latest deployment. Every example still passed one.

### Verification

- Internal `/docs` link check: 0 broken links, 0 orphan pages.
- Markdown table column counts consistent across every edited table.
- No `bun format` run: `package.json:36` scopes prettier to `{ts,tsx,js,jsx,json,md}`, and all four changed files are `.mdx`, so a repo-wide run would only touch unrelated files.

### Not addressed here

Larger gaps found while checking these, left for separate PRs: missing changelog entries for v0.2.3 and v0.3.0, no API reference pages for `jobs`/`apps`/`updates`/`notices`, and no reference for Openship's own environment variables (the code reads ~90; `.env.example` has 15).