### PR TITLE
docs: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
+Fill in the sections below and delete any that genuinely don't apply.
+-->
+
+## Summary
+
+<!-- What does this PR do, in one or two sentences? -->
+
+## Motivation
+
+<!-- What was broken, or what did the linked issue agree on? Why is this change needed? -->
+
+## Related issue
+
+<!--
+New features, behavior changes, new dependencies, new endpoints, and schema/migration changes
+need a maintainer to agree on scope *and* approach in an issue **before** the code is written —
+link that issue here (for example: Closes #123).
+
+Bug fixes, tests, docs, and small self-contained improvements don't need one. Write "None".
+-->
+
+## Changes
+
+<!-- Bullet what changed, grouped by workspace (apps/api, apps/dashboard, packages/db, ...). -->
+
+## Verification
+
+<!--
+How you actually verified this: the commands you ran and the before/after behavior.
+Paste real output rather than describing what should happen.
+-->
+
+```bash
+
+```
+
+## Screenshots
+
+<!-- Before/after for dashboard, web, or desktop changes. Delete this section if not applicable. -->
+
+## Checklist
+
+- [ ] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
+- [ ] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
+- [ ] A test fails without this change and passes with it (or I explained above why there isn't one)
+- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
+- [ ] I understand every line of this diff and can explain it in review


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` so new pull requests are prompted for the
context CONTRIBUTING.md already asks for.

## Motivation

CONTRIBUTING.md asks contributors to explain the why, state exactly how they verified
the change, and keep each PR to one scoped change — but there was no pull request
template, so none of it was prompted for and reviewers had to ask for the same context
by hand on every PR.

## Related issue

Closes #229

## Changes

- `.github/pull_request_template.md` (new, 49 lines) — Summary, Motivation, Related
  issue, Changes, Verification, Screenshots, and Checklist, in the order proposed in
  the issue.

Two deliberate choices worth flagging for review:

- Guidance lives in HTML comments, so it is hidden in the rendered PR body and the
  merged description stays clean.
- Every checklist item maps to a rule already in CONTRIBUTING.md (one change per PR,
  scope the diff, prove it, green before you open, understand your whole diff) rather
  than to generic boilerplate. The three "green" commands are one item instead of
  three, to keep the list short enough to be read rather than blind-ticked.

Happy to reword or drop the last checklist item if you'd rather phrase the
accountability line yourself.

## Verification

```bash
$ bunx prettier --check .github/pull_request_template.md
Checking formatting...
All matched files use Prettier code style!

$ git show --stat HEAD
 .github/pull_request_template.md | 49 ++++++++++++++++++++++++++++++++++++++++
 1 file changed, 49 insertions(+)
```

This adds one markdown file and changes no code path, so the workspace test suites
were not run: there is nothing they cover that this change can affect, and no test
could fail without it and pass with it. Prettier was run on this file alone rather
than through `bun format`, so no pre-existing drift in unrelated files leaked into
the diff.

Prose is hand-wrapped at 100 columns to match `printWidth` and the existing
`CONTRIBUTING.md` style, since `proseWrap` is left at Prettier's default of
`preserve`.

This PR description is the template itself, filled in — the first check that it works.

## Screenshots

N/A — no UI changes.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it — N/A, explained under Verification
- [x] `bun format` is clean on the changed file; no workspace test or lint target is affected
- [x] I understand every line of this diff and can explain it in review
