### PR TITLE
Fix Cloud sign-in on private HTTP dashboards

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -16,6 +16,7 @@
     "clean": "rm -rf .next .turbo node_modules"
   },
   "dependencies": {
+    "@noble/hashes": "^2.0.1",
     "@radix-ui/react-slot": "^1.2.4",
     "@repo/core": "workspace:*",
     "@repo/onboarding": "workspace:*",

--- a/apps/dashboard/src/app/cloud-connect-callback/page.tsx
+++ b/apps/dashboard/src/app/cloud-connect-callback/page.tsx
@@ -42,6 +42,14 @@ function CloudConnectCallbackInner() {
   const [errorMessage, setErrorMessage] = useState<string>("");
 
   useEffect(() => {
+    if (searchParams.get("setup_error") === "pkce") {
+      setStatus("error");
+      setErrorMessage(
+        "Openship could not securely start the Cloud sign-in. Close this window and try again.",
+      );
+      return;
+    }
+
     const code = searchParams.get("code");
     const state = searchParams.get("state") ?? "";
 

--- a/apps/dashboard/src/context/CloudContext.tsx
+++ b/apps/dashboard/src/context/CloudContext.tsx
@@ -351,7 +351,14 @@ export function CloudProvider({ children }: { children: ReactNode }) {
     const handle = openAuthWindow();
     prepareConnectUrl()
       .then((url) => handle.navigate(url))
-      .catch(() => handle.close());
+      .catch((error) => {
+        // Never silently close the popup. Self-hosted dashboards are often
+        // served over private-LAN HTTP, where browser security APIs differ
+        // from HTTPS. Keep the window open with an actionable local error if
+        // setup still fails after the PKCE fallback.
+        console.error("Unable to prepare Openship Cloud sign-in", error);
+        handle.navigate(`${window.location.origin}/cloud-connect-callback?setup_error=pkce`);
+      });
     handle.onClose(() => checkStatus());
   }, [prepareConnectUrl, checkStatus]);
 

--- a/apps/dashboard/src/lib/cloud-auth.test.ts
+++ b/apps/dashboard/src/lib/cloud-auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api/urls", () => ({
+  getCloudApiOrigin: () => "https://api.openship.io",
+  getCloudDashboardUrl: () => "https://app.openship.io",
+}));
+
+import { computePkceChallenge } from "./cloud-auth";
+
+describe("computePkceChallenge", () => {
+  it("computes the RFC 7636 S256 example without Web Crypto", async () => {
+    const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+    await expect(computePkceChallenge(verifier, null)).resolves.toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
+  });
+
+  it("matches the Web Crypto implementation", async () => {
+    const verifier = "openship-private-lan-pkce-regression-test";
+
+    const native = await computePkceChallenge(verifier, globalThis.crypto.subtle);
+    const fallback = await computePkceChallenge(verifier, null);
+
+    expect(fallback).toBe(native);
+  });
+});

--- a/apps/dashboard/src/lib/cloud-auth.ts
+++ b/apps/dashboard/src/lib/cloud-auth.ts
@@ -1,4 +1,5 @@
 import { getCloudApiOrigin, getCloudDashboardUrl } from "@/lib/api/urls";
+import { sha256 } from "@noble/hashes/sha2.js";
 
 export const DESKTOP_CLOUD_FLOW = "desktop-cloud";
 const DEFAULT_APP_NAME = "Openship Desktop";
@@ -61,10 +62,16 @@ export function generatePkceVerifier(): string {
 }
 
 /** RFC 7636 S256 code_challenge: base64url(SHA-256(verifier)). */
-export async function computePkceChallenge(verifier: string): Promise<string> {
+export async function computePkceChallenge(
+  verifier: string,
+  subtleCrypto: SubtleCrypto | null | undefined = globalThis.crypto?.subtle,
+): Promise<string> {
   const data = new TextEncoder().encode(verifier);
-  const digest = await crypto.subtle.digest("SHA-256", data);
-  return base64UrlEncode(new Uint8Array(digest));
+  if (subtleCrypto) {
+    const digest = await subtleCrypto.digest("SHA-256", data);
+    return base64UrlEncode(new Uint8Array(digest));
+  }
+  return base64UrlEncode(sha256(data));
 }
 
 /** Random flow id, used as the storage key for the verifier and the

--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
       "name": "@repo/dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@noble/hashes": "^2.0.1",
         "@radix-ui/react-slot": "^1.2.4",
         "@repo/core": "workspace:*",
         "@repo/onboarding": "workspace:*",


### PR DESCRIPTION
## Summary

- preserve PKCE S256 generation when a self-hosted dashboard is served from a private HTTP origin where `crypto.subtle` is unavailable
- keep the auth popup open with an actionable callback error instead of silently closing it when setup fails
- add RFC 7636 and native-vs-fallback regression coverage

## Root cause

The browser flow opens an `about:blank` popup synchronously, then prepares the PKCE handoff asynchronously. On a private-LAN HTTP origin, Web Crypto exposes secure randomness but not `crypto.subtle`. `computePkceChallenge()` therefore rejects, and the existing catch handler immediately closes the popup. To the user, the OpenShip Cloud sign-in window appears and disappears with no explanation.

The fallback uses the already-resolved `@noble/hashes` package to calculate SHA-256 while retaining the existing random verifier and PKCE binding. Native Web Crypto remains the preferred path whenever it is available.

## User impact

- self-hosted users no longer get a flashing, unexplained popup
- PKCE is not disabled or downgraded
- HTTPS and desktop flows continue to use their existing behavior
- any remaining setup failure is rendered in the popup and logged instead of being hidden

## Validation

- `bun run --cwd apps/dashboard test` — 30 tests passed
- RFC 7636 S256 example passes through the fallback
- fallback output matches native Web Crypto output
- production dashboard build passed with the release environment:
  - `NODE_ENV=production`
  - `CLOUD_MODE=false`
  - `OPENSHIP_TARGET=local`
  - `NEXT_PUBLIC_API_PROXY=true`
- reproduced before/after against a self-hosted OpenShip 0.4.8 instance

Contributed by Madd Technologies.
