### PR TITLE
docs: fix stale bun dev:local command in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ cd openship
 bun install --frozen-lockfile
 cp apps/api/.env.example apps/api/.env
 cp apps/dashboard/.env.example apps/dashboard/.env
-bun dev:local
+bun dev
 ```
 
 This starts the API and dashboard used for local development:


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` tells new contributors to run `bun dev:local`, but no such script exists in the root `package.json`.
- The closest match is `dev`, which runs `turbo run dev --filter=@repo/api --filter=@repo/dashboard` — this is what actually starts the API (port 4000) and dashboard (port 3001), matching the description and ports table right below the command in the guide.

## Test plan
- [x] Followed the Development Setup steps in `CONTRIBUTING.md` verbatim and hit `error: Script not found "dev:local"`.
- [x] Confirmed `bun dev` is the only root script that matches the documented behavior (verified against `package.json` and `turbo.json`).
- [x] Ran `bun dev` after the fix and confirmed the API and dashboard start successfully on the documented ports.