### PR TITLE
chore: update Discord invite link across web and dashboard

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/[[...slug]]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/[[...slug]]/page.tsx
@@ -731,7 +731,7 @@ const ProjectSettingsContent = () => {
       label: t.projects.help.joinCommunity,
       icon: <ExternalLink className="w-4 h-4" />,
       onClick: () => {
-        window.open("https://discord.gg/openship", "_blank");
+        window.open("https://discord.gg/Q9eWNCeXjg", "_blank");
       },
     },
   ];

--- a/apps/web/src/app/(site)/layout.tsx
+++ b/apps/web/src/app/(site)/layout.tsx
@@ -132,7 +132,7 @@ const organizationLd = {
   sameAs: [
     "https://github.com/oblien/openship",
     "https://x.com/openshipio",
-    "https://discord.gg/openship",
+    "https://discord.gg/Q9eWNCeXjg",
   ],
   contactPoint: [
     {

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -128,7 +128,7 @@ export function Footer() {
             </a>
             {/* Discord */}
             <a
-              href="https://discord.gg/openship"
+              href="https://discord.gg/Q9eWNCeXjg"
               target="_blank"
               rel="noopener noreferrer"
               className="th-text-muted transition-colors hover:text-[var(--th-text-strong)]"


### PR DESCRIPTION
Updates the Discord community invite link to a valid, up-to-date invite across all user-facing entry points.
Closes #171
