### PR TITLE
fix(dashboard): refresh sidebar project count after delete

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/[[...slug]]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/[[...slug]]/page.tsx
@@ -35,6 +35,7 @@ import { useToast } from "@/context/ToastContext";
 import { useModal } from "@/context/ModalContext";
 import { useI18n, interpolate } from "@/components/i18n-provider";
 import { ApiError, getApiErrorMessage, projectsApi } from "@/lib/api";
+import { invalidateSidebarNavCounts } from "@/lib/sidebar-nav-counts";
 import ErrorState from "@/components/shared/ErrorState";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { HelpMenu } from "@/components/HelpMenu";
@@ -497,6 +498,7 @@ const ProjectSettingsContent = () => {
         if (err instanceof ApiError && err.status === 404) {
           clearInterval(iv);
           showToast(t.projects.delete.alreadyDeleted, "success");
+          invalidateSidebarNavCounts();
           router.push("/");
         }
       }
@@ -546,6 +548,7 @@ const ProjectSettingsContent = () => {
             "success",
           );
         }
+        invalidateSidebarNavCounts();
         router.push("/");
         return;
       }
@@ -561,6 +564,7 @@ const ProjectSettingsContent = () => {
           "success",
           t.projects.delete.partialCleanupTitle,
         );
+        invalidateSidebarNavCounts();
         router.push("/");
         return;
       }
@@ -681,6 +685,7 @@ const ProjectSettingsContent = () => {
       // 404: someone else already deleted the project in another tab.
       if (err instanceof ApiError && err.status === 404) {
         showToast(t.projects.delete.alreadyDeleted, "success");
+        invalidateSidebarNavCounts();
         router.push("/");
         return;
       }

--- a/apps/dashboard/src/components/sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar.tsx
@@ -37,6 +37,10 @@ import { useCloud } from "@/context/CloudContext";
 import { DismissiblePopover } from "@/components/ui/Popover";
 import { setActiveOrganizationId } from "@/lib/api/client";
 import { projectsApi } from "@/lib/api";
+import {
+  getSidebarNavCountsRevision,
+  subscribeSidebarNavCounts,
+} from "@/lib/sidebar-nav-counts";
 
 /**
  * Org list / member shapes from Better Auth's organization plugin.
@@ -159,12 +163,17 @@ export function Sidebar() {
   const [collapsed, setCollapsed] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [navCounts, setNavCounts] = useState<{ projects: number; apps: number } | null>(null);
+  const [navCountsRevision, setNavCountsRevision] = useState(getSidebarNavCountsRevision);
   const countFor = (key: string): number | null => {
     if (!navCounts) return null;
     if (key === "projects") return navCounts.projects;
     if (key === "apps") return navCounts.apps;
     return null;
   };
+
+  useEffect(() => subscribeSidebarNavCounts(() => {
+    setNavCountsRevision(getSidebarNavCountsRevision());
+  }), []);
 
   // Org switcher state. Lazy-loaded — `list()` and the active org fetch
   // only fire after the first popover open so the sidebar doesn't pay
@@ -263,7 +272,7 @@ export function Sidebar() {
     return () => {
       cancelled = true;
     };
-  }, [orgsLoaded, activeOrgId]);
+  }, [orgsLoaded, activeOrgId, navCountsRevision]);
 
   async function handleOrgSwitch(orgId: string) {
     if (orgId === activeOrgId) {

--- a/apps/dashboard/src/lib/sidebar-nav-counts.ts
+++ b/apps/dashboard/src/lib/sidebar-nav-counts.ts
@@ -1,0 +1,20 @@
+/** Shared revision so project create/delete can refresh Sidebar Projects/Apps counts. */
+
+let revision = 0;
+const listeners = new Set<() => void>();
+
+export function getSidebarNavCountsRevision(): number {
+  return revision;
+}
+
+export function invalidateSidebarNavCounts(): void {
+  revision += 1;
+  listeners.forEach((cb) => cb());
+}
+
+export function subscribeSidebarNavCounts(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary
- Invalidate the left-nav Projects/Apps counts when a project is deleted, so the sidebar tally updates without a hard refresh
- Subscribe the Sidebar to a shared revision bumped from the delete success paths

## Test plan
- [ ] Open the dashboard and note the Projects count in the left sidebar
- [ ] Create a project, confirm the count increases (after navigating back if needed)
- [ ] Delete that project from its draft/settings page
- [ ] Confirm the sidebar Projects count decrements immediately after redirect (no manual reload)
- [ ] Confirm Apps count is unchanged by deleting a non-app project


Made with [Cursor](https://cursor.com)