### PR TITLE
fix(core): workspace detectors read commented-out entries as real ones

### DIFF
--- a/apps/api/test/lib/workspace-detectors.test.ts
+++ b/apps/api/test/lib/workspace-detectors.test.ts
@@ -137,6 +137,46 @@ describe("rush.json detector", () => {
       ),
     ).toEqual(["apps/app"]);
   });
+
+  it("reads a JSONC rush.json (the shape `rush init` generates)", () => {
+    expect(
+      rush.parseSubProjects(`/**
+ * This is the main configuration file for Rush.
+ * For full documentation, please see https://rushjs.io
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
+  "rushVersion": "5.140.0",
+  "pnpmVersion": "8.15.8",
+
+  /**
+   * Rush can manage everything in the repo.
+   */
+  "projects": [
+    // The web app
+    {
+      "packageName": "@org/app",
+      "projectFolder": "apps/app"
+    },
+    {
+      "packageName": "@org/lib",
+      "projectFolder": "libraries/lib" // shared code
+    }
+  ]
+}
+`),
+    ).toEqual(["apps/app", "libraries/lib"]);
+  });
+
+  it("keeps a `//` that lives inside a JSON string", () => {
+    expect(
+      rush.parseSubProjects(`{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
+  "projects": [{ "packageName": "@org/app", "projectFolder": "apps/app" }]
+}
+`),
+    ).toEqual(["apps/app"]);
+  });
 });
 
 // ─── Cargo (Rust) ────────────────────────────────────────────────────────────
@@ -321,6 +361,39 @@ describe("pom.xml (Maven) detector", () => {
   <groupId>com.example</groupId>
   <artifactId>app</artifactId>
   <version>1.0.0</version>
+</project>
+`),
+    ).toEqual([]);
+  });
+
+  it("ignores commented-out <module> entries", () => {
+    expect(
+      maven.parseSubProjects(`<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <packaging>pom</packaging>
+  <modules>
+    <module>app</module>
+    <!-- <module>legacy-api</module> -->
+    <!--
+      <module>experimental</module>
+    -->
+    <module>services/api</module>
+  </modules>
+</project>
+`),
+    ).toEqual(["app", "services/api"]);
+  });
+
+  it("returns [] when the whole <modules> block is commented out", () => {
+    expect(
+      maven.parseSubProjects(`<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <artifactId>app</artifactId>
+  <!--
+  <modules>
+    <module>old</module>
+  </modules>
+  -->
 </project>
 `),
     ).toEqual([]);

--- a/packages/core/src/workspaces/comments.ts
+++ b/packages/core/src/workspaces/comments.ts
@@ -1,0 +1,62 @@
+/**
+ * Comment strippers for the hand-rolled workspace manifest readers.
+ *
+ * Two of the manifests we read allow comments that a strict parser does not:
+ * `rush.json` is JSONC, and `pom.xml` is XML. Removing them before matching
+ * keeps a commented-out entry from being read as a live one - the same rule the
+ * TOML (`#`), Gradle (`//`, block) and go.work (`//`) readers already follow.
+ */
+
+/**
+ * Remove `//` line and block comments from JSON-with-comments.
+ *
+ * String-aware: a `//` inside a JSON string stays put, so the `$schema` URL
+ * every `rush.json` carries survives.
+ */
+export function stripJsonComments(content: string): string {
+  let out = "";
+  let inString = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += content[++i] ?? "";
+        continue;
+      }
+      if (ch === '"') inString = false;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+
+    if (ch === "/" && content[i + 1] === "/") {
+      const newline = content.indexOf("\n", i);
+      if (newline === -1) break;
+      i = newline - 1; // the newline itself is copied on the next iteration
+      continue;
+    }
+
+    if (ch === "/" && content[i + 1] === "*") {
+      const end = content.indexOf("*/", i + 2);
+      if (end === -1) break;
+      i = end + 1;
+      continue;
+    }
+
+    out += ch;
+  }
+
+  return out;
+}
+
+/** Remove `<!-- … -->` comments. XML comments never nest, so the lazy match is exact. */
+export function stripXmlComments(content: string): string {
+  return content.replace(/<!--[\s\S]*?-->/g, "");
+}

--- a/packages/core/src/workspaces/maven.ts
+++ b/packages/core/src/workspaces/maven.ts
@@ -1,3 +1,4 @@
+import { stripXmlComments } from "./comments";
 import type { WorkspaceDetector } from "./types";
 
 /**
@@ -17,10 +18,11 @@ import type { WorkspaceDetector } from "./types";
  * Implementation note: we scope module extraction to the first `<modules>...</modules>`
  * block so we don't accidentally pick up modules listed under `<profiles>` or
  * other irrelevant places. This is the dominant real-world shape; profile-only
- * monorepos are rare.
+ * monorepos are rare. `<!-- … -->` comments are stripped first, so a
+ * commented-out `<module>` is not read as a declared one.
  */
 function parsePomXml(content: string): string[] {
-  const modulesBlock = content.match(/<modules\b[^>]*>([\s\S]*?)<\/modules>/i);
+  const modulesBlock = stripXmlComments(content).match(/<modules\b[^>]*>([\s\S]*?)<\/modules>/i);
   if (!modulesBlock) return [];
 
   const moduleEntries = modulesBlock[1].matchAll(/<module\b[^>]*>\s*([\s\S]*?)\s*<\/module>/gi);

--- a/packages/core/src/workspaces/rush.ts
+++ b/packages/core/src/workspaces/rush.ts
@@ -1,3 +1,4 @@
+import { stripJsonComments } from "./comments";
 import type { WorkspaceDetector } from "./types";
 
 /**
@@ -6,11 +7,15 @@ import type { WorkspaceDetector } from "./types";
  *
  * We pull `projectFolder` from each entry. Rush projects are always literal
  * paths (no globs), so the downstream matcher treats them as exact.
+ *
+ * `rush.json` is JSONC - Rush reads it with a comment-tolerant parser and the
+ * file `rush init` generates opens with a block comment - so comments are
+ * stripped before `JSON.parse`.
  */
 function parseRushJson(content: string): string[] {
   let parsed: { projects?: unknown } | null = null;
   try {
-    parsed = JSON.parse(content) as { projects?: unknown };
+    parsed = JSON.parse(stripJsonComments(content)) as { projects?: unknown };
   } catch {
     return [];
   }


### PR DESCRIPTION
Two of the hand-rolled workspace manifest readers ignore the comment syntax their format allows, so a comment changes the detected repo topology. They fail in opposite directions.

## 1. `rush.json` — the detector never fires on a real Rush repo

`rush.json` is **JSONC**: Rush reads it with a comment-tolerant parser, and the file `rush init` generates opens with a `/** … */` banner and carries `//` notes between entries. `parseRushJson` calls plain `JSON.parse`, which throws on every one of those, and the `catch` returns `[]`.

Input — the stock `rush init` shape (abridged):

```jsonc
/**
 * This is the main configuration file for Rush.
 */
{
  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
  "projects": [
    // The web app
    { "packageName": "@org/app", "projectFolder": "apps/app" },
    { "packageName": "@org/lib", "projectFolder": "libraries/lib" }
  ]
}
```

| | result |
|---|---|
| expected | `["apps/app", "libraries/lib"]` |
| actual | `[]` |

Net effect: the Rush detector is inert on any repo that kept the generated file — no workspace context, no sub-project hints.

## 2. `pom.xml` — commented-out modules are read as declared ones

`parsePomXml` regex-matches `<module>` without stripping `<!-- … -->` first.

```xml
<modules>
  <module>app</module>
  <!-- <module>legacy-api</module> -->
  <!--
    <module>experimental</module>
  -->
  <module>services/api</module>
</modules>
```

| | result |
|---|---|
| expected | `["app", "services/api"]` |
| actual | `["app", "legacy-api", "experimental", "services/api"]` |

And the stronger case — a pom whose **entire** `<modules>` block is commented out still returns `["old"]` instead of `[]`:

```xml
<project>
  <artifactId>app</artifactId>
  <!--
  <modules>
    <module>old</module>
  </modules>
  -->
</project>
```

That one isn't just a stray path. A non-empty result flips `hasAnyWorkspaceContext`, so `discoverMonorepoApps` takes the **formal-workspace** branch and treats a single-module project as a workspace container. Separately, concrete (non-glob) workspace patterns are seeded directly into `discoverProjectRootHints` without any tree confirmation, so a commented-out module becomes a `workspace`-sourced project-root hint for a directory that need not exist in the repo.

## Cause and fix

Every sibling reader in this directory already strips comments before matching — TOML `#` (`toml-helpers`, cargo/uv), Gradle `//` and `/* */`, `go.work` `//`, pnpm YAML `#`. These two were the gap. New `workspaces/comments.ts` adds the two missing strippers and both detectors run their input through it first.

The JSONC stripper is **string-aware**, which matters: a naive `//` strip would corrupt the `https://…` `$schema` URL that every `rush.json` carries. XML comments never nest, so the lazy `<!--[\s\S]*?-->` match is exact.

No public API change — the helpers are internal to `packages/core/src/workspaces/`.

## Tests

Four cases added to `apps/api/test/lib/workspace-detectors.test.ts`:

1. `reads a JSONC rush.json (the shape rush init generates)`
2. `keeps a // that lives inside a JSON string` — pins the string-awareness
3. `ignores commented-out <module> entries`
4. `returns [] when the whole <modules> block is commented out`

**Verified they catch the bug:** with `comments.ts`, `rush.ts` and `maven.ts` stashed, 1 / 3 / 4 fail (`3 failed | 39 passed`); restored, `42 passed`. Case 2 passes either way by design — it's the guard that the fix doesn't break the `$schema` URL.

## Verification

- `bun run test` → **7 successful, 7 total**
- `bun run --cwd apps/api lint` → clean
- `packages/core/src/workspaces/{comments,rush,maven}.ts` → `prettier --check` clean. The test file has **pre-existing** prettier drift on `main` (imports, several `expect(...)` wrappings, line 411, the `parseWorkspaceManifest` blocks), so per CONTRIBUTING I did not run `--write` over it — I confirmed prettier flags no line inside my additions (`140–179`, `365–397`).

## Alternative

The Rush half could instead be "try `JSON.parse`, and only strip comments on failure", keeping the fast path byte-identical. I went with unconditional stripping because it's the same shape as the other readers here and the string-aware pass is cheap. Happy to switch if you'd prefer the fallback form, or to split this into two PRs if you'd rather review the Rush and Maven halves separately.
