### PR TITLE
Guard fresh Compose installs in releases

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -14,7 +14,7 @@ name: Docker images
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag:
@@ -148,7 +148,11 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$METADATA_JSON") \
             $(printf "${SRC}@sha256:%s " *)
 
-      - name: Inspect
+      - name: Verify public manifest
         run: |
+          # Compose installs pull these images without registry credentials.
+          # Remove the workflow login so private or otherwise inaccessible
+          # packages fail the release instead of appearing to publish cleanly.
+          docker logout ghcr.io
           docker buildx imagetools inspect \
-            "ghcr.io/${{ github.repository_owner }}/openship-${{ matrix.image }}:${{ steps.meta.outputs.version }}" || true
+            "ghcr.io/${{ github.repository_owner }}/openship-${{ matrix.image }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,7 +507,7 @@ jobs:
       - name: Verify Compose install support
         run: |
           bun run --cwd apps/cli test
-          bun apps/cli/dist/index.js up --help | grep -F -- "--compose"
+          node apps/cli/dist/index.js up --help | grep -F -- "--compose"
 
       - name: Publish to npm (OIDC trusted publishing — no token)
         working-directory: apps/cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   # Manual run publishes ONLY the CLI to npm (current version, no tag / installers).
   workflow_dispatch: {}
 
@@ -238,7 +238,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Restore bun cache
         uses: actions/cache@v6
@@ -258,7 +258,7 @@ jobs:
       - name: Build installer
         shell: bash
         env:
-          APPIMAGE_EXTRACT_AND_RUN: '1'
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         run: bun run --cwd apps/desktop make
 
       - name: Collect + rename installer
@@ -358,7 +358,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Restore bun cache
         uses: actions/cache@v6
@@ -484,7 +484,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: "24"
           registry-url: https://registry.npmjs.org
 
       - name: Ensure npm supports trusted publishing (OIDC)
@@ -503,6 +503,11 @@ jobs:
 
       - name: Build CLI
         run: bun run --cwd apps/cli build
+
+      - name: Verify Compose install support
+        run: |
+          bun run --cwd apps/cli test
+          bun apps/cli/dist/index.js up --help | grep -F -- "--compose"
 
       - name: Publish to npm (OIDC trusted publishing — no token)
         working-directory: apps/cli

--- a/apps/cli/test/e2e/up.test.ts
+++ b/apps/cli/test/e2e/up.test.ts
@@ -98,6 +98,13 @@ afterEach(() => {
 });
 
 describe("openship up --compose (edge chain)", () => {
+  it("uses Compose by default when Docker is available", async () => {
+    const r = await runCommand(upCommand, []);
+    expect(r.code).toBe(0);
+    expect(e.calls).toBe(1);
+    expect(h.composeUpCalls).toBe(1);
+  });
+
   it("exits before the edge preflight when docker/compose is missing", async () => {
     h.hasDocker = false;
     const r = await runCommand(upCommand, ["--compose"]);
@@ -128,12 +135,19 @@ describe("openship up --compose (edge chain)", () => {
     e.plan = {
       proceed: true,
       action: "migrate",
-      sites: [{ serverNames: ["a.com"], ssl: true, target: { kind: "proxy", url: "http://127.0.0.1:3000" } }],
+      sites: [
+        {
+          serverNames: ["a.com"],
+          ssl: true,
+          target: { kind: "proxy", url: "http://127.0.0.1:3000" },
+        },
+      ],
       certPems: { "/etc/ssl/a.crt": { certPem: "CERT", keyPem: "KEY" } },
     };
     fetchStub = stubFetch((req) => {
       if (req.url.endsWith("/api/health")) return { status: 200, json: { ok: true } };
-      if (req.url.endsWith("/api/system/edge/import-sites")) return { status: 200, json: { registered: ["a.com"], warnings: [] } };
+      if (req.url.endsWith("/api/system/edge/import-sites"))
+        return { status: 200, json: { registered: ["a.com"], warnings: [] } };
       return { status: 404, json: {} };
     });
 
@@ -146,7 +160,9 @@ describe("openship up --compose (edge chain)", () => {
     expect(importCall!.method).toBe("POST");
     expect(importCall!.headers["x-internal-token"]).toBe("tok");
     expect((importCall!.body as any).sites).toHaveLength(1);
-    expect((importCall!.body as any).certPems).toEqual({ "/etc/ssl/a.crt": { certPem: "CERT", keyPem: "KEY" } });
+    expect((importCall!.body as any).certPems).toEqual({
+      "/etc/ssl/a.crt": { certPem: "CERT", keyPem: "KEY" },
+    });
     // Edge is serving → the takeover journal is closed, so the NEXT run doesn't
     // read it as interrupted and restart the proxy we just replaced.
     expect(e.completes).toBe(1);


### PR DESCRIPTION
## Summary

Make the documented fresh-Linux Compose path an enforced release contract. A CLI release must expose and test the Compose install path, and its published container images must be pullable by an unauthenticated server.

## Reproduction

I attempted fresh Openship installations on AWS EC2 using Ubuntu 24.04 and Ubuntu 26.04. In both cases setup completed, but the dashboard was not reachable through the configured custom domain.

The detailed Ubuntu 24.04 ARM64 reproduction used Docker Engine 29.6.2, Docker Compose 5.3.1, and the current npm release (`openship@0.3.0`):

1. Install Docker and verify that the non-root `ubuntu` user can access the Docker daemon.
2. Install Openship with `curl -fsSL https://get.openship.io | sh`.
3. Run `openship up --public-url https://openship.example.com`.
4. Point the domain at the EC2 public IP and allow inbound TCP 80 and 443.
5. Open the custom domain.

## Expected result

On Linux with working Docker, `openship up` should select Compose mode and start Postgres, Redis, the API, dashboard, and OpenResty edge. The edge should bind ports 80 and 443 so the custom domain can serve the dashboard with TLS.

## Actual result with the published CLI

- `openship@0.3.0` has no documented `--compose` or `--bare` options.
- It installs bare mode as a user systemd service even though Docker is available.
- The API and dashboard listen only on localhost ports 3001 and 4000.
- Nothing listens on ports 80 or 443.
- Cloudflare returns error 521 because it cannot connect to the origin.
- Anonymous pulls of `ghcr.io/oblien/openship-api:latest`, `openship-dashboard:latest`, and `openship-edge:latest` return HTTP 403.

The same user-visible result occurred on Ubuntu 26.04: installation appeared successful, but no working HTTPS edge was available for the custom domain. Ubuntu-specific edge handling is discussed in #86, and the Ubuntu 24.04 domain failure is documented in #102.

## Why both checks are required

The current `main` branch already contains the newer selection logic that defaults to Compose on Linux and attempts to install Docker when necessary. That logic was added after the published `v0.3.0` package, but the default no-flag behavior did not have an explicit regression test and the npm publication job did not verify that the built package exposed Compose support.

Even with the newer CLI, a fresh installation still depends on public GHCR images. The Docker image workflow currently inspects manifests while authenticated and suppresses failures with `|| true`, so it can succeed while ordinary servers receive HTTP 403.

## Changes

- Add an end-to-end CLI regression test proving that `openship up` with no mode flag starts Compose when Docker is available.
- Run the CLI suite immediately before npm publication.
- Smoke-test the built CLI and require `openship up --help` to expose `--compose`.
- Log out of GHCR before inspecting published image manifests.
- Stop suppressing manifest inspection failures so private, missing, or inaccessible images fail the workflow.

This PR prevents the broken combination seen in `v0.3.0` from being published again. A new npm release containing the existing Compose-selection implementation is still required, and the GHCR packages must be public before the anonymous manifest checks can pass.

## Validation

- CLI test suite: 19 files and 126 tests passed
- CLI production build completed successfully
- Built CLI help contains `--compose` when executed with Bun
- Prettier checks passed for all changed files
- Workflow YAML parsed successfully
- `git diff --check` passed

Relates to #151 and #102.