### PR TITLE
docs: sync three pages that drifted from recent commits

### DIFF
--- a/apps/web/content/docs/dashboard/settings.mdx
+++ b/apps/web/content/docs/dashboard/settings.mdx
@@ -126,7 +126,7 @@ team organization.
 Decide what you get told about and where it goes.
 
 - **Delivery channels** — where notifications are sent. Add an **Email**, **Webhook**, **Slack**, **Discord**,
-  or **In-app** (dashboard bell) channel. Unverified channels are skipped until verified.
+  **Microsoft Teams**, or **In-app** (dashboard bell) channel. Unverified channels are skipped until verified.
 - **What to be notified about** — a grid of events × channels; each cell you switch on is one subscription.
 - **Organization defaults** — the subscriptions applied when a new member joins. Members can override their
   own per-channel.

--- a/apps/web/content/docs/troubleshooting/domains-ssl.mdx
+++ b/apps/web/content/docs/troubleshooting/domains-ssl.mdx
@@ -189,8 +189,9 @@ certificate.
 <Callout title="One more thing to check: the hostname itself" type="info">
 If **Add domain** is rejected before you even reach verification, the hostname failed a basic check — e.g.
 `Domain "app.example.com" is already in use` (it's attached elsewhere) or
-`"…" is not a valid public hostname.` (a bare IP, `localhost`, or a single-label name). Free `*.opsh.io`-style
-subdomains aren't added here either — those live in the project's public endpoints, not as custom domains.
+`"…" is not a valid public hostname.` (a bare IP, `localhost`, a single-label name, or a dot-separated label
+longer than 63 characters). Free `*.opsh.io`-style subdomains aren't added here either — those live in the
+project's public endpoints, not as custom domains.
 </Callout>
 
 <Cards>

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>

--- a/docs/i18n/README.pt.md
+++ b/docs/i18n/README.pt.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm sürümü" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="Lisans" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Web sitesi" /></a>

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -6,6 +6,12 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/38817?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-38817">
+    <img src="https://trendshift.io/api/badge/repositories/38817" alt="Trendshift" width="250" height="55" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/openship"><img src="https://img.shields.io/npm/v/openship?color=0b7285&label=npm" alt="npm version" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License" /></a>
   <a href="https://openship.io"><img src="https://img.shields.io/badge/website-openship.io-0b7285" alt="Website" /></a>


### PR DESCRIPTION
Three docs fixes, each following up a recent commit that changed behaviour without updating the page describing it. Docs only — no source changes.

### 1. Microsoft Teams missing from the Settings page

`3fa75f2` added `msteams` as a notification channel and updated `docs/api/notifications.mdx`, but `docs/dashboard/settings.mdx` still listed only Email, Webhook, Slack, Discord and In-app — so a shipped channel went undocumented on the page users read first.

Checked against the code rather than the commit message: `NotificationsTab.tsx:365` renders the `msteams` option, `en/settings.json:511` labels it "Microsoft Teams", `notification-workers.ts:359` registers the worker. The list now matches the picker's order.

### 2. Trendshift badge only on the English README

`6a11d56` added the badge to `README.md`. The eight translations under `docs/i18n/` mirror the English header blocks exactly, so they now differ.

`CONTRIBUTING.md:84` states the rule: add a badge "to the root README and every localized README".

The block is copied verbatim from `README.md:9-13` into the same slot. No path rewrite (both URLs absolute), no translation (alt text is the product name).

### 3. Hostname rejection reasons now incomplete

`71ae8b9` capped each dot-separated label at the 63-octet DNS limit, adding a fourth way to trigger `"…" is not a valid public hostname.`. The troubleshooting page still listed three.

Worth noting since that commit only touched `packages/core`: I traced the message to confirm the page is in scope. `domain.service.ts:88` throws that exact string, gated on `isValidCustomHostname` at line 87 — the same function changed at `packages/core/src/utils.ts:62-64`. The Add domain flow the page documents is the flow the new check runs in.

### Notes

- No `prettier --write`. The committed `README.md` already fails `prettier --check` before these changes, CI doesn't run prettier, and `.mdx` isn't in the `format` glob. Reformatting would bury the change in unrelated churn.
- Prose changes are plain text inside existing elements; no MDX structure touched.
