### PR TITLE
Close Cloud popup after successful login

### DIFF
--- a/apps/dashboard/src/app/cloud-connect-callback/page.tsx
+++ b/apps/dashboard/src/app/cloud-connect-callback/page.tsx
@@ -29,6 +29,7 @@ import { Loader2, Check, AlertCircle } from "lucide-react";
 import { cloudApi } from "@/lib/api";
 import { getApiErrorMessage } from "@/lib/api/client";
 import { CONNECT_PKCE_STORAGE_PREFIX } from "@/lib/cloud-auth";
+import { closeAuthWindowAfterSuccess } from "@/utils/authWindow";
 import { AuthShell } from "@/components/auth-shell";
 import { useI18n } from "@/components/i18n-provider";
 
@@ -94,15 +95,9 @@ function CloudConnectCallbackInner() {
         } catch {
           /* opener gone / cross-origin throws — ignore */
         }
-        if (window.opener) {
-          setTimeout(() => {
-            try {
-              window.close();
-            } catch {
-              /* user closed manually */
-            }
-          }, 600);
-        }
+        // Cloud login may clear window.opener via Cross-Origin-Opener-Policy.
+        // The popup is still script-opened and should close after success.
+        closeAuthWindowAfterSuccess();
       })
       .catch((err) => {
         setStatus("error");

--- a/apps/dashboard/src/utils/authWindow.test.ts
+++ b/apps/dashboard/src/utils/authWindow.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { closeAuthWindowAfterSuccess } from "./authWindow";
+
+describe("closeAuthWindowAfterSuccess", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("closes a script-opened auth popup even when no opener is available", () => {
+    vi.useFakeTimers();
+    const close = vi.fn();
+
+    closeAuthWindowAfterSuccess(600, { close });
+
+    expect(close).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(600);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("does not surface a browser close error after connection succeeds", () => {
+    vi.useFakeTimers();
+    const close = vi.fn(() => {
+      throw new Error("close denied");
+    });
+
+    closeAuthWindowAfterSuccess(0, { close });
+
+    expect(() => vi.runAllTimers()).not.toThrow();
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/dashboard/src/utils/authWindow.ts
+++ b/apps/dashboard/src/utils/authWindow.ts
@@ -29,6 +29,27 @@ export interface AuthWindowHandle {
 /** Factory function signature - consumers only see this. */
 export type WindowOpenerFn = (initialUrl?: string) => AuthWindowHandle;
 
+/**
+ * Close the current browser auth popup after a successful callback.
+ *
+ * OAuth providers may apply Cross-Origin-Opener-Policy while the popup is on
+ * their origin. That deliberately clears `window.opener`, but the window is
+ * still script-opened and may close itself after it returns to our callback.
+ * Never gate this close on the opener reference.
+ */
+export function closeAuthWindowAfterSuccess(
+  delayMs = 600,
+  targetWindow: Pick<Window, "close"> = window,
+): void {
+  setTimeout(() => {
+    try {
+      targetWindow.close();
+    } catch {
+      /* window already closed / browser denied close */
+    }
+  }, delayMs);
+}
+
 /* ── Environment detection ────────────────────────────────────────── */
 
 function isElectron(): boolean {


### PR DESCRIPTION
## What changed

- close the Cloud authentication popup after a successful local finalize even when `window.opener` is unavailable
- keep the existing best-effort `postMessage` refresh when the opener survives
- add regression coverage for the self-close delay and browser close errors

## Root cause

The OpenShip Cloud login origin can apply `Cross-Origin-Opener-Policy` during the OAuth-style handoff. That severs `window.opener`. The callback page incorrectly used the opener reference as the condition for calling `window.close()`, so a successful script-opened popup could remain visible indefinitely.

## Impact

Self-hosted users get a predictable completion flow: the popup stays open while sign-in is in progress, shows success after the local connection is finalized, and then closes automatically. The dashboard still refreshes from the popup-close poll if cross-origin isolation prevents `postMessage`.

## Validation

- `bun run --cwd apps/dashboard test` — 32/32 tests passed
- production Next.js build with the local/self-hosted proxy configuration — passed
- `git diff --check` — passed
- reproduced the affected Cloud login handoff with `window.opener === null`
