### PR TITLE
fix(api): harden webhook SSRF guard against DNS rebinding and IP encodings

### DIFF
--- a/apps/api/src/lib/notification-workers.ts
+++ b/apps/api/src/lib/notification-workers.ts
@@ -19,6 +19,7 @@ import { repos, type NotificationChannel, type NotificationDelivery } from "@rep
 import { sendMail } from "./mail";
 import { decrypt } from "./encryption";
 import { findCategory } from "./notification-categories";
+import { assertPublicHttpsUrl } from "./ssrf-guard";
 import { safeErrorMessage } from "@repo/core";
 
 /* ─── Render helpers ─────────────────────────────────────────────────────── */
@@ -157,36 +158,6 @@ async function sendEmail(
   });
 }
 
-/** Validate a webhook URL to prevent SSRF. */
-function assertPublicWebhookUrl(url: string): void {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error("Webhook URL is malformed");
-  }
-  if (parsed.protocol !== "https:") {
-    throw new Error("Webhook URL must use HTTPS");
-  }
-  const host = parsed.hostname.toLowerCase();
-  const blocked =
-    host === "localhost" ||
-    host === "0.0.0.0" ||
-    host === "::1" ||
-    host === "127.0.0.1" ||
-    host.endsWith(".local") ||
-    /^127\./.test(host) ||
-    /^10\./.test(host) ||
-    /^192\.168\./.test(host) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-    /^169\.254\./.test(host) ||
-    /^0\./.test(host) ||
-    host === "[::1]";
-  if (blocked) {
-    throw new Error(`Webhook URL targets a private or loopback host: ${host}`);
-  }
-}
-
 async function sendWebhook(
   delivery: NotificationDelivery,
   channel: NotificationChannel,
@@ -195,7 +166,7 @@ async function sendWebhook(
   if (!config?.url) {
     throw new Error("Webhook channel has no URL configured");
   }
-  assertPublicWebhookUrl(config.url);
+  await assertPublicHttpsUrl(config.url);
 
   const payload = (delivery.payload ?? {}) as Record<string, unknown>;
   const body = JSON.stringify({

--- a/apps/api/src/lib/ssrf-guard.test.ts
+++ b/apps/api/src/lib/ssrf-guard.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock DNS so the resolve-and-check path is deterministic and offline. Each
+// test sets what the hostname resolves to via `mockLookup`.
+const mockLookup = vi.fn();
+vi.mock("node:dns/promises", () => ({
+  lookup: (host: string, opts: unknown) => mockLookup(host, opts),
+}));
+
+import {
+  isPrivateIp,
+  isBlockedHostLiteral,
+  assertPublicHttpsUrl,
+  SsrfBlockedError,
+} from "./ssrf-guard";
+
+describe("isPrivateIp", () => {
+  it("flags IPv4 loopback / private / link-local / CGNAT / this-network", () => {
+    for (const ip of [
+      "127.0.0.1",
+      "127.10.20.30",
+      "10.0.0.5",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "100.64.0.1", // CGNAT
+      "0.0.0.0",
+    ]) {
+      expect(isPrivateIp(ip), ip).toBe(true);
+    }
+  });
+
+  it("allows public IPv4", () => {
+    for (const ip of [
+      "8.8.8.8",
+      "1.1.1.1",
+      "172.15.0.1",
+      "172.32.0.1",
+      "100.63.0.1",
+      "192.167.0.1",
+    ]) {
+      expect(isPrivateIp(ip), ip).toBe(false);
+    }
+  });
+
+  it("flags IPv6 loopback / link-local / ULA / mapped-private", () => {
+    for (const ip of [
+      "::1",
+      "::",
+      "fe80::1",
+      "fd00::1",
+      "fc00::1",
+      "::ffff:127.0.0.1",
+      "::ffff:169.254.169.254",
+    ]) {
+      expect(isPrivateIp(ip), ip).toBe(true);
+    }
+  });
+
+  it("allows public IPv6 and mapped-public", () => {
+    for (const ip of ["2606:4700:4700::1111", "::ffff:8.8.8.8"]) {
+      expect(isPrivateIp(ip), ip).toBe(false);
+    }
+  });
+
+  it("returns false for non-IP strings", () => {
+    expect(isPrivateIp("example.com")).toBe(false);
+  });
+});
+
+describe("isBlockedHostLiteral", () => {
+  it("blocks local DNS names and private IP literals", () => {
+    for (const h of [
+      "localhost",
+      "foo.localhost",
+      "printer.local",
+      "metadata.google.internal",
+      "svc.internal",
+      "127.0.0.1",
+      "[::1]",
+      "169.254.169.254",
+    ]) {
+      expect(isBlockedHostLiteral(h), h).toBe(true);
+    }
+  });
+
+  it("allows public names and IPs (DNS not consulted here)", () => {
+    for (const h of ["example.com", "hooks.example.org", "8.8.8.8"]) {
+      expect(isBlockedHostLiteral(h), h).toBe(false);
+    }
+  });
+});
+
+describe("assertPublicHttpsUrl", () => {
+  beforeEach(() => mockLookup.mockReset());
+
+  it("rejects non-HTTPS", async () => {
+    await expect(assertPublicHttpsUrl("http://example.com/hook")).rejects.toBeInstanceOf(
+      SsrfBlockedError,
+    );
+  });
+
+  it("rejects a malformed URL", async () => {
+    await expect(assertPublicHttpsUrl("not a url")).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it("rejects literal private/metadata IPs without touching DNS", async () => {
+    await expect(assertPublicHttpsUrl("https://169.254.169.254/latest/meta-data/")).rejects.toThrow(
+      /private host/,
+    );
+    await expect(assertPublicHttpsUrl("https://127.0.0.1/")).rejects.toThrow(/private host/);
+    await expect(assertPublicHttpsUrl("https://[::1]/")).rejects.toThrow(/private host/);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects known-local DNS names", async () => {
+    await expect(assertPublicHttpsUrl("https://metadata.google.internal/")).rejects.toThrow(
+      /local host/,
+    );
+    await expect(assertPublicHttpsUrl("https://localhost/")).rejects.toThrow(/local host/);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects DNS rebinding: public name that resolves to a private IP", async () => {
+    mockLookup.mockResolvedValue([{ address: "169.254.169.254" }]);
+    await expect(assertPublicHttpsUrl("https://rebind.attacker.example/")).rejects.toThrow(
+      /resolves to a private address/,
+    );
+    expect(mockLookup).toHaveBeenCalledWith("rebind.attacker.example", { all: true });
+  });
+
+  it("rejects when ANY resolved address is private (mixed record set)", async () => {
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34" }, { address: "10.0.0.5" }]);
+    await expect(assertPublicHttpsUrl("https://mixed.example/")).rejects.toThrow(
+      /resolves to a private address/,
+    );
+  });
+
+  it("rejects a host that fails to resolve to any address", async () => {
+    // Empty result set exercises the same "does not resolve" refusal as a
+    // lookup error, without an eagerly-rejected mock promise.
+    mockLookup.mockResolvedValue([]);
+    await expect(assertPublicHttpsUrl("https://nope.example/")).rejects.toThrow(/does not resolve/);
+  });
+
+  it("allows a public name that resolves to public addresses", async () => {
+    mockLookup.mockResolvedValue([{ address: "93.184.216.34" }]);
+    await expect(assertPublicHttpsUrl("https://hooks.example.com/x")).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/ssrf-guard.ts
+++ b/apps/api/src/lib/ssrf-guard.ts
@@ -1,0 +1,149 @@
+/**
+ * SSRF guard for server-initiated HTTP requests to user-supplied URLs.
+ *
+ * Currently used by the outbound webhook notification channel: an operator (or,
+ * on the multi-tenant SaaS, any org member) supplies a URL and the API POSTs to
+ * it. Without a guard that URL can point at cloud metadata (169.254.169.254),
+ * loopback, or the internal network — a classic SSRF.
+ *
+ * A literal-hostname denylist alone is not enough:
+ *   - A hostname the attacker controls can resolve to a private/metadata IP
+ *     (DNS rebinding), so we must inspect the RESOLVED addresses, not the name.
+ *   - Numeric IP encodings (decimal `2130706433`, hex `0x7f000001`, octal) slip
+ *     past dotted-quad regexes; getaddrinfo normalises them, so resolving and
+ *     checking the result covers them too.
+ *
+ * So the authoritative check (`assertPublicHttpsUrl`) resolves the host and
+ * rejects if the literal host OR any resolved address falls in a non-public
+ * range. A cheaper synchronous literal check (`isBlockedHostLiteral`) is exposed
+ * for input validation, where DNS-time-of-check is pointless (rebinding) and we
+ * only want fast feedback on obviously-local input.
+ */
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+/**
+ * IPv4 in a loopback, private, link-local, CGNAT, or "this network" block.
+ * A string that isn't a clean dotted quad is refused (caller only passes
+ * values `isIP()` already classified as IPv4, so this is defence in depth).
+ */
+function isPrivateIpv4(ip: string): boolean {
+  const octets = ip.split(".");
+  if (octets.length !== 4) return true;
+  const nums = octets.map((o) => Number(o));
+  if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true;
+  const [a, b] = nums;
+  if (a === 0) return true; //                       0.0.0.0/8  "this network"
+  if (a === 10) return true; //                      10.0.0.0/8  RFC1918
+  if (a === 127) return true; //                     127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; //        169.254.0.0/16 link-local + cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 RFC1918
+  if (a === 192 && b === 168) return true; //        192.168.0.0/16 RFC1918
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  return false;
+}
+
+/** IPv6 loopback, unspecified, link-local, ULA, or IPv4-mapped private. */
+function isPrivateIpv6(ip: string): boolean {
+  const v = ip.toLowerCase();
+  if (v === "::1" || v === "::") return true; //     loopback / unspecified
+  if (/^fe[89ab]/.test(v)) return true; //           fe80::/10 link-local
+  if (/^f[cd][0-9a-f]{2}/.test(v)) return true; //   fc00::/7  unique local (ULA)
+  const mapped = v.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/); // ::ffff:a.b.c.d
+  if (mapped) return isPrivateIpv4(mapped[1]);
+  return false;
+}
+
+/** True for any IP literal that must not be reachable from a server fetch. */
+export function isPrivateIp(ip: string): boolean {
+  const host = ip.replace(/^\[|\]$/g, "");
+  const family = isIP(host);
+  if (family === 4) return isPrivateIpv4(host);
+  if (family === 6) return isPrivateIpv6(host);
+  return false;
+}
+
+/** DNS names that always denote a local/internal target, never a public one. */
+function isBlockedHostname(host: string): boolean {
+  const h = host.toLowerCase().replace(/\.$/, "");
+  return (
+    h === "localhost" ||
+    h === "ip6-localhost" ||
+    h.endsWith(".localhost") ||
+    h.endsWith(".local") || //     mDNS / Bonjour
+    h.endsWith(".internal") //     GCP/AWS internal zones incl. metadata.google.internal
+  );
+}
+
+/**
+ * Synchronous literal check (no DNS): true when the host is an obviously-local
+ * DNS name or a private IP literal. For input validation / fast UX feedback —
+ * NOT a substitute for `assertPublicHttpsUrl`, which also resolves DNS.
+ */
+export function isBlockedHostLiteral(host: string): boolean {
+  const h = host.replace(/^\[|\]$/g, "");
+  if (!h) return true;
+  if (isBlockedHostname(h)) return true;
+  if (isIP(h) && isPrivateIp(h)) return true;
+  return false;
+}
+
+/**
+ * Assert a user-supplied URL is safe for the server to fetch:
+ *   - HTTPS only
+ *   - hostname is not a known-local DNS name
+ *   - neither the literal host nor ANY DNS-resolved address is loopback,
+ *     private, link-local, ULA, CGNAT, or cloud-metadata
+ *
+ * Throws `SsrfBlockedError` otherwise. Async because it resolves DNS — this is
+ * what defeats rebinding and numeric-encoding tricks a name-only check misses.
+ */
+export async function assertPublicHttpsUrl(rawUrl: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError("URL is malformed");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new SsrfBlockedError("URL must use HTTPS");
+  }
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (!host) throw new SsrfBlockedError("URL has no host");
+  if (isBlockedHostname(host)) {
+    throw new SsrfBlockedError(`URL targets a local host: ${host}`);
+  }
+
+  // IP literal (any notation isIP recognises) → check it directly, no DNS.
+  if (isIP(host)) {
+    if (isPrivateIp(host)) {
+      throw new SsrfBlockedError(`URL targets a private host: ${host}`);
+    }
+    return;
+  }
+
+  // DNS name → resolve and reject if ANY address is non-public. Covers
+  // rebinding and numeric-host encodings that getaddrinfo normalises.
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(host, { all: true });
+  } catch {
+    throw new SsrfBlockedError(`URL host does not resolve: ${host}`);
+  }
+  if (addresses.length === 0) {
+    throw new SsrfBlockedError(`URL host does not resolve: ${host}`);
+  }
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new SsrfBlockedError(`URL host resolves to a private address: ${host} → ${address}`);
+    }
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -21,6 +21,7 @@ import { getRequestContext } from "../../lib/request-context";
 import { audit, auditContextFrom } from "../../lib/audit";
 import { encrypt } from "../../lib/encryption";
 import { CATEGORIES } from "../../lib/notification-categories";
+import { isBlockedHostLiteral } from "../../lib/ssrf-guard";
 import { randomBytes } from "node:crypto";
 
 const VALID_CHANNEL_KINDS = new Set(["email", "webhook", "in_app", "slack", "discord", "msteams"]);
@@ -320,7 +321,26 @@ function sanitizeChannelConfig(kind: string, raw: unknown): ConfigOk | ConfigErr
     }
     case "webhook": {
       const url = String(cfg.url ?? "").trim();
-      if (!/^https?:\/\//.test(url)) return { ok: false, error: "Invalid webhook URL" };
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(url);
+      } catch {
+        return { ok: false, error: "Invalid webhook URL" };
+      }
+      // HTTPS-only + reject obviously-local hosts up front (SSRF). The
+      // authoritative guard runs at delivery time (it also resolves DNS, which
+      // a registration-time check can't rely on — the name can be rebound
+      // later), but blocking here gives immediate feedback and keeps junk out
+      // of storage. See lib/ssrf-guard.
+      if (parsedUrl.protocol !== "https:") {
+        return { ok: false, error: "Webhook URL must use HTTPS" };
+      }
+      if (isBlockedHostLiteral(parsedUrl.hostname)) {
+        return {
+          ok: false,
+          error: "Webhook URL must not target a private, loopback, or link-local host",
+        };
+      }
       // Auto-generate a signing secret if the user didn't supply one —
       // we'll show it back via the verification flow so they can save it.
       const rawSecret =


### PR DESCRIPTION
The outbound webhook notification channel lets a user supply a URL that the API POSTs to. The existing guard (added in the recent security fix) only inspected the literal hostname, which still leaves several ways to reach the internal network or cloud metadata:

- A public hostname that resolves to a private/metadata IP — DNS rebinding. `https://rebind.example/` resolving to `169.254.169.254` passes a name-only check.
- Numeric IP encodings (decimal `2130706433`, hex, octal) that sidestep the dotted-quad regexes.
- IPv6 link-local (`fe80::/10`), ULA (`fc00::/7`), and IPv4-mapped (`::ffff:127.0.0.1`) addresses.
- `.internal` hosts, including `metadata.google.internal` (GCP metadata).

## What changed

- New `apps/api/src/lib/ssrf-guard.ts`. `assertPublicHttpsUrl()` requires HTTPS, then resolves the host and refuses if the literal host **or any resolved address** is loopback, private, link-local, ULA, CGNAT (100.64/10), or cloud-metadata. Resolving is what defeats rebinding and the numeric-encoding tricks (getaddrinfo normalises them to a real IP that then gets checked).
- `notification-workers.ts` now calls the shared guard at delivery time instead of the local literal-only check.
- `notifications.controller.ts` rejects non-HTTPS and obviously-local hosts at channel registration too, so bad URLs get immediate feedback and never reach storage.

Registration previously accepted `http://`; it now requires `https://`, which matches the delivery-time guard that already required HTTPS (an http webhook would have failed at send anyway).

## Known residual

Resolve-then-fetch has an inherent TOCTOU window — a determined rebinding attacker could return a public IP to the guard's lookup and a private one to `fetch`'s own lookup. Fully closing that needs pinning the resolved IP and connecting to it directly, which is a larger change; this PR removes the practical, single-request bypasses.

## Tests / checks

- New `ssrf-guard.test.ts` (15 cases): IPv4/IPv6 classifier across all blocked ranges + public addresses, literal-host rejection, HTTPS-only, and the DNS-resolution path (rebinding to a private IP, mixed record sets, unresolvable hosts, public pass). All pass.
- `tsc --noEmit`: the changed files are clean.

Note: `main` currently fails `tsc` due to an unrelated pre-existing syntax error in `apps/api/src/modules/mail/mail.service.ts` (a duplicated `);` around line 390), which is outside the scope of this PR.