### PR TITLE
build: remove @repo/adapters from cli publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,7 +555,7 @@ jobs:
           # tsup bundles the @repo/* deps into dist/, so strip them from the
           # published manifest — otherwise npm emits uninstallable workspace:*
           # specifiers for packages that aren't on the registry.
-          npm pkg delete dependencies.@repo/core dependencies.@repo/onboarding
+          npm pkg delete dependencies.@repo/core dependencies.@repo/onboarding dependencies.@repo/adapters
           # Prereleases (v1.2.3-rc.1) publish to the `next` dist-tag, not `latest`.
           if [[ "${TAG}" == *-* ]]; then
             npm publish --access public --tag next


### PR DESCRIPTION
<!--
Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
Fill in the sections below and delete any that genuinely don't apply.
-->

## Summary

Updated npm pkg delete command to remove additional dependencies from the published manifest.

## Motivation

<!-- What was broken, or what did the linked issue agree on? Why is this change needed? -->

## Related issue

<!--
New features, behavior changes, new dependencies, new endpoints, and schema/migration changes
need a maintainer to agree on scope *and* approach in an issue **before** the code is written —
link that issue here (for example: Closes #123).

Bug fixes, tests, docs, and small self-contained improvements don't need one. Write "None".
-->
Fixes #253 

## Changes

<!-- Bullet what changed, grouped by workspace (apps/api, apps/dashboard, packages/db, ...). -->

## Verification

<!--
How you actually verified this: the commands you ran and the before/after behavior.
Paste real output rather than describing what should happen.
-->

```bash

```

## Screenshots

<!-- Before/after for dashboard, web, or desktop changes. Delete this section if not applicable. -->

## Checklist

- [ ] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [ ] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [ ] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [ ] I understand every line of this diff and can explain it in review
