### PR TITLE
fix(api): weight self-hosted analytics avg response time by request count

### DIFF
--- a/apps/api/src/modules/analytics/analytics.service.ts
+++ b/apps/api/src/modules/analytics/analytics.service.ts
@@ -88,18 +88,21 @@ function toMgmtBucket(b: {
 }
 
 /** Reduce an array of buckets into a summary. */
-function summariseBuckets(buckets: MgmtAnalyticsBucket[], lastUpdated: string): AnalyticsSummary {
+export function summariseBuckets(
+  buckets: MgmtAnalyticsBucket[],
+  lastUpdated: string,
+): AnalyticsSummary {
   const totalReqs = buckets.reduce((s, b) => s + b.requests, 0);
   const totalUnique = buckets.reduce((s, b) => s + b.unique_requests, 0);
   const totalIn = buckets.reduce((s, b) => s + b.bandwidth_in, 0);
   const totalOut = buckets.reduce((s, b) => s + b.bandwidth_out, 0);
-  const avgRt = buckets.reduce((s, b) => s + b.response_time, 0) / buckets.length;
+  const weightedRt = buckets.reduce((s, b) => s + b.response_time * b.requests, 0);
   return {
     totalRequests: totalReqs,
     uniqueVisitors: totalUnique,
     bandwidthIn: totalIn,
     bandwidthOut: totalOut,
-    avgResponseTimeMs: Math.round(avgRt * 1000),
+    avgResponseTimeMs: totalReqs > 0 ? Math.round((weightedRt / totalReqs) * 1000) : 0,
     lastUpdated,
   };
 }
@@ -124,7 +127,7 @@ function summariseCloudBuckets(
   };
 }
 
-function buildHourlyPeriods(
+export function buildHourlyPeriods(
   buckets: MgmtAnalyticsBucket[],
   fromMinute: number,
   toMinute: number,
@@ -136,8 +139,7 @@ function buildHourlyPeriods(
       uniqueVisitors: number;
       bandwidthIn: number;
       bandwidthOut: number;
-      responseTimeTotal: number;
-      bucketCount: number;
+      responseTimeWeighted: number;
     }
   >();
 
@@ -148,16 +150,14 @@ function buildHourlyPeriods(
       uniqueVisitors: 0,
       bandwidthIn: 0,
       bandwidthOut: 0,
-      responseTimeTotal: 0,
-      bucketCount: 0,
+      responseTimeWeighted: 0,
     };
 
     current.requests += bucket.requests;
     current.uniqueVisitors += bucket.unique_requests;
     current.bandwidthIn += bucket.bandwidth_in;
     current.bandwidthOut += bucket.bandwidth_out;
-    current.responseTimeTotal += bucket.response_time;
-    current.bucketCount += 1;
+    current.responseTimeWeighted += bucket.response_time * bucket.requests;
     hourly.set(hourKey, current);
   }
 
@@ -178,8 +178,8 @@ function buildHourlyPeriods(
       bandwidthIn: current?.bandwidthIn ?? 0,
       bandwidthOut: current?.bandwidthOut ?? 0,
       avgResponseTimeMs:
-        current && current.bucketCount > 0
-          ? Math.round((current.responseTimeTotal / current.bucketCount) * 1000)
+        current && current.requests > 0
+          ? Math.round((current.responseTimeWeighted / current.requests) * 1000)
           : 0,
       topPaths: [],
       trafficByHour: {},

--- a/apps/api/test/modules/analytics/response-time-weighting.test.ts
+++ b/apps/api/test/modules/analytics/response-time-weighting.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  summariseBuckets,
+  buildHourlyPeriods,
+} from "../../../src/modules/analytics/analytics.service";
+
+interface Bucket {
+  minute: number;
+  requests: number;
+  unique_requests: number;
+  bandwidth_in: number;
+  bandwidth_out: number;
+  response_time: number;
+}
+
+function bucket(minute: number, requests: number, responseTime: number): Bucket {
+  return {
+    minute,
+    requests,
+    unique_requests: requests,
+    bandwidth_in: 0,
+    bandwidth_out: 0,
+    response_time: responseTime,
+  };
+}
+
+describe("analytics response-time averaging", () => {
+  // response_time is a per-minute average (see server_analytics schema). Two
+  // minutes with very different request counts: 1 request at 1000ms, then 99 at
+  // 100ms. Request-weighted average = (1*1.0 + 99*0.1) / 100 = 0.109s → 109ms.
+  const uneven = [bucket(0, 1, 1.0), bucket(1, 99, 0.1)];
+  const WEIGHTED_MS = 109;
+
+  it("summariseBuckets weights avgResponseTimeMs by request count", () => {
+    expect(summariseBuckets(uneven, "now").avgResponseTimeMs).toBe(WEIGHTED_MS);
+  });
+
+  it("buildHourlyPeriods weights avgResponseTimeMs by request count", () => {
+    const periods = buildHourlyPeriods(uneven, 0, 1);
+    expect(periods).toHaveLength(1);
+    expect(periods[0].avgResponseTimeMs).toBe(WEIGHTED_MS);
+  });
+
+  it("reports 0 (not NaN) when a period carries no requests", () => {
+    const noTraffic = [bucket(0, 0, 0), bucket(1, 0, 0)];
+    expect(summariseBuckets(noTraffic, "now").avgResponseTimeMs).toBe(0);
+    expect(buildHourlyPeriods(noTraffic, 0, 1)[0].avgResponseTimeMs).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`server_analytics.response_time` is documented in the schema as a **per-minute average** response time (seconds). The self-hosted analytics reducers average those per-minute averages **unweighted** — dividing by the *number of minute-buckets* rather than by total requests. So a period's `avgResponseTimeMs` is wrong whenever minutes carry unequal traffic.

The OpenShip **Cloud** path already does this correctly: `summariseCloudBuckets` / `buildCloudHourlyPeriods` compute `response_time_sum / requests` (request-weighted). Only the self-hosted path (`summariseBuckets` / `buildHourlyPeriods`) was unweighted — so self-hosters see a distorted number that the cloud dashboard does not.

### Concrete failing input

Two minutes inside one period:

| minute | requests | per-minute avg |
|--------|----------|----------------|
| 0 | 1 | 1000 ms |
| 1 | 99 | 100 ms |

| | avgResponseTimeMs |
|--|--|
| **Correct** (request-weighted: `(1·1000 + 99·100)/100`) | **109 ms** |
| Reported before this fix (`(1000 + 100)/2`) | 550 ms |

A single slow request in an otherwise-quiet minute drags the whole period's reported latency up ~5×.

## Fix

`summariseBuckets` and `buildHourlyPeriods` now weight each minute by its request count and divide by total requests — the same computation the cloud path already uses. Both guard a zero-request period so it returns `0` instead of `NaN` (again matching `summariseCloudBuckets`). No wire/DB shape changes; the two pure functions are exported so they can be unit-tested (existing precedent in this repo).

## Tests

Added `apps/api/test/modules/analytics/response-time-weighting.test.ts`:
- `summariseBuckets` and `buildHourlyPeriods` report the request-weighted 109 ms for the table above.
- A no-traffic period reports `0`, not `NaN`.

Verified the test **fails against unpatched source** (reports 550 ms) and **passes with the fix**.

## Verification
- `bun run test` → all 6 turbo tasks successful (748 passed in `@repo/api`, incl. the 3 new tests).
- `bun run --cwd apps/api lint` → clean.
- Touched files pass `npx prettier --check`; the file has two pre-existing unrelated drifts on `main` (an import block and a `queryBuckets` call) that I deliberately left untouched to keep the diff surgical.