### PR TITLE
test(cli): cover the domain command (domains, DNS, SSL)

### DIFF
--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -220,3 +220,31 @@ describe("openship domain renew", () => {
     expect(JSON.parse(out)).toEqual(SSL.data);
   });
 });
+
+// ─── verify-ssl (recheck only, no reissue) ───────────────────────────────────
+
+describe("openship domain verify-ssl", () => {
+  it("POSTs /domains/:id/verify-ssl and exits 0 when the cert is valid", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: { domain: "app.example.com", sslStatus: "valid", verified: true } } }));
+    const { err, code } = await runCommand(domainCommand, ["verify-ssl", "d1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/d1/verify-ssl`);
+    expect(err).toContain("status:  valid");
+  });
+
+  it("exits 1 when the certificate is not valid yet", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: { domain: "app.example.com", sslStatus: "pending", verified: false } } }));
+    const { code } = await runCommand(domainCommand, ["verify-ssl", "d1"]);
+    expect(code).toBe(1);
+  });
+
+  it("does NOT exit 1 in json mode even when the cert is not valid", async () => {
+    setJsonMode(true);
+    const data = { domain: "app.example.com", sslStatus: "pending", verified: false };
+    fetchStub = stubFetch(() => ({ json: { data } }));
+    const { out, code } = await runCommand(domainCommand, ["verify-ssl", "d1"]);
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual(data);
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -92,3 +92,27 @@ describe("openship domain add", () => {
     expect(JSON.parse(out)).toEqual({ domain: ADDED.data, records: ADDED.records });
   });
 });
+
+// ─── preview (no changes saved) ──────────────────────────────────────────────
+
+describe("openship domain preview", () => {
+  const PREVIEW = { data: { mode: "cloud", records: [{ type: "TXT", host: "_openship", value: "verify=abc" }] } };
+
+  it("POSTs the hostname to /domains/preview and prints the record table", async () => {
+    fetchStub = stubFetch(() => ({ json: PREVIEW }));
+    const { out, err, code } = await runCommand(domainCommand, ["preview", "app.example.com"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/preview`);
+    expect(fetchStub.calls[0].body).toEqual({ hostname: "app.example.com" });
+    expect(err).toContain("DNS mode: cloud");
+    expect(out).toContain("verify=abc");
+  });
+
+  it("emits the records result as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: PREVIEW }));
+    const { out } = await runCommand(domainCommand, ["preview", "app.example.com"]);
+    expect(JSON.parse(out)).toEqual(PREVIEW.data);
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -154,3 +154,24 @@ describe("openship domain verify", () => {
     expect(err).toContain("verifier crashed");
   });
 });
+
+// ─── primary ─────────────────────────────────────────────────────────────────
+
+describe("openship domain primary", () => {
+  const PRIMARY = { data: { id: "d1", hostname: "app.example.com", isPrimary: true } };
+
+  it("POSTs /domains/:id/primary", async () => {
+    fetchStub = stubFetch(() => ({ json: PRIMARY }));
+    const { code } = await runCommand(domainCommand, ["primary", "d1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/d1/primary`);
+  });
+
+  it("emits the updated domain as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: PRIMARY }));
+    const { out } = await runCommand(domainCommand, ["primary", "d1"]);
+    expect(JSON.parse(out)).toEqual(PRIMARY.data);
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -198,3 +198,25 @@ describe("openship domain records", () => {
     expect(JSON.parse(out)).toEqual(RECORDS.data);
   });
 });
+
+// ─── renew (reissue SSL) ─────────────────────────────────────────────────────
+
+describe("openship domain renew", () => {
+  const SSL = { data: { domain: "app.example.com", sslStatus: "issued", issuer: "Let's Encrypt", expiresAt: "2026-10-01" } };
+
+  it("POSTs /domains/:id/renew and prints the certificate status", async () => {
+    fetchStub = stubFetch(() => ({ json: SSL }));
+    const { err, code } = await runCommand(domainCommand, ["renew", "d1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/d1/renew`);
+    expect(err).toContain("status:  issued");
+  });
+
+  it("emits the SSL result as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: SSL }));
+    const { out } = await runCommand(domainCommand, ["renew", "d1"]);
+    expect(JSON.parse(out)).toEqual(SSL.data);
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -283,3 +283,33 @@ describe("openship domain renew-all", () => {
     expect(JSON.parse(out)).toEqual(RESULT.data);
   });
 });
+
+// ─── auth + error handling (shared across subcommands) ───────────────────────
+
+describe("openship domain error + auth handling", () => {
+  it("surfaces the API {error} message and exits 1", async () => {
+    fetchStub = stubFetch(() => ({ status: 500, json: { error: "db down" } }));
+    const { err, code } = await runCommand(domainCommand, ["list", "-p", "prj1"]);
+    expect(code).toBe(1);
+    expect(err).toContain("db down");
+  });
+
+  it("sends the bearer token when logged in", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: [] } }));
+    await runCommand(domainCommand, ["list", "-p", "prj1"]);
+    expect(fetchStub.calls[0].headers.authorization).toBe("Bearer tok");
+  });
+
+  it("still issues the request unauthenticated when logged out (domain has no pre-flight login guard)", async () => {
+    // Unlike `server`/`mail`, domain.ts does not short-circuit on a missing
+    // token — it sends the request with no Authorization header and lets the
+    // API reject it. Pin that so adding a pre-flight guard is a deliberate change.
+    h.token = null;
+    fetchStub = stubFetch(() => ({ status: 401, json: { error: "unauthorized" } }));
+    const { err, code } = await runCommand(domainCommand, ["list", "-p", "prj1"]);
+    expect(fetchStub.calls).toHaveLength(1);
+    expect(fetchStub.calls[0].headers.authorization).toBeUndefined();
+    expect(code).toBe(1);
+    expect(err).toContain("unauthorized");
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -116,3 +116,41 @@ describe("openship domain preview", () => {
     expect(JSON.parse(out)).toEqual(PREVIEW.data);
   });
 });
+
+// ─── verify (apiRaw: 200 verified vs 422 not-propagated-yet) ──────────────────
+
+describe("openship domain verify", () => {
+  it("reports a verified domain and exits 0", async () => {
+    fetchStub = stubFetch(() => ({ json: { verified: true, cnameVerified: true, txtVerified: true, message: "Domain verified" } }));
+    const { err, code } = await runCommand(domainCommand, ["verify", "d1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/d1/verify`);
+    expect(err).toContain("route/CNAME: ok");
+    expect(err).toContain("TXT: ok");
+  });
+
+  it("treats a 422 (DNS not propagated) as not-verified and exits 1 without throwing", async () => {
+    fetchStub = stubFetch(() => ({ status: 422, json: { verified: false, cnameVerified: false, txtVerified: true } }));
+    const { err, code } = await runCommand(domainCommand, ["verify", "d1"]);
+    expect(code).toBe(1); // the whole point of the command: unverified is a failure exit
+    expect(fetchStub.calls).toHaveLength(1); // 422 is handled, not surfaced as an error before the request
+    expect(err).toContain("route/CNAME: missing");
+  });
+
+  it("prints the raw result and does NOT exit 1 in json mode even when unverified", async () => {
+    setJsonMode(true);
+    const body = { verified: false, cnameVerified: false, txtVerified: false };
+    fetchStub = stubFetch(() => ({ status: 422, json: body }));
+    const { out, code } = await runCommand(domainCommand, ["verify", "d1"]);
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual(body);
+  });
+
+  it("surfaces a non-422 error (e.g. 500) and exits 1", async () => {
+    fetchStub = stubFetch(() => ({ status: 500, json: { error: "verifier crashed" } }));
+    const { err, code } = await runCommand(domainCommand, ["verify", "d1"]);
+    expect(code).toBe(1);
+    expect(err).toContain("verifier crashed");
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// domain.ts calls the api-client directly (no local login guard); the config
+// seam supplies the base URL + token, caps is stubbed self-hosted.
+const h = vi.hoisted(() => ({ token: "tok" as string | null }));
+vi.mock("../../src/lib/config", () => ({
+  getApiUrl: () => "http://api.test",
+  getToken: () => h.token,
+}));
+vi.mock("../../src/lib/caps", () => ({
+  fetchCaps: async () => ({ selfHosted: true }),
+  requireSelfHost: () => {},
+}));
+
+import { domainCommand } from "../../src/commands/domain";
+import { setJsonMode } from "../../src/lib/output";
+import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
+
+const API = "http://api.test/api";
+
+let fetchStub: FetchStub;
+beforeEach(() => {
+  h.token = "tok";
+});
+afterEach(() => {
+  fetchStub?.restore();
+  setJsonMode(false);
+});
+
+// ─── list ────────────────────────────────────────────────────────────────────
+
+describe("openship domain list", () => {
+  const DOMAINS = [
+    { id: "d1", hostname: "app.example.com", domainType: "primary", isPrimary: true, verified: true, status: "active", sslStatus: "issued" },
+    { id: "d2", hostname: "www.example.com", verified: false, status: "pending" },
+  ];
+
+  it("GETs /domains for the project and tabulates the rows", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: DOMAINS } }));
+    const { out, code } = await runCommand(domainCommand, ["list", "-p", "prj 1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls).toHaveLength(1);
+    expect(fetchStub.calls[0].method).toBe("GET");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains?projectId=prj%201`); // project id is URL-encoded
+    expect(out).toContain("app.example.com");
+    expect(out).toContain("d2");
+  });
+
+  it("emits the raw rows as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: { data: DOMAINS } }));
+    const { out } = await runCommand(domainCommand, ["list", "-p", "prj1"]);
+    expect(JSON.parse(out)).toEqual(DOMAINS);
+  });
+
+  it("renders an empty table when the project has no domains", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: [] } })); // the API always returns a data array, empty when none
+    const { code } = await runCommand(domainCommand, ["list", "-p", "prj1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls).toHaveLength(1);
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -60,3 +60,35 @@ describe("openship domain list", () => {
     expect(fetchStub.calls).toHaveLength(1);
   });
 });
+
+// ─── add ─────────────────────────────────────────────────────────────────────
+
+describe("openship domain add", () => {
+  const ADDED = {
+    data: { id: "d9", hostname: "app.example.com" },
+    records: { mode: "selfhosted", records: [{ type: "CNAME", host: "app", value: "edge.example.net" }] },
+  };
+
+  it("POSTs the hostname to /domains and points the user at verify", async () => {
+    fetchStub = stubFetch(() => ({ status: 201, json: ADDED }));
+    const { err, code } = await runCommand(domainCommand, ["add", "app.example.com", "-p", "prj1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains`);
+    expect(fetchStub.calls[0].body).toEqual({ projectId: "prj1", hostname: "app.example.com", isPrimary: false });
+    expect(err).toContain("openship domain verify d9"); // next-step hint names the new id
+  });
+
+  it("sets isPrimary when --primary is passed", async () => {
+    fetchStub = stubFetch(() => ({ status: 201, json: ADDED }));
+    await runCommand(domainCommand, ["add", "app.example.com", "-p", "prj1", "--primary"]);
+    expect(fetchStub.calls[0].body).toMatchObject({ isPrimary: true });
+  });
+
+  it("emits the domain and its DNS records as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ status: 201, json: ADDED }));
+    const { out } = await runCommand(domainCommand, ["add", "app.example.com", "-p", "prj1"]);
+    expect(JSON.parse(out)).toEqual({ domain: ADDED.data, records: ADDED.records });
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -248,3 +248,38 @@ describe("openship domain verify-ssl", () => {
     expect(JSON.parse(out)).toEqual(data);
   });
 });
+
+// ─── renew-all (org-wide) ────────────────────────────────────────────────────
+
+describe("openship domain renew-all", () => {
+  const RESULT = {
+    data: { renewed: 2, results: [
+      { domain: "a.example.com", status: "renewed" },
+      { domain: "b.example.com", status: "failed", error: "rate limited" },
+    ] },
+  };
+
+  it("POSTs /domains/renew-all and tabulates the per-domain results", async () => {
+    fetchStub = stubFetch(() => ({ json: RESULT }));
+    const { out, code } = await runCommand(domainCommand, ["renew-all"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("POST");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/renew-all`);
+    expect(out).toContain("b.example.com");
+    expect(out).toContain("rate limited");
+  });
+
+  it("notes when nothing needed renewal", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: { renewed: 0, results: [] } } }));
+    const { err, code } = await runCommand(domainCommand, ["renew-all"]);
+    expect(code).toBe(0);
+    expect(err).toContain("Nothing needed renewal");
+  });
+
+  it("emits the renew-all result as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: RESULT }));
+    const { out } = await runCommand(domainCommand, ["renew-all"]);
+    expect(JSON.parse(out)).toEqual(RESULT.data);
+  });
+});

--- a/apps/cli/test/e2e/domain.test.ts
+++ b/apps/cli/test/e2e/domain.test.ts
@@ -175,3 +175,26 @@ describe("openship domain primary", () => {
     expect(JSON.parse(out)).toEqual(PRIMARY.data);
   });
 });
+
+// ─── records ─────────────────────────────────────────────────────────────────
+
+describe("openship domain records", () => {
+  const RECORDS = { data: { mode: "selfhosted", records: [{ type: "A", host: "@", value: "203.0.113.5" }] } };
+
+  it("GETs the existing DNS records for a domain", async () => {
+    fetchStub = stubFetch(() => ({ json: RECORDS }));
+    const { out, err, code } = await runCommand(domainCommand, ["records", "d1"]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].method).toBe("GET");
+    expect(fetchStub.calls[0].url).toBe(`${API}/domains/d1/records`);
+    expect(err).toContain("DNS mode: selfhosted");
+    expect(out).toContain("203.0.113.5");
+  });
+
+  it("emits the records result as JSON in json mode", async () => {
+    setJsonMode(true);
+    fetchStub = stubFetch(() => ({ json: RECORDS }));
+    const { out } = await runCommand(domainCommand, ["records", "d1"]);
+    expect(JSON.parse(out)).toEqual(RECORDS.data);
+  });
+});


### PR DESCRIPTION
## Problem

The CLI test suite (#182) covered `server`, `token`, `deployment`, `project`, and the raw `api` passthrough, but `domain` — the largest remaining API-shaped command, 9 subcommands spanning custom domains, DNS verification, and SSL — still has no coverage beyond `tsc --noEmit`. Its contracts are exactly the kind that drift silently: the per-subcommand method/path/body, the `verify` 200-vs-422 handling, and the non-zero exits that gate scripting (`verify`/`verify-ssl` exit 1 when a domain isn't verified). A refactor that repoints a route, reshapes a body, or drops an unverified-exit ships green today.

Follows #181; builds on the harness merged in #182.

## Summary

`test/e2e/domain.test.ts` (27 tests) drives `domainCommand` over the same stubbed-socket harness the rest of the suite uses — the command action and the real `api-client` (URL building, `/api` prefix, auth header, `ApiError` mapping) run for real; only `fetch` and the config/caps seams are stubbed.

- **list** — `GET /domains?projectId=…` (project id URL-encoded), table vs JSON rows, empty result.
- **add** — `POST /domains { projectId, hostname, isPrimary }`, `--primary` toggles the flag, the `openship domain verify <id>` next-step hint, and the `{ domain, records }` JSON shape.
- **preview** — `POST /domains/preview { hostname }`, DNS-record table, JSON.
- **verify** — `POST /domains/:id/verify` via `apiRaw`: 200 verified → exit 0; **422 (DNS not propagated) → exit 1 without throwing**; json mode prints the body and does **not** exit; a non-422 (500) surfaces and exits 1.
- **primary** — `POST /domains/:id/primary`, JSON.
- **records** — `GET /domains/:id/records`, DNS-record table, JSON.
- **renew** — `POST /domains/:id/renew`, SSL status, JSON.
- **verify-ssl** — `POST /domains/:id/verify-ssl`: valid → exit 0; **not-valid → exit 1**; json mode does **not** exit.
- **renew-all** — `POST /domains/renew-all`, per-domain results table vs the "Nothing needed renewal" note, JSON.
- **auth + errors** — an API `{error}` is surfaced and exits 1; the bearer token is sent when logged in.

## Design notes

- **Offline and fast.** No live API/DNS; body and exit assertions read `fetchStub.calls` and the exit code, so they hold regardless of spinner rendering. Each test is a real regression sentinel, not a coverage number — verified by mutation: removing both unverified-exit lines from `domain.ts` fails exactly the two exit tests and nothing else.
- **Documented behavior finding (not fixed here):** unlike `server`/`mail`/`service`, `domain.ts` has no pre-flight login guard — when logged out it issues the request with no `Authorization` header and lets the API reject it, rather than short-circuiting. One test pins that (request still made, no auth header, API 401 surfaced) so adding a pre-flight guard later is a deliberate, visible change. Left as-is; out of scope for a test-only PR.
- **Reuses the merged harness** (`test/helpers/*`) and vitest runner from #182 — no runner or dependency changes, lockfile untouched.

## Verification

Run twice, clean, both green:

- `bun run --cwd apps/cli test` → 12 files, **76 tests** passed (49 prior + 27 domain) ×2
- `bun run --cwd apps/cli lint` (`tsc --noEmit`) → clean (exit 0)
- `bun install --frozen-lockfile` → no changes (lockfile matches)
- mutation check: neutralizing the two `!verified → process.exit(1)` lines fails exactly the `verify` 422 and `verify-ssl` invalid tests, then reverted.

Reproduced against committed `HEAD`: working tree matches `HEAD`, full suite green.

## Commits

Ten atomic commits, one per subcommand plus the shared auth/error concern; each adds a self-contained `describe` block and is green in isolation:

```
test(cli): cover domain list over a mocked API
test(cli): cover domain add and its DNS-record hints
test(cli): cover domain preview DNS-record output
test(cli): cover domain verify 200/422/error exit paths
test(cli): cover domain primary
test(cli): cover domain records
test(cli): cover domain renew
test(cli): cover domain verify-ssl valid/invalid exit paths
test(cli): cover domain renew-all org-wide results
test(cli): cover domain auth header and API-error exit paths
```

## Not in scope

Commands that need a new test seam the harness doesn't yet provide: `lib/service` (ssh2/dockerode) for `stop`/`service`/`status`, a `child_process` seam for `deploy`/`doctor`/`install`/`update`, an interactive `@clack` stdin seam for `up`/`wizard`/`reset-admin`, and a `$HOME` config-file seam for `context`/`config`/`cache`/`backup`/`system`/`login`/`logout`/`init`. Each seam is a separate follow-up. `mail install` is covered on its own branch pending #141.
