### PR TITLE
fix: preserve desktop MCP OAuth consent through login

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -153,6 +153,16 @@ export async function desktopLogin(c: Context) {
   });
   await setSessionCookie(c, session.token, session.expiresAt);
 
+  // Return through the dashboard's login layout when an OAuth flow is pending.
+  // That layout owns the returnTo allowlist, so this endpoint only relays the
+  // value as an encoded query parameter and never redirects to it directly.
+  const returnTo = c.req.query("returnTo");
+  if (returnTo) {
+    const loginUrl = new URL("/login", `${dashboardUrl}/`);
+    loginUrl.searchParams.set("returnTo", returnTo);
+    return c.redirect(loginUrl.toString());
+  }
+
   return c.redirect(dashboardUrl);
 }
 

--- a/apps/dashboard/src/app/(auth)/login/page.tsx
+++ b/apps/dashboard/src/app/(auth)/login/page.tsx
@@ -122,9 +122,12 @@ function LoginPageInner() {
   if (authMode === "none") {
     const apiUrl = getApiOrigin(typeof window !== "undefined" ? window.location.origin : undefined);
     // Redirect to the desktop-login endpoint which creates a real
-    // session cookie and redirects back to the dashboard.
+    // session cookie and redirects back to the dashboard. Preserve a
+    // validated OAuth consent return path through that API round-trip.
     if (typeof window !== "undefined") {
-      window.location.href = `${apiUrl}/api/auth/desktop-login`;
+      const desktopLoginUrl = new URL("/api/auth/desktop-login", apiUrl);
+      if (postLoginUrl) desktopLoginUrl.searchParams.set("returnTo", postLoginUrl);
+      window.location.href = desktopLoginUrl.toString();
     }
     return (
       <AuthShell>

--- a/apps/dashboard/src/lib/cloud-auth.test.ts
+++ b/apps/dashboard/src/lib/cloud-auth.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api/urls", () => ({
+  getCloudApiOrigin: (url?: string) => url ?? "https://api.example.com",
+  getCloudDashboardUrl: (url?: string) => url ?? "https://app.example.com",
+}));
+
+import { getPostAuthRedirect, validateReturnTo } from "./cloud-auth";
+
+describe("MCP OAuth returnTo", () => {
+  it("preserves the consent request through login", () => {
+    const returnTo = "/mcp/authorize?client_id=desktop-client&consent_code=abc";
+    const params = new URLSearchParams({ returnTo });
+
+    expect(validateReturnTo(returnTo)).toBe(returnTo);
+    expect(getPostAuthRedirect(params)).toBe(returnTo);
+  });
+
+  it("still rejects external redirects", () => {
+    expect(validateReturnTo("//evil.example/mcp/authorize")).toBeNull();
+    expect(validateReturnTo("https://evil.example/mcp/authorize")).toBeNull();
+  });
+});

--- a/apps/dashboard/src/lib/cloud-auth.ts
+++ b/apps/dashboard/src/lib/cloud-auth.ts
@@ -167,9 +167,8 @@ export function getPostAuthRedirect(searchParams: SearchParamsLike) {
  *   - Must be a relative path starting with a single `/`.
  *   - Must NOT start with `//` (protocol-relative URLs).
  *   - Path must match an allowlisted prefix. Currently only
- *     `/cloud-authorize` (the consent page that minted the link) and
- *     `/` (root) are accepted; widen this list intentionally as new
- *     pages need it.
+ *     `/cloud-authorize`, `/mcp/authorize`, and `/` (root) are accepted;
+ *     widen this list intentionally as new pages need it.
  *
  * Returns the validated path, or `null` when the input is unsafe or
  * missing. Callers should treat `null` as "no returnTo" and fall back
@@ -191,7 +190,7 @@ export function validateReturnTo(input: string | null): string | null {
   // Split off any query/fragment for the prefix check, but keep them on
   // the returned value so the consent page reloads with its params.
   const pathOnly = input.split(/[?#]/)[0];
-  const ALLOWED_PREFIXES = ["/cloud-authorize", "/"];
+  const ALLOWED_PREFIXES = ["/cloud-authorize", "/mcp/authorize", "/"];
   const isAllowed = ALLOWED_PREFIXES.some((prefix) => {
     if (prefix === "/") return pathOnly === "/";
     return pathOnly === prefix || pathOnly.startsWith(prefix + "/");


### PR DESCRIPTION
Closes #119

## Summary

Current `main` now advertises the packaged desktop app's dynamic API and dashboard origins correctly. One part of the MCP OAuth flow remains broken in zero-auth mode: creating the local session drops the pending consent return path, and `/mcp/authorize` is not accepted by the existing safe `returnTo` allowlist.

This change:

- preserves the validated MCP consent path when the desktop login page requests a zero-auth session
- relays that path through `/api/auth/desktop-login` and back through the dashboard's existing redirect validator
- allows `/mcp/authorize` in the safe relative-path allowlist while continuing to reject external redirects
- adds focused regression coverage for the MCP consent return path

This leaves `main`'s `OPENSHIP_ADVERTISED_ORIGIN` implementation unchanged.

## Testing

- dashboard test suite: 27 tests pass
- API and dashboard TypeScript checks pass
- external and protocol-relative `returnTo` values remain rejected
