### PR TITLE
fix(edge): materialize vhost symlinks before container startup

### DIFF
--- a/packages/adapters/src/system/proxy/detect.ts
+++ b/packages/adapters/src/system/proxy/detect.ts
@@ -132,7 +132,21 @@ export async function sanitizeEdgeVhosts(
   // POSIX sh, one pass, no per-file round trips (this runs over SSH).
   const script = [
     `for f in ${sq(sitesDir)}/*.conf; do`,
-    `  [ -f "$f" ] || continue;`,
+    // A host-side vhost may be a symlink into /etc/nginx/sites-available. That
+    // target is deliberately not mounted in the edge container, so leaving the
+    // link here makes nginx's include glob fail at startup. Materialize valid
+    // links before the container mounts this directory; remove dangling ones.
+    `  [ -e "$f" ] || [ -L "$f" ] || continue;`,
+    `  if [ -L "$f" ]; then`,
+    `    if [ ! -e "$f" ]; then`,
+    `      echo "dropped-dangling-link $f"; rm -f "$f"; continue;`,
+    `    fi;`,
+    `    if cat "$f" > "$f.osh-link"; then`,
+    `      rm -f "$f"; mv "$f.osh-link" "$f"; echo "materialized-link $f";`,
+    `    else`,
+    `      rm -f "$f.osh-link"; echo "dropped-unreadable-link $f"; rm -f "$f"; continue;`,
+    `    fi;`,
+    `  fi;`,
     // A real server_name is anything that isn't the `_` wildcard.
     `  if ! grep -qE '^[[:space:]]*server_name[[:space:]]+[^_;[:space:]]' "$f"; then`,
     `    echo "dropped-catchall $f"; rm -f "$f"; continue;`,
@@ -149,6 +163,12 @@ export async function sanitizeEdgeVhosts(
       onLog(vhostLog(`Dropped catch-all vhost ${file} — the edge image provides it.`, "warn"));
     } else if (action === "unset-default") {
       onLog(vhostLog(`Removed default_server from ${file} — the edge image owns it.`, "warn"));
+    } else if (action === "materialized-link") {
+      onLog(vhostLog(`Materialized linked edge vhost ${file} for the container mount.`, "warn"));
+    } else if (action === "dropped-dangling-link") {
+      onLog(vhostLog(`Dropped dangling edge vhost link ${file}.`, "warn"));
+    } else if (action === "dropped-unreadable-link") {
+      onLog(vhostLog(`Dropped unreadable edge vhost link ${file}.`, "warn"));
     }
   }
 }

--- a/packages/adapters/src/system/proxy/edge-guards.test.ts
+++ b/packages/adapters/src/system/proxy/edge-guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -86,6 +86,25 @@ describe("sanitizeEdgeVhosts (real shell, real files)", () => {
     await sanitizeEdgeVhosts(new LocalExecutor(), dir, (l) => said.push(l.message));
     expect(await readFile(join(dir, "onvo.conf"), "utf8")).toBe(once);
     expect(said).toEqual([]); // nothing left to report
+  });
+
+  it("materializes valid symlinks and removes dangling links before the container mounts them", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openship-vhosts-links-"));
+    const source = join(dir, "source.conf");
+    const linked = join(dir, "linked.conf");
+    const dangling = join(dir, "dangling.conf");
+    await writeFile(source, PLAIN_VHOST);
+    await symlink(source, linked);
+    await symlink(join(dir, "missing.conf"), dangling);
+
+    const said: string[] = [];
+    await sanitizeEdgeVhosts(new LocalExecutor(), dir, (l) => said.push(l.message));
+
+    expect((await lstat(linked)).isSymbolicLink()).toBe(false);
+    expect(await readFile(linked, "utf8")).toBe(PLAIN_VHOST);
+    expect(await readdir(dir)).not.toContain("dangling.conf");
+    expect(said.join("\n")).toMatch(/Materialized linked edge vhost .*linked\.conf/);
+    expect(said.join("\n")).toMatch(/Dropped dangling edge vhost link .*dangling\.conf/);
   });
 });
 


### PR DESCRIPTION
## What changed

- Materialize valid Edge vhost symlinks before the state directory is mounted into the OpenResty container.
- Remove dangling or unreadable links so Nginx does not include inaccessible paths.
- Add a regression test covering both valid and dangling symlinks.

## Root cause

Bare migration can preserve a conventional host-side `sites-enabled` symlink whose target lives outside the mounted Edge state tree. It becomes dangling in the container and prevents Nginx from starting.

## Validation

- `bun test packages/adapters/src/system/proxy/edge-guards.test.ts`
- 8 tests passed

Fixes #284.