### PR TITLE
fix(email): populate mailbox display name for webmail sender (#218)

### DIFF
--- a/apps/email/server/src/lib/schemas.ts
+++ b/apps/email/server/src/lib/schemas.ts
@@ -49,6 +49,7 @@ export const signInSchema = z
   .object({
     email: z.email(),
     password: z.string().min(1),
+    name: z.string().optional(),
   })
   .strict();
 

--- a/apps/email/server/src/routes/auth.ts
+++ b/apps/email/server/src/routes/auth.ts
@@ -226,13 +226,16 @@ authRoutes.post('/sign-in', async (c) => {
   let liveIds: string[];
 
   if (existing) {
+    if (parsed.data.name !== undefined) {
+      await db.update(schema.session).set({ name: parsed.data.name }).where(eq(schema.session.id, existing.id));
+    }
     activeId = existing.id;
     activeExpiresAt = existing.expiresAt;
     liveIds = [existing.id, ...existingIds.filter((id) => id !== existing.id)];
   } else {
     const created = await createSession({
       email: parsed.data.email,
-      name: null,
+      name: parsed.data.name ?? null,
       password: parsed.data.password,
       imapHost,
       imapPort,

--- a/apps/email/server/src/trpc/routes/mail.ts
+++ b/apps/email/server/src/trpc/routes/mail.ts
@@ -44,6 +44,17 @@ function senderToAddress(s: SenderInput): string {
   return s.name ? `${s.name.replace(/[<>]/g, '')} <${s.email}>` : s.email;
 }
 
+export function formatFromAddress(
+  fromEmail: string | undefined,
+  sessionEmail: string,
+  sessionName: string | null | undefined,
+): string {
+  const raw = fromEmail || sessionEmail;
+  if (raw.includes('<')) return raw;
+  const name = sessionName?.replace(/[<>"]/g, '').trim();
+  return name ? `"${name}" <${raw.trim()}>` : raw;
+}
+
 // Folder comes in as a loose string (client uses `bin`/`draft`/`snoozed`
 // while the canonical enum is `trash`/`drafts`). Normalize on the way in
 // instead of rejecting; see normalizeFolderSlug.
@@ -154,7 +165,8 @@ export const mailRouter = router({
     .mutation(({ ctx, input }) => {
       const refsHeader = input.headers?.References;
       const inReplyToHeader = input.headers?.['In-Reply-To'];
-      return driverSend(ctx.smtp, ctx.imap, input.fromEmail || ctx.session.email, {
+      const fromAddress = formatFromAddress(input.fromEmail, ctx.session.email, ctx.session.name);
+      return driverSend(ctx.smtp, ctx.imap, fromAddress, {
         to: input.to.map(senderToAddress),
         cc: input.cc?.map(senderToAddress),
         bcc: input.bcc?.map(senderToAddress),

--- a/apps/email/server/test/from-header.test.ts
+++ b/apps/email/server/test/from-header.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { signInSchema } from "../src/lib/schemas";
+import { formatFromAddress } from "../src/trpc/routes/mail";
+
+describe("Webmail From display name", () => {
+  describe("signInSchema", () => {
+    it("accepts name in sign-in input", () => {
+      const parsed = signInSchema.parse({
+        email: "user@example.com",
+        password: "secretpassword",
+        name: "Bikram C",
+      });
+      expect(parsed.name).toBe("Bikram C");
+    });
+
+    it("works when name is omitted", () => {
+      const parsed = signInSchema.parse({
+        email: "user@example.com",
+        password: "secretpassword",
+      });
+      expect(parsed.name).toBeUndefined();
+    });
+  });
+
+  describe("formatFromAddress", () => {
+    it("formats bare email with session display name", () => {
+      const from = formatFromAddress(undefined, "user@example.com", "Bikram C");
+      expect(from).toBe('"Bikram C" <user@example.com>');
+    });
+
+    it("sanitizes special characters in session display name", () => {
+      const from = formatFromAddress(undefined, "user@example.com", "Bikram <C>");
+      expect(from).toBe('"Bikram C" <user@example.com>');
+    });
+
+    it("falls back to bare address when session name is missing or empty", () => {
+      expect(formatFromAddress(undefined, "user@example.com", null)).toBe("user@example.com");
+      expect(formatFromAddress(undefined, "user@example.com", "")).toBe("user@example.com");
+    });
+
+    it("preserves explicitly formatted fromEmail input", () => {
+      const from = formatFromAddress(
+        '"Custom Name" <custom@example.com>',
+        "user@example.com",
+        "Bikram C",
+      );
+      expect(from).toBe('"Custom Name" <custom@example.com>');
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #218.

When sending email from the webmail app (`apps/email`), the `From:` header was generated with a bare email address (e.g. `user@example.com <user@example.com>`) instead of incorporating the mailbox owner's display name (`"Name" <user@example.com>`).

### Problem
1. `signInSchema` rejected optional `name` in sign-in payload.
2. `auth.ts` hardcoded `name: null` when calling `createSession`.
3. `mailRouter.send` passed bare `fromEmail` directly to `driverSend` without formatting the display name from `ctx.session.name`.

### Solution
- **`apps/email/server/src/lib/schemas.ts`**: Updated `signInSchema` to accept `name: z.string().optional()`.
- **`apps/email/server/src/routes/auth.ts`**: Persisted `parsed.data.name` when creating sessions or updating active sessions on sign-in.
- **`apps/email/server/src/trpc/routes/mail.ts`**: Exported `formatFromAddress` helper to format sender addresses as `"Display Name" <email>` and applied it in `mailRouter.send`.
- **`apps/email/server/test/from-header.test.ts`**: Added unit tests importing and verifying `signInSchema` and `formatFromAddress` behavior directly.

### Verification
- `bun run --cwd apps/email/server build` (`tsc --noEmit`) passed with **0 errors**.
- `bun test apps/email/server/test/from-header.test.ts` passed **6/6 tests**.

> **Note on Verification**: Verified via unit tests (`bun test`) and TypeScript build check. Live end-to-end SMTP/IMAP email delivery against a running mail container was not performed.
