### PR TITLE
fix(desktop): bundle the iRedMail engine and point the API at it

### DIFF
--- a/apps/api/src/modules/mail/mail.service.ts
+++ b/apps/api/src/modules/mail/mail.service.ts
@@ -13,6 +13,7 @@
  */
 
 import { resolve } from "node:path";
+import { existsSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import type { CommandExecutor, LogEntry, SystemLogCallback, SystemLog } from "@repo/adapters";
 import { updatePostmasterPassword } from "./mail-credentials.service";
@@ -44,8 +45,9 @@ const REMOTE_ENGINE_DIR = "/root/iRedMail-engine";
  * Absolute path to `apps/email/engine/` on the openship API host.
  *
  * `MAIL_SERVER_ENGINE_DIR` overrides for ops who pin a packaged build to a
- * fixed location; otherwise resolved relative to apps/api's cwd so the
- * monorepo dev layout works without configuration.
+ * fixed location - the desktop app sets it to its bundled copy of the tree,
+ * which has no monorepo to resolve against. Otherwise resolved relative to
+ * apps/api's cwd so the monorepo dev layout works without configuration.
  */
 function resolveLocalEngineDir(): string {
   if (process.env.MAIL_SERVER_ENGINE_DIR) {
@@ -425,6 +427,19 @@ export async function stepTransferEngine(
   const stepId = 7;
   const localEngine = resolveLocalEngineDir();
   log(stepId, "info", `Transferring engine ${localEngine} → ${REMOTE_ENGINE_DIR}...`);
+
+  // Fail with the actual cause. transferIn shells out to tar, so a missing
+  // engine dir surfaces as "tar: could not chdir to ..." (exit 1), which reads
+  // like a transport problem rather than a build/config one.
+  if (!existsSync(localEngine)) {
+    return {
+      stepId,
+      success: false,
+      message:
+        `Mail engine not found at ${localEngine}. Set MAIL_SERVER_ENGINE_DIR to the ` +
+        `apps/email/engine tree on this host.`,
+    };
+  }
 
   try {
     await exec.transferIn(localEngine, REMOTE_ENGINE_DIR, (entry) => {

--- a/apps/desktop/build/stage.ts
+++ b/apps/desktop/build/stage.ts
@@ -7,6 +7,7 @@
  *   resources/dashboard/              the dashboard's own Next standalone output
  *   resources/migrations/             drizzle .sql  → OPENSHIP_MIGRATIONS_DIR
  *   resources/pglite/                 pglite.wasm + pglite.data → OPENSHIP_PGLITE_ASSETS_DIR
+ *   resources/mail-engine/            apps/email/engine tree → MAIL_SERVER_ENGINE_DIR
  *
  * Invoked by electron-forge's `generateAssets` hook (forge.config.js) and also
  * runnable standalone with `bun run build/stage.ts`. Must run under bun — it
@@ -26,6 +27,7 @@ const RESOURCES = join(DESKTOP_DIR, "resources");
 const API_DIR = join(REPO_ROOT, "apps/api");
 const DASHBOARD_DIR = join(REPO_ROOT, "apps/dashboard");
 const DB_DRIZZLE_DIR = join(REPO_ROOT, "packages/db/drizzle");
+const MAIL_ENGINE_DIR = join(REPO_ROOT, "apps/email/engine");
 
 const isWin = process.platform === "win32";
 const API_BIN = isWin ? "openship-api.exe" : "openship-api";
@@ -256,6 +258,21 @@ function main(): void {
       }
       cpSync(src, join(dest, file));
     }
+  });
+
+  // 5. iRedMail engine tree — the mail setup's step 7 tars this directory onto
+  //    the target box. It is plain shell/config data the compiled binary can't
+  //    embed, and unlike the dev checkout the packaged app has no monorepo to
+  //    resolve it from, so it must ship as a resource and be handed to the API
+  //    via MAIL_SERVER_ENGINE_DIR (set at spawn in services.ts).
+  step("copying mail engine → resources/mail-engine/", () => {
+    if (!existsSync(join(MAIL_ENGINE_DIR, "iRedMail.sh"))) {
+      throw new Error(
+        `mail engine missing — expected ${join(MAIL_ENGINE_DIR, "iRedMail.sh")}. ` +
+          `Mail server setup cannot run without it.`,
+      );
+    }
+    cpSync(MAIL_ENGINE_DIR, join(RESOURCES, "mail-engine"), { recursive: true });
   });
 
   // NB: OpenResty Lua is NOT staged here. Unlike migrations/pglite (plain data

--- a/apps/desktop/forge.config.js
+++ b/apps/desktop/forge.config.js
@@ -60,6 +60,9 @@ module.exports = {
       path.join(RESOURCES, "dashboard"),
       path.join(RESOURCES, "migrations"),
       path.join(RESOURCES, "pglite"),
+      // iRedMail engine tree — staged to the target box by the mail setup flow,
+      // located at runtime via MAIL_SERVER_ENGINE_DIR (services.ts).
+      path.join(RESOURCES, "mail-engine"),
       // ssh2 + dockerode (externalized from the --compile binary) — resolved at
       // runtime via NODE_PATH=<Resources>/node_modules in services.ts.
       path.join(RESOURCES, "node_modules"),

--- a/apps/desktop/src/main/services.ts
+++ b/apps/desktop/src/main/services.ts
@@ -96,6 +96,7 @@ function resourcePaths() {
     apiBin: join(root, "bin", API_BIN),
     migrationsDir: join(root, "migrations"),
     pgliteDir: join(root, "pglite"),
+    mailEngineDir: join(root, "mail-engine"),
     dashboardDir: join(root, "dashboard", "apps", "dashboard"),
     // ssh2 + dockerode live here (externalized from the compiled API binary);
     // the binary resolves them via NODE_PATH — see the spawn below.
@@ -216,7 +217,8 @@ export async function startLocalServices(internalToken: string): Promise<void> {
   if (started) return;
   started = true;
 
-  const { apiBin, migrationsDir, pgliteDir, dashboardDir, nodeModulesDir } = resourcePaths();
+  const { apiBin, migrationsDir, pgliteDir, mailEngineDir, dashboardDir, nodeModulesDir } =
+    resourcePaths();
   const userData = app.getPath("userData");
   const dataDir = join(userData, "data");
   mkdirSync(dataDir, { recursive: true });
@@ -285,6 +287,12 @@ export async function startLocalServices(internalToken: string): Promise<void> {
       PGLITE_DATA_DIR: dataDir,
       OPENSHIP_MIGRATIONS_DIR: migrationsDir,
       OPENSHIP_PGLITE_ASSETS_DIR: pgliteDir,
+      // The mail setup's engine-transfer step tars this tree onto the target
+      // box. Without it the API falls back to a cwd-relative monorepo path
+      // (`../../apps/email/engine`), which in the packaged app resolves two
+      // levels above userData — a directory that does not exist — and setup
+      // dies at step 7 with "tar: could not chdir".
+      MAIL_SERVER_ENGINE_DIR: mailEngineDir,
       // The dashboard + API run on dynamic ports not in the API's static origin
       // table — trust both loopback spellings of each explicitly so CORS /
       // origin-guard / auth accept them regardless of which a client resolves.

--- a/apps/desktop/test/bundled-resources.test.ts
+++ b/apps/desktop/test/bundled-resources.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Static contract check across the three files that decide what the packaged
+ * app can reach at runtime: build/stage.ts (what gets staged into resources/),
+ * forge.config.js (what actually ships in the .app), and src/main/services.ts
+ * (how the API is told where it landed).
+ *
+ * A payload staged but not shipped — or shipped but never handed to the API —
+ * only fails in a packaged build, never in `bun dev`, because the dev layout
+ * resolves the same files from the monorepo. That is exactly how the mail
+ * engine regressed: the API fell back to a cwd-relative
+ * `../../apps/email/engine`, which in the packaged app pointed two levels above
+ * userData, and setup died at step 7 with "tar: could not chdir".
+ * Pure text scan — no Electron runtime or packaged build needed.
+ */
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+const stage = read("../build/stage.ts");
+const forge = read("../forge.config.js");
+const services = read("../src/main/services.ts");
+
+const matchAll = (src: string, re: RegExp) => [...src.matchAll(re)].map((m) => m[1]);
+
+// Directories stage.ts writes under resources/. Build-scratch probe files
+// (__ssh2-probe*) are created and removed within a step — not payload.
+const staged = new Set(
+  matchAll(stage, /join\(RESOURCES,\s*"([^"]+)"/g).filter((name) => !name.startsWith("__")),
+);
+
+// Directories forge copies into the packaged app (packagerConfig.extraResource).
+const shipped = new Set(matchAll(forge, /path\.join\(RESOURCES,\s*"([^"]+)"\)/g));
+
+describe("bundled resources contract", () => {
+  it("every directory staged into resources/ is shipped via extraResource", () => {
+    const missing = [...staged].filter((name) => !shipped.has(name));
+    expect(missing, `stage.ts stages payload forge never ships: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("every extraResource entry is actually staged by stage.ts", () => {
+    const missing = [...shipped].filter((name) => !staged.has(name));
+    expect(missing, `forge ships payload stage.ts never produces: ${missing.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("the mail engine is staged, shipped, and located for the API (regression: setup step 7)", () => {
+    expect(staged.has("mail-engine"), "stage.ts does not stage resources/mail-engine").toBe(true);
+    expect(shipped.has("mail-engine"), "forge.config.js does not ship resources/mail-engine").toBe(
+      true,
+    );
+    expect(
+      /mailEngineDir:\s*join\(root,\s*"mail-engine"\)/.test(services),
+      "resourcePaths() does not expose mailEngineDir",
+    ).toBe(true);
+    expect(
+      /MAIL_SERVER_ENGINE_DIR:\s*mailEngineDir/.test(services),
+      "the API is spawned without MAIL_SERVER_ENGINE_DIR — it would fall back to the monorepo path",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What was broken

Mail server setup fails at step 7 in the packaged desktop app (0.3.0, macOS):

```
Setup failed
Engine transfer failed: tar failed (exit 1): tar: could not chdir to '/Users/<user>/Library/apps/email/engine'
```

Two separate causes, both only reachable in a packaged build:

1. **The engine tree is never bundled.** `build/stage.ts` stages the API binary, dashboard, migrations and pglite assets, but not `apps/email/engine`. Nothing in `Openship.app/Contents/Resources` contains `iRedMail.sh`.

2. **The path the API falls back to is wrong there.** `resolveLocalEngineDir()` (`apps/api/src/modules/mail/mail.service.ts`) uses `resolve(process.cwd(), "../../apps/email/engine")`, which is correct only when the API runs from `apps/api` in the monorepo. `services.ts` spawns it with `cwd: userData`, so it resolves to `~/Library/apps/email/engine` — two levels above `~/Library/Application Support/Openship`. Confirmed against the shipped binary and the running process:

   ```
   $ lsof -p <openship-api pid> | awk '$4=="cwd"'
   ... /Users/<user>/Library/Application Support/Openship
   ```

`bun dev` never hits either one, because the dev layout resolves the same tree from the checkout.

## The change

Stage `apps/email/engine` as `resources/mail-engine` (1.5 MB) and hand it to the API via `MAIL_SERVER_ENGINE_DIR` at spawn — the same stage → `extraResource` → env-var pattern already used for `OPENSHIP_MIGRATIONS_DIR` and `OPENSHIP_PGLITE_ASSETS_DIR`. `MAIL_SERVER_ENGINE_DIR` was already supported by `resolveLocalEngineDir()`; nothing set it. Dev behaviour is unchanged: with the variable unset, the monorepo-relative fallback still applies.

`stepTransferEngine` now also checks the directory exists before calling `transferIn`. `transferIn` shells out to `tar`, so a missing engine surfaced as a bare `tar` exit 1, which reads like an SSH/transport failure rather than a missing directory.

## Verification

**Live run.** Against the shipped 0.3.0 app on macOS 15 targeting an Ubuntu 24.04 DigitalOcean droplet, with `MAIL_SERVER_ENGINE_DIR` pointed at a copy of the engine tree — i.e. exactly the state this PR produces automatically. Step 7, which previously failed outright, now completes:

```
Transferring engine /Users/<user>/Library/Application Support/Openship/mail-engine → /root/iRedMail-engine...
Packing source into a single archive...
Uploading 200 KB archive via rsync (resumable)...
Transferred 200 KB and extracted on the server.
Engine staged
```

Step 8 then passes as well (`iRedMail.sh` found, made executable). Setup proceeds to step 9.

**Build.** `bun run build/stage.ts` (with the pinned Bun 1.3.3 from `.bun-version`) completes and produces `resources/mail-engine/iRedMail.sh`; the ssh2 `#25500` canary still passes.

**Test.** New `apps/desktop/test/bundled-resources.test.ts` — a static contract scan in the style of the existing `ipc-contract.test.ts`, checking that everything `stage.ts` stages is shipped by `forge.config.js` and, for the engine specifically, that `resourcePaths()` exposes it and the API is spawned with `MAIL_SERVER_ENGINE_DIR`. Reverting the three source files and keeping the test reproduces the failure:

```
× the mail engine is staged, shipped, and located for the API (regression: setup step 7)
  AssertionError: stage.ts does not stage resources/mail-engine: expected false to be true
```

With the fix: 6 passed.

**Suite.** `bun run test` — 7/7 workspace tasks, 969 API tests passing. `bun run --cwd apps/desktop lint` and `bun run --cwd apps/api lint` clean. `bun format` reformats a lot of pre-existing drift repo-wide; per CONTRIBUTING I dropped all of it and confirmed with `prettier --check` that none of the reformatting falls on lines this PR adds.

## Separate issue found downstream (not addressed here)

With the transfer fixed, setup reaches step 9 and fails there for an unrelated reason — the vendored engine is iRedMail 1.8.1, and the installer's own online version check rejects it:

```
[ INFO ] Checking new version of iRedMail ...
<< ERROR >> Your iRedMail version (1.8.1) is out of date, please
<< ERROR >> download the latest version and try again:
Installer exited with code 255
```

`check_new_iredmail()` in `pkgs/get_all.sh` queries `l.iredmail.org` and `exit 255` when upstream reports `UPDATE_AVAILABLE`. Upstream is currently 1.8.4, so mail setup cannot complete on any build — packaged or dev — until `apps/email/engine` is bumped. Replacing the tree with 1.8.4 locally gets past it; all the config keys the mail service generates (`BACKEND`, `FIRST_DOMAIN`, `STORAGE_BASE_DIR`, `USE_FAIL2BAN`, the DB password vars, `DOMAIN_ADMIN_PASSWD_PLAIN`, and the six `AUTO_*` flags) still exist in 1.8.4, and it supports Ubuntu 24.04. That's a vendored-dependency bump and a different change, so it's left out of this PR — happy to open it separately if you'd like.

I have not run a full `make` + complete iRedMail install end to end, for the reason above.