### PR TITLE
fix(api/dashboard): make "Include www" actually connect and route the www variant

### DIFF
--- a/apps/api/src/modules/domains/domain.schema.ts
+++ b/apps/api/src/modules/domains/domain.schema.ts
@@ -26,6 +26,9 @@ export const AddDomainBody = Type.Object({
     pattern: "^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$",
   }),
   isPrimary: Type.Optional(Type.Boolean({ default: false })),
+  /** Also connect the `www.` variant. It becomes its OWN pending row: the edge
+   *  binds one server_name per row and SSL renewal resolves www by hostname. */
+  includeWww: Type.Optional(Type.Boolean({ default: false })),
   /** Externally-managed ingress + TLS (Cloudflare Tunnel, LB): verify via TXT
    *  only, skip certbot, serve plain HTTP. Domain need not resolve to the box. */
   externalIngress: Type.Optional(Type.Boolean({ default: false })),

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -130,6 +130,7 @@ export async function addDomain(ctx: RequestContext, data: TAddDomainBody) {
       project,
       domain.externalIngress,
     );
+    await addWwwSibling(ctx, data, hostname);
     return { domain, records };
   }
 
@@ -155,7 +156,27 @@ export async function addDomain(ctx: RequestContext, data: TAddDomainBody) {
   }
 
   const records = await buildRecords(domain.hostname, token, project, domain.externalIngress);
+  await addWwwSibling(ctx, data, hostname);
   return { domain, records };
+}
+
+/**
+ * "Include www" asks for a SECOND routable hostname, not a flag on the apex row:
+ * the edge binds one server_name per domain row, and SSL provisioning resolves
+ * the www record by hostname (`domain-ssl.ts`, the `includeWww` branch). So the
+ * variant only exists once it has its own row, which then verifies and certs on
+ * its own. Runs after the apex so an apex conflict aborts before we mint www.
+ */
+async function addWwwSibling(ctx: RequestContext, data: TAddDomainBody, hostname: string) {
+  if (!data.includeWww || hostname.startsWith("www.")) return;
+
+  await addDomain(ctx, {
+    projectId: data.projectId,
+    hostname: `www.${hostname}`,
+    // The apex keeps primary — www is a sibling route, not a replacement.
+    isPrimary: false,
+    externalIngress: data.externalIngress,
+  });
 }
 
 /**

--- a/apps/api/src/modules/projects/project.controller.ts
+++ b/apps/api/src/modules/projects/project.controller.ts
@@ -1999,6 +1999,7 @@ export async function connectDomain(c: Context) {
       projectId: id,
       hostname: body.domain.trim(),
       isPrimary: true,
+      includeWww: body.includeWww ?? false,
       externalIngress: body.externalIngress ?? false,
     });
 

--- a/apps/api/test/modules/domains/domain-add.test.ts
+++ b/apps/api/test/modules/domains/domain-add.test.ts
@@ -110,6 +110,33 @@ describe("addDomain retries", () => {
     });
   });
 
+  it("materializes the www variant as its own row when includeWww is set", async () => {
+    domainRepo.findByHostname.mockResolvedValue(null);
+    domainRepo.create.mockImplementation(async (data: any) => ({ id: `dom_${data.hostname}`, ...data }));
+
+    await addDomain(context as any, {
+      projectId: project.id,
+      hostname: "example.com",
+      isPrimary: true,
+      includeWww: true,
+    });
+
+    // The edge binds one server_name per domain row and SSL renewal looks the
+    // www record up by hostname, so "include www" is only real once a second
+    // row exists. Left out, the toggle silently connects the apex alone.
+    expect(domainRepo.create.mock.calls.map(([data]: [any]) => data.hostname)).toEqual([
+      "example.com",
+      "www.example.com",
+    ]);
+    // The apex stays primary — the www row is a sibling, not a replacement.
+    expect(domainRepo.create.mock.calls[1][0]).toMatchObject({
+      hostname: "www.example.com",
+      isPrimary: false,
+      verified: false,
+      status: "pending",
+    });
+  });
+
   it("still rejects a domain owned by another project", async () => {
     domainRepo.findByHostname.mockResolvedValue({
       ...existingDomain,

--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
@@ -734,14 +734,24 @@ export const DomainSettings = () => {
         );
       }
 
+      const target = hasProjectServer
+        ? { port: portValue }
+        : { targetPath: newDomainPath.trim() || "/" };
       const nextEndpoint = createPublicEndpoint({
         domainType: newDomainType,
         ...(isCustom ? { customDomain: host } : { domain: host }),
-        ...(hasProjectServer ? { port: portValue } : { targetPath: newDomainPath.trim() || "/" }),
+        ...target,
       });
+      // publicEndpoints — not the domain rows — are what the backend reconciles
+      // routing against, and it deletes any project row this list omits. So the
+      // www variant has to ship in the same save as the apex or it never binds
+      // a vhost, and the row the connect call just created is dropped again.
+      const nextEndpoints = isCustom && includeWww
+        ? [nextEndpoint, createPublicEndpoint({ domainType: "custom", customDomain: `www.${host}`, ...target })]
+        : [nextEndpoint];
       const label = isCustom ? host : `${host}.${baseDomain}`;
       const ok = await persistPublicEndpoints(
-        [...publicEndpoints, nextEndpoint],
+        [...publicEndpoints, ...nextEndpoints],
         isCustom
           ? interpolate(t.projectSettings.domains.toast.addedCustom, { label })
           : interpolate(t.projectSettings.domains.toast.addedFree, { label }),

--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
@@ -695,8 +695,10 @@ export const DomainSettings = () => {
     const portValue = newDomainPort.trim();
 
     // The "Include www" toggle owns the www record — a hand-typed "www."
-    // prefix would double it up, so block it with guidance instead.
-    if (isCustom && host.startsWith("www.")) {
+    // prefix would double it up, so block it with guidance instead. Only while
+    // the toggle is ON: with it off nothing else claims the variant, and the
+    // block was the sole reason www could not be added as a domain at all.
+    if (isCustom && includeWww && host.startsWith("www.")) {
       showToast(t.projectSettings.domains.add.noWww, "error", t.projectSettings.domains.toast.addDomainTitle);
       return;
     }


### PR DESCRIPTION
## Problem

"Include www" does nothing. The toggle is offered on the add-domain form, the CLI exposes it as `--include-www`, and the request body carries it — but `www.<domain>` never becomes reachable and no www record is ever created.

The same feature also blocked the manual escape hatch: typing `www.example.com` as a domain was rejected outright, so neither path produced a working www.

## Cause

Two independent defects, both on the "include www" path.

**1. The flag was accepted and dropped.** `connectDomain` types `includeWww` on its body and then forwards four other fields (`project.controller.ts:1998`):

```ts
const body = await c.req.json<{ domain: string; includeWww?: boolean; externalIngress?: boolean }>();
...
const result = await domainService.addDomain(getRequestContext(c), {
  projectId: id,
  hostname: body.domain.trim(),
  isPrimary: true,
  externalIngress: body.externalIngress ?? false,   // includeWww is gone
});
```

`AddDomainBody` had no such field and nothing under `modules/domains/` referenced www, so the flag had no implementation to reach. That also left the `includeWww` branch in `domain-ssl.ts:288` permanently dead — it resolves the www record by hostname and no code path had ever created that row.

**2. Even a www row would not have survived.** `publicEndpoints`, not the domain rows, are what routing reconciles against, and `syncProjectPublicRoutes` deletes every project-level row the submitted list omits (`project-route-store.ts:107`):

```ts
for (const domain of existingDomains) {
  if (!desiredByHostname.has(domain.hostname.toLowerCase())) {
    await repos.domain.remove(domain.id);
  }
}
```

The add-domain form sends only the apex endpoint, so the www row would have been removed by the save that immediately follows the connect call. Driving the real `addDomain` + `syncProjectPublicRoutes` over an in-memory domain table, replaying the form's two-step flow:

| step | rows after |
|---|---|
| connect `{ domain, includeWww: true }`, then save `[apex]` | `example.com` only |
| seed apex **and** www, then save `[apex]` | `www.example.com` deleted |
| save `[apex, www]` | both rows, both routable |

That last row is the shape the fix had to take: the variant has to be in the endpoint list, not just in the domain table.

**3. The manual path was closed too.** `DomainSettings.tsx:699` rejected any custom hostname starting with `www.` unconditionally, on the premise that the toggle owns that record. With the toggle owning nothing, both routes to a www domain were shut. The reported workaround was to delete the apex, add `www.` as the primary, then re-add the apex as a secondary.

## Fix

**API — `includeWww` reaches the service and mints the row.** Added to `AddDomainBody`; `addDomain` materializes the variant as its own pending row. www is a second routable hostname, not a flag on the apex row — the edge binds one `server_name` per row (`nginx.ts:601`) — so it recurses through `addDomain` to reuse hostname validation, the cross-project conflict check and the interrupted-connect retry path. It runs after the apex, so an apex conflict aborts before the sibling is minted, and the apex keeps `isPrimary`.

**Dashboard — the variant ships in the endpoint list.** Both endpoints go in the same save when the toggle is on, sharing the apex's port or target path, so the variant reaches the reconciler and survives it. It stays pending until its own DNS verification, matching how every other custom domain is treated.

**Dashboard — the `www.` guard is gated on the toggle.** It now fires exactly when the toggle would in fact double up the record, instead of on every submission.

## Tests

Added one regression case to `apps/api/test/modules/domains/domain-add.test.ts` on the existing mocked-repo harness. It asserts the created hostnames in order and pins that the sibling is non-primary and pending, so it covers both "www exists" and "the apex is not displaced".

**Verified it fails without the source change:**

```
AssertionError: expected [ 'example.com' ] to deeply equal [ 'example.com', 'www.example.com' ]

- Expected
+ Received

  [
    "example.com",
-   "www.example.com",
  ]
```

- `npx vitest run` in `apps/api` → **113 files, 1161 passed | 3 skipped** (two separate clean runs, 9.85s / 9.76s).
- `npx vitest run` in `apps/dashboard` → **5 files, 28 passed** (two separate clean runs).
- `tsc --noEmit` → exit 0 in both apps.
- Reproduced against committed `HEAD`, replaying the flow end to end:

```
after connect : [ 'example.com', 'www.example.com' ]
after save    : [ 'example.com     port=3000 primary=true  verified=false',
                  'www.example.com port=3000 primary=false verified=false' ]
routed vhosts : [ 'example.com -> :3000', 'www.example.com -> :3000' ]
```

`routed vhosts` is `deriveProjectRouteState`'s output — the list the edge binds. Before the change it held the apex alone.

The dashboard edit has no unit test: `handleSubmitDomains` is inline in a 2000-line component and extracting it would be a refactor well outside this fix. It is covered by typecheck plus the endpoint-list behavior pinned above, which is the contract it now relies on.

## Scope

Addresses #289, items 2.2 (www never routes) and 2.3 (manual www entry blocked). Not marked `Closes` — the issue bundles two more reports that this does not touch, listed below. Three commits:

1. `fix(api): honor includeWww when connecting a custom domain` — schema, service, controller, regression test
2. `fix(dashboard): only block a typed www. host while Include www is on`
3. `fix(dashboard): save the www variant as a public endpoint so it routes`

Deliberately **not** in this PR:

- **Item 1** — SSL not auto-applied on project creation. Different subsystem (`ssl.service.ts` and the deploy pipeline), unrelated cause; folding it in would mix two root causes in one review.
- **Item 2.1** — the toggle missing from the create-project wizard. Component placement, not a defect on this path.

Both deserve their own change; happy to take either next.

Not proven here: no live deploy was run. The vhost binding is traced through `deriveProjectRouteState` → `reapplyProjectLiveRoutes` → `nginx.ts:601`, not observed on a real edge. Non-overlapping with any open PR — the three others touching `domain.service.ts` (#196, #293) are hundreds of lines away, and nothing else touches `DomainSettings.tsx`.
