### PR TITLE
fix(backup): stop volume backups writing a second copy to the container log

### DIFF
--- a/packages/adapters/src/backup/executors/docker.ts
+++ b/packages/adapters/src/backup/executors/docker.ts
@@ -194,6 +194,14 @@ export class DockerBackupExecutor implements BackupExecutor {
     const hostConfig: Dockerode.HostConfig = {
       Binds: [`${source.source}:/mnt:ro`],
       AutoRemove: true,
+      // The archive streams over `attach()` below — the daemon's default
+      // json-file driver would ALSO write every byte of it to
+      // /var/lib/docker/containers as a log. That's a second copy of the whole
+      // backup, and worse than a copy: json-file escapes binary, so a 4.6 GB
+      // volume ballooned to a 12 GB log file here. Backups then spike the
+      // host's disk by more than the data they read and only release it when
+      // the helper exits. Nothing ever reads these logs.
+      LogConfig: { Type: "none", Config: {} },
     };
 
     const helper = await this.dockerode.createContainer({

--- a/packages/adapters/test/backup-helper-logging.test.ts
+++ b/packages/adapters/test/backup-helper-logging.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The backup helper streams a volume's archive over `attach()`. With the
+ * daemon's default json-file driver, Docker ALSO writes every byte to
+ * /var/lib/docker/containers — a second copy of the whole backup, inflated
+ * further because json-file escapes binary. Observed on a live box: a 4.6 GB
+ * volume produced a 12 GB log, so a backup spiked host disk by far more than
+ * it read and only released it when the helper exited.
+ *
+ * Asserted against the source because the alternative is a full dockerode
+ * double, which would pin far more of the executor's shape than this one
+ * property is worth.
+ */
+const executorSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../src/backup/executors/docker.ts"),
+  "utf8",
+);
+
+describe("backup helper container", () => {
+  it("disables container logging for the archive stream", () => {
+    expect(executorSource).toMatch(/LogConfig:\s*\{\s*Type:\s*"none"/);
+  });
+
+  it("keeps the log config on the same HostConfig that binds the source", () => {
+    const hostConfig = executorSource.slice(
+      executorSource.indexOf("const hostConfig"),
+      executorSource.indexOf("const helper ="),
+    );
+    expect(hostConfig).toContain(":/mnt:ro");
+    expect(hostConfig).toContain("AutoRemove: true");
+    expect(hostConfig).toMatch(/LogConfig/);
+  });
+});


### PR DESCRIPTION
Found on a live self-host while investigating an unexplained 9 GB of disk growth.

## What happens

`DockerBackupExecutor` runs a helper container that tars a volume to stdout:

```
sh -c 'apk add --no-cache zstd >/dev/null 2>&1; tar -c -C /mnt . | zstd -c -3'
```

The caller consumes that archive over `helper.attach({ stream: true, stdout: true })`. But the helper's `HostConfig` only set `Binds` and `AutoRemove` — with no `LogConfig`, the daemon's default `json-file` driver applies, so Docker *also* writes every byte of the archive into `/var/lib/docker/containers/<id>/<id>-json.log`.

Nothing ever reads that log. It is a second copy of the entire backup.

## Why it's worse than a duplicate

`json-file` wraps output in JSON and escapes it, and an archive is binary. Measured on the affected box:

| | |
|---|---|
| Bind source | 4.6 GB |
| Resulting container log | **12 GB** |
| Two helpers running concurrently | ~24 GB of duplication for one backup run |

Because `AutoRemove: true` takes the log with the container, this presents as a large **transient spike** rather than steady growth — which is the shape that fills a disk without warning. Host disk went from 56% to 79% in about two minutes during a routine backup, and every container on that host shares the same filesystem.

## Fix

Set the helper's log driver to `none`. The archive never travelled through the log — it goes over `attach()` — so nothing about the backup path changes; only the duplicate write disappears.

```diff
 const hostConfig: Dockerode.HostConfig = {
   Binds: [`${source.source}:/mnt:ro`],
   AutoRemove: true,
+  LogConfig: { Type: "none", Config: {} },
 };
```

## Tests

Two cases asserting the helper disables logging and that the setting stays on the same `HostConfig` that binds the source read-only. They check the source text rather than standing up a dockerode double — the alternative pins far more of the executor's shape than this one property justifies, and the comment says so.

`tsc --noEmit` clean; `packages/adapters` suite green (365 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
