### PR TITLE
fix(api): compute dashboard home stats with SQL aggregates

### DIFF
--- a/apps/api/src/modules/analytics/analytics.service.ts
+++ b/apps/api/src/modules/analytics/analytics.service.ts
@@ -519,28 +519,18 @@ export async function getContainerInfo(ctx: RequestContext, projectId: string) {
  * the active org only (not cross-org).
  */
 export async function getDashboardStats(ctx: RequestContext) {
-  const { rows: projects, total: totalProjects } = await repos.project.listByOrganization(
-    ctx.organizationId,
-    { page: 1, perPage: 10_000 },
-  );
+  const [projectCounts, deploymentsByStatus] = await Promise.all([
+    repos.project.countByOrganization(ctx.organizationId),
+    repos.deployment.countByStatusForOrganization(ctx.organizationId),
+  ]);
 
-  const activeProjects = projects.filter((p) => p.activeDeploymentId).length;
-
-  // Aggregate deployment counts across all projects
   let totalDeployments = 0;
-  let failedDeployments = 0;
-  let successDeployments = 0;
-
-  for (const p of projects.slice(0, 50)) {
-    // Limit to 50 projects for perf
-    const { rows } = await repos.deployment.listByProject(p.id, { page: 1, perPage: 100 });
-    totalDeployments += rows.length;
-    failedDeployments += rows.filter((d) => d.status === "failed").length;
-    successDeployments += rows.filter((d) => d.status === "ready").length;
-  }
+  for (const count of Object.values(deploymentsByStatus)) totalDeployments += count;
+  const successDeployments = deploymentsByStatus["ready"] ?? 0;
+  const failedDeployments = deploymentsByStatus["failed"] ?? 0;
 
   return {
-    projects: { total: totalProjects, active: activeProjects },
+    projects: { total: projectCounts.total, active: projectCounts.active },
     deployments: {
       total: totalDeployments,
       success: successDeployments,

--- a/packages/db/src/repos/dashboard-stats.repo.test.ts
+++ b/packages/db/src/repos/dashboard-stats.repo.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import * as schema from "../schema";
+import { createProjectRepo } from "./project.repo";
+import { createDeploymentRepo } from "./deployment.repo";
+
+const MIGRATIONS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
+
+/**
+ * Real (in-memory PGlite) tests for the dashboard-stats aggregates:
+ * project.countByOrganization + deployment.countByStatusForOrganization.
+ * These replaced the walk-projects-and-count-in-JS path that capped at 50
+ * projects / 100 deployments each, so the interesting cases are exactly the
+ * ones past those old caps. FK enforcement is disabled so we can seed
+ * project/deployment rows without parent org/group rows.
+ */
+async function freshDb() {
+  const client = new PGlite("memory://");
+  const db = drizzle(client, { schema });
+  await migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  await client.exec("SET session_replication_role = replica;"); // skip FK seeding
+  return {
+    db,
+    projectRepo: createProjectRepo(db),
+    deploymentRepo: createDeploymentRepo(db),
+  };
+}
+
+type Db = Awaited<ReturnType<typeof freshDb>>["db"];
+
+async function seedProject(
+  db: Db,
+  id: string,
+  organizationId: string,
+  opts?: { activeDeploymentId?: string; deletedAt?: Date },
+) {
+  await db.insert(schema.project).values({
+    id,
+    organizationId,
+    groupId: `app_${id}`,
+    name: id,
+    slug: id,
+    activeDeploymentId: opts?.activeDeploymentId ?? null,
+    deletedAt: opts?.deletedAt ?? null,
+  });
+}
+
+async function seedDeployments(
+  db: Db,
+  projectId: string,
+  organizationId: string,
+  statuses: string[],
+) {
+  await db.insert(schema.deployment).values(
+    statuses.map((status, i) => ({
+      id: `dep_${projectId}_${i}`,
+      projectId,
+      organizationId,
+      branch: "main",
+      status,
+    })),
+  );
+}
+
+describe("dashboard stats aggregates", () => {
+  let db: Db;
+  let projectRepo: ReturnType<typeof createProjectRepo>;
+  let deploymentRepo: ReturnType<typeof createDeploymentRepo>;
+
+  beforeEach(async () => {
+    ({ db, projectRepo, deploymentRepo } = await freshDb());
+  }, 30_000);
+
+  it("counts deployments across more than 50 projects (old cap)", async () => {
+    for (let i = 0; i < 60; i++) {
+      await seedProject(db, `proj_${i}`, "org_1");
+      await seedDeployments(db, `proj_${i}`, "org_1", ["ready"]);
+    }
+    const counts = await deploymentRepo.countByStatusForOrganization("org_1");
+    expect(counts).toEqual({ ready: 60 });
+  });
+
+  it("counts more than 100 deployments in one project (old cap)", async () => {
+    await seedProject(db, "proj_big", "org_1");
+    // Terminal statuses only — the uq_deployment_one_active_per_project
+    // partial index allows at most one queued/building/deploying per project.
+    const statuses = [
+      ...Array<string>(70).fill("ready"),
+      ...Array<string>(40).fill("failed"),
+      ...Array<string>(10).fill("cancelled"),
+    ];
+    await seedDeployments(db, "proj_big", "org_1", statuses);
+    const counts = await deploymentRepo.countByStatusForOrganization("org_1");
+    expect(counts).toEqual({ ready: 70, failed: 40, cancelled: 10 });
+  });
+
+  it("groups by status and never double-counts a deployment", async () => {
+    await seedProject(db, "proj_a", "org_1");
+    await seedProject(db, "proj_b", "org_1");
+    await seedDeployments(db, "proj_a", "org_1", ["ready", "failed", "building"]);
+    await seedDeployments(db, "proj_b", "org_1", ["ready", "cancelled"]);
+    const counts = await deploymentRepo.countByStatusForOrganization("org_1");
+    expect(counts).toEqual({ ready: 2, failed: 1, building: 1, cancelled: 1 });
+    const total = Object.values(counts).reduce((a, b) => a + b, 0);
+    expect(total).toBe(5);
+  });
+
+  it("excludes soft-deleted projects and other orgs from deployment counts", async () => {
+    await seedProject(db, "proj_live", "org_1");
+    await seedProject(db, "proj_gone", "org_1", { deletedAt: new Date() });
+    await seedProject(db, "proj_other", "org_2");
+    await seedDeployments(db, "proj_live", "org_1", ["ready"]);
+    await seedDeployments(db, "proj_gone", "org_1", ["ready", "failed"]);
+    await seedDeployments(db, "proj_other", "org_2", ["ready"]);
+    expect(await deploymentRepo.countByStatusForOrganization("org_1")).toEqual({ ready: 1 });
+  });
+
+  it("returns an empty record for an org with no deployments", async () => {
+    await seedProject(db, "proj_idle", "org_1");
+    expect(await deploymentRepo.countByStatusForOrganization("org_1")).toEqual({});
+  });
+
+  it("counts total and active projects, ignoring soft-deleted and other orgs", async () => {
+    await seedProject(db, "proj_active", "org_1", { activeDeploymentId: "dep_x" });
+    await seedProject(db, "proj_inactive", "org_1");
+    await seedProject(db, "proj_gone", "org_1", {
+      activeDeploymentId: "dep_y",
+      deletedAt: new Date(),
+    });
+    await seedProject(db, "proj_other", "org_2", { activeDeploymentId: "dep_z" });
+    expect(await projectRepo.countByOrganization("org_1")).toEqual({ total: 2, active: 1 });
+    expect(await projectRepo.countByOrganization("org_empty")).toEqual({ total: 0, active: 0 });
+  });
+
+  it("counts totals correctly past the old 50-project cap", async () => {
+    for (let i = 0; i < 55; i++) {
+      await seedProject(db, `proj_${i}`, "org_1", i % 2 === 0 ? { activeDeploymentId: `dep_${i}` } : undefined);
+    }
+    expect(await projectRepo.countByOrganization("org_1")).toEqual({ total: 55, active: 28 });
+  });
+});

--- a/packages/db/src/repos/deployment.repo.ts
+++ b/packages/db/src/repos/deployment.repo.ts
@@ -1,7 +1,7 @@
 import { eq, and, desc, gte, lte, inArray, isNull, ne, sql } from "drizzle-orm";
 import { generateId } from "@repo/core";
 import type { Database } from "../client";
-import { deployment, buildSession } from "../schema";
+import { deployment, buildSession, project } from "../schema";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -86,6 +86,32 @@ export function createDeploymentRepo(db: Database) {
         .where(eq(deployment.organizationId, organizationId));
 
       return { rows, total: Number(total), page, perPage };
+    },
+
+    /**
+     * Deployment counts grouped by status across every non-deleted project
+     * in an organization. One aggregate query — powers the dashboard home
+     * stats without walking projects one by one. Joins through `project`
+     * (rather than using deployment.organizationId directly) so deployments
+     * of soft-deleted projects stay out of the counts, matching what the
+     * org-scoped project listings show.
+     */
+    async countByStatusForOrganization(
+      organizationId: string,
+    ): Promise<Record<string, number>> {
+      const rows = await db
+        .select({
+          status: deployment.status,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(deployment)
+        .innerJoin(project, eq(deployment.projectId, project.id))
+        .where(and(eq(project.organizationId, organizationId), isNull(project.deletedAt)))
+        .groupBy(deployment.status);
+
+      const out: Record<string, number> = {};
+      for (const r of rows) out[r.status] = Number(r.count);
+      return out;
     },
 
     /**

--- a/packages/db/src/repos/project.repo.ts
+++ b/packages/db/src/repos/project.repo.ts
@@ -165,6 +165,24 @@ export function createProjectRepo(db: Database) {
     },
 
     /**
+     * Project counts for the dashboard home — total and with-an-active-
+     * deployment, in one aggregate query instead of listing every row.
+     */
+    async countByOrganization(
+      organizationId: string,
+    ): Promise<{ total: number; active: number }> {
+      const [row] = await db
+        .select({
+          total: sql<number>`count(*)::int`,
+          active: sql<number>`count(*) filter (where ${project.activeDeploymentId} is not null)::int`,
+        })
+        .from(project)
+        .where(and(eq(project.organizationId, organizationId), isNull(project.deletedAt)));
+
+      return { total: Number(row?.total ?? 0), active: Number(row?.active ?? 0) };
+    },
+
+    /**
      * Every non-deleted project across ALL orgs — for the instance-wide
      * updates:scan job (each row carries its own organizationId). Capped so a
      * pathological instance can't run an unbounded sweep.


### PR DESCRIPTION
`getDashboardStats` listed up to 10,000 project rows and then queried each project's deployments one by one — up to 51 sequential DB queries per dashboard load. It also only looked at the first 50 projects and the first 100 deployments per project, so the total/success/failed counts were silently understated for larger orgs, and `pending` (derived by subtraction) was wrong too.

This replaces the walk with two aggregate queries that run in parallel:

- `deployment.repo.ts`: new `countByStatusForOrganization()` — a single `GROUP BY status` count, joined through `project` so soft-deleted projects stay excluded (same scope as the old org-scoped listing).
- `project.repo.ts`: new `countByOrganization()` — total and active project counts in one query.
- `analytics.service.ts`: `getDashboardStats` now uses the two aggregates. Response shape is unchanged.

Counts are now exact at any org size and the endpoint does constant work.

Tested with `tsc --noEmit` in `packages/db` and `apps/api` (both clean). No existing tests cover this path.