### PR TITLE
fix(release): remove unsupported --no-absolute-names tar flag (GNU tar compat)

### DIFF
--- a/apps/api/src/lib/release-download.ts
+++ b/apps/api/src/lib/release-download.ts
@@ -210,7 +210,7 @@ export async function fetchAndExtractRelease(
     // 6. Extract into scratch dir.
     mkdirSync(scratchDir, { recursive: true });
     await runTar(
-      ["-xzf", scratchTarball, "-C", scratchDir, "--no-absolute-names"],
+      ["-xzf", scratchTarball, "-C", scratchDir],
       envOverride,
     );
 


### PR DESCRIPTION
Fixes #225

`--no-absolute-names` is not a valid GNU tar option (used on Linux).
GNU tar strips leading `/` from absolute paths by default, so the flag is unnecessary.

The pre-extraction `assertTarEntriesSafe` already validates all entry paths for traversal attacks before extraction runs.