### PR TITLE
fix(api): honor linked project root directory

### DIFF
--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -458,6 +458,7 @@ async function reconcileComposeDrift(
       repo: project.gitRepo,
       branch,
       ctx,
+      rootDirectory: project.rootDirectory || undefined,
     });
     const services = info.services ?? [];
     if (services.length === 0) return;

--- a/apps/api/src/modules/deployments/local-source.ts
+++ b/apps/api/src/modules/deployments/local-source.ts
@@ -71,7 +71,10 @@ function createLocalReader(dirPath: string): ProjectReader {
   };
 }
 
-export async function resolveFromLocal(dirPath: string): Promise<ProjectInfo> {
+export async function resolveFromLocal(
+  dirPath: string,
+  rootDirectory?: string,
+): Promise<ProjectInfo> {
   const st = await stat(dirPath);
   if (!st.isDirectory()) {
     throw new Error("Path is not a directory");
@@ -91,5 +94,6 @@ export async function resolveFromLocal(dirPath: string): Promise<ProjectInfo> {
       default_branch: "main",
     },
     "main",
+    rootDirectory,
   );
 }

--- a/apps/api/src/modules/deployments/prepare.service.ts
+++ b/apps/api/src/modules/deployments/prepare.service.ts
@@ -56,13 +56,15 @@ export type Source =
       owner: string;
       repo: string;
       branch?: string;
+      /** Select a configured project root instead of running repository-wide detection. */
+      rootDirectory?: string;
       /** Request-scoped context — required when source === "github" so
        *  getRepository can resolve org-scoped install + cache keys.
        *  Optional in the type for back-compat with old callers; the
        *  github resolver throws when it's missing. */
       ctx?: RequestContext;
     }
-  | { source: "local"; path: string };
+  | { source: "local"; path: string; rootDirectory?: string };
 
 export interface ProjectInfo {
   repository: {
@@ -395,6 +397,7 @@ interface SelectedProjectSnapshot {
 async function selectProjectSnapshot(
   reader: ProjectReader,
   rootSnapshot: ProjectRootSnapshotInput,
+  requestedRootDirectory?: string,
 ): Promise<SelectedProjectSnapshot> {
   const treeEntries = await reader.listTree().catch(() => [] as RepoTreeEntry[]);
   const hints = discoverProjectRootHints(
@@ -407,11 +410,38 @@ async function selectProjectSnapshot(
     hints.map((hint) => loadCandidateSnapshot(reader, hint.rootDirectory, hint.source)),
   )).filter((candidate): candidate is ProjectRootSnapshotInput => Boolean(candidate));
 
+  const normalizedRequestedRoot = normalizeProjectRootDirectory(requestedRootDirectory);
+  let requestedSnapshot: ProjectRootSnapshotInput | null | undefined;
+
+  if (requestedRootDirectory !== undefined) {
+    requestedSnapshot = normalizedRequestedRoot
+      ? candidates.find(
+          (candidate) =>
+            normalizeProjectRootDirectory(candidate.rootDirectory) === normalizedRequestedRoot,
+        ) ?? await loadCandidateSnapshot(reader, normalizedRequestedRoot, "discovered")
+      : rootSnapshot;
+
+    if (!requestedSnapshot) {
+      throw new Error(`Configured root directory "${requestedRootDirectory}" was not found`);
+    }
+  }
+
+  const selectionCandidates =
+    requestedSnapshot &&
+    !candidates.some(
+      (candidate) =>
+        normalizeProjectRootDirectory(candidate.rootDirectory) ===
+        normalizeProjectRootDirectory(requestedSnapshot.rootDirectory),
+    )
+      ? [...candidates, requestedSnapshot]
+      : candidates;
   const selected = applyWorkspaceContext(
     rootSnapshot,
-    selectPreferredProjectRoot(rootSnapshot, candidates),
+    requestedSnapshot
+      ? selectPreferredProjectRoot(requestedSnapshot, [])
+      : selectPreferredProjectRoot(rootSnapshot, candidates),
   );
-  const monorepo = discoverMonorepoApps(rootSnapshot, candidates);
+  const monorepo = discoverMonorepoApps(rootSnapshot, selectionCandidates);
 
   return { selected, monorepo };
 }
@@ -453,7 +483,13 @@ export async function resolveProjectInfo(input: Source): Promise<ProjectInfo> {
     if (!input.ctx) {
       throw new Error("resolveProjectInfo(github): ctx is required");
     }
-    return resolveFromGitHub(input.ctx, input.owner, input.repo, input.branch);
+    return resolveFromGitHub(
+      input.ctx,
+      input.owner,
+      input.repo,
+      input.branch,
+      input.rootDirectory,
+    );
   }
 
   if (env.CLOUD_MODE) {
@@ -462,7 +498,7 @@ export async function resolveProjectInfo(input: Source): Promise<ProjectInfo> {
 
   // Dynamic import keeps local-source (node:fs) out of the cloud module graph.
   const { resolveFromLocal } = await import("./local-source");
-  return resolveFromLocal(input.path);
+  return resolveFromLocal(input.path, input.rootDirectory);
 }
 
 type RepoMeta = Parameters<typeof toProjectInfo>[0];
@@ -475,9 +511,14 @@ export async function resolveFromReader(
   reader: ProjectReader,
   repoMeta: RepoMeta,
   selectedBranch: string,
+  requestedRootDirectory?: string,
 ): Promise<ProjectInfo> {
   const rootSnapshot = await readProjectSnapshot(reader);
-  const { selected, monorepo } = await selectProjectSnapshot(reader, rootSnapshot);
+  const { selected, monorepo } = await selectProjectSnapshot(
+    reader,
+    rootSnapshot,
+    requestedRootDirectory,
+  );
   const [composeContent, composeEnvContent] = await Promise.all([
     readComposeText(reader, selected.rootDirectory, selected.files),
     readProjectText(reader, selected.rootDirectory, ".env"),
@@ -494,6 +535,7 @@ async function resolveFromGitHub(
   owner: string,
   repo: string,
   branch?: string,
+  rootDirectory?: string,
 ): Promise<ProjectInfo> {
   const repository = await githubService.getRepository(ctx, owner, repo, {
     withBranches: true,
@@ -512,6 +554,7 @@ async function resolveFromGitHub(
     createGitHubReader(ctx, owner, repo, selectedBranch),
     repository,
     selectedBranch,
+    rootDirectory,
   );
 }
 

--- a/apps/api/src/modules/projects/project-crud.service.ts
+++ b/apps/api/src/modules/projects/project-crud.service.ts
@@ -530,6 +530,9 @@ export async function linkProjectRepo(
     gitRepo: repo,
     gitBranch: defaultBranch,
     gitUrl,
+    // Linking a local project changes its source of truth. Keeping the old
+    // path would make the runtime transfer local files and skip the Git clone.
+    localPath: null,
   };
 
   const strategy = await resolveWebhookStrategy(project!);
@@ -565,6 +568,7 @@ export async function linkProjectRepo(
       gitOwner: owner,
       gitRepo: repo,
       gitUrl,
+      localPath: null,
       installationId: (gitFields.installationId as number | undefined) ?? input.installationId,
       ...(typeof gitFields.webhookId === "number" ? { webhookId: gitFields.webhookId } : {}),
     };
@@ -1596,4 +1600,3 @@ export async function getLatestDeploymentSession(
       : null,
   };
 }
-

--- a/apps/api/test/modules/deployments/prepare.service.test.ts
+++ b/apps/api/test/modules/deployments/prepare.service.test.ts
@@ -46,4 +46,34 @@ describe("resolveProjectInfo", () => {
     expect(result.services?.map((service) => service.name)).toEqual(["web"]);
     expect(result.rootEnv).toEqual({ PORT: "9090" });
   });
+
+  it("honors an explicitly configured Compose root", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-root-"));
+    tempDirs.push(tempDir);
+
+    await writeFile(
+      join(tempDir, "docker-compose.yml"),
+      ["services:", "  unrelated:", "    image: nginx:alpine"].join("\n"),
+    );
+    await mkdir(join(tempDir, "stacks", "leverageai"), { recursive: true });
+    await writeFile(
+      join(tempDir, "stacks", "leverageai", "compose.yml"),
+      [
+        "services:",
+        "  backend:",
+        "    image: ghcr.io/example/backend:v1.2.3",
+        "  frontend:",
+        "    image: ghcr.io/example/web:v1.2.3",
+      ].join("\n"),
+    );
+
+    const result = await resolveProjectInfo({
+      source: "local",
+      path: tempDir,
+      rootDirectory: "stacks/leverageai",
+    });
+
+    expect(result.rootDirectory).toBe("stacks/leverageai");
+    expect(result.services?.map((service) => service.name)).toEqual(["backend", "frontend"]);
+  });
 });


### PR DESCRIPTION
## What changed

- honor a project's configured `rootDirectory` when resolving Compose drift from GitHub
- reject a missing configured root instead of silently reconciling an unrelated repository root
- clear stale local source paths when a local project is linked to GitHub, including sibling environments
- add coverage for selecting an explicit nested Compose root when the repository also has a root Compose file

## Why

An adopted local Compose project can be linked to a GitHub repository whose deployment manifest lives in a subdirectory. Previously, the link kept `localPath`, while drift reconciliation auto-detected the repository root and could import unrelated services. This makes the linked GitHub repository and configured root the actual deployment source.

## Validation

- `bun run --cwd apps/api test -- test/modules/deployments/prepare.service.test.ts`
- `bun run --cwd apps/api lint`
- `git diff --check`
