### PR TITLE
fix(core): PEP 621 dependencies are dropped when `[project]` holds another array

### DIFF
--- a/apps/api/test/lib/language-detectors.test.ts
+++ b/apps/api/test/lib/language-detectors.test.ts
@@ -4,7 +4,14 @@ import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { detectStack, type RepoFile } from "../../src/lib/stack-detector";
-import { STACKS, LANGUAGES, getRuntimeImage, type StackId, type StackDefinition } from "@repo/core";
+import {
+  STACKS,
+  LANGUAGES,
+  collectDependencies,
+  getRuntimeImage,
+  type StackId,
+  type StackDefinition,
+} from "@repo/core";
 
 /**
  * Per-stack recipe validation. Loads the real fixtures in `fixtures/deploy/`
@@ -143,6 +150,53 @@ describe("package-manager-aware Python install", () => {
     });
     expect(r.stack).toBe("django");
     expect(r.buildCommand).toBe("pip install -r requirements.txt && python manage.py collectstatic --noinput");
+  });
+});
+
+describe("PEP 621 [project].dependencies", () => {
+  const deps = (toml: string) => Object.keys(collectDependencies({ "pyproject.toml": toml }));
+
+  it("reads dependencies listed after another array-valued key", () => {
+    expect(
+      deps(
+        '[project]\nname = "svc"\nauthors = [{ name = "Ada", email = "ada@example.com" }]\ndependencies = ["fastapi", "uvicorn"]\n',
+      ),
+    ).toEqual(["fastapi", "uvicorn"]);
+
+    expect(
+      deps(
+        '[project]\nname = "svc"\nclassifiers = ["Private :: Do Not Upload"]\ndependencies = ["flask"]\n',
+      ),
+    ).toEqual(["flask"]);
+  });
+
+  it("keeps reading past a requirement that carries extras", () => {
+    expect(
+      deps('[project]\nname = "svc"\ndependencies = ["uvicorn[standard]", "fastapi"]\n'),
+    ).toEqual(["uvicorn", "fastapi"]);
+    expect(
+      deps(
+        '[project]\nname = "svc"\ndependencies = ["fastapi", "uvicorn[standard]", "sqlalchemy"]\n',
+      ),
+    ).toEqual(["fastapi", "uvicorn", "sqlalchemy"]);
+  });
+
+  it("stops at the end of the [project] table", () => {
+    expect(
+      deps(
+        '[project]\nname = "svc"\ndependencies = ["fastapi"]\n\n[tool.pytest.ini_options]\naddopts = ["-q"]\n',
+      ),
+    ).toEqual(["fastapi"]);
+    expect(deps('[project]\nname = "svc"\n\n[tool.uv]\ndependencies = ["ruff"]\n')).toEqual([]);
+  });
+
+  it("resolves the framework recipe for a manifest with project metadata", () => {
+    const r = detectStack([{ name: "pyproject.toml" }, { name: "main.py" }], undefined, {
+      "pyproject.toml":
+        '[project]\nname = "svc"\nrequires-python = ">=3.12"\nauthors = [{ name = "Ada" }]\ndependencies = ["fastapi", "uvicorn"]\n',
+    });
+    expect(r.stack).toBe("fastapi");
+    expect(r.startCommand).toBe("uvicorn main:app --host 0.0.0.0 --port 8000");
   });
 });
 

--- a/packages/core/src/languages/python.ts
+++ b/packages/core/src/languages/python.ts
@@ -28,13 +28,39 @@ function parseRequirementsTxt(content: string): Record<string, string> {
   return deps;
 }
 
+/**
+ * Contents of the array literal assigned to `key` in a TOML table body, or null
+ * when the key is absent. Scans for the closing `]` tracking quote state and
+ * nesting, so brackets inside values (`"uvicorn[standard]"`) don't end it.
+ */
+function sliceArrayValue(body: string, key: string): string | null {
+  const open = body.match(new RegExp(`(?:^|\\n)\\s*${key}\\s*=\\s*\\[`));
+  if (!open || open.index === undefined) return null;
+
+  const from = open.index + open[0].length;
+  let depth = 1;
+  let quote: string | null = null;
+  for (let i = from; i < body.length; i++) {
+    const char = body[i];
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === "[") depth++;
+    else if (char === "]" && --depth === 0) return body.slice(from, i);
+  }
+  return null;
+}
+
 function parsePyprojectToml(content: string): Record<string, string> {
   const deps: Record<string, string> = {};
 
   // PEP 621 standard: [project].dependencies = ["flask>=2.0", "sqlalchemy"]
-  const pep621 = content.match(/\[project\][^[]*?dependencies\s*=\s*\[([\s\S]*?)\]/);
-  if (pep621) {
-    const items = pep621[1].matchAll(/["']([^"']+)["']/g);
+  const project = content.match(/\[project\]([\s\S]*?)(?=\n\[|$)/);
+  const pep621 = project ? sliceArrayValue(project[1], "dependencies") : null;
+  if (pep621 !== null) {
+    const items = pep621.matchAll(/["']([^"']+)["']/g);
     for (const item of items) {
       const m = item[1].match(/^([A-Za-z0-9][A-Za-z0-9._-]*)/);
       if (m) deps[normalizeName(m[1])] = "*";


### PR DESCRIPTION
## Problem

`parsePyprojectToml` finds the PEP 621 dependency list with a single regex:

```ts
content.match(/\[project\][^[]*?dependencies\s*=\s*\[([\s\S]*?)\]/)
```

Neither half survives contact with a real `pyproject.toml`:

1. **`[^[]*?` cannot cross a `[`.** Any array-valued key declared before `dependencies` — `authors`, `classifiers`, `keywords`, `maintainers` — breaks the match outright, and **every dependency is lost**.
2. **`([\s\S]*?)\]` stops at the first `]`.** A requirement carrying extras (`"uvicorn[standard]"`) closes the array early, so entries after it are lost — and when the extras entry comes first, the list comes back empty.

Both fail silently: the deps map is just empty, framework detection finds nothing, and the project falls back to the generic `python` stack.

| `[project]` manifest | detected deps (before) | after |
|---|---|---|
| `authors = [{ name = "Ada" }]` then `dependencies = ["fastapi", "uvicorn"]` | `{}` | `fastapi, uvicorn` |
| `classifiers = ["Private :: Do Not Upload"]` then `dependencies = ["flask"]` | `{}` | `flask` |
| `dependencies = ["uvicorn[standard]", "fastapi"]` | `{}` | `uvicorn, fastapi` |
| `dependencies = ["fastapi", "uvicorn[standard]", "sqlalchemy"]` | `fastapi` | `fastapi, uvicorn, sqlalchemy` |

The user-visible end of it — a stock FastAPI manifest that happens to declare `authors`:

```toml
[project]
name = "svc"
requires-python = ">=3.12"
authors = [{ name = "Ada", email = "ada@example.com" }]
dependencies = ["fastapi", "uvicorn"]
```

| | stack | start command |
|---|---|---|
| before | `python` | `python app.py` |
| after | `fastapi` | `uvicorn main:app --host 0.0.0.0 --port 8000` |

`python app.py` is not a file this project has, so the deploy starts and dies.

The existing test passes only because its fixture has no array before `dependencies` and no extras:

```ts
'[project]\nname = "svc"\ndependencies = ["fastapi", "uvicorn"]\n'
```

## Fix

Two steps instead of one regex:

1. Slice the `[project]` table with `(?=\n\[|$)` — the same idiom `parsePipfile` and the Poetry branch in this file already use, and it keeps the "don't wander into the next section" property the old `[^[]` was reaching for.
2. Read the array literal with a quote-aware bracket scan (`sliceArrayValue`), so `[` / `]` inside a quoted value can't terminate it.

Poetry, Pipfile and the `optional-dependencies` branches are untouched.

## Tests

Four cases in `apps/api/test/lib/language-detectors.test.ts`:

- array-valued key (`authors`, `classifiers`) before `dependencies`
- extras in first and middle position
- `[project]`-table boundary — a later `[tool.uv] dependencies` must **not** be read, and a trailing section must not truncate
- end-to-end: the manifest above resolves to the `fastapi` recipe

Verified the first three **fail** with `packages/core/src/languages/python.ts` stashed (3 failed / 25 passed) and pass with it restored. The boundary case pins existing behaviour and passes both ways, deliberately.

`bun run test` → 7/7 turbo tasks successful, `apps/api` 1186 passed (1182 on `main` + the 4 new). `bun run --cwd apps/api lint` clean.

`packages/core/src/languages/python.ts` is prettier-clean before and after. `language-detectors.test.ts` has pre-existing prettier drift on `main`; I hand-formatted my own additions to prettier's shape and left the pre-existing lines alone, so the diff stays surgical.

## Alternative

If you'd rather not carry a hand-rolled scanner, the same two bugs can be fixed by keeping the regex and just widening it (`[\s\S]*?` for the table, `["']\s*\]` for the terminator) — smaller diff, but it re-opens the "wanders into the next section" hole and still mis-handles a bare `]` inside a value. Happy to switch if you prefer that trade.
