### PR TITLE
fix(adapters): apk update probe reads a repo URL as the version

### DIFF
--- a/packages/adapters/src/system/available-version.test.ts
+++ b/packages/adapters/src/system/available-version.test.ts
@@ -33,6 +33,28 @@ function fakeExecutor(candidates: Record<string, string>): CommandExecutor {
   } as unknown as CommandExecutor;
 }
 
+const APK: EnvironmentProfile = {
+  os: "linux", arch: "amd64", distro: "alpine",
+  packageManager: "apk", serviceManager: "openrc", isRoot: true, canSudo: false,
+};
+
+/** Fake `apk policy <pkg>` output: version lines end in `:`, each followed by
+ *  indented source lines including an HTTPS repo URL (whose own `:` must not be
+ *  read as a version). */
+function fakeApkExecutor(policies: Record<string, string>): CommandExecutor {
+  return {
+    exec: async (cmd: string) => {
+      const m = cmd.match(/apk policy '([^']+)'/);
+      if (m) {
+        const out = policies[m[1]!];
+        if (out === undefined) throw new Error("no such package");
+        return out;
+      }
+      throw new Error("unexpected command");
+    },
+  } as unknown as CommandExecutor;
+}
+
 const status = (name: string, version: string): ComponentStatus => ({
   name, label: name, description: "", installable: true, installed: true, version, healthy: true, message: "",
 });
@@ -76,5 +98,34 @@ describe("enrichAvailableVersions", () => {
     ];
     await enrichAvailableVersions(fakeExecutor({ git: "2.44.0-1" }), APT, s);
     expect(s[0]!.updateAvailable).toBeUndefined();
+  });
+
+  it("apk: reads the newest version line, not the repo URL that follows it", async () => {
+    const policy = [
+      "git policy:",
+      "  2.30.0-r0:",
+      "    lib/apk/db/installed",
+      "  2.43.0-r0:",
+      "    https://dl-cdn.alpinelinux.org/alpine/v3.19/main",
+      "",
+    ].join("\n");
+    const s = [status("git", "2.30.0")];
+    await enrichAvailableVersions(fakeApkExecutor({ git: policy }), APK, s);
+    expect(s[0]!.availableVersion).toBe("2.43.0");
+    expect(s[0]!.updateAvailable).toBe(true);
+  });
+
+  it("apk: does NOT flag when the only available version equals installed", async () => {
+    const policy = [
+      "rsync policy:",
+      "  3.2.7-r0:",
+      "    lib/apk/db/installed",
+      "    https://dl-cdn.alpinelinux.org/alpine/v3.19/main",
+      "",
+    ].join("\n");
+    const s = [status("rsync", "3.2.7")];
+    await enrichAvailableVersions(fakeApkExecutor({ rsync: policy }), APK, s);
+    expect(s[0]!.updateAvailable).toBeUndefined();
+    expect(s[0]!.availableVersion).toBeUndefined();
   });
 });

--- a/packages/adapters/src/system/available-version.ts
+++ b/packages/adapters/src/system/available-version.ts
@@ -69,9 +69,11 @@ async function probeCandidate(
     return out?.trim().split(/\s+/)[1]?.trim() ?? null;
   }
   if (pm === "apk") {
-    // `apk policy` prints the repo versions; the last indented line is newest.
+    // `apk policy` prints one `  <version>:` line per available version (colon at
+    // end of line), each followed by indented source lines (installed marker, repo
+    // URLs); the last version line is newest.
     const out = await tryExec(executor, `apk policy ${q} 2>/dev/null`);
-    const versions = [...(out?.matchAll(/^\s+([\w.+~-]+):/gm) ?? [])].map((m) => m[1]!);
+    const versions = [...(out?.matchAll(/^\s+([\w.+~-]+):\s*$/gm) ?? [])].map((m) => m[1]!);
     return versions.length ? versions[versions.length - 1]! : null;
   }
   return null;


### PR DESCRIPTION
## Problem

On Alpine hosts, the "is a newer version available?" probe for infra components (git / rsync / openresty / certbot) **never flags an update**, even when one exists in the local index.

`probeCandidate`'s apk branch ([`available-version.ts:71`](https://github.com/oblien/openship/blob/main/packages/adapters/src/system/available-version.ts#L71)) parses `apk policy` output and returns the last matched version:

```ts
const versions = [...(out?.matchAll(/^\s+([\w.+~-]+):/gm) ?? [])].map((m) => m[1]!);
return versions.length ? versions[versions.length - 1]! : null;
```

`apk policy` prints an indented `  <version>:` line per available version, each followed by indented **source** lines — one of which, on every real Alpine box, is the HTTPS repo URL:

```
git policy:
  2.30.0-r0:
    lib/apk/db/installed
  2.43.0-r0:
    https://dl-cdn.alpinelinux.org/alpine/v3.19/main
```

The regex `^\s+([\w.+~-]+):` also matches that URL line: `[\w.+~-]+` matches `https` and the required `:` is the one in `https://`. So `matchAll` yields `["2.30.0-r0", "2.43.0-r0", "https"]` and the function returns the **last** element:

| input | expected | actual |
|---|---|---|
| the `apk policy git` output above | `2.43.0-r0` | `"https"` |

Downstream, `normalizePkgVersion("https")` → `"https"` → `parseSemver` → `[0,0,0]`, so `compareSemver(avail, installed) > 0` is never true → `updateAvailable` is never set on apk hosts.

## Cause

The version-line regex only requires a `:` *somewhere* after the token. A repo URL's in-line `://` satisfies that, so source lines are mis-read as versions.

## Fix

Anchor the colon to end-of-line — `apk policy`'s version lines are exactly `  <version>:` (colon terminates the line), while source lines either have no colon or carry it mid-line:

```diff
-const versions = [...(out?.matchAll(/^\s+([\w.+~-]+):/gm) ?? [])].map((m) => m[1]!);
+const versions = [...(out?.matchAll(/^\s+([\w.+~-]+):\s*$/gm) ?? [])].map((m) => m[1]!);
```

With the fix the same fixture returns `2.43.0-r0`.

## Tests

`available-version.test.ts` previously exercised only the `apt` branch. Added two apk cases:

- **newer available → flags the update** (`2.30.0` installed, `2.43.0-r0` available with an HTTPS source line) — asserts `availableVersion === "2.43.0"` and `updateAvailable === true`.
- **only version equals installed → no flag** — pins the negative direction.

I verified the newer-version test **fails without the regex change** (the probe returns `"https"`, leaving `updateAvailable` undefined) and passes with it.

- `bun run test` → all 6 turbo tasks successful.
- `bun run --cwd apps/api lint` → clean.

Note: `available-version.test.ts` has pre-existing Prettier drift on `main` (compact multi-property object literals). Per CONTRIBUTING I did **not** run `--write` over it; the new `APK` profile const matches the existing `APT` const's style, and the rest of my additions are Prettier-clean.