### PR TITLE
fix(core): Gradle settings reader drops every module but the first in a multi-line include

### DIFF
--- a/apps/api/test/lib/workspace-detectors.test.ts
+++ b/apps/api/test/lib/workspace-detectors.test.ts
@@ -349,10 +349,39 @@ include(":services:worker")
     ).toEqual(["services/api", "services/worker"]);
   });
 
+  it("parses a multi-line Kotlin include( … ) list", () => {
+    expect(
+      gradle.parseSubProjects(`rootProject.name = "monorepo"
+include(
+    ":app",
+    ":feature:login",
+    ":core:data",
+)
+`),
+    ).toEqual(["app", "feature/login", "core/data"]);
+  });
+
+  it("parses a Groovy include continued over lines with a trailing comma", () => {
+    expect(
+      gradle.parseSubProjects(`include ':app',
+        ':libs:shared'
+`),
+    ).toEqual(["app", "libs/shared"]);
+  });
+
   it("ignores includeBuild (composite builds, not modules)", () => {
     expect(
       gradle.parseSubProjects(`rootProject.name = "root"
 includeBuild("../shared-lib")
+include 'app'
+`),
+    ).toEqual(["app"]);
+  });
+
+  it("ignores includeFlat (sibling directories outside the repo root)", () => {
+    expect(
+      gradle.parseSubProjects(`rootProject.name = "root"
+includeFlat 'sibling-lib'
 include 'app'
 `),
     ).toEqual(["app"]);

--- a/packages/core/src/workspaces/gradle.ts
+++ b/packages/core/src/workspaces/gradle.ts
@@ -1,12 +1,47 @@
 import type { WorkspaceDetector } from "./types";
 
 /**
+ * Read the argument list of one `include` call, starting just past the keyword.
+ *
+ * Parenthesized form (`include(...)`) runs to the matching `)`, so a list split
+ * over several lines is read whole. The bare form runs to end of line, plus any
+ * following lines while the previous one ends in a comma (Groovy's line
+ * continuation).
+ */
+function readIncludeArgs(content: string, start: number): string {
+  let i = start;
+  while (content[i] === " " || content[i] === "\t") i++;
+
+  if (content[i] === "(") {
+    let depth = 0;
+    for (let j = i; j < content.length; j++) {
+      if (content[j] === "(") depth++;
+      else if (content[j] === ")" && --depth === 0) return content.slice(i + 1, j);
+    }
+    return content.slice(i + 1);
+  }
+
+  let args = "";
+  for (;;) {
+    const newline = content.indexOf("\n", i);
+    const line = newline === -1 ? content.slice(i) : content.slice(i, newline);
+    args += line;
+    if (newline === -1 || !line.trimEnd().endsWith(",")) return args;
+    i = newline + 1;
+  }
+}
+
+/**
  * Gradle multi-project - `settings.gradle` or `settings.gradle.kts` declares
  * the included sub-projects via `include` calls:
  *
  *     include 'app', 'libs:shared'
  *     include(":services:api")
  *     include ":services:worker"
+ *     include(
+ *         ":feature:login",
+ *         ":core:data",
+ *     )
  *
  * Gradle uses colon-prefixed paths (`:services:api`); we convert them to
  * slash-separated filesystem paths (`services/api`) since that's how the rest
@@ -23,13 +58,14 @@ function parseGradleSettings(content: string): string[] {
     .join("\n");
 
   const paths: string[] = [];
-  const includePattern = /include\s*(?:\(\s*)?((?:[^()\n]+))(?:\))?/g;
+  // `include` as its own call. The word boundary excludes the settings-level
+  // `includeBuild` / `includeFlat`, which reference other builds and sibling
+  // directories rather than modules of this build.
+  const includePattern = /\binclude\b/g;
 
   let match: RegExpExecArray | null;
   while ((match = includePattern.exec(cleaned)) !== null) {
-    const args = match[1];
-    // Skip Gradle settings-level calls like `includeBuild` (which composes builds, not modules).
-    if (/^Build\b/.test(args)) continue;
+    const args = readIncludeArgs(cleaned, match.index + match[0].length);
     // Capture every quoted string in this include() call.
     const stringPattern = /"([^"]+)"|'([^']+)'/g;
     let stringMatch: RegExpExecArray | null;


### PR DESCRIPTION
`parseGradleSettings` captures an `include` call's arguments with `[^()\n]+`, which cannot cross a newline. The multi-line form that Android Studio and the Kotlin DSL generate is therefore truncated to its first entry.

## Failing input

`settings.gradle.kts`:

```kotlin
rootProject.name = "monorepo"
include(
    ":app",
    ":feature:login",
    ":core:data",
)
```

| | result |
|---|---|
| expected | `["app", "feature/login", "core/data"]` |
| actual | `["app"]` |

The Groovy continuation form fails identically:

```groovy
include ':app',
        ':libs:shared'
```

| | result |
|---|---|
| expected | `["app", "libs/shared"]` |
| actual | `["app"]` |

The single-line forms already covered by the existing tests (`include 'app', 'libs:shared'` and `include(":services:api")`) are unaffected — the bug is specific to a list broken across lines, which is the shape essentially every multi-module Android project ships.

Consequence beyond the missing paths: workspace patterns feed `hasAnyWorkspaceContext` and are seeded directly into `discoverProjectRootHints`, so the dropped modules never become monorepo sub-app candidates at all.

## Fix

Read the argument list positionally rather than with a line-bound regex:

- `include(` → scan to the matching `)`, newlines included.
- bare `include` → to end of line, plus following lines while the previous one ends in a comma.

The quoted-string extraction, `:a:b` → `a/b` conversion, and dedupe are untouched.

## One behaviour change worth flagging

`includeBuild` used to be skipped by testing the *captured argument text* for a leading `"Build"`. Matching `\binclude\b` excludes it at the token level instead — which also excludes `includeFlat`, previously not skipped.

That is a fix rather than a regression: `includeFlat 'sibling-lib'` resolves to `../sibling-lib`, a sibling of the root directory and outside the repo, but it used to be emitted as the sub-project path `"sibling-lib"` — a directory that doesn't exist at that location. There's a test pinning it now. Say the word if you'd rather keep `includeFlat` emitting and I'll narrow the token match.

## Tests

Three cases added to `apps/api/test/lib/workspace-detectors.test.ts`:

1. `parses a multi-line Kotlin include( … ) list`
2. `parses a Groovy include continued over lines with a trailing comma`
3. `ignores includeFlat (sibling directories outside the repo root)`

**Verified they catch the bug:** with `gradle.ts` stashed, all three fail (`3 failed | 38 passed`); restored, `41 passed`. The pre-existing `include` / `includeBuild` cases pass throughout.

## Verification

- `bun run test` → **7 successful, 7 total**
- `bun run --cwd apps/api lint` → clean
- `packages/core/src/workspaces/gradle.ts` → `prettier --check` clean (and clean on `main`, so no drift introduced). The test file has pre-existing prettier drift on `main`, so per CONTRIBUTING I didn't run `--write` over it; I confirmed prettier flags no line inside my additions (`352–371`, `381–389`).

Independent of #294 (comment handling in the `rush.json` / `pom.xml` readers) — different file, no overlap, either can land first.
