### PR TITLE
Dashboard: fix typecheck error in AddCustomAppModal

### DIFF
--- a/apps/dashboard/src/components/apps/AddCustomAppModal.tsx
+++ b/apps/dashboard/src/components/apps/AddCustomAppModal.tsx
@@ -109,7 +109,7 @@ export function AddCustomAppModal({
             <span>{error}</span>
           </div>
         )}
-        {template && !error && (
+        {template != null && !error && (
           <div className="mt-4 space-y-2">
             <div className="flex items-center gap-2 rounded-xl border border-success/40 bg-success/[0.05] px-3 py-2.5 text-sm text-success">
               <CheckCircle2 className="size-4 shrink-0" />


### PR DESCRIPTION
CI's Typecheck job fails on `main` (and therefore on every PR, including #222):

```
src/components/apps/AddCustomAppModal.tsx(112,9): error TS2322: Type 'unknown' is not assignable to type 'ReactNode'.
```

`template` is `useState<unknown>`, so `{template && …}` can evaluate to the `unknown` value itself when it's falsy, and JSX rejects `unknown` as a child. Comparing against `null` narrows the guard to a boolean.

Introduced on `main` in e8bc360; the #235 merge run shows the same failure, so this is not specific to any open PR.

One-line change, no behavior difference (`template` is only ever `null` or a parsed object).