### PR TITLE
chore: ignore build artifacts from deploy fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@ apps/desktop/resources/
 apps/cli/README.md
 # bun build --compile scratch/leftover binaries
 *.bun-build
+# Build artifacts left behind by running the deploy fixtures locally.
+# Scoped to fixtures/deploy/ on purpose: a bare `build/` or `bin/` rule would
+# also swallow the tracked apps/desktop/build/ and apps/cli/build/ sources.
+fixtures/deploy/*/obj/
+fixtures/deploy/*/bin/
+fixtures/deploy/*/.gradle/
+fixtures/deploy/*/build/
 
 # Environment
 .env


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules for the build artifacts that running the deploy fixtures leaves behind, so they stop showing up as untracked files.

## Motivation

Building the fixtures under `fixtures/deploy/` (for example to test a .NET or Kotlin deploy) leaves toolchain output in the working tree. `git status` then reports untracked directories that are pure build output, which is noise during review and easy to commit by accident.

Observed on a clean checkout after exercising the fixtures:

```
?? fixtures/deploy/dotnet/obj/
?? fixtures/deploy/kotlin/.gradle/
```

The existing `# Build outputs` block covers `dist/`, `.next/`, `.turbo/`, and `out/`, but nothing for the .NET or Gradle fixtures.

## Related issue

None. Small self-contained improvement, which CONTRIBUTING.md allows as a direct PR.

## Changes

- `.gitignore`: ignore `obj/`, `bin/`, `.gradle/`, and `build/` **under `fixtures/deploy/*/` only**.

`obj/` and `.gradle/` are the two I directly observed. `bin/` and `build/` are the sibling outputs the same two toolchains emit (dotnet writes `bin/` alongside `obj/`; Gradle writes `build/` alongside `.gradle/`), included so the same report does not recur.

### Why these are scoped to `fixtures/deploy/*/`

A bare `build/` or `bin/` rule would also match `apps/desktop/build/` and `apps/cli/build/`, which are **tracked source directories**, not output. Scoping the rules to the fixtures avoids shadowing them. There is a comment in the file recording this so the next person does not widen the pattern.

## Verification

The rules match the actual artifacts:

```bash
$ git check-ignore -v fixtures/deploy/dotnet/obj/project.assets.json fixtures/deploy/kotlin/.gradle/vcs-1
.gitignore:24:fixtures/deploy/*/obj/     fixtures/deploy/dotnet/obj/project.assets.json
.gitignore:26:fixtures/deploy/*/.gradle/ fixtures/deploy/kotlin/.gradle/vcs-1
```

No tracked file is shadowed by the new rules:

```bash
$ git ls-files | grep -E "^fixtures/deploy/[^/]+/(obj|bin|\.gradle|build)/"
(no output)
```

The tracked build directories stay visible, which is the specific risk of a broader pattern:

```bash
$ git check-ignore -v apps/desktop/build/bundle.mjs apps/cli/build/stage-server.ts
(no output, i.e. not ignored)
```

## Checklist

- [x] One change per PR, one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped, no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

Note on the test checkbox: `.gitignore` rules are not unit-testable, so the `git check-ignore` output above is the equivalent evidence, including the negative case proving tracked sources are not caught.
