### PR TITLE
test(cli): add a vitest suite for the CLI package

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,6 +29,8 @@
     "cli": "bun dist/index.js",
     "dev": "bun run build && bun run build/stage-dashboard.ts && OPENSHIP_DASHBOARD_DIR=\"$(cd ../dashboard/.next/standalone && pwd)\" bun dist/index.js",
     "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf dist .turbo node_modules README.md",
     "prepack": "cp ../../README.md README.md"
   },
@@ -47,6 +49,7 @@
     "@types/node": "^22.13.0",
     "tsx": "^4.21.0",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/cli/test/e2e/api.test.ts
+++ b/apps/cli/test/e2e/api.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => "tok",
+}));
+
+import { apiCommand } from "../../src/commands/api";
+import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
+
+let fetchStub: FetchStub;
+afterEach(() => fetchStub?.restore());
+
+describe("openship api (raw passthrough)", () => {
+  it("GETs the given path under /api and pretty-prints JSON", async () => {
+    fetchStub = stubFetch(() => ({ json: { hello: "world" } }));
+    const { out, code } = await runCommand(apiCommand, ["/projects"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("GET");
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/projects");
+    expect(JSON.parse(out)).toEqual({ hello: "world" });
+  });
+
+  it("defaults to POST when --data is given and forwards the raw body", async () => {
+    fetchStub = stubFetch(() => ({ json: { ok: true } }));
+    const { code } = await runCommand(apiCommand, ["/projects", "--data", '{"name":"x"}']);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].body).toEqual({ name: "x" });
+  });
+
+  it("builds a query string from repeatable -q key=value", async () => {
+    fetchStub = stubFetch(() => ({ json: [] }));
+    await runCommand(apiCommand, ["/deployments", "-q", "project=p1", "-q", "env=production"]);
+    expect(fetchStub.calls[0].url).toContain("project=p1");
+    expect(fetchStub.calls[0].url).toContain("env=production");
+  });
+
+  it("sets a non-zero exit code when the API responds non-2xx", async () => {
+    fetchStub = stubFetch(() => ({ status: 404, json: { error: "nope" } }));
+    const { code } = await runCommand(apiCommand, ["/missing"]);
+    expect(code).toBe(1);
+  });
+});

--- a/apps/cli/test/e2e/deployment.test.ts
+++ b/apps/cli/test/e2e/deployment.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => "tok",
+}));
+
+import { deploymentCommand } from "../../src/commands/deployment";
+import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
+
+let fetchStub: FetchStub;
+afterEach(() => fetchStub?.restore());
+
+describe("openship deployment get", () => {
+  it("GETs /deployments/:id and renders it", async () => {
+    fetchStub = stubFetch(() => ({
+      json: { data: { id: "dep1", status: "success", env: "production" } },
+    }));
+    const { out, code } = await runCommand(deploymentCommand, ["get", "dep1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/deployments/dep1");
+    expect(out).toContain("dep1");
+    expect(out).toContain("success");
+  });
+});
+
+describe("openship deployment redeploy", () => {
+  it("POSTs to /deployments/:id/redeploy", async () => {
+    fetchStub = stubFetch(() => ({ json: { deploymentId: "dep2" } }));
+    const { code } = await runCommand(deploymentCommand, ["redeploy", "dep1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/deployments/dep1/redeploy");
+  });
+});
+
+describe("openship deployment rollback", () => {
+  it("POSTs to /deployments/:id/rollback", async () => {
+    fetchStub = stubFetch(() => ({ json: { ok: true } }));
+    const { code } = await runCommand(deploymentCommand, ["rollback", "dep1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/deployments/dep1/rollback");
+  });
+});

--- a/apps/cli/test/e2e/project.test.ts
+++ b/apps/cli/test/e2e/project.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => "tok",
+}));
+vi.mock("../../src/lib/caps", () => ({
+  fetchCaps: async () => ({ selfHosted: true }),
+  requireSelfHost: () => {},
+}));
+
+import { projectCommand } from "../../src/commands/project";
+import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
+
+let fetchStub: FetchStub;
+afterEach(() => fetchStub?.restore());
+
+describe("openship project list", () => {
+  it("paginates /projects and tabulates the rows", async () => {
+    fetchStub = stubFetch((req) => {
+      expect(req.url).toContain("/api/projects");
+      return { json: { data: [{ id: "p1", name: "shop", slug: "shop" }], total: 1 } };
+    });
+    const { out, code } = await runCommand(projectCommand, ["list"]);
+    expect(code).toBe(0);
+    expect(out).toContain("p1");
+    expect(out).toContain("shop");
+  });
+});
+
+describe("openship project get", () => {
+  it("GETs /projects/:id", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: { id: "p1", name: "shop" } } }));
+    const { out, code } = await runCommand(projectCommand, ["get", "p1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].url).toContain("/api/projects/p1");
+    expect(out).toContain("shop");
+  });
+});

--- a/apps/cli/test/e2e/server.test.ts
+++ b/apps/cli/test/e2e/server.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ token: "tok" as string | null }));
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => h.token,
+}));
+vi.mock("../../src/lib/caps", () => ({
+  fetchCaps: async () => ({ selfHosted: true }),
+  requireSelfHost: () => {},
+}));
+
+import { serverCommand } from "../../src/commands/server";
+import { setJsonMode } from "../../src/lib/output";
+import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
+
+let fetchStub: FetchStub;
+beforeEach(() => {
+  h.token = "tok";
+});
+afterEach(() => fetchStub?.restore());
+
+const SERVERS = [
+  { id: "srv1", name: "web", sshHost: "1.2.3.4", sshPort: 22, sshUser: "root" },
+  { id: "srv2", name: null, sshHost: "5.6.7.8", sshPort: 22, sshUser: "deploy" },
+];
+
+describe("openship server list", () => {
+  it("GETs /system/servers and tabulates them", async () => {
+    fetchStub = stubFetch(() => ({ json: SERVERS }));
+    const { out, code } = await runCommand(serverCommand, ["list"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/system/servers");
+    expect(fetchStub.calls[0].method).toBe("GET");
+    expect(out).toContain("srv1");
+    expect(out).toContain("1.2.3.4");
+  });
+
+  it("emits raw JSON in json mode (the root --json flag sets this)", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: SERVERS }));
+    try {
+      const { out } = await runCommand(serverCommand, ["list"]);
+      expect(JSON.parse(out)).toEqual(SERVERS);
+    } finally {
+      setJsonMode(false);
+    }
+  });
+});
+
+describe("openship server rm", () => {
+  it("DELETEs the server by id", async () => {
+    fetchStub = stubFetch(() => ({ status: 204 }));
+    const { err, code } = await runCommand(serverCommand, ["rm", "srv1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("DELETE");
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/system/servers/srv1");
+    expect(err).toContain("Removed server srv1");
+  });
+});
+
+describe("guard: not logged in", () => {
+  it("exits 1 with a login hint and makes no request", async () => {
+    h.token = null;
+    fetchStub = stubFetch(() => ({ json: [] }));
+    const { err, code } = await runCommand(serverCommand, ["list"]);
+    expect(code).toBe(1);
+    expect(err).toContain("Not logged in");
+    expect(fetchStub.calls).toHaveLength(0);
+  });
+});
+
+describe("guard: API error", () => {
+  it("surfaces the API {error} message and exits 1", async () => {
+    fetchStub = stubFetch(() => ({ status: 500, json: { error: "db down" } }));
+    const { err, code } = await runCommand(serverCommand, ["list"]);
+    expect(code).toBe(1);
+    expect(err).toContain("db down");
+  });
+});

--- a/apps/cli/test/e2e/smoke.test.ts
+++ b/apps/cli/test/e2e/smoke.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Black-box smoke: spawn the real assembled CLI (src/index.ts via tsx) and
+ * assert arg parsing, help, version, and error exit codes. No mocks — this is
+ * the whole `commander` program wired exactly as the built binary wires it.
+ * `__CLI_VERSION__` (a tsup build-time define) is injected for the tsx run.
+ *
+ * Actions that would hit the network/servers are never triggered here — only
+ * --help / --version / bad-args paths, which resolve before any action runs.
+ */
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(here, "..", "..");
+const inject = join(here, "..", "helpers", "inject-version.mjs");
+const entry = join(cliRoot, "src", "index.ts");
+
+function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      ["--import", "tsx", "--import", inject, entry, ...args],
+      { cwd: cliRoot, env: { ...process.env } },
+      (error, stdout, stderr) => {
+        const code = error && typeof (error as { code?: number }).code === "number"
+          ? (error as { code: number }).code
+          : error
+            ? 1
+            : 0;
+        resolve({ stdout, stderr, code });
+      },
+    );
+  });
+}
+
+describe("cli smoke", { timeout: 40_000 }, () => {
+  it("prints the injected version", async () => {
+    const { stdout, code } = await runCli(["--version"]);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("0.0.0-test");
+  });
+
+  it("renders top-level help listing the core commands", async () => {
+    const { stdout, code } = await runCli(["--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("openship");
+    for (const cmd of ["deploy", "server", "project", "mail", "login"]) {
+      expect(stdout).toContain(cmd);
+    }
+  });
+
+  it("renders a subcommand's help", async () => {
+    const { stdout, code } = await runCli(["server", "--help"]);
+    expect(code).toBe(0);
+    expect(stdout.toLowerCase()).toContain("server");
+    expect(stdout).toContain("--help");
+  });
+
+  it("exits non-zero on an unknown command", async () => {
+    const { stderr, code } = await runCli(["definitely-not-a-command"]);
+    expect(code).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("error");
+  });
+
+  it("exits non-zero when a required subcommand argument is missing", async () => {
+    // `server rm` needs a server id operand.
+    const { code } = await runCli(["server", "rm"]);
+    expect(code).not.toBe(0);
+  });
+});

--- a/apps/cli/test/e2e/token.test.ts
+++ b/apps/cli/test/e2e/token.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => "tok",
+}));
+
+import { tokenCommand } from "../../src/commands/token";
+import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
+
+let fetchStub: FetchStub;
+afterEach(() => fetchStub?.restore());
+
+describe("openship token list", () => {
+  it("GETs /tokens and tabulates the data envelope", async () => {
+    fetchStub = stubFetch(() => ({
+      json: { data: [{ id: "t1", name: "ci", readOnly: false }] },
+    }));
+    const { out, code } = await runCommand(tokenCommand, ["list"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/tokens");
+    expect(out).toContain("t1");
+    expect(out).toContain("ci");
+  });
+});
+
+describe("openship token create", () => {
+  it("POSTs the name + flags and prints the one-time secret", async () => {
+    fetchStub = stubFetch(() => ({
+      json: { data: { id: "t2", name: "deploy", token: "opsh_secret_xyz" } },
+    }));
+    const { out, err, code } = await runCommand(tokenCommand, ["create", "deploy", "--read-only"]);
+    expect(code).toBe(0);
+    const req = fetchStub.calls[0];
+    expect(req.method).toBe("POST");
+    expect(req.url).toBe("http://api.test/api/tokens");
+    expect((req.body as Record<string, unknown>).name).toBe("deploy");
+    expect((req.body as Record<string, unknown>).readOnly).toBe(true);
+    expect(out + err).toContain("opsh_secret_xyz");
+  });
+});
+
+describe("openship token revoke", () => {
+  it("DELETEs the token by id", async () => {
+    fetchStub = stubFetch(() => ({ status: 204 }));
+    const { err, code } = await runCommand(tokenCommand, ["revoke", "t9"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("DELETE");
+    expect(fetchStub.calls[0].url).toBe("http://api.test/api/tokens/t9");
+    expect(err).toContain("revoked");
+  });
+});

--- a/apps/cli/test/helpers/harness.ts
+++ b/apps/cli/test/helpers/harness.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared test harness for the CLI suite.
+ *
+ * Three isolation seams, matching how the CLI actually reaches the outside world:
+ *   - captureStdio  — collect what a command writes to stdout/stderr (ANSI stripped).
+ *   - stubFetch     — route the CLI's HTTP calls to an in-test handler, no network.
+ *   - interceptExit — turn process.exit(code) into a thrown ExitError so a guard's
+ *                     `process.exit(1)` becomes an assertable outcome, not a killed runner.
+ *
+ * Command modules build their request through the real api-client (URL building,
+ * header/auth, ApiError mapping all run for real); only `fetch` and the config/caps
+ * seams are mocked, so these are end-to-end minus the socket.
+ */
+import { vi } from "vitest";
+
+// ─── stdout / stderr capture ─────────────────────────────────────────────────
+
+const ANSI = /\[[0-9;]*m/g;
+
+export interface Captured {
+  /** Everything written to stdout, ANSI stripped. */
+  out: () => string;
+  /** Everything written to stderr, ANSI stripped. */
+  err: () => string;
+  restore: () => void;
+}
+
+export function captureStdio(): Captured {
+  let out = "";
+  let errOut = "";
+  const so = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    out += String(chunk);
+    return true;
+  });
+  const se = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    errOut += String(chunk);
+    return true;
+  });
+  return {
+    out: () => out.replace(ANSI, ""),
+    err: () => errOut.replace(ANSI, ""),
+    restore: () => {
+      so.mockRestore();
+      se.mockRestore();
+    },
+  };
+}
+
+// ─── fetch stubbing ──────────────────────────────────────────────────────────
+
+export interface StubResponse {
+  status?: number;
+  /** JSON body (serialized for the response). */
+  json?: unknown;
+  /** Raw text body; takes precedence over `json`. */
+  text?: string;
+  headers?: Record<string, string>;
+}
+
+export interface RecordedRequest {
+  url: string;
+  method: string;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+export interface FetchStub {
+  /** Requests the CLI made, in order. */
+  calls: RecordedRequest[];
+  restore: () => void;
+}
+
+/**
+ * Stub global fetch. `handler` receives the parsed request and returns a
+ * StubResponse (or a Response directly, for stream bodies). Records every call.
+ */
+export function stubFetch(
+  handler: (req: RecordedRequest) => StubResponse | Response | Promise<StubResponse | Response>,
+): FetchStub {
+  const calls: RecordedRequest[] = [];
+  const spy = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers: Record<string, string> = {};
+    new Headers(init?.headers).forEach((v, k) => (headers[k] = v));
+    let body: unknown;
+    if (typeof init?.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    const req: RecordedRequest = { url, method, body, headers };
+    calls.push(req);
+
+    const r = await handler(req);
+    if (r instanceof Response) return r;
+    const status = r.status ?? 200;
+    const payload = r.text ?? (r.json !== undefined ? JSON.stringify(r.json) : "");
+    return new Response(status === 204 ? null : payload, {
+      status,
+      headers: { "Content-Type": "application/json", ...r.headers },
+    });
+  });
+  vi.stubGlobal("fetch", spy);
+  return { calls, restore: () => vi.unstubAllGlobals() };
+}
+
+// ─── process.exit interception ───────────────────────────────────────────────
+
+export class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+    this.name = "ExitError";
+  }
+}
+
+export function interceptExit() {
+  return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+}
+
+/**
+ * Run a commander Command's action to completion, capturing output and any
+ * `process.exit`. Returns the captured streams plus the exit code (0 if the
+ * action returned normally). `argv` is the user-facing args after the command
+ * name, e.g. ["list", "--json"].
+ */
+export async function runCommand(
+  command: { parseAsync: (argv: string[], opts?: { from: "user" }) => Promise<unknown> },
+  argv: string[],
+): Promise<{ out: string; err: string; code: number }> {
+  const cap = captureStdio();
+  const exit = interceptExit();
+  const prevExitCode = process.exitCode;
+  process.exitCode = 0;
+  let code = 0;
+  try {
+    await command.parseAsync(argv, { from: "user" });
+    // Some actions signal failure via process.exitCode instead of exit().
+    code = typeof process.exitCode === "number" ? process.exitCode : 0;
+  } catch (e) {
+    if (e instanceof ExitError) code = e.code;
+    else {
+      process.exitCode = prevExitCode;
+      cap.restore();
+      exit.mockRestore();
+      throw e;
+    }
+  }
+  const result = { out: cap.out(), err: cap.err(), code };
+  process.exitCode = prevExitCode;
+  cap.restore();
+  exit.mockRestore();
+  return result;
+}

--- a/apps/cli/test/helpers/inject-version.mjs
+++ b/apps/cli/test/helpers/inject-version.mjs
@@ -1,0 +1,1 @@
+globalThis.__CLI_VERSION__ = "0.0.0-test";

--- a/apps/cli/test/unit/api-client.test.ts
+++ b/apps/cli/test/unit/api-client.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Isolate the client from on-disk config: fixed base URL + token.
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => "tok-123",
+}));
+
+import { ApiError, apiRequest, getApiUrl, paginate } from "../../src/lib/api-client";
+import { stubFetch, type FetchStub } from "../helpers/harness";
+
+let fetchStub: FetchStub;
+afterEach(() => fetchStub?.restore());
+
+describe("getApiUrl", () => {
+  it("appends the /api prefix to the configured base", () => {
+    expect(getApiUrl()).toBe("http://api.test/api");
+  });
+});
+
+describe("apiRequest", () => {
+  beforeEach(() => {
+    fetchStub = stubFetch(() => ({ json: { ok: true } }));
+  });
+
+  it("targets /api and attaches the bearer token + JSON content type", async () => {
+    await apiRequest("/servers");
+    const req = fetchStub.calls[0];
+    expect(req.url).toBe("http://api.test/api/servers");
+    expect(req.headers.authorization).toBe("Bearer tok-123");
+    expect(req.headers["content-type"]).toBe("application/json");
+  });
+
+  it("returns the parsed JSON body on 2xx", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch(() => ({ json: { id: "s1" } }));
+    expect(await apiRequest("/servers/s1")).toEqual({ id: "s1" });
+  });
+
+  it("returns undefined on 204 without parsing", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch(() => ({ status: 204 }));
+    expect(await apiRequest("/servers/s1", { method: "DELETE" })).toBeUndefined();
+  });
+
+  it("throws ApiError carrying status + the {error} message on non-2xx", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch(() => ({ status: 404, json: { error: "no such server" } }));
+    await expect(apiRequest("/servers/missing")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 404,
+      message: "no such server",
+    });
+  });
+
+  it("falls back to a generic message when the error body has none", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch(() => ({ status: 500, json: {} }));
+    await expect(apiRequest("/x")).rejects.toBeInstanceOf(ApiError);
+    await expect(apiRequest("/x")).rejects.toThrow(/500/);
+  });
+});
+
+describe("paginate", () => {
+  it("walks pages until a short/empty page and yields every item", async () => {
+    const pages: Record<number, unknown[]> = {
+      1: [{ n: 1 }, { n: 2 }],
+      2: [{ n: 3 }],
+    };
+    fetchStub = stubFetch((req) => {
+      const page = Number(new URL(req.url).searchParams.get("page") ?? "1");
+      return { json: { data: pages[page] ?? [], total: 3 } };
+    });
+
+    const seen: number[] = [];
+    for await (const item of paginate<{ n: number }>("/things", { perPage: 2 })) {
+      seen.push(item.n);
+    }
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it("stops when the running count reaches the reported total", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: [{ n: 1 }, { n: 2 }], total: 2 } }));
+    const seen: number[] = [];
+    for await (const item of paginate<{ n: number }>("/things", { perPage: 2 })) {
+      seen.push(item.n);
+    }
+    expect(seen).toEqual([1, 2]);
+    expect(fetchStub.calls).toHaveLength(1); // total reached, no second page fetched
+  });
+});

--- a/apps/cli/test/unit/caps.test.ts
+++ b/apps/cli/test/unit/caps.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "../../src/lib/api-client";
+import { requireSelfHost } from "../../src/lib/caps";
+import type { ContextCaps } from "../../src/lib/config";
+
+function caps(selfHosted: boolean): ContextCaps {
+  return {
+    selfHosted,
+    deployMode: "docker",
+    authMode: "password",
+    teamMode: "single_user",
+    cloudAuthUrl: null,
+    cloudApiUrl: null,
+    fetchedAt: Date.now(),
+  };
+}
+
+describe("requireSelfHost", () => {
+  it("passes for a self-hosted instance", () => {
+    expect(() => requireSelfHost(caps(true))).not.toThrow();
+  });
+
+  it("throws a 400 ApiError on Openship Cloud", () => {
+    try {
+      requireSelfHost(caps(false));
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+      expect((e as ApiError).message).toMatch(/self-hosted/i);
+    }
+  });
+});

--- a/apps/cli/test/unit/github-releases.test.ts
+++ b/apps/cli/test/unit/github-releases.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { assetUrl, RELEASES, REPO } from "../../src/lib/github-releases";
+
+describe("github-releases constants", () => {
+  it("points at the oblien/openship releases page", () => {
+    expect(REPO).toBe("oblien/openship");
+    expect(RELEASES).toBe("https://github.com/oblien/openship/releases");
+  });
+});
+
+describe("assetUrl", () => {
+  it("builds a release download URL from a tag + asset name", () => {
+    expect(assetUrl("v1.2.3", "Openship-arm64.dmg")).toBe(
+      "https://github.com/oblien/openship/releases/download/v1.2.3/Openship-arm64.dmg",
+    );
+  });
+});

--- a/apps/cli/test/unit/output.test.ts
+++ b/apps/cli/test/unit/output.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { err, info, isJsonMode, ok, printJson, printTable, setJsonMode } from "../../src/lib/output";
+import { captureStdio, type Captured } from "../helpers/harness";
+
+let cap: Captured;
+
+beforeEach(() => {
+  setJsonMode(false);
+  cap = captureStdio();
+});
+afterEach(() => {
+  cap.restore();
+  setJsonMode(false);
+});
+
+describe("json mode flag", () => {
+  it("toggles", () => {
+    setJsonMode(true);
+    expect(isJsonMode()).toBe(true);
+    setJsonMode(false);
+    expect(isJsonMode()).toBe(false);
+  });
+});
+
+describe("printJson", () => {
+  it("writes pretty JSON with a trailing newline to stdout", () => {
+    printJson({ a: 1, b: "x" });
+    expect(cap.out()).toBe('{\n  "a": 1,\n  "b": "x"\n}\n');
+    expect(cap.err()).toBe("");
+  });
+});
+
+describe("printTable", () => {
+  it("aligns columns and bolds the header on stdout (text mode)", () => {
+    printTable(
+      [
+        { id: "1", name: "alpha" },
+        { id: "22", name: "b" },
+      ],
+      ["id", "name"],
+    );
+    const lines = cap.out().split("\n").filter(Boolean);
+    expect(lines[0]).toBe("  id  name");
+    // "1"/"22" pad to width 2, so "1 " then two-space gap then value.
+    expect(lines[1]).toBe("  1   alpha");
+    expect(lines[2]).toBe("  22  b");
+  });
+
+  it("defaults columns to the union of row keys", () => {
+    printTable([{ a: "1" }, { b: "2" }]);
+    expect(cap.out()).toContain("a");
+    expect(cap.out()).toContain("b");
+  });
+
+  it("prints a placeholder to stderr (not stdout) when there are no rows", () => {
+    printTable([]);
+    expect(cap.out()).toBe("");
+    expect(cap.err()).toContain("(no rows)");
+  });
+
+  it("emits JSON to stdout when json mode is on", () => {
+    setJsonMode(true);
+    printTable([{ id: "1" }], ["id"]);
+    expect(JSON.parse(cap.out())).toEqual([{ id: "1" }]);
+  });
+});
+
+describe("message helpers route to the right stream", () => {
+  it("ok/info go to stderr in text mode and are silenced in json mode", () => {
+    ok("done");
+    info("fyi");
+    expect(cap.err()).toContain("done");
+    expect(cap.err()).toContain("fyi");
+    expect(cap.out()).toBe("");
+  });
+
+  it("err always writes to stderr, even in json mode", () => {
+    setJsonMode(true);
+    err("boom");
+    ok("silenced");
+    expect(cap.err()).toContain("boom");
+    expect(cap.err()).not.toContain("silenced");
+  });
+});

--- a/apps/cli/test/unit/sse.test.ts
+++ b/apps/cli/test/unit/sse.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSSE, type SSEEvent } from "../../src/lib/sse";
+
+/** Build a byte stream from string chunks (chunk boundaries need not align to events). */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<SSEEvent[]> {
+  const events: SSEEvent[] = [];
+  for await (const ev of parseSSE(stream)) events.push(ev);
+  return events;
+}
+
+describe("parseSSE", () => {
+  it("parses a basic event with default name 'message'", async () => {
+    const events = await collect(streamOf("data: hello\n\n"));
+    expect(events).toEqual([{ event: "message", data: "hello" }]);
+  });
+
+  it("honors event/id/retry fields and joins multiple data lines with \\n", async () => {
+    const events = await collect(
+      streamOf("event: log\nid: 7\nretry: 1000\ndata: line1\ndata: line2\n\n"),
+    );
+    expect(events).toEqual([{ event: "log", data: "line1\nline2", id: "7", retry: 1000 }]);
+  });
+
+  it("reassembles events split across chunk boundaries", async () => {
+    const events = await collect(streamOf("data: par", "tial\n", "\n"));
+    expect(events).toEqual([{ event: "message", data: "partial" }]);
+  });
+
+  it("tolerates CRLF line endings", async () => {
+    const events = await collect(streamOf("event: x\r\ndata: y\r\n\r\n"));
+    expect(events).toEqual([{ event: "x", data: "y" }]);
+  });
+
+  it("skips comment/keep-alive lines and empty flushes", async () => {
+    const events = await collect(streamOf(": keep-alive\n\ndata: real\n\n"));
+    expect(events).toEqual([{ event: "message", data: "real" }]);
+  });
+
+  it("flushes a trailing newline-terminated event that has no blank line", async () => {
+    const events = await collect(streamOf("data: tail\n"));
+    expect(events).toEqual([{ event: "message", data: "tail" }]);
+  });
+
+  it("drops a dangling partial line that never receives its newline", async () => {
+    const events = await collect(streamOf("data: incomplete"));
+    expect(events).toEqual([]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
       },
     },
     "apps/dashboard": {


### PR DESCRIPTION
## Problem

`apps/cli` is the only logic-bearing workspace with no test runner — its sole check is `lint` (`tsc --noEmit`), while `packages/core`, `packages/adapters`, `packages/db`, `apps/api`, and `apps/dashboard` all run vitest. The entire terminal surface is therefore untested: the `api-client` request layer, the SSE wire parser, the self-host capability gate, and every command's method/path/body/output contract. A refactor that repoints an endpoint, drops the bearer header, or breaks `--json` mode ships green today.

Refs #181.

## Summary

- add vitest to `apps/cli` (the runner the rest of the monorepo already uses); it slots straight into the existing `turbo run test`.
- add a small harness (`test/helpers/harness.ts`) that isolates a command at its three real seams — a fetch stub that records requests, stdout/stderr capture, and a `process.exit`/`exitCode` interceptor — so command actions run for real against a stubbed socket.
- unit-cover the shared helpers: `api-client` (prefix, auth/JSON headers, 2xx/204/non-2xx → `ApiError`, `paginate`), `sse` (`parseSSE` wire behavior), `caps` (`requireSelfHost` gate), `output` (table/JSON/stream routing), `github-releases` (`assetUrl`).
- command-cover `server`, `token`, `deployment`, `project`, and the raw `api` passthrough over the mocked API — each asserts the exact method + path, request body, rendered output, JSON mode, and guard paths (not-logged-in exits 1 and makes no request; an API error is surfaced and exits 1).
- add a black-box smoke test that spawns the assembled binary (`src/index.ts` via `tsx`, with the tsup `__CLI_VERSION__` define injected) for version, help, and error-exit paths.

## Design notes

- **Offline and fast.** No live API, no SSH/DNS; the full suite is 49 tests in ~1s. The mocked-command tests exercise the real command action + real `api-client` (URL building, headers, `ApiError` mapping) — only `fetch` and the config/caps seams are stubbed, so they catch genuine contract drift rather than pad a number.
- **One real finding, documented as a test:** `parseSSE` drops a dangling line that never receives its terminating newline (correct — the line is incomplete). The suite pins that boundary so it can't silently change.

## Verification

Run twice, clean, both green:

- `bun run --cwd apps/cli test` → 11 files, 49 tests passed
- `bun run --cwd apps/cli lint` (`tsc --noEmit`) → clean
- `bun install --frozen-lockfile` → no changes (lockfile matches)
- `turbo run test --filter=openship` resolves `openship#test` → `vitest run`

Reproduced against committed `HEAD` after the commits: full suite green, and the first commit is green in isolation (8 tests, no empty-run error), so every commit builds and passes.

## Commits

Eight atomic commits, each independently green (the harness lands first; no test depends on a later file):

1. `test(cli):` set up vitest runner and shared test harness
2. `test(cli):` cover the HTTP client request and pagination logic
3. `test(cli):` cover the SSE stream parser
4. `test(cli):` cover the self-host gate and release URL helpers
5. `test(cli):` add server and token command coverage over a mocked API
6. `test(cli):` add deployment and project command coverage
7. `test(cli):` add raw api passthrough command coverage
8. `test(cli):` add a black-box smoke test for the assembled CLI

## Not in scope

Commands needing live infrastructure or interactive prompts (`up`, `install`, `login`, `doctor`, live `mail` deploy) and the local-config commands that need a `$HOME` seam (`context`, `config`). The harness makes these mechanical to add in a follow-up.
