### PR TITLE
fix(api): resolve compose `<<` merge keys so anchored env reaches services

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -66,7 +66,11 @@ export interface ComposeParseOptions {
 // ─── Parser ──────────────────────────────────────────────────────────────────
 
 export function parseComposeFile(content: string, options: ComposeParseOptions = {}): ComposeParseResult {
-  const doc = parseYaml(content);
+  // `merge: true` is required, not cosmetic: the parser defaults to YAML 1.2,
+  // where `<<` is an ordinary key. Compose files that hoist shared config into
+  // an anchor (`x-environment: &shared` + `<<: *shared`) otherwise lose every
+  // anchored value and carry a literal "<<" key through to the container env.
+  const doc = parseYaml(content, { merge: true });
 
   if (!doc || typeof doc !== "object") {
     return { services: [], volumes: [], networks: [] };

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -493,4 +493,30 @@ services:
     const parsed = parseComposeFile(`version: "3.9"\nnetworks:\n  default:\n`);
     expect(parsed.services).toEqual([]);
   });
+
+  it("resolves `<<` merge keys so an anchored environment block reaches the service", () => {
+    const parsed = parseComposeFile(`
+x-environment: &shared
+  DB_HOST: postgres
+  RAILS_ENV: production
+  SETTINGS__APP_COMPONENT: base
+
+services:
+  web:
+    image: app:latest
+    environment:
+      <<: *shared
+      SETTINGS__APP_COMPONENT: web
+`);
+    // The yaml package parses as YAML 1.2, where `<<` is an ordinary key unless
+    // merge support is enabled. Left off, every anchored var is dropped and the
+    // unresolved anchor lands as a literal "<<" var stringified to
+    // "[object Object]" - which deploy.service.ts then spreads into the
+    // container environment. An explicit key still wins over the merged one.
+    expect(parsed.services[0]?.environment).toEqual({
+      DB_HOST: "postgres",
+      RAILS_ENV: "production",
+      SETTINGS__APP_COMPONENT: "web",
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Compose lets a file hoist shared config into an anchor and merge it into each service with `<<`. The parser doesn't resolve the merge — the anchored block is dropped and `<<` survives as a literal environment key:

```yaml
x-environment: &environment_variables
  DB_HOST: postgres
  DB_PASSWORD: ${DB_PASSWORD:-password}
  SECRET_KEY_BASE: ${SECRET_KEY_BASE:-key}
  SETTINGS__DEPLOY_MODE: compose
  # …54 vars in total

services:
  web:
    image: *base_image
    environment:
      <<: *environment_variables      # ← never merged
      RAILS_SERVE_STATIC_FILES: "true"
      SETTINGS__APP_COMPONENT: web
```

Against the `dependabot-gitlab` compose file from #286, run through the real `parseComposeFile`:

| service | parsed (before) | parsed (after) |
|---|---|---|
| `migration` | `{"<<": "[object Object]"}` ❌ | 54 vars ✅ |
| `web` | `<<` + 2 explicit ❌ | 56 vars ✅ |
| `worker` | `<<` + 8 explicit ❌ | 62 vars ✅ |
| `background-tasks` | `{"<<": "[object Object]"}` ❌ | 54 vars ✅ |

Both symptoms in the issue come from this: the anchor renders as `[object Object]`, and the shared block the file defines is never picked up.

This is not display-only. `prepare.service.ts:543` persists the parsed services, and `deploy.service.ts:809` spreads `svc.environment` into the container environment:

```ts
const mergedEnv: Record<string, string> = resolvePublicUrlPlaceholders({
  ...decryptedProjectEnv,
  ...depEnv,
  ...((svc.environment as Record<string, string>) ?? {}),
  ...decryptedServiceEnv,
}, …);
```

So an anchored project deploys with `DB_HOST`, `DB_PASSWORD`, `SECRET_KEY_BASE` and `SSL_CERT_FILE` absent, plus a bogus var named `<<`. Anchors are common in non-trivial compose files precisely because they avoid repeating a large env block per service.

## Cause

`parseComposeFile` (`apps/api/src/lib/compose-parser.ts:69`) called the parser with no options:

```ts
const doc = parseYaml(content);
```

`yaml@2.8.2` parses as YAML 1.2, where merge keys are not part of the spec and `<<` is an ordinary key; merge support is opt-in via `{ merge: true }`. So the alias resolves to the anchor's map but is never folded into the parent, and `parseEnvironment`'s object branch (`:202`) then does `String(val)` on that map, yielding `"[object Object]"`.

Plain aliases (`image: *base_image`, `depends_on: *service_dependencies`) always resolve and were never affected — only `<<`.

## Fix

Enable merge support at the single parse site:

```ts
const doc = parseYaml(content, { merge: true });
```

One site covers every consumer — `prepare.service.ts:543`, `migrate.service.ts:91` and `docker-inspect.service.ts:98` all route through `parseComposeFile`, so the fix lands at the shared root rather than per caller.

Semantics confirmed against the installed parser before relying on them:

| input | result |
|---|---|
| `<<: *shared` + an explicit duplicate key | explicit key wins, per the merge-key spec |
| `<<: [*a, *b]` | both maps merged |
| file with no anchors | parsed identically to before |

## Tests

Added one regression case to `apps/api/test/lib/compose-parser.test.ts` (`resolves \`<<\` merge keys so an anchored environment block reaches the service`). It asserts the whole environment object with `toEqual`, so a single assertion pins all three properties: anchored vars merged in, explicit key overriding the merged one, and no `<<` leaking through.

**Verified it fails without the source change:**

```
AssertionError: expected { '<<': '[object Object]', …(1) }
                to deeply equal { DB_HOST: 'postgres', …(2) }

- Expected
+ Received
  {
-   "DB_HOST": "postgres",
-   "RAILS_ENV": "production",
+   "<<": "[object Object]",
    "SETTINGS__APP_COMPONENT": "web",
  }
```

- `npx vitest run` in `apps/api` → **113 files, 1161 passed | 3 skipped** (two separate clean runs, 10.82s / 10.31s).
- `tsc --noEmit` → exit 0.
- Reproduced against committed `HEAD` in a detached worktree: all four affected services parse their full env, `services still carrying a "<<" key: 0` (was 4).
- Touched-file scope only; lockfile untouched, no unrelated churn.

## Scope

Closes #286. Two files, one commit.

Same class as the long-form volume/port series (#133 / #135 / #140): a compose spelling whose intent is honored end to end once parsed, but which the parser silently drops before anything downstream can act on it. Non-overlapping with any open PR — no other PR touches `compose-parser.ts`.

Merge keys are the only YAML 1.1 carry-over enabled here; nothing else about the parse changes, and files without anchors are byte-for-byte unaffected.
