### PR TITLE
fix(core): Spring YAML port detection picks up any `port:` key in the document

### DIFF
--- a/apps/api/test/lib/language-detectors.test.ts
+++ b/apps/api/test/lib/language-detectors.test.ts
@@ -198,6 +198,38 @@ describe("JVM port detection from Spring config", () => {
     });
     expect(r.port).toBe(8080);
   });
+
+  /** `application.yml`, where a `port:` key belongs to whichever mapping encloses it. */
+  const yamlPort = (yml: string) =>
+    detectStack([{ name: "pom.xml" }], undefined, {
+      "pom.xml":
+        "<project><parent><artifactId>spring-boot-starter-parent</artifactId></parent></project>",
+      "application.yml": yml,
+    }).port;
+
+  it("reads server.port from a YAML block", () => {
+    expect(yamlPort("server:\n  port: 8081\n")).toBe(8081);
+    expect(yamlPort('server:\n  port: "8081"\n')).toBe(8081);
+    expect(yamlPort("server:\n  ssl:\n    enabled: true\n  port: 8443\n")).toBe(8443);
+    expect(yamlPort("server: {port: 8081}\n")).toBe(8081);
+  });
+
+  it("keeps the stack default when only another mapping declares a port", () => {
+    expect(
+      yamlPort("server:\n  servlet:\n    context-path: /api\nspring:\n  mail:\n    port: 587\n"),
+    ).toBe(8080);
+    expect(yamlPort("spring:\n  data:\n    redis:\n      port: 6379\n")).toBe(8080);
+    expect(yamlPort("spring:\n  datasource:\n    port: 5432\n")).toBe(8080);
+    expect(yamlPort("server:\n  # port: 9999\n  servlet:\n    context-path: /api\n")).toBe(8080);
+  });
+
+  it("prefers the top-level server.port over management.server.port", () => {
+    expect(yamlPort("management:\n  server:\n    port: 9091\nserver:\n  port: 8081\n")).toBe(8081);
+  });
+
+  it("still reads a top-level bare port", () => {
+    expect(yamlPort("port: 7000\n")).toBe(7000);
+  });
 });
 
 describe(".NET recipe", () => {

--- a/packages/core/src/languages/java.ts
+++ b/packages/core/src/languages/java.ts
@@ -24,10 +24,48 @@ function clampPort(raw: string): number | null {
   return port > 0 && port <= 65535 ? port : null;
 }
 
+const YAML_PORT_RE = /^port:\s*["']?(\d{2,5})/;
+
+/**
+ * `server.port` from a YAML document: the `port:` scalar that is a direct child
+ * of a top-level `server:` mapping, in block or flow form. Returns null when the
+ * document has no such key.
+ */
+function springYamlPort(yml: string): string | null {
+  const inline = yml.match(/^server:\s*\{[^}]*\bport:\s*["']?(\d{2,5})/m);
+  if (inline) return inline[1]!;
+
+  let inServer = false;
+  let childIndent: number | null = null;
+  for (const raw of yml.split("\n")) {
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+
+    if (inServer) {
+      if (indent > 0) {
+        if (childIndent === null) childIndent = indent;
+        if (indent === childIndent) {
+          const m = trimmed.match(YAML_PORT_RE);
+          if (m) return m[1]!;
+        }
+        continue;
+      }
+      inServer = false;
+    }
+
+    if (indent === 0 && /^server:$/.test(trimmed)) {
+      inServer = true;
+      childIndent = null;
+    }
+  }
+  return null;
+}
+
 /**
  * Recover the port from Spring-style config. `server.port=9090` in
- * application.properties, or a `server:\n  port: 9090` block (or a bare
- * `port:`) in application.yml/yaml.
+ * application.properties, or a `server:\n  port: 9090` block (or a top-level
+ * bare `port:`) in application.yml/yaml.
  *
  * Deliberately does NOT match `server.port=${PORT:8080}` — when the app reads
  * the port from an env var the runtime already injects `PORT`, so the stack's
@@ -46,8 +84,8 @@ function detectJavaPort(context: PortDetectionContext): number | null {
   for (const name of ["application.yml", "application.yaml"]) {
     const yml = fc[name];
     if (!yml) continue;
-    const m = yml.match(/server:[\s\S]*?\bport:\s*["']?(\d{2,5})/) ?? yml.match(/^\s*port:\s*["']?(\d{2,5})/m);
-    if (m) return clampPort(m[1]);
+    const port = springYamlPort(yml) ?? yml.match(/^port:\s*["']?(\d{2,5})/m)?.[1];
+    if (port) return clampPort(port);
   }
 
   return null;


### PR DESCRIPTION
## Problem

`detectJavaPort` reads `server.port` out of `application.yml` with a regex that scans the **whole document**:

```ts
const m = yml.match(/server:[\s\S]*?\bport:\s*["']?(\d{2,5})/)
       ?? yml.match(/^\s*port:\s*["']?(\d{2,5})/m);
```

Neither branch is scoped to the `server:` mapping. The first is a lazy match that will happily jump past the end of the `server:` block to find a `port:`; the second's `^\s*` matches **any** indentation, so a deeply nested key satisfies the "bare `port:`" fallback.

`port:` is a common key under other Spring mappings — `spring.mail.port`, `spring.data.redis.port`, `spring.datasource.port`, `management.server.port` — so ordinary configs resolve to the wrong port:

| `application.yml` | expected | actual |
| --- | --- | --- |
| `server:` block with no port, then `spring.mail.port: 587` | 8080 (stack default) | **587** |
| no `server:` block, `spring.data.redis.port: 6379` | 8080 | **6379** |
| `spring.datasource.port: 5432` | 8080 | **5432** |
| `management.server.port: 9091` before `server.port: 8081` | 8081 | **9091** |

This isn't cosmetic: `stack-detector.ts` wires the result straight into `StackResult.port` (`detectPortFromLanguages(...) ?? stackDef.defaultPort`), which becomes the container port openship exposes, proxies to, and health-checks. A Spring Boot app that mentions Redis on 6379 in its `application.yml` gets deployed with its ingress pointed at 6379, where nothing is listening.

Only `application.properties` had test coverage, which is why this went unnoticed — the YAML path had none.

## Fix

Replace the document-wide regex with a small indentation-aware scan (`springYamlPort`) that returns the `port:` scalar which is a **direct child of a top-level `server:` mapping**, and anchor the bare-`port:` fallback to column 0 so a nested key can no longer satisfy it.

Preserved behaviours: block form, quoted values (`port: "8081"`), `port:` appearing after sibling sub-mappings (`server:` → `ssl:` → … → `port:`), the inline flow form `server: {port: 8081}`, a genuine top-level bare `port:`, comment lines, and the existing `${PORT:8080}` opt-out.

## Tests

Four cases added to `apps/api/test/lib/language-detectors.test.ts`, alongside the existing properties-file ones:

- `reads server.port from a YAML block` — block, quoted, port-after-sibling, and flow forms
- `keeps the stack default when only another mapping declares a port` — the `spring.mail` / `redis` / `datasource` / commented-out cases
- `prefers the top-level server.port over management.server.port`
- `still reads a top-level bare port`

**Verified they catch the bug:** with `packages/core/src/languages/java.ts` stashed, two fail —

```
× keeps the stack default when only another mapping declares a port
  AssertionError: expected 587 to be 8080
× prefers the top-level server.port over management.server.port
  AssertionError: expected 9091 to be 8081
```

— and both pass with the fix restored.

## Alternative

A real YAML parser would be more rigorous than a line scan, but `@repo/core` has no YAML dependency and this module is deliberately regex-only (`java.ts` notes it has "no Maven XML parser, no Gradle DSL parser"). The scan keeps the zero-dep constraint while being correct for the block and flow shapes Spring configs actually use. Happy to switch if you'd rather pull in a parser here.

## Verification

- `bun run test` → **7/7 turbo tasks successful** (`@repo/api` 114 files / 1182 passed, `@repo/core` 19, `@repo/adapters` 69, `@repo/db` 9, `openship` 21, dashboard 6, desktop 1)
- `bun run --cwd apps/api lint` → clean
- Both touched files carry pre-existing prettier drift on `main`, so per CONTRIBUTING I hand-formatted rather than running `--write`; `npx prettier --parser typescript < file | diff - file` touches no line I added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)