### PR TITLE
fix(dashboard): clamp negative deployment log times

### DIFF
--- a/apps/dashboard/src/utils/deploymentPhaseDetector.test.ts
+++ b/apps/dashboard/src/utils/deploymentPhaseDetector.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { parseLogEntry } from "./deploymentPhaseDetector";
+
+describe("parseLogEntry", () => {
+  it("clamps negative elapsed time to 00:00 for phase markers", () => {
+    const startTime = Date.parse("2026-01-01T00:01:00Z");
+
+    expect(parseLogEntry("---PHASE: build---", "2026-01-01T00:00:30Z", startTime)).toEqual({
+      type: "info",
+      text: "",
+      time: "00:00",
+    });
+  });
+
+  it("clamps negative elapsed time to 00:00 for regular log lines", () => {
+    const startTime = Date.parse("2026-01-01T00:01:00Z");
+
+    expect(parseLogEntry("Building application", "2026-01-01T00:00:30Z", startTime).time).toBe(
+      "00:00",
+    );
+  });
+
+  it("preserves normal elapsed-time formatting for in-order events", () => {
+    const startTime = Date.parse("2026-01-01T00:01:00Z");
+
+    expect(parseLogEntry("Deployment complete!", "2026-01-01T00:02:05Z", startTime)).toEqual({
+      type: "success",
+      text: "Deployment complete!",
+      time: "01:05",
+    });
+  });
+});

--- a/apps/dashboard/src/utils/deploymentPhaseDetector.ts
+++ b/apps/dashboard/src/utils/deploymentPhaseDetector.ts
@@ -24,6 +24,14 @@ export interface SSEMessage {
   timestamp: string;
 }
 
+function formatElapsedTime(timestamp: string, startTime: number): string {
+  const currentTime = Math.max(0, Math.floor((new Date(timestamp).getTime() - startTime) / 1000));
+  const mins = Math.floor(currentTime / 60);
+  const secs = currentTime % 60;
+
+  return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+}
+
 /**
  * Analyzes a log message and determines the current deployment phase and progress
  */
@@ -172,10 +180,7 @@ export function parseLogEntry(text: string, timestamp: string, startTime: number
   // Skip phase markers in the log display
   if (text.match(/---PHASE:\s*\w+---/i)) {
     // Return a special marker that can be filtered out if needed
-    const currentTime = Math.floor((new Date(timestamp).getTime() - startTime) / 1000);
-    const mins = Math.floor(currentTime / 60);
-    const secs = currentTime % 60;
-    const time = `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+    const time = formatElapsedTime(timestamp, startTime);
 
     return { type: "info", text: "", time }; // Empty text to hide phase markers
   }
@@ -202,10 +207,7 @@ export function parseLogEntry(text: string, timestamp: string, startTime: number
   }
 
   // Calculate time from timestamp
-  const currentTime = Math.floor((new Date(timestamp).getTime() - startTime) / 1000);
-  const mins = Math.floor(currentTime / 60);
-  const secs = currentTime % 60;
-  const time = `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  const time = formatElapsedTime(timestamp, startTime);
 
   // Clean up the text (remove extra whitespace, line breaks)
   const cleanText = text.trim();


### PR DESCRIPTION
## Problem
Issue #244 reports that `parseLogEntry` formats out-of-order SSE events as malformed negative timestamps such as `-3:-40`. That can happen when a log event timestamp arrives earlier than the recorded deployment start time.

## Triage / Root cause
`apps/dashboard/src/utils/deploymentPhaseDetector.ts` computes elapsed seconds directly from `timestamp - startTime` in two places and formats the negative result without clamping. Both the phase-marker branch and the regular log-entry branch therefore render invalid `mm:ss` strings for the same skewed input.

## Fix
- add a shared elapsed-time formatter for `parseLogEntry`
- clamp negative elapsed seconds to `0` before formatting
- add regression coverage for both phase-marker and regular log lines, plus a normal in-order event

## Verification
```bash
export PATH="$HOME/.bun/bin:$PATH"
bun install --frozen-lockfile
bun run --cwd apps/dashboard test src/utils/deploymentPhaseDetector.test.ts
```
Passed locally.

Additional check on clean `upstream/main`:
```bash
export PATH="$HOME/.bun/bin:$PATH"
bun install --frozen-lockfile
bun run --cwd apps/dashboard test
```
That currently fails in `src/i18n/i18n-parity.test.ts` on `upstream/main` itself (`dashboard: 224 missing (baseline 200)`, `chrome: 144 missing (baseline 0)`), so the red GitHub Actions `Test` job is pre-existing and unrelated to this patch.

## Notes / Risks
This PR intentionally addresses only the negative-time formatting bug from #244 so it stays isolated from the other phase-detection issues discussed there.