### PR TITLE
fix www, edge logs crache, memory leak in the executer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -317,6 +317,53 @@ Goal: mail ships as **server image + admin image**, administrable on its own.
 
 ---
 
+## Migrate / edge
+
+### Adopted static roots need an explicit decision step in the CLI
+
+**Shipped:** `unreachableStaticRoots()`
+(`packages/adapters/src/system/proxy/import/index.ts`) reports adopted `static`
+sites whose docroot sits outside `EDGE_CONTAINER_MOUNTS` — i.e. the paths the
+containerized edge cannot read.
+
+**Not shipped:** anything that acts on it. Found on a live 15-site migration: two
+sites (`root /home/App.Front/dist/site/browser`) came up **500** —
+`rewrite or internal redirection cycle while internally redirecting to
+"/index.html"`, because `try_files` can't find an index in a directory that isn't
+mounted. Nothing warned; the operator saw two broken sites and no reason.
+
+- [ ] Migrate wizard: after the scan, if `unreachableStaticRoots()` is non-empty,
+      show the paths and make the operator choose per site (or once for all):
+      **copy** the tree under `/opt/openship/static` (already mounted — works
+      immediately, but a snapshot: rebuilding the frontend needs a re-copy),
+      **mount** the host path into the edge (correct long-term; costs an edge
+      recreate, which blips every site on the box), or **leave** it with the 500
+      spelled out. Same shape as the existing "N config items won't migrate"
+      block, but a decision rather than a warning.
+- [ ] Whichever action runs must rewrite the route's `staticRoot` (and the
+      `<slug>.route.json` beside the vhost — `provisionCert` replays it after every
+      renewal, so a root fixed only in the `.conf` reverts on renew).
+- [ ] The mount path needs a way to add a bind mount without hand-editing
+      `docker-compose.yml` — the edge is the one container whose mounts depend on
+      what the box was serving before us.
+
+### SSL provisioning is invisible in the deploy log
+
+A new project's route is registered with `tls: true`, but the 443 block is only
+emitted once the cert exists (`packages/adapters/src/infra/nginx.ts:594`
+`route.tls && certsExist(domain)`), so there is a ~1 minute window where the site
+answers HTTP and nothing on HTTPS. Verified end-to-end on a live box: cert written
+`01:00:13.137`, vhost re-rendered with TLS `01:00:13.661`, `https=200` right after
+— the pipeline is correct, but during the gap it is indistinguishable from broken,
+and two people have now reported it as an SSL bug.
+
+- [ ] Log it: "route live on HTTP — provisioning the certificate, HTTPS in ~1 min"
+      at registration, then a line when the cert lands (or fails). Issuance is
+      best-effort by design ("domains never fail a deploy"), which is exactly why
+      the *silence* has to go.
+
+---
+
 ## Open TODO markers in code
 
 Verified present; listed so they aren't lost.

--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -1,6 +1,5 @@
 import {
   createPlatform,
-  createHostExecutor,
   DockerRuntime,
   type CommandExecutor,
   type DockerConnectionOptions,
@@ -437,7 +436,17 @@ export async function resolveServerExecutor(
     if (!server.isLocal) {
       repos.server.update(server.id, { isLocal: true }).catch(() => {});
     }
-    return { id: server.id, executor: createHostExecutor(), conn, isLocal: true, ssh: null };
+    // POOLED, not a fresh `createHostExecutor()`. This executor outlives the call
+    // (the deploy holds it), so it can't be scoped with `withHostExecutor` — but
+    // `acquire` returns the shared host channel for a local row, which is what
+    // stops one deploy from leaving behind an sshd session (#291).
+    return {
+      id: server.id,
+      executor: await sshManager.acquire(server.id),
+      conn,
+      isLocal: true,
+      ssh: null,
+    };
   }
   const executor = await sshManager.acquire(server.id);
   const ssh = server.sshHost ? await buildSshConfig(server) : null;

--- a/apps/api/src/lib/ssh-manager.host-channel.test.ts
+++ b/apps/api/src/lib/ssh-manager.host-channel.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The HOST channel is pooled, and these tests pin the property that #291 was
+ * missing rather than the one that merely looks right.
+ *
+ * `createHostExecutor()` is a FACTORY: when the API is containerized it builds a
+ * NEW SshExecutor to the host on every call, so an unpooled caller leaked one sshd
+ * session per call — 8,000+ in a few hours, then OOM. Pooling alone isn't the fix
+ * to assert; the fix is that the connection is (a) created once, (b) actually
+ * CLOSED when idle, and (c) never closed while a borrower still holds it.
+ */
+
+const h = vi.hoisted(() => ({
+  created: 0,
+  disposed: 0,
+  /** Rows by id — `isLocalHostRow` reads `isLocal`. */
+  rows: {} as Record<string, { id: string; isLocal: boolean; sshHost?: string } | undefined>,
+  makeExecutor: () => ({}) as Record<string, unknown>,
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: { server: { get: vi.fn(async (id: string) => h.rows[id]) } },
+}));
+
+vi.mock("@repo/adapters", () => ({
+  createHostExecutor: vi.fn(() => {
+    h.created += 1;
+    return {
+      // Only `dispose` matters here; the manager feature-detects the rest.
+      dispose: vi.fn(async () => {
+        h.disposed += 1;
+      }),
+    };
+  }),
+}));
+
+// isLocalHostRow decides "is this row THIS box". Keyed off the fixture flag so the
+// test doesn't depend on env/loopback resolution.
+vi.mock("./box-org", () => ({
+  isLocalHostRow: vi.fn(async (row: { isLocal?: boolean }) => Boolean(row?.isLocal)),
+}));
+
+import { sshManager } from "./ssh-manager";
+
+/** Reach into the pool — there's no public accessor, and the whole point is to
+ *  assert the cache state that the leak was a symptom of. */
+const pool = () => (sshManager as unknown as { servers: Map<string, unknown> }).servers;
+
+beforeEach(() => {
+  h.created = 0;
+  h.disposed = 0;
+  h.rows = {
+    "local-1": { id: "local-1", isLocal: true, sshHost: "127.0.0.1" },
+    "local-2": { id: "local-2", isLocal: true, sshHost: "10.0.0.5" },
+  };
+  for (const key of [...pool().keys()]) {
+    (sshManager as unknown as { dropServer: (k: string, f?: boolean) => void }).dropServer(
+      key,
+      true,
+    );
+  }
+  h.created = 0;
+  h.disposed = 0;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("host channel pooling", () => {
+  it("builds ONE executor across repeated withHostExecutor calls", async () => {
+    // The regression shape: this endpoint-style call used to mint a connection each
+    // time. Ten calls, one connection.
+    const seen = new Set<unknown>();
+    for (let i = 0; i < 10; i++) {
+      await sshManager.withHostExecutor(async (exec) => {
+        seen.add(exec);
+        return true;
+      });
+    }
+    expect(h.created).toBe(1);
+    expect(seen.size).toBe(1);
+    expect(h.disposed).toBe(0);
+  });
+
+  it("does not dispose on scope exit — the pool owns the lifetime", async () => {
+    // The old idiom required every caller to dispose; the new one must NOT, or two
+    // concurrent callers would close each other's connection.
+    await sshManager.withHostExecutor(async () => true);
+    expect(h.disposed).toBe(0);
+  });
+
+  it("dedups concurrent first-acquires instead of orphaning N-1 connections", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => sshManager.withHostExecutor(async (exec) => exec)),
+    );
+    expect(h.created).toBe(1);
+    expect(new Set(results).size).toBe(1);
+  });
+
+  it("propagates the acquire failure instead of reporting a phantom success", async () => {
+    // createHostExecutor throws by design when the API is containerized with no
+    // host channel. Swallowing that is how a caller concludes "host reachable".
+    const { createHostExecutor } = await import("@repo/adapters");
+    vi.mocked(createHostExecutor).mockImplementationOnce(() => {
+      throw new Error("no host channel is configured");
+    });
+    await expect(sshManager.withHostExecutor(async () => "nope")).rejects.toThrow(
+      /no host channel/,
+    );
+  });
+});
+
+describe("host channel is reclaimed, not merely reused", () => {
+  it("disposes the connection once idle — the part that actually stops the leak", async () => {
+    vi.useFakeTimers();
+    await sshManager.withHostExecutor(async () => true);
+    expect(h.created).toBe(1);
+    expect(h.disposed).toBe(0);
+
+    // Past the idle window: the pool must CLOSE it, or "pooled" just means the leak
+    // grows more slowly.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(h.disposed).toBe(1);
+
+    // And a later caller transparently gets a fresh one.
+    vi.useRealTimers();
+    await sshManager.withHostExecutor(async () => true);
+    expect(h.created).toBe(2);
+  });
+});
+
+describe("local server rows share the one host channel", () => {
+  it("two different local rows do not open two host connections", async () => {
+    const a = await sshManager.acquire("local-1");
+    const b = await sshManager.acquire("local-2");
+    expect(h.created).toBe(1);
+    expect(a).toBe(b);
+  });
+
+  it("a local row is cached so probeReachable can short-circuit", async () => {
+    await sshManager.acquire("local-1");
+    expect(pool().has("local-1")).toBe(true);
+  });
+
+  it("dropping a BORROWED row never closes the shared connection", async () => {
+    // The trap in sharing one executor under several keys: idle-dropping one local
+    // row must not end the channel the other row and withHostExecutor still use.
+    await sshManager.acquire("local-1");
+    await sshManager.acquire("local-2");
+    (sshManager as unknown as { dropServer: (k: string, f?: boolean) => void }).dropServer(
+      "local-1",
+      true,
+    );
+
+    expect(h.disposed).toBe(0);
+    expect(pool().has("local-1")).toBe(false);
+    // Still usable through the other borrower and the channel itself.
+    await sshManager.withHostExecutor(async () => true);
+    expect(h.created).toBe(1);
+  });
+});
+
+describe("host channel survives while a borrower is live (the owner/borrower lifecycle)", () => {
+  it("never serves a disposed executor when the owner idles under a HOT borrower", async () => {
+    // Regression: the top-of-acquire fast path used to return the row's borrow
+    // marker and refresh only ITS idle timer — so the owner idled out and disposed
+    // the shared executor while the row was still being acquired, and the next
+    // acquire handed back a DISPOSED executor. Re-acquiring a local row must keep
+    // the owner alive.
+    vi.useFakeTimers();
+    const a = await sshManager.acquire("local-1");
+    expect(h.created).toBe(1);
+
+    // Keep the borrower hot with a cache-hit BEFORE its 5-min window, crossing the
+    // owner's ORIGINAL 5-min deadline in the process.
+    await vi.advanceTimersByTimeAsync(3 * 60_000);
+    await sshManager.acquire("local-1");
+    await vi.advanceTimersByTimeAsync(3 * 60_000);
+
+    const b = await sshManager.acquire("local-1");
+    expect(h.disposed).toBe(0); // owner never idled out from under the live row
+    expect(h.created).toBe(1); // …so it was never rebuilt
+    expect(b).toBe(a); // …and the same live executor is still handed out
+    vi.useRealTimers();
+  });
+
+  it("keeps the shared channel alive across a retain placed BEFORE the first acquire", async () => {
+    // The real call order for a stream/deploy is retain(rowId) THEN acquire(rowId);
+    // retain can't yet know the row is local, so protection is enforced at drop
+    // time. A hold longer than the idle window must not lose the channel.
+    vi.useFakeTimers();
+    sshManager.retain("local-1");
+    await sshManager.acquire("local-1");
+    expect(h.created).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000); // well past the 5-min idle window
+    expect(h.disposed).toBe(0); // guard: a borrowing row is retained
+
+    const live = await sshManager.withHostExecutor(async () => "ok");
+    expect(live).toBe("ok"); // still the same live channel
+    expect(h.created).toBe(1);
+
+    // Releasing re-arms the owner's idle timer, so it IS reclaimed once idle.
+    sshManager.release("local-1");
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(h.disposed).toBe(1);
+    vi.useRealTimers();
+  });
+});

--- a/apps/api/src/lib/ssh-manager.ts
+++ b/apps/api/src/lib/ssh-manager.ts
@@ -259,7 +259,23 @@ interface ServerConnection {
   idleTimer: ReturnType<typeof setTimeout> | null;
   /** Unsubscribe from the executor's onDisconnect, called when we drop it. */
   unsubDisconnect?: () => void;
+  /**
+   * This entry BORROWS an executor owned by another key (the host channel, shared
+   * by every local row). Dropping it must forget the entry WITHOUT disposing the
+   * executor — the owner and the other borrowers are still using it.
+   */
+  shared?: boolean;
 }
+
+/**
+ * Reserved pool key for the HOST channel — the machine Openship itself runs on.
+ *
+ * Not a server id: the host channel is needed before any server row exists
+ * (startup self-deploy, `selfEdgePreflight`) and is the same connection no matter
+ * which local row asks for it. A reserved key keeps it in the one cache that has
+ * idle cleanup, instead of a second lifecycle nobody remembers to close.
+ */
+const HOST_CHANNEL_KEY = "__openship_host__";
 
 // ─── Manager ─────────────────────────────────────────────────────────────────
 
@@ -267,6 +283,14 @@ export class SshConnectionManager {
   private servers = new Map<string, ServerConnection>();
   private connecting = new Map<string, Promise<CommandExecutor>>();
   private retainCounts = new Map<string, number>();
+  /**
+   * Server-row ids we've classified as THIS host (they borrow the one host
+   * channel under {@link HOST_CHANNEL_KEY}). Lets the sync lifecycle paths
+   * (`acquire` routing, the idle-drop guard, `release` re-arm) recognise a local
+   * row without an async DB lookup. Membership tracks a live borrow marker: added
+   * on acquire, removed when the marker is dropped.
+   */
+  private localHostRows = new Set<string>();
   /** Per-server serial FIFO queue for journaled (mutating) ops — see run(). */
   private queues = new Map<string, OpQueue>();
   /** Executors whose remote journal wrapper is deployed (per-instance cache). */
@@ -292,6 +316,15 @@ export class SshConnectionManager {
     const startedAt = Date.now();
     if (this.destroyed) throw new Error("SshManager has been destroyed");
 
+    // A row we've ALREADY classified as this host resolves to the shared channel
+    // directly — BEFORE the generic cache fast-path below. That path returns the
+    // row's borrow marker (`.executor`), which goes stale the instant the owner is
+    // reclaimed and rebuilt: it would hand back a DISPOSED executor. Routing through
+    // acquireHostChannel re-validates the owner every call, and skips the DB lookup.
+    if (this.localHostRows.has(serverId)) {
+      return this.acquireLocalHost(serverId, startedAt);
+    }
+
     const cached = this.servers.get(serverId);
     if (cached) {
       this.touchIdleTimer(serverId);
@@ -305,11 +338,14 @@ export class SshConnectionManager {
     // resolveServerExecutor so probe-gated flows (Test Connection, Scan Ports) that call
     // acquire don't hang. Placed before the cooldown gate so a row that failed dialing
     // 127.0.0.1 before this fix isn't stuck "cooling down". Org-gated via isLocalHostRow.
+    //
+    // POOLED through the same cache as a remote server, and that matters: when the
+    // API is containerized `createHostExecutor()` builds a NEW SshExecutor to the
+    // host every call, so an unpooled path leaked one sshd session per call —
+    // 8,000+ in hours, then OOM (#291). Every local row shares the one host channel.
     const row = await repos.server.get(serverId).catch(() => undefined);
     if (row && (await isLocalHostRow(row))) {
-      this.recordSuccess(serverId);
-      debugSsh(`acquire:local-host server=${serverId} (${formatDuration(startedAt)})`);
-      return createHostExecutor();
+      return this.acquireLocalHost(serverId, startedAt);
     }
 
     // Circuit-breaker: a server that just failed repeatedly is in cooldown —
@@ -334,16 +370,7 @@ export class SshConnectionManager {
     this.connecting.set(serverId, promise);
     try {
       const exec = await promise;
-      const conn: ServerConnection = { executor: exec, idleTimer: null };
-      // React to a transport drop the instant it happens (L1). The executor has
-      // already rejected its own in-flight ops; here we drive manager-side
-      // recovery.
-      if (typeof exec.onDisconnect === "function") {
-        conn.unsubDisconnect = exec.onDisconnect((err) => this.onExecutorDisconnect(serverId, err));
-      }
-      this.servers.set(serverId, conn);
-      this.touchIdleTimer(serverId);
-      this.recordSuccess(serverId);
+      this.cacheConnection(serverId, exec);
       debugSsh(`acquire:executor-ready server=${serverId} (${formatDuration(startedAt)})`);
       return exec;
     } catch (err) {
@@ -368,6 +395,114 @@ export class SshConnectionManager {
    * MUTATING commands that must not double-apply, use `run()` / `execJournaled()`
    * instead (exactly-once via the remote journal).
    */
+  /**
+   * Put an executor in the cache with the full bookkeeping: disconnect wiring,
+   * idle timer, success record.
+   *
+   * One implementation on purpose. This sequence used to be inline in `acquire`,
+   * and the moment a second path needed it the copy drifted — and the copy that
+   * drifts is the one that leaks.
+   */
+  private cacheConnection(
+    serverId: string,
+    exec: CommandExecutor,
+    opts: { shared?: boolean } = {},
+  ): void {
+    const conn: ServerConnection = { executor: exec, idleTimer: null, shared: opts.shared };
+    // React to a transport drop the instant it happens (L1). The executor has
+    // already rejected its own in-flight ops; here we drive manager-side recovery.
+    // A borrowed entry doesn't subscribe — the OWNER's subscription already fires,
+    // and a second one would drop the shared executor twice.
+    if (!opts.shared && typeof exec.onDisconnect === "function") {
+      conn.unsubDisconnect = exec.onDisconnect((err) => this.onExecutorDisconnect(serverId, err));
+    }
+    this.servers.set(serverId, conn);
+    this.touchIdleTimer(serverId);
+    this.recordSuccess(serverId);
+  }
+
+  /**
+   * The pooled HOST channel — one connection to the machine Openship runs on,
+   * reused by every caller and reclaimed by the same idle timer as a server.
+   */
+  private async acquireHostChannel(): Promise<CommandExecutor> {
+    const cached = this.servers.get(HOST_CHANNEL_KEY);
+    if (cached) {
+      this.touchIdleTimer(HOST_CHANNEL_KEY);
+      return cached.executor;
+    }
+    // Dedup concurrent first-acquires: without this, N simultaneous callers each
+    // build their own SshExecutor and N-1 are orphaned — the leak in miniature.
+    const pending = this.connecting.get(HOST_CHANNEL_KEY);
+    if (pending) return pending;
+
+    // createHostExecutor throws (deliberately) when the API is containerized with
+    // no host channel provisioned. Let that propagate: callers must NOT silently
+    // treat "cannot reach the host at all" as success.
+    const promise = (async () => createHostExecutor())();
+    this.connecting.set(HOST_CHANNEL_KEY, promise);
+    try {
+      const exec = await promise;
+      this.cacheConnection(HOST_CHANNEL_KEY, exec);
+      debugSsh("acquire:host-channel ready");
+      return exec;
+    } finally {
+      this.connecting.delete(HOST_CHANNEL_KEY);
+    }
+  }
+
+  /**
+   * Resolve a LOCAL server row to the shared host channel, keeping a borrow marker
+   * under the row id so `isConnected`/`probeReachable` short-circuit and the row
+   * shows up in idle cleanup. Going through `acquireHostChannel` re-validates (and
+   * rebuilds) the owner every call, so the marker can never hand back a stale or
+   * disposed executor if the owner was reclaimed since the last acquire.
+   */
+  private async acquireLocalHost(serverId: string, startedAt: number): Promise<CommandExecutor> {
+    this.localHostRows.add(serverId);
+    const exec = await this.acquireHostChannel();
+    this.cacheSharedMarker(serverId, exec);
+    this.recordSuccess(serverId);
+    debugSsh(`acquire:local-host server=${serverId} (${formatDuration(startedAt)})`);
+    return exec;
+  }
+
+  /**
+   * (Re)point a local row's borrow marker at the CURRENT host-channel executor.
+   * Clears any prior idle timer first so a stale one can't drop the fresh marker,
+   * and — like every cached entry — arms a new one unless the row is retained.
+   * A marker never subscribes onDisconnect (the owner's subscription is the one)
+   * and is never disposed on drop (see {@link dropServer}); it only borrows.
+   */
+  private cacheSharedMarker(serverId: string, exec: CommandExecutor): void {
+    const existing = this.servers.get(serverId);
+    if (existing?.idleTimer) clearTimeout(existing.idleTimer);
+    this.servers.set(serverId, { executor: exec, idleTimer: null, shared: true });
+    this.touchIdleTimer(serverId);
+  }
+
+  /**
+   * Run `fn` against the HOST machine — the local box, over SSH when the API is
+   * containerized.
+   *
+   * Use this for every "this machine" operation. The executor is POOLED, so there
+   * is nothing to dispose and no way to leak one: the previous idiom handed out a
+   * fresh `createHostExecutor()` and relied on each caller remembering a
+   * `try/finally`, which is how #291 reached 8,000+ orphaned sshd sessions.
+   * Deliberately mirrors `withExecutor(serverId, fn)` so there is one shape for
+   * "give me an executor for X".
+   */
+  async withHostExecutor<T>(fn: (executor: CommandExecutor) => Promise<T>): Promise<T> {
+    const exec = await this.acquireHostChannel();
+    try {
+      return await fn(exec);
+    } finally {
+      // Extend the idle window from LAST USE, not from acquisition, or a long op
+      // can have the connection dropped from under its own tail.
+      this.touchIdleTimer(HOST_CHANNEL_KEY);
+    }
+  }
+
   async withExecutor<T>(
     serverId: string,
     fn: (executor: CommandExecutor) => Promise<T>,
@@ -584,6 +719,11 @@ export class SshConnectionManager {
     if (count === 0) {
       this.retainCounts.delete(serverId);
       this.touchIdleTimer(serverId);
+      // A local row borrows the shared host channel; when its last hold ends,
+      // re-arm the OWNER's idle timer too. The owner's own timer was consumed and
+      // skipped by the drop guard while this row was held, so without this the
+      // channel would never be reclaimed after a long local-host op.
+      if (this.localHostRows.has(serverId)) this.touchIdleTimer(HOST_CHANNEL_KEY);
     } else {
       this.retainCounts.set(serverId, count);
     }
@@ -777,16 +917,59 @@ export class SshConnectionManager {
       return;
     }
 
+    // The shared host channel outlives its own idle timer while ANY local row that
+    // borrows it is still retained by a long-lived op — the deploy/stream holds the
+    // ROW id, not this key, and its `retain` runs before the row's first `acquire`,
+    // so propagating retain counts onto the owner is racy. Guarding at drop time
+    // isn't; `release()` re-arms the timer so the channel is still reclaimed once
+    // nothing holds it. `force` (invalidate/shutdown) always drops.
+    if (!force && serverId === HOST_CHANNEL_KEY && this.anyLocalRowRetained()) {
+      debugSsh("drop-server:skip-host-channel (a borrowing row is retained)");
+      return;
+    }
+
     if (conn.idleTimer) clearTimeout(conn.idleTimer);
     if (conn.unsubDisconnect) {
       try { conn.unsubDisconnect(); } catch { /* best-effort */ }
     }
     this.retainCounts.delete(serverId);
-    if ("dispose" in conn.executor && typeof conn.executor.dispose === "function") {
+    // A BORROWED entry (a local row pointing at the shared host channel) must only
+    // be forgotten — disposing here would close the one host connection that every
+    // other local row and `withHostExecutor` caller is still using.
+    if (
+      !conn.shared &&
+      "dispose" in conn.executor &&
+      typeof conn.executor.dispose === "function"
+    ) {
       conn.executor.dispose();
     }
     this.servers.delete(serverId);
-    debugSsh(`drop-server server=${serverId}`);
+    if (conn.shared) this.localHostRows.delete(serverId);
+    // Reclaiming the shared channel strands every borrow marker pointing at it —
+    // forget them so `isConnected`/`probeReachable` don't report a dead channel and
+    // the next `acquire` rebuilds cleanly. Markers are forgotten, never disposed.
+    if (serverId === HOST_CHANNEL_KEY) this.forgetHostChannelBorrowers();
+    debugSsh(`drop-server server=${serverId}${conn.shared ? " (borrowed, not disposed)" : ""}`);
+  }
+
+  /** A local row currently held by a long-lived op — see the host-channel drop guard. */
+  private anyLocalRowRetained(): boolean {
+    for (const id of this.localHostRows) {
+      if ((this.retainCounts.get(id) ?? 0) > 0) return true;
+    }
+    return false;
+  }
+
+  /** Forget every borrow marker (never dispose — a marker doesn't own the executor)
+   *  once the shared host channel is gone; the next acquire re-points them. */
+  private forgetHostChannelBorrowers(): void {
+    for (const id of [...this.localHostRows]) {
+      const conn = this.servers.get(id);
+      if (!conn?.shared) continue;
+      if (conn.idleTimer) clearTimeout(conn.idleTimer);
+      this.servers.delete(id);
+      this.localHostRows.delete(id);
+    }
   }
 }
 

--- a/apps/api/src/lib/startup/self-deploy.ts
+++ b/apps/api/src/lib/startup/self-deploy.ts
@@ -192,10 +192,14 @@ async function foreignProxyBlocksEdge(
   log?: (message: string, level?: "info" | "warn" | "error") => void,
 ): Promise<{ blocked: boolean; owner?: string }> {
   try {
-    const { createHostExecutor, foreignProxyOnEdge } = await import("@repo/adapters");
-    // Probe the HOST's :80/:443, not the api container's netns — createHostExecutor
-    // is LocalExecutor bare, SSH→host when containerized (OPENSHIP_HOST_SSH_*).
-    const { blocked, owner } = await foreignProxyOnEdge(createHostExecutor());
+    const { foreignProxyOnEdge } = await import("@repo/adapters");
+    const { sshManager } = await import("../ssh-manager");
+    // Probe the HOST's :80/:443, not the api container's netns — the host channel is
+    // LocalExecutor bare, SSH→host when containerized (OPENSHIP_HOST_SSH_*). Pooled,
+    // so there's nothing to dispose (see withHostExecutor).
+    const { blocked, owner } = await sshManager.withHostExecutor((exec) =>
+      foreignProxyOnEdge(exec),
+    );
     if (!blocked) return { blocked: false };
     log?.(
       `Not issuing TLS: ${owner} still owns ports 80/443, so Openship isn't the reverse proxy yet — ` +
@@ -419,9 +423,12 @@ export function registerSelfAdoptReconcile(): void {
       // left dark. Best-effort; root Linux only.
       if (isLinuxRoot()) {
         try {
-          const { createHostExecutor, recoverInterruptedTakeover } = await import("@repo/adapters");
-          // Recover takeover on the HOST (createHostExecutor: local bare, SSH→host containerized).
-          await recoverInterruptedTakeover(createHostExecutor(), (e) => console.log(`[self-deploy] ${e.message}`));
+          const { recoverInterruptedTakeover } = await import("@repo/adapters");
+          const { sshManager } = await import("../ssh-manager");
+          // Recover takeover on the HOST (local bare, SSH→host containerized).
+          await sshManager.withHostExecutor((exec) =>
+            recoverInterruptedTakeover(exec, (e) => console.log(`[self-deploy] ${e.message}`)),
+          );
         } catch {}
       }
 

--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -27,7 +27,6 @@ import {
   DEFAULT_BUILD_RESOURCE_CONFIG,
   ensurePortAvailable,
   allocateHostPort,
-  createHostExecutor,
   runDeployPipeline,
   isMultiServiceRuntime,
   waitForReady,
@@ -42,6 +41,7 @@ import {
   resolveEffectiveTarget,
 } from "../../lib/deployment-runtime";
 import { ensureRoutingReady } from "../../lib/edge-reconcile";
+import { sshManager } from "../../lib/ssh-manager";
 import {
   resolveBuildRuntimeModes,
   resolveDeployRouting,
@@ -1269,7 +1269,12 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
       )
         .filter((p) => p.id !== project.id && typeof p.hostPort === "number")
         .map((p) => p.hostPort as number);
-      pinnedHostPort = await allocateHostPort(phase.targetExecutor ?? createHostExecutor(), { avoid });
+      // The deploy's own executor when it has one; otherwise the POOLED host
+      // channel — never a bare `createHostExecutor()`, which builds a fresh
+      // SSH connection per call and leaked one sshd session each time (#291).
+      pinnedHostPort = phase.targetExecutor
+        ? await allocateHostPort(phase.targetExecutor, { avoid })
+        : await sshManager.withHostExecutor((exec) => allocateHostPort(exec, { avoid }));
       await repos.project
         .update(project.id, { hostPort: pinnedHostPort })
         .catch((err) => logger.log(`Couldn't persist host port ${pinnedHostPort}: ${safeErrorMessage(err)}\n`, "warn"));

--- a/apps/api/src/modules/domains/domain.schema.ts
+++ b/apps/api/src/modules/domains/domain.schema.ts
@@ -29,6 +29,12 @@ export const AddDomainBody = Type.Object({
   /** Externally-managed ingress + TLS (Cloudflare Tunnel, LB): verify via TXT
    *  only, skip certbot, serve plain HTTP. Domain need not resolve to the box. */
   externalIngress: Type.Optional(Type.Boolean({ default: false })),
+  /**
+   * Also claim `www.<hostname>`. Creates a SECOND pending domain row — the SSL
+   * layer's own `includeWww` only ever acted on an existing verified www ROW, so
+   * without this the toggle was a no-op end to end (issue #289).
+   */
+  includeWww: Type.Optional(Type.Boolean({ default: false })),
 });
 
 /** Operator-supplied certificate (BYO / Cloudflare Origin CA) to install for a

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -18,7 +18,13 @@ import { repos, type Domain, type Project } from "@repo/db";
 import { NotFoundError, ConflictError, ValidationError, safeErrorMessage, normalizeCustomHostname, isValidCustomHostname, SYSTEM } from "@repo/core";
 import { platform, assertResourceInOrg } from "../../lib/controller-helpers";
 import { buildBackgroundContext, type RequestContext } from "../../lib/request-context";
-import { manageDomainSsl, installDomainCert, provisionDomainCertForVerify, verifyExistingCert } from "../../lib/domain-ssl";
+import {
+  manageDomainSsl,
+  installDomainCert,
+  provisionDomainCertForVerify,
+  verifyExistingCert,
+  tlsIssuedElsewhere,
+} from "../../lib/domain-ssl";
 import { getRoutingBaseDomain } from "../../lib/routing-domains";
 import { resolveRecords } from "../../lib/dns-resolver";
 import { resolveProjectServerHost } from "../../lib/server-target";
@@ -117,6 +123,13 @@ export async function addDomain(ctx: RequestContext, data: TAddDomainBody) {
     if (data.isPrimary && !existing.isPrimary) {
       await repos.domain.setPrimary(data.projectId, existing.id);
     }
+    // Re-saving with the toggle on must be able to ADD the www row that a first
+    // save (or an older build) never created.
+    if (data.includeWww) {
+      await addWwwSibling(ctx, data, hostname).catch((err) =>
+        console.warn(`[domains] www.${hostname} not added: ${safeErrorMessage(err)}`),
+      );
+    }
 
     const domain = {
       ...existing,
@@ -154,8 +167,51 @@ export async function addDomain(ctx: RequestContext, data: TAddDomainBody) {
     await repos.domain.setPrimary(data.projectId, domain.id);
   }
 
+  // "Include www" is a REQUEST FOR A SECOND HOSTNAME, so it has to exist as its own
+  // row: verification, DNS records, SSL and routing are all keyed per row, and
+  // `manageDomainSsl`'s www branch explicitly looks for `www.<host>` in the domain
+  // table. Without this the toggle set a flag nothing ever read (issue #289).
+  //
+  // Best-effort: the apex is what the caller asked for and already succeeded. A www
+  // that can't be claimed (already taken by another project, invalid) must not undo
+  // it — the apex stays, and the operator can add www by hand.
+  if (data.includeWww) {
+    await addWwwSibling(ctx, data, hostname).catch((err) =>
+      console.warn(`[domains] www.${hostname} not added: ${safeErrorMessage(err)}`),
+    );
+  }
+
   const records = await buildRecords(domain.hostname, token, project, domain.externalIngress);
   return { domain, records };
+}
+
+/**
+ * "Include www" asks for a SECOND routable hostname, not a flag on the apex row: the
+ * edge binds one `server_name` per row, and `domain-ssl.ts`'s www branch resolves the
+ * variant BY HOSTNAME — so it only exists once it has a row, which then verifies and
+ * certs on its own.
+ *
+ * Recurses through `addDomain` on purpose: hostname validation, the cross-project
+ * conflict check and the interrupted-connect retry path all live there and must apply
+ * to the variant too. Runs AFTER the apex so an apex conflict aborts before we mint a
+ * sibling, and the apex keeps `isPrimary`.
+ *
+ * NOTE: the row alone is not enough — `syncProjectPublicRoutes` deletes project-level
+ * rows the submitted endpoint list omits, so the caller must also include
+ * `www.<apex>` in `publicEndpoints` (the dashboard does this in the same save).
+ */
+async function addWwwSibling(
+  ctx: RequestContext,
+  data: TAddDomainBody,
+  hostname: string,
+): Promise<void> {
+  if (hostname.startsWith("www.")) return;
+  await addDomain(ctx, {
+    projectId: data.projectId,
+    hostname: `www.${hostname}`,
+    isPrimary: false,
+    externalIngress: data.externalIngress,
+  });
 }
 
 /**
@@ -332,11 +388,9 @@ async function withServerHostExecutor<T>(
 ): Promise<T | null> {
   const serverId = await resolveServerIdForProject(project);
   if (!serverId) return null;
-  const server = await repos.server.getInOrganization(serverId, ctx.organizationId).catch(() => null);
-  if (server?.isLocal) {
-    const { createHostExecutor } = await import("@repo/adapters");
-    return fn(createHostExecutor());
-  }
+  // No local/remote branch: `acquire` already returns the pooled HOST channel for a
+  // local row. The old branch handed out a fresh `createHostExecutor()` per call and
+  // never closed it — one leaked sshd session per domain/SSL status read (#291).
   return sshManager.withExecutor(serverId, fn).catch(() => null);
 }
 
@@ -362,12 +416,18 @@ async function edgeHostUnreachable(ctx: RequestContext, project: Project): Promi
   if (!serverId) return false;
   const server = await repos.server.getInOrganization(serverId, ctx.organizationId).catch(() => null);
   if (!server?.isLocal) return false;
-  const { createHostExecutor } = await import("@repo/adapters");
-  const exec = createHostExecutor();
-  return (
-    (await exec.exists("/.dockerenv").catch(() => false)) ||
-    (await exec.exists("/run/.containerenv").catch(() => false))
-  );
+  return sshManager
+    .withHostExecutor(
+      async (exec) =>
+        (await exec.exists("/.dockerenv").catch(() => false)) ||
+        (await exec.exists("/run/.containerenv").catch(() => false)),
+    )
+    // Acquiring the host channel THROWS when the API is containerized with no
+    // channel provisioned — which is precisely this function's "unreachable" case,
+    // so it must answer TRUE. Answering false would let verify march on to a
+    // certbot attempt that fails far from the cause, instead of surfacing
+    // HOST_CHANNEL_HINT below.
+    .catch(() => true);
 }
 
 const HOST_CHANNEL_HINT =
@@ -874,12 +934,99 @@ export interface PendingVerificationResult {
   stillPending: number;
   failed: number;
   total: number;
+  /** Phase 2: certs issued for already-verified domains that had none. */
+  sslIssued?: number;
+  /** Phase 2: still without a cert, backed off for a later run. */
+  sslRetrying?: number;
   details: Array<{
     hostname: string;
     status: "verified" | "still_pending" | "failed";
     message?: string;
     error?: string;
   }>;
+}
+
+/**
+ * Per-hostname retry backoff for the SSL phase, in memory.
+ *
+ * Let's Encrypt allows ~5 failures per hostname per hour; a flat 13-minute retry
+ * burns that on a genuinely misconfigured domain and gets the whole account rate-
+ * limited. Doubles 15m → 30m → 1h → 2h → 4h, capped at 6h, and keeps trying at that
+ * cadence forever rather than giving up — the operator's DNS/firewall fix must heal
+ * itself without another manual click.
+ *
+ * Deliberately NOT a DB column: an API restart clearing it is the behaviour we want
+ * (a redeploy/restart is a strong signal something changed), and it avoids a
+ * migration for state that is worthless after a few hours.
+ */
+const sslRetryAt = new Map<string, { next: number; delayMs: number }>();
+const SSL_RETRY_MIN_MS = 15 * 60_000;
+const SSL_RETRY_MAX_MS = 6 * 60 * 60_000;
+
+function sslRetryDue(id: string): boolean {
+  const e = sslRetryAt.get(id);
+  return !e || Date.now() >= e.next;
+}
+
+function sslRetryScheduled(id: string): void {
+  const prev = sslRetryAt.get(id);
+  const delayMs = Math.min(prev ? prev.delayMs * 2 : SSL_RETRY_MIN_MS, SSL_RETRY_MAX_MS);
+  sslRetryAt.set(id, { next: Date.now() + delayMs, delayMs });
+}
+
+/** Issued (or externally handled) — stop backing off, so a re-break retries fast. */
+function sslRetryCleared(id: string): void {
+  sslRetryAt.delete(id);
+}
+
+/**
+ * Phase 2 of the domain sweep: finish TLS for domains that are already verified but
+ * never got a certificate.
+ *
+ * Reuses `verifyDomainSsl` — the exact call the dashboard's own retry makes — so
+ * there is ONE issuance path, not a cron-flavoured copy of it. Best-effort per
+ * domain, matching the golden rule: routing/TLS never fails anything, it only
+ * reports. What changes is that it now self-heals instead of waiting for a human.
+ */
+async function issuePendingSsl(limit: number): Promise<{ issued: number; retrying: number }> {
+  const rows = await repos.domain.findPendingSsl(limit).catch(() => []);
+  let issued = 0;
+  let retrying = 0;
+
+  for (const d of rows) {
+    if (tlsIssuedElsewhere(d)) {
+      sslRetryCleared(d.id);
+      continue;
+    }
+    if (!sslRetryDue(d.id)) continue;
+
+    const project = await repos.project.findById(d.projectId).catch(() => null);
+    if (!project?.organizationId) continue;
+
+    try {
+      await verifyDomainSsl(
+        buildBackgroundContext({
+          userId: "",
+          organizationId: project.organizationId,
+          label: "domains:verify-pending",
+        }),
+        d.id,
+      );
+      const after = await repos.domain.findById(d.id).catch(() => null);
+      if (after?.sslStatus === "active") {
+        issued++;
+        sslRetryCleared(d.id);
+      } else {
+        retrying++;
+        sslRetryScheduled(d.id);
+      }
+    } catch {
+      retrying++;
+      sslRetryScheduled(d.id);
+    }
+  }
+
+  return { issued, retrying };
 }
 
 export async function verifyPendingDomains(opts?: {
@@ -961,6 +1108,11 @@ export async function verifyPendingDomains(opts?: {
       });
     }
   }
+
+  // Phase 2, same sweep: verified domains whose cert never landed.
+  const ssl = await issuePendingSsl(limit).catch(() => ({ issued: 0, retrying: 0 }));
+  result.sslIssued = ssl.issued;
+  result.sslRetrying = ssl.retrying;
 
   return result;
 }

--- a/apps/api/src/modules/domains/ensure-edge.controller.ts
+++ b/apps/api/src/modules/domains/ensure-edge.controller.ts
@@ -53,11 +53,10 @@ async function withEdgeExecutor<T>(
   organizationId: string,
   fn: (exec: CommandExecutor) => Promise<T>,
 ): Promise<T> {
-  const server = await repos.server.getInOrganization(serverId, organizationId).catch(() => null);
-  if (server?.isLocal) {
-    const { createHostExecutor } = await import("@repo/adapters");
-    return fn(createHostExecutor());
-  }
+  // No local/remote branch: `acquire` already returns the pooled HOST channel for a
+  // local row (and never dials its display sshHost). Branching here to a fresh
+  // `createHostExecutor()` is what leaked a connection per poll of this endpoint —
+  // the dashboard calls edgeStatus on a timer (#291).
   return sshManager.withExecutor(serverId, fn);
 }
 

--- a/apps/api/src/modules/jobs/job.registry.ts
+++ b/apps/api/src/modules/jobs/job.registry.ts
@@ -115,14 +115,24 @@ export const SYSTEM_JOB_DEFS: SystemJobDef[] = [
   {
     key: "domains:verify-pending",
     label: "Domain DNS verification",
-    // Re-checks every pending custom domain and auto-flips it to verified once
-    // DNS propagates — the lazy half of the verify lifecycle. Off the :00/:30
-    // marks. Cloud verifies via Oblien too, so gate only desktop out.
+    // TWO phases, one sweep: (1) re-check pending custom domains and flip them to
+    // verified once DNS propagates, (2) finish TLS for domains that verified but
+    // whose first issuance failed — those sat in `provisioning` forever, needing a
+    // manual Verify + Redeploy (#289), because the verify sweep only selects
+    // unverified rows and the renewal sweep only selects certs that already exist.
+    // Off the :00/:30 marks. Cloud verifies via Oblien too, so gate only desktop out.
     defaultCron: "*/13 * * * *",
     available: () => platform().target !== "desktop",
     run: async () => {
       const r = await verifyPendingDomains();
-      return { verified: r.verified, failed: r.failed, pending: r.stillPending, total: r.total };
+      return {
+        verified: r.verified,
+        failed: r.failed,
+        pending: r.stillPending,
+        total: r.total,
+        sslIssued: r.sslIssued ?? 0,
+        sslRetrying: r.sslRetrying ?? 0,
+      };
     },
   },
   {

--- a/apps/api/src/modules/mail/mail.service.ts
+++ b/apps/api/src/modules/mail/mail.service.ts
@@ -22,6 +22,7 @@ import {
   installOpenResty,
   installCertbot,
   foreignProxyOnEdge,
+  resolveOurEdgeContainer,
 } from "@repo/adapters";
 
 // ─── Shell quoting helper ─────────────────────────────────────────────────────
@@ -307,6 +308,26 @@ export async function stepEnsureReverseProxy(
   log: StepLogger,
 ): Promise<StepResult> {
   const stepId = 4;
+
+  // A CONTAINER edge is the main path now, and it has no host `openresty.service`
+  // to query or start — `systemctl start openresty` would fail on a box where the
+  // edge is perfectly healthy. Ask the container instead, and let the shared
+  // detector below confirm it really owns the ports (#288).
+  const edgeContainer = await resolveOurEdgeContainer(exec).catch(() => null);
+  if (edgeContainer) {
+    log(stepId, "info", `Edge container ${edgeContainer} provides OpenResty — checking it serves :80/:443...`);
+    const { blocked, owner } = await foreignProxyOnEdge(exec);
+    if (blocked) {
+      return {
+        stepId,
+        success: false,
+        message: `Ports 80/443 are held by another proxy (${owner}). Stop it, or migrate it from the dashboard, then rerun.`,
+      };
+    }
+    log(stepId, "info", `Openship's edge container is the active reverse proxy`);
+    return { stepId, success: true, message: "Openship's edge container is the active reverse proxy" };
+  }
+
   log(stepId, "info", "Checking OpenResty service status...");
 
   const active = (

--- a/apps/api/src/modules/projects/project.controller.ts
+++ b/apps/api/src/modules/projects/project.controller.ts
@@ -2000,6 +2000,7 @@ export async function connectDomain(c: Context) {
       hostname: body.domain.trim(),
       isPrimary: true,
       externalIngress: body.externalIngress ?? false,
+      includeWww: body.includeWww ?? false,
     });
 
     audit.recordAsync(auditContextFrom(c, organizationId, userId), {

--- a/apps/api/src/modules/system/self-app.controller.ts
+++ b/apps/api/src/modules/system/self-app.controller.ts
@@ -18,6 +18,7 @@ import type { Context } from "hono";
 import type { ImportedSite, ManualCert } from "@repo/adapters";
 import { repos, db, schema, eq } from "@repo/db";
 import { SYSTEM, safeErrorMessage } from "@repo/core";
+import { sshManager } from "../../lib/ssh-manager";
 import { env } from "../../config";
 import { assertNotCloud, platform } from "../../lib/controller-helpers";
 import { ensureLocalUser } from "../../lib/local-user";
@@ -415,14 +416,18 @@ export async function selfEdgePreflight(c: Context) {
   }
 
   try {
-    const { createHostExecutor, detectEdge, importSites } = await import("@repo/adapters");
+    const { detectEdge, importSites } = await import("@repo/adapters");
     // Host-op executor: LocalExecutor bare, SSH→host.docker.internal when
     // containerized (OPENSHIP_HOST_SSH_* set). Inspecting the api container's
     // own netns would return a wrong migrate/takeover prompt in docker mode.
-    const executor = createHostExecutor();
-    const status = await detectEdge(executor);
-    // Scan the foreign proxy's sites (if importable) so the CLI can offer migration.
-    const { sites, warnings } = await importSites(executor, status);
+    // Pooled — this endpoint is polled by the CLI/wizard, and a per-call executor
+    // is what leaked sshd sessions until OOM (#291).
+    const { status, sites, warnings } = await sshManager.withHostExecutor(async (executor) => {
+      const detected = await detectEdge(executor);
+      // Scan the foreign proxy's sites (if importable) so the CLI can offer migration.
+      const scanned = await importSites(executor, detected);
+      return { status: detected, sites: scanned.sites, warnings: scanned.warnings };
+    });
     return c.json({ status, sites, warnings });
   } catch (err) {
     return c.json({ error: safeErrorMessage(err) }, 500);

--- a/apps/api/test/lib/host-executor-guard.test.ts
+++ b/apps/api/test/lib/host-executor-guard.test.ts
@@ -3,11 +3,17 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 /**
- * Host-control paths must run through createHostExecutor() — LocalExecutor when
- * bare, SSH→host.docker.internal when containerized (OPENSHIP_HOST_SSH_*). A
- * no-arg createExecutor() is ALWAYS LocalExecutor, which in Docker-deployed mode
- * silently probes the api container's own netns instead of the host (the
- * "single switchable executor" fix). This guards against regressing to it.
+ * Host-control paths must run through the HOST channel — LocalExecutor when bare,
+ * SSH→host.docker.internal when containerized (OPENSHIP_HOST_SSH_*). A no-arg
+ * createExecutor() is ALWAYS LocalExecutor, which in Docker-deployed mode silently
+ * probes the api container's own netns instead of the host (the "single switchable
+ * executor" fix). This guards against regressing to it.
+ *
+ * TWO spellings are accepted, and the pooled one is preferred:
+ *   • `sshManager.withHostExecutor(fn)` — the pooled channel. Use this.
+ *   • `createHostExecutor()` — the raw factory. Every call builds a NEW SSH
+ *     connection to the host, so an un-disposed one leaks an sshd session (#291);
+ *     only the manager should call it now.
  *
  * self-edge.ts is intentionally excluded: it early-returns in docker-edge mode
  * and its createExecutor() only runs bare, where local IS the host.
@@ -21,11 +27,13 @@ const HOST_CONTROL_FILES = [
 
 describe("host-control executor guard", () => {
   for (const rel of HOST_CONTROL_FILES) {
-    it(`${rel} uses createHostExecutor, not no-arg createExecutor()`, () => {
+    it(`${rel} targets the host channel, not a no-arg createExecutor()`, () => {
       const src = read(rel);
       const noArg = [...src.matchAll(/\bcreateExecutor\(\s*\)/g)];
-      expect(noArg.length, "no-arg createExecutor() found — use createHostExecutor()").toBe(0);
-      expect(src.includes("createHostExecutor")).toBe(true);
+      expect(noArg.length, "no-arg createExecutor() found — use withHostExecutor()").toBe(0);
+      const usesHostChannel =
+        src.includes("withHostExecutor") || src.includes("createHostExecutor");
+      expect(usesHostChannel, "no host-channel accessor found in a host-control file").toBe(true);
     });
   }
 });

--- a/apps/api/test/modules/domains/domain-add.test.ts
+++ b/apps/api/test/modules/domains/domain-add.test.ts
@@ -126,4 +126,48 @@ describe("addDomain retries", () => {
     expect(domainRepo.create).not.toHaveBeenCalled();
     expect(domainRepo.update).not.toHaveBeenCalled();
   });
+
+  // The toggle used to set a flag nothing read: the controller dropped it and the SSL
+  // layer's www branch only ever resolved an EXISTING row (#289). www is a second
+  // routable hostname — the edge binds one server_name per row — so it only exists
+  // once it has its own row.
+  it("materializes the www variant as its own row when includeWww is set", async () => {
+    domainRepo.findByHostname.mockResolvedValue(null);
+    domainRepo.create.mockImplementation(async (data: any) => ({ id: `dom_${data.hostname}`, ...data }));
+
+    await addDomain(context as any, {
+      projectId: project.id,
+      hostname: "example.com",
+      isPrimary: true,
+      includeWww: true,
+    } as any);
+
+    expect(domainRepo.create.mock.calls.map(([data]: [any]) => data.hostname)).toEqual([
+      "example.com",
+      "www.example.com",
+    ]);
+    // The apex keeps primary — the variant is a sibling, not a replacement — and it
+    // starts pending so it verifies and certs on its own like any custom domain.
+    expect(domainRepo.create.mock.calls[1][0]).toMatchObject({
+      hostname: "www.example.com",
+      isPrimary: false,
+      verified: false,
+      status: "pending",
+    });
+  });
+
+  it("never stacks www on www", async () => {
+    domainRepo.findByHostname.mockResolvedValue(null);
+    domainRepo.create.mockImplementation(async (data: any) => ({ id: `dom_${data.hostname}`, ...data }));
+
+    await addDomain(context as any, {
+      projectId: project.id,
+      hostname: "www.example.com",
+      includeWww: true,
+    } as any);
+
+    expect(domainRepo.create.mock.calls.map(([data]: [any]) => data.hostname)).toEqual([
+      "www.example.com",
+    ]);
+  });
 });

--- a/apps/api/test/modules/domains/domain-cert-reuse.test.ts
+++ b/apps/api/test/modules/domains/domain-cert-reuse.test.ts
@@ -45,8 +45,14 @@ vi.mock("../../../src/lib/controller-helpers", async (importOriginal) => {
 });
 
 vi.mock("../../../src/lib/domain-ssl", () => sslMocks);
+// Both accessors hand back the SAME host executor, which is the point: a local
+// server row and the host channel are one connection, so cert ops land on the
+// host's /etc/letsencrypt either way.
 vi.mock("../../../src/lib/ssh-manager", () => ({
-  sshManager: { withExecutor: vi.fn(async (_id: string, fn: (e: CommandExecutor) => unknown) => fn(hostExec.current!)) },
+  sshManager: {
+    withExecutor: vi.fn(async (_id: string, fn: (e: CommandExecutor) => unknown) => fn(hostExec.current!)),
+    withHostExecutor: vi.fn(async (fn: (e: CommandExecutor) => unknown) => fn(hostExec.current!)),
+  },
 }));
 vi.mock("@repo/adapters", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@repo/adapters")>();

--- a/apps/cli/src/commands/wizard.ts
+++ b/apps/cli/src/commands/wizard.ts
@@ -50,6 +50,7 @@ import { saveInstanceUrl, readInstanceUrl } from "../lib/ports";
 import { runRepair, looksCorrupted, lastServiceError } from "../lib/repair";
 import {
   ensureDocker,
+  dockerGap,
   hasDockerCompose,
   composeUp,
   composeInternalToken,
@@ -621,11 +622,20 @@ export async function runWizard(): Promise<void> {
   //    host-net Docker) and a failed Docker ensure fall back to the bare service.
   let method: "compose" | "bare" = "bare";
   if (process.platform === "linux") {
-    if (hasDockerCompose()) {
+    // Say what's ACTUALLY missing. "Docker isn't installed" on a box that has
+    // Docker but no Compose plugin (Debian's docker.io) sent operators chasing
+    // the wrong problem, and re-running get.docker.com for a daemon that's merely
+    // unreachable can't help — it just rewrites their docker repo config.
+    const gap = dockerGap();
+    if (!gap) {
       method = "compose";
+    } else if (!gap.installable) {
+      log.warn(`${gap.summary} — using the bare process service instead.`);
+      if (gap.hint) log.info(gap.hint);
+      method = "bare";
     } else {
-      log.step("Docker isn't installed — installing it now (get.docker.com)…");
-      method = (await ensureDocker()) ? "compose" : "bare";
+      log.step(`${gap.summary} — installing via get.docker.com…`);
+      method = (await ensureDocker({ onNotice: (line) => log.info(line) })) ? "compose" : "bare";
       if (method === "bare") {
         log.warn("Couldn't install Docker automatically — falling back to the bare process service.");
       }

--- a/apps/cli/src/lib/compose.ts
+++ b/apps/cli/src/lib/compose.ts
@@ -11,7 +11,7 @@
  * Lifecycle (up/stop/update/status) routes here when ~/.openship/install-method
  * is "compose"; otherwise the bare service backend handles it.
  */
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
@@ -91,12 +91,72 @@ function writeInstallMethod(method: InstallMethod): void {
   writeFileSync(INSTALL_METHOD_FILE, method, { mode: 0o600 });
 }
 
-/** docker + `docker compose` both present. */
+/**
+ * Why Docker isn't usable, as three SEPARATE facts.
+ *
+ * Collapsing them into one boolean is what made the wizard announce "Docker
+ * isn't installed" on a box that had Docker but no Compose plugin (Debian's
+ * `docker.io` package ships none) — and then re-run get.docker.com for a daemon
+ * that was merely unreachable, which cannot help and rewrites the host's docker
+ * repo config on the way.
+ */
+export interface DockerState {
+  /** `docker` is on PATH. Client-only probe — never touches the socket. */
+  binary: boolean;
+  /** `docker compose` resolves (Compose v2 plugin). Also client-only. */
+  plugin: boolean;
+  /** The daemon answers US. False when it's stopped OR the socket denies this
+   *  user (not in the `docker` group) — indistinguishable from here, so the
+   *  hint below covers both. */
+  daemon: boolean;
+}
+
+export function dockerState(): DockerState {
+  const ok = (args: string[]) => spawnSync("docker", args, { stdio: "ignore" }).status === 0;
+  // `docker --version` is the client; `docker version` (no dashes) contacts the
+  // daemon and is the one that fails on a permission-denied socket.
+  if (!ok(["--version"])) return { binary: false, plugin: false, daemon: false };
+  return { binary: true, plugin: ok(["compose", "version"]), daemon: ok(["version"]) };
+}
+
+export interface DockerGap {
+  /** One line, safe to show a user verbatim. */
+  summary: string;
+  /** True when running the Docker installer would actually close this gap. */
+  installable: boolean;
+  /** What the operator should do when we can't. */
+  hint?: string;
+}
+
+/** null when Docker is fully usable. */
+export function dockerGap(state: DockerState = dockerState()): DockerGap | null {
+  if (!state.binary) {
+    return { summary: "Docker isn't installed", installable: true };
+  }
+  if (!state.plugin) {
+    return {
+      summary: "Docker is installed but the Compose plugin (`docker compose`) is missing",
+      installable: true,
+    };
+  }
+  if (!state.daemon) {
+    const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
+    return {
+      summary: "Docker is installed but its daemon isn't reachable",
+      // Reinstalling changes nothing: a group change only applies to NEW logins,
+      // and a stopped daemon needs starting, not installing.
+      installable: false,
+      hint: asRoot
+        ? "Start it with: systemctl start docker"
+        : `Add your user to the docker group: sudo usermod -aG docker ${userInfo().username} — then log out and back in (or run: newgrp docker). If the daemon is stopped: sudo systemctl start docker`,
+    };
+  }
+  return null;
+}
+
+/** docker + `docker compose` present AND the daemon reachable. */
 export function hasDockerCompose(): boolean {
-  const docker = spawnSync("docker", ["version"], { stdio: "ignore" });
-  if (docker.status !== 0) return false;
-  const compose = spawnSync("docker", ["compose", "version"], { stdio: "ignore" });
-  return compose.status === 0;
+  return dockerGap() === null;
 }
 
 /**
@@ -129,9 +189,25 @@ function shQuote(s: string): string {
  * false and the caller falls back to the bare service. The installer's own
  * output is inherited (that's the real progress the operator sees).
  */
-export async function ensureDocker(): Promise<boolean> {
-  if (hasDockerCompose()) return true;
+export interface EnsureDockerOpts {
+  /** Where narration goes. Defaults to stderr; the wizard passes clack's log so
+   *  the lines match the rest of its output. */
+  onNotice?: (line: string) => void;
+}
+
+export async function ensureDocker(opts: EnsureDockerOpts = {}): Promise<boolean> {
+  const notice = opts.onNotice ?? ((line: string) => process.stderr.write(`  ${line}\n`));
+  const state = dockerState();
+  const gap = dockerGap(state);
+  if (!gap) return true;
   if (process.platform !== "linux") return false;
+  // An unreachable daemon is not an installation problem — say what to do and
+  // stop, rather than running the Docker installer over a working install.
+  if (!gap.installable) {
+    notice(gap.summary + ".");
+    if (gap.hint) notice(gap.hint);
+    return false;
+  }
 
   const plan = systemCatalog.installs.docker({
     os: "linux",
@@ -141,15 +217,52 @@ export async function ensureDocker(): Promise<boolean> {
 
   const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
   const sudo = !asRoot && hasCmd("sudo") ? "sudo " : "";
-  const sh = (script: string): number =>
-    spawnSync("sh", ["-c", sudo ? `${sudo}sh -c ${shQuote(script)}` : script], {
-      stdio: "inherit",
-    }).status ?? 1;
 
-  if (sh(plan.installCommand) !== 0) return false;
+  // Set expectations BEFORE the child takes over the terminal. get.docker.com
+  // prints its commit line and then goes quiet for minutes while apt fetches
+  // ~150 MB — on a small VPS that silence reads as a hang, and operators kill it.
+  notice("This can take 2-5 minutes on a small VPS (~150 MB of packages) and stays quiet while apt works.");
+  if (state.binary) {
+    // The installer detects the existing docker, prints a scary-looking warning
+    // and then `sleep 20` before continuing. Pre-empt it or the pause looks broken.
+    notice("Docker's installer will warn that docker already exists and pause ~20s before continuing — that's expected.");
+  }
+
+  const sh = (script: string): Promise<number> =>
+    new Promise((resolve) => {
+      const child = spawn("sh", ["-c", sudo ? `${sudo}sh -c ${shQuote(script)}` : script], {
+        stdio: "inherit",
+      });
+      // Heartbeat: the ONLY output during the long apt phase, so an operator can
+      // tell "still working" from "wedged". spawn (not spawnSync) purely so this
+      // timer can fire — a sync child blocks the event loop and prints nothing.
+      const started = Date.now();
+      const tick = setInterval(() => {
+        const s = Math.round((Date.now() - started) / 1000);
+        notice(`still installing Docker — ${Math.floor(s / 60)}m${String(s % 60).padStart(2, "0")}s elapsed…`);
+      }, 30_000);
+      const done = (code: number) => {
+        clearInterval(tick);
+        resolve(code);
+      };
+      child.on("error", () => done(1));
+      child.on("close", (code) => done(code ?? 1));
+    });
+
+  if ((await sh(plan.installCommand)) !== 0) return false;
   // Best-effort daemon start (get.docker.com already enables it on systemd).
-  if (plan.startCommand) sh(plan.startCommand);
-  return hasDockerCompose();
+  if (plan.startCommand) await sh(plan.startCommand);
+
+  const after = dockerGap();
+  if (!after) {
+    notice("Docker ready.");
+    return true;
+  }
+  // Installed fine, still not usable — almost always the group: root installed
+  // it, this (non-root) process still can't open the socket until a new login.
+  notice(after.summary + ".");
+  if (after.hint) notice(after.hint);
+  return false;
 }
 
 export interface ComposeUpOpts {

--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/DomainSettings.tsx
@@ -694,9 +694,12 @@ export const DomainSettings = () => {
     const isCustom = newDomainType === "custom";
     const portValue = newDomainPort.trim();
 
-    // The "Include www" toggle owns the www record — a hand-typed "www."
-    // prefix would double it up, so block it with guidance instead.
-    if (isCustom && host.startsWith("www.")) {
+    // `www.x` is a legitimate hostname to add on its own — refuse it only when THIS
+    // project already has that exact row, which is the real error (a duplicate).
+    // This used to reject every typed `www.` on the grounds that the "Include www"
+    // toggle owned it; the toggle created nothing (#289), so the rule blocked the
+    // only workaround users had.
+    if (isCustom && domainsData.domains.some((d: any) => (d.domain ?? d.hostname) === host)) {
       showToast(t.projectSettings.domains.add.noWww, "error", t.projectSettings.domains.toast.addDomainTitle);
       return;
     }
@@ -732,14 +735,31 @@ export const DomainSettings = () => {
         );
       }
 
+      const target = hasProjectServer
+        ? { port: portValue }
+        : { targetPath: newDomainPath.trim() || "/" };
       const nextEndpoint = createPublicEndpoint({
         domainType: newDomainType,
         ...(isCustom ? { customDomain: host } : { domain: host }),
-        ...(hasProjectServer ? { port: portValue } : { targetPath: newDomainPath.trim() || "/" }),
+        ...target,
       });
+      // The www variant must be in THIS save, not just in the domain table:
+      // `syncProjectPublicRoutes` deletes every project-level domain row the
+      // submitted endpoint list omits (project-route-store.ts:108), so a row the
+      // connect call just minted would be removed by the save that follows it.
+      // publicEndpoints is the source of truth for routing — the variant has to be
+      // in it to survive, verify, and get a cert of its own.
+      const wwwEndpoint =
+        isCustom && includeWww && !host.startsWith("www.")
+          ? createPublicEndpoint({
+              domainType: newDomainType,
+              customDomain: `www.${host}`,
+              ...target,
+            })
+          : null;
       const label = isCustom ? host : `${host}.${baseDomain}`;
       const ok = await persistPublicEndpoints(
-        [...publicEndpoints, nextEndpoint],
+        [...publicEndpoints, nextEndpoint, ...(wwwEndpoint ? [wwwEndpoint] : [])],
         isCustom
           ? interpolate(t.projectSettings.domains.toast.addedCustom, { label })
           : interpolate(t.projectSettings.domains.toast.addedFree, { label }),
@@ -1669,10 +1689,13 @@ export const DomainSettings = () => {
   // True when the panel is showing preview (pre-Connect) data only. Used
   // to tweak the explainer text inside the panel.
   const isPreviewOnly = dnsRecords.length === 0 && previewedRecords.length > 0;
-  // Custom domains must be entered bare; the "Include www" toggle adds the www
-  // record. A typed "www." prefix is a mistake, so flag it and block submit.
+  // Only a DUPLICATE blocks submit now. A typed `www.` is fine — the "Include www"
+  // toggle is a convenience for claiming both at once, not the sole owner of www.
   const newDomainHasWww =
-    newDomainType === "custom" && newDomain.trim().toLowerCase().startsWith("www.");
+    newDomainType === "custom" &&
+    domainsData.domains.some(
+      (d: any) => (d.domain ?? d.hostname) === newDomain.trim().toLowerCase(),
+    );
 
   return (
     <div className="space-y-5">

--- a/apps/dashboard/src/components/routing/RoutingModePicker.tsx
+++ b/apps/dashboard/src/components/routing/RoutingModePicker.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React from "react";
-import { useI18n } from "@/components/i18n-provider";
+import { useI18n, interpolate } from "@/components/i18n-provider";
 import PublicEndpointsCard from "@/components/routing/PublicEndpointsCard";
-import type { PublicEndpoint } from "@/context/deployment/types";
+import { createPublicEndpoint, type PublicEndpoint } from "@/context/deployment/types";
 
 /**
  * Free / Custom / None routing picker, rendered as a COMPACT segmented tab (the
@@ -58,6 +58,39 @@ export function RoutingModePicker({
 }: RoutingModePickerProps) {
   const { t } = useI18n();
   const w = t.widgets.routing.settingsCard;
+
+  // The apex the www variant would attach to: the first custom endpoint's hostname.
+  const apex = endpoints.find((e) => e.domainType === "custom")?.customDomain?.trim().toLowerCase();
+  const wwwCandidate = apex && !apex.startsWith("www.") ? apex : null;
+  const wwwIncluded =
+    !!wwwCandidate &&
+    endpoints.some(
+      (e) => e.domainType === "custom" && e.customDomain?.trim().toLowerCase() === `www.${wwwCandidate}`,
+    );
+
+  /** Add/remove the `www.` endpoint, mirroring the apex's port or target path. */
+  const toggleWww = (on: boolean) => {
+    if (!wwwCandidate) return;
+    const host = `www.${wwwCandidate}`;
+    if (!on) {
+      onEndpointsChange(
+        endpoints.filter(
+          (e) => !(e.domainType === "custom" && e.customDomain?.trim().toLowerCase() === host),
+        ),
+      );
+      return;
+    }
+    const primary = endpoints.find((e) => e.domainType === "custom");
+    onEndpointsChange([
+      ...endpoints,
+      createPublicEndpoint({
+        domainType: "custom",
+        customDomain: host,
+        ...(primary?.port ? { port: primary.port } : {}),
+        ...(primary?.targetPath ? { targetPath: primary.targetPath } : {}),
+      }),
+    ]);
+  };
   const tabs: Array<{ value: RoutingMode; label: string }> = [
     { value: "free", label: w.free },
     { value: "custom", label: w.custom },
@@ -84,6 +117,28 @@ export function RoutingModePicker({
         <p className="px-1 pt-0.5 text-xs text-muted-foreground">{labels.noneDesc}</p>
       ) : (
         <div className="pt-1">
+          {/* Offered wherever a CUSTOM domain is chosen — including initial setup,
+              where it was missing entirely (#289 item 2.1) and users had to come back
+              to the project's Domains tab afterwards. `www.<apex>` is appended as its
+              own endpoint because publicEndpoints is what routing reconciles against:
+              `syncProjectPublicRoutes` mints the pending row from it, then the domain
+              sweep verifies it and issues its cert. A flag on the apex would be
+              dropped by the same reconciler. */}
+          {mode === "custom" && wwwCandidate && (
+            <label className="mb-2 flex cursor-pointer items-start gap-2 px-1">
+              <input
+                type="checkbox"
+                checked={wwwIncluded}
+                onChange={(e) => toggleWww(e.target.checked)}
+                className="mt-0.5 size-3.5 accent-primary"
+              />
+              <span className="text-xs text-muted-foreground">
+                {interpolate(t.projectSettings.domains.add.includeWwwDesc, {
+                  domain: wwwCandidate,
+                })}
+              </span>
+            </label>
+          )}
           <PublicEndpointsCard
             projectName={projectName}
             endpoints={endpoints}

--- a/apps/dashboard/src/i18n/locales/en/projectSettings.json
+++ b/apps/dashboard/src/i18n/locales/en/projectSettings.json
@@ -706,7 +706,7 @@
       "includeWwwFallback": "yourdomain.com",
       "externalIngress": "External ingress & TLS",
       "externalIngressDesc": "TLS terminates upstream (Cloudflare Tunnel, load balancer). Verify by TXT only — the domain need not point at this server, and we won't issue a certificate.",
-      "noWww": "Enter the domain without \"www.\" — turn on \"Include www\" below to add it.",
+      "noWww": "That domain is already on this project.",
       "adding": "Adding...",
       "submit": "Add domain"
     },

--- a/packages/adapters/src/infra/nginx.ts
+++ b/packages/adapters/src/infra/nginx.ts
@@ -185,6 +185,13 @@ export interface NginxProviderOptions {
    * silently repoint `sitesDir` at a host directory nothing serves from.
    */
   pinPaths?: boolean;
+  /**
+   * This edge is a CONTAINER and commands run INSIDE it, so the OpenResty master
+   * is pid 1 — see buildReloadCommand. Set by the two container-edge builders in
+   * proxy/ensure-container-edge.ts; never inferred, because guessing it wrong
+   * means a failed reload kills the container and 502s every site.
+   */
+  containerEdge?: boolean;
 }
 
 const DEFAULT_CERT_DIR = "/etc/letsencrypt/live";
@@ -313,13 +320,15 @@ export class NginxProvider implements RoutingProvider, SslProvider {
   private readonly executor: CommandExecutor | null;
   private reloadCommand: string;
   private readonly pinPaths: boolean;
+  private readonly containerEdge: boolean;
 
   constructor(opts: NginxProviderOptions) {
     this.sitesDir = opts.paths.sitesDir;
     this.acmeEmail = opts.acmeEmail;
     this.certDir = opts.certDir ?? DEFAULT_CERT_DIR;
     this.executor = opts.executor ?? null;
-    this.reloadCommand = buildReloadCommand(opts.paths);
+    this.containerEdge = opts.containerEdge ?? false;
+    this.reloadCommand = buildReloadCommand(opts.paths, { containerEdge: this.containerEdge });
     this.pinPaths = opts.pinPaths ?? false;
   }
 
@@ -943,7 +952,9 @@ ${webhookLocation}${extraLocations}
         try {
           const freshPaths = await detectOpenRestyPaths(this.executor);
           this.sitesDir = freshPaths.sitesDir;
-          this.reloadCommand = buildReloadCommand(freshPaths);
+          this.reloadCommand = buildReloadCommand(freshPaths, {
+            containerEdge: this.containerEdge,
+          });
         } catch {
           // Detection failed - fall through with current cached paths
         }

--- a/packages/adapters/src/infra/openresty-lua.ts
+++ b/packages/adapters/src/infra/openresty-lua.ts
@@ -187,19 +187,43 @@ export async function detectOpenRestyPaths(
 /**
  * Build the OpenResty reload command from detected paths.
  *
- * Primary: `openresty -t` then `openresty -s reload` (graceful, zero-downtime).
- * Fallback: if reload fails (e.g. not running), kill everything and start fresh.
+ * Primary (both modes): `openresty -t` then `-s reload` — graceful, zero-downtime.
+ *
+ * What happens when reload FAILS is where the two modes diverge, and getting it
+ * wrong takes every site on the box down:
+ *
+ *   • CONTAINER edge — the master IS pid 1. Killing it exits the container, the
+ *     restart policy brings it back, and every proxied site 502s for the seconds
+ *     in between. "Not running" is also impossible here: if the master were dead
+ *     the container would already be gone. So a failed reload is a real problem to
+ *     SURFACE, never something to recover by suicide.
+ *   • BARE host — a failed reload usually does mean "not running", so starting it
+ *     is right. But it is recovered WITHOUT a pattern kill: `pkill -f openresty`
+ *     also matches a host-networked edge CONTAINER's master (see
+ *     edge-check.test.ts), so the blind kill could take down the very edge it was
+ *     trying to recover. Only start when no live master is on the pid file;
+ *     otherwise report it rather than killing a process we can't identify.
  */
-export function buildReloadCommand(paths: OpenRestyPaths): string {
+export function buildReloadCommand(
+  paths: OpenRestyPaths,
+  opts: { containerEdge?: boolean } = {},
+): string {
+  if (opts.containerEdge) {
+    return `${paths.bin} -t 2>&1 || exit 1
+${paths.bin} -s reload 2>&1 || exit 1`;
+  }
+
   return `${paths.bin} -t 2>&1 || exit 1
 
 if ${paths.bin} -s reload 2>/dev/null; then
   exit 0
 fi
 
-pkill -f '[o]penresty' >/dev/null 2>&1 || true
-pkill -f '[n]ginx' >/dev/null 2>&1 || true
-sleep 1
+if [ -f ${paths.pidPath} ] && kill -0 "$(cat ${paths.pidPath} 2>/dev/null)" 2>/dev/null; then
+  echo "openresty (pid $(cat ${paths.pidPath})) is running but refused -s reload" >&2
+  exit 1
+fi
+
 rm -f ${paths.pidPath}
 ${paths.bin}`;
 }

--- a/packages/adapters/src/infra/reload-command.test.ts
+++ b/packages/adapters/src/infra/reload-command.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { buildReloadCommand } from "./openresty-lua";
+import { containerEdgeProvider, localContainerEdgeProvider } from "../system/proxy/ensure-container-edge";
+import type { CommandExecutor } from "../types";
+
+/**
+ * The reload command's FAILURE path, which is where it could take a whole box
+ * offline (#292: "opening project logs causes openship-edge to crash/restart").
+ *
+ * The old fallback was `pkill -f '[o]penresty'`. Inside the edge container that
+ * pattern matches the container's own master — which is pid 1 — so a single failed
+ * reload exited the container, the restart policy brought it back, and every
+ * proxied site 502'd in between. The codebase already knew this shape: the
+ * uninstall path documents it (edge-check.test.ts) because `pkill -f openresty`
+ * also matches a HOST-NETWORKED container's master from the host side.
+ */
+
+const paths = {
+  bin: "/usr/local/openresty/bin/openresty",
+  confPath: "/usr/local/openresty/nginx/conf/nginx.conf",
+  confDir: "/usr/local/openresty/nginx/conf",
+  sitesDir: "/usr/local/openresty/nginx/conf/sites-enabled",
+  pidPath: "/usr/local/openresty/nginx/logs/nginx.pid",
+};
+
+describe("buildReloadCommand — container edge", () => {
+  const cmd = buildReloadCommand(paths, { containerEdge: true });
+
+  it("never kills anything: the master is pid 1", () => {
+    expect(cmd).not.toMatch(/pkill/);
+    expect(cmd).not.toMatch(/\bkill\b/);
+  });
+
+  it("still validates before reloading, so a bad config can't be loaded", () => {
+    expect(cmd).toContain(`${paths.bin} -t`);
+    expect(cmd).toContain(`${paths.bin} -s reload`);
+  });
+
+  it("fails loudly instead of restarting the process itself", () => {
+    // No bare `<bin>` start line — starting a second master inside a container
+    // whose pid 1 is already the master is never the answer.
+    const lines = cmd.split("\n").map((l) => l.trim());
+    expect(lines.some((l) => l === paths.bin)).toBe(false);
+    // Both steps propagate failure to the caller (who can `docker restart`).
+    expect(cmd).toMatch(/-t .*\|\| exit 1/);
+    expect(cmd).toMatch(/-s reload .*\|\| exit 1/);
+  });
+});
+
+describe("buildReloadCommand — bare host", () => {
+  const cmd = buildReloadCommand(paths);
+
+  it("no longer pattern-kills — that also matches a host-networked edge container", () => {
+    expect(cmd).not.toMatch(/pkill/);
+  });
+
+  it("still recovers a stopped OpenResty by starting it", () => {
+    expect(cmd).toContain(`rm -f ${paths.pidPath}`);
+    expect(cmd.trim().endsWith(paths.bin)).toBe(true);
+  });
+
+  it("refuses to kill a master that IS alive but wouldn't reload", () => {
+    // The only way to reach the fallback with a live master is a stale/mismatched
+    // pid file. Killing an unidentified process is worse than reporting it.
+    expect(cmd).toContain(`kill -0`);
+    expect(cmd).toMatch(/refused -s reload/);
+    expect(cmd).toMatch(/exit 1/);
+  });
+});
+
+describe("the container-edge builders opt in", () => {
+  // Both builders are the ONLY places that know commands run inside the edge, so
+  // the flag has to be set there — inferring it elsewhere is how it drifts.
+  const exec = { exec: async () => "" } as unknown as CommandExecutor;
+
+  it("containerEdgeProvider produces a kill-free reload", async () => {
+    const provider = await containerEdgeProvider(exec, "openship-edge");
+    const cmd = (provider as unknown as { reloadCommand: string }).reloadCommand;
+    expect(cmd).not.toMatch(/pkill/);
+    expect(cmd).toContain("-s reload");
+  });
+
+  it("localContainerEdgeProvider produces a kill-free reload", async () => {
+    const provider = await localContainerEdgeProvider("openship-edge");
+    const cmd = (provider as unknown as { reloadCommand: string }).reloadCommand;
+    expect(cmd).not.toMatch(/pkill/);
+    expect(cmd).toContain("-s reload");
+  });
+});

--- a/packages/adapters/src/system/installer.ts
+++ b/packages/adapters/src/system/installer.ts
@@ -265,6 +265,24 @@ export async function installOpenResty(
   onLog: SystemLogCallback,
   config?: InstallerConfig,
 ): Promise<InstallResult> {
+  // The edge CONTAINER already IS OpenResty, and it holds :80/:443 in host
+  // network mode. Installing the host package on top of it is not merely
+  // redundant — the Debian postinst STARTS openresty.service, the bind fails with
+  // "Address already in use", and dpkg is left half-configured, which breaks every
+  // later apt operation on the box (#288). Same guard `installCertbot` already
+  // has, for the same reason: the edge provides the component.
+  const edge = await resolveOurEdgeContainer(executor).catch(() => null);
+  if (edge) {
+    const inEdge = await executor
+      .exec(containerCommand(edge, "openresty -v 2>&1"))
+      .catch(() => "");
+    if (inEdge.trim()) {
+      const parsed = systemCatalog.checks.openresty.parseVersion(inEdge.trim());
+      onLog(log(`OpenResty ${parsed} provided by the edge container — nothing to install`));
+      return { component: "openresty", success: true, version: parsed };
+    }
+  }
+
   // Gate on privilege BEFORE touching the box, so a non-privileged run bails
   // out cleanly instead of stopping a running OpenResty and then failing at apt.
   const prep = await prepareExecutor(executor, "openresty");

--- a/packages/adapters/src/system/proxy/ensure-container-edge.ts
+++ b/packages/adapters/src/system/proxy/ensure-container-edge.ts
@@ -118,7 +118,7 @@ async function runningImage(
  */
 export type EdgeProviderOptions = Omit<
   NginxProviderOptions,
-  "executor" | "paths" | "pinPaths"
+  "executor" | "paths" | "pinPaths" | "containerEdge"
 >;
 
 /**
@@ -143,6 +143,9 @@ export async function containerEdgeProvider(
     // MUST be pinned: re-detection answers from inside the container and would
     // repoint sitesDir at a host dir the edge never reads.
     pinPaths: true,
+    // Reload runs INSIDE the container, where the master is pid 1 — so a failed
+    // reload must never fall back to killing it (#292).
+    containerEdge: true,
   });
 }
 
@@ -169,6 +172,8 @@ export async function localContainerEdgeProvider(
     // nginx.conf + the Lua are BAKED into the image — nothing to detect, install
     // or patch, and detection would answer from inside the container anyway.
     pinPaths: true,
+    // `docker exec`s into the edge, so the master is pid 1 there too (#292).
+    containerEdge: true,
   });
 }
 

--- a/packages/adapters/src/system/proxy/import/apache-edge-cases.test.ts
+++ b/packages/adapters/src/system/proxy/import/apache-edge-cases.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from "vitest";
+import type { CommandExecutor } from "../../../types";
+import { scanApache } from "./apache";
+
+/**
+ * Apache migration edge cases, written against config a real `httpd:2.4` accepted
+ * (verified with `apachectl -S`, whose vhost-file discovery this exercises).
+ *
+ * The pattern that made these worth chasing: Apache's `:80` half of a TLS site
+ * usually carries a DocumentRoot ALONGSIDE its redirect, so it parsed as a real
+ * static site and then collided with the `:443` vhost for the same ServerName —
+ * one vhost file per host, and the live HTTPS site lost.
+ */
+
+/** Answers `apachectl -S` with a dump and any `cat` with the vhost text. */
+const exec = (conf: string, dump?: string): CommandExecutor =>
+  ({
+    exec: async (cmd: string) => {
+      if (cmd.includes("apachectl -S")) return dump ?? "";
+      if (cmd.startsWith("cat ")) return conf;
+      return "";
+    },
+  }) as unknown as CommandExecutor;
+
+const site = (
+  res: { sites: Array<{ serverNames: string[]; target: unknown }> },
+  host: string,
+) => res.sites.find((s) => s.serverNames.includes(host));
+const urlOf = (s: { target: unknown } | undefined) =>
+  (s?.target as { url?: string; root?: string } | undefined)?.url;
+const rootOf = (s: { target: unknown } | undefined) =>
+  (s?.target as { url?: string; root?: string } | undefined)?.root;
+
+describe("apache: the :80 redirect half vs the :443 site", () => {
+  // Real-world shape: mod_rewrite redirect AND a DocumentRoot on the :80 vhost.
+  const conf = `
+<VirtualHost *:80>
+    ServerName shop.example.com:80
+    ServerAlias www.shop.example.com
+    DocumentRoot /var/www/shop
+    RewriteEngine on
+    RewriteCond %{HTTPS} off
+    RewriteRule ^(.*)$ https://shop.example.com$1 [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName shop.example.com:443
+    ServerAlias www.shop.example.com
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/shop.pem
+    SSLCertificateKeyFile /etc/ssl/private/shop.key
+    ProxyPass /api http://127.0.0.1:9000/ retry=0
+    ProxyPass / http://127.0.0.1:8080/
+    ProxyPassReverse / http://127.0.0.1:8080/
+</VirtualHost>
+`;
+
+  test("keeps the TLS proxy, not the redirect vhost's docroot", async () => {
+    const res = await scanApache(exec(conf));
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].ssl).toBe(true);
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:8080/");
+  });
+
+  test("strips the port from ServerName — `example.com:443` is not a hostname", async () => {
+    // Carried through, this produced `server_name shop.example.com:443`, which
+    // matches no request at all.
+    const res = await scanApache(exec(conf));
+    expect(res.sites[0].serverNames).toEqual(["shop.example.com", "www.shop.example.com"]);
+  });
+
+  test("keeps the full path fan-out for later use", async () => {
+    const res = await scanApache(exec(conf));
+    expect(res.sites[0].routes?.map((r) => r.path)).toEqual(["/api", "/"]);
+  });
+
+  test("carries the existing cert paths so the takeover can reuse them", async () => {
+    const res = await scanApache(exec(conf));
+    expect(res.sites[0].tls).toEqual({
+      certPath: "/etc/ssl/certs/shop.pem",
+      keyPath: "/etc/ssl/private/shop.key",
+    });
+  });
+
+  test("a `Redirect permanent` half is recognised as well as a RewriteRule one", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:80>
+    ServerName r.example.com
+    DocumentRoot /var/www/r
+    Redirect permanent / https://r.example.com/
+</VirtualHost>
+<VirtualHost *:443>
+    ServerName r.example.com
+    SSLEngine on
+    ProxyPass / http://127.0.0.1:7000/
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toHaveLength(1);
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:7000/");
+  });
+
+  test("a redirect-only host with NO TLS vhost is reported, not silently dropped", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:80>
+    ServerName legacy.example.com
+    Redirect permanent / https://legacy.example.com/
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toEqual([]);
+    expect(
+      res.warnings.some((w) => w.includes("legacy.example.com") && w.includes("nothing to serve")),
+    ).toBe(true);
+  });
+
+  test("a :80 vhost that really serves content is NOT treated as a redirect", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:80>
+    ServerName plain.example.com
+    DocumentRoot /var/www/plain
+</VirtualHost>
+`),
+    );
+    expect(rootOf(site(res, "plain.example.com"))).toBe("/var/www/plain");
+  });
+});
+
+describe("apache: upstreams we can't express", () => {
+  test("PHP-FPM (ProxyPassMatch → fcgi) is refused even though a DocumentRoot exists", async () => {
+    // Emitting the docroot would serve .php as PLAIN TEXT — source disclosure,
+    // credentials in config.php included. Refusing is the only safe answer.
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName php.example.com
+    SSLEngine on
+    DocumentRoot /var/www/php
+    ProxyPassMatch ^/(.*\\.php(/.*)?)$ unix:/run/php-fpm.sock|fcgi://localhost/var/www/php
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => /PHP-FPM/i.test(w))).toBe(true);
+  });
+
+  test("a balancer:// cluster is refused with its name", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName cluster.example.com
+    SSLEngine on
+    ProxyPass / balancer://mycluster/
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes("balancer://mycluster/"))).toBe(true);
+  });
+
+  test("ProxyPass ... ! exclusions don't become the upstream", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName ex.example.com
+    SSLEngine on
+    ProxyPass /static !
+    ProxyPass / http://127.0.0.1:6000/
+</VirtualHost>
+`),
+    );
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:6000/");
+  });
+});
+
+describe("apache: names and TLS detection", () => {
+  test("ServerAlias across several lines all become serverNames", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName a.example.com
+    ServerAlias b.example.com c.example.com
+    ServerAlias d.example.com
+    SSLEngine on
+    ProxyPass / http://127.0.0.1:5000/
+</VirtualHost>
+`),
+    );
+    expect(res.sites[0].serverNames).toEqual([
+      "a.example.com",
+      "b.example.com",
+      "c.example.com",
+      "d.example.com",
+    ]);
+  });
+
+  test("TLS is inferred from the :443 arg, SSLEngine, or a cert path", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName byport.example.com
+    ProxyPass / http://127.0.0.1:1/
+</VirtualHost>
+<VirtualHost *:8443>
+    ServerName byengine.example.com
+    SSLEngine on
+    ProxyPass / http://127.0.0.1:2/
+</VirtualHost>
+<VirtualHost *:9000>
+    ServerName bycert.example.com
+    SSLCertificateFile /etc/ssl/x.pem
+    ProxyPass / http://127.0.0.1:3/
+</VirtualHost>
+`),
+    );
+    expect(res.sites.every((s) => s.ssl)).toBe(true);
+  });
+
+  test("a VirtualHost with no ServerName is reported", async () => {
+    const res = await scanApache(
+      exec("<VirtualHost *:80>\n  DocumentRoot /var/www/x\n</VirtualHost>\n"),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes("no ServerName"))).toBe(true);
+  });
+
+  test("two real vhosts for one host collapse to the TLS/proxy one", async () => {
+    // Both serve content (no redirect), so only the collapse prevents the plain
+    // static one from overwriting the TLS proxy.
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:80>
+    ServerName dual.example.com
+    DocumentRoot /var/www/dual
+</VirtualHost>
+<VirtualHost *:443>
+    ServerName dual.example.com
+    SSLEngine on
+    ProxyPass / http://127.0.0.1:4000/
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toHaveLength(1);
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:4000/");
+    expect(res.warnings.some((w) => w.includes("second VirtualHost"))).toBe(true);
+  });
+});
+
+describe("apache: apachectl -S vhost discovery", () => {
+  test("finds vhost files in a non-standard path from the real dump format", async () => {
+    // Verbatim `apachectl -S` shape from httpd:2.4 — the paths come from its
+    // trailing `(file:line)` annotations, which is how Include-resolved configs
+    // in non-conventional locations are found at all.
+    const dump = `VirtualHost configuration:
+*:80                   is a NameVirtualHost
+         default server shop.example.com (/opt/custom/vhosts.conf:1)
+         port 80 namevhost shop.example.com (/opt/custom/vhosts.conf:1)
+                 alias www.shop.example.com
+*:443                  is a NameVirtualHost
+         default server shop.example.com (/opt/custom/vhosts.conf:10)
+ServerRoot: "/usr/local/apache2"`;
+    const conf = `
+<VirtualHost *:443>
+    ServerName shop.example.com
+    SSLEngine on
+    ProxyPass / http://127.0.0.1:8080/
+</VirtualHost>
+`;
+    const calls: string[] = [];
+    const tracking = {
+      exec: async (cmd: string) => {
+        calls.push(cmd);
+        if (cmd.includes("apachectl -S")) return dump;
+        if (cmd.startsWith("cat ")) return conf;
+        return "";
+      },
+    } as unknown as CommandExecutor;
+
+    const res = await scanApache(tracking);
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:8080/");
+    // Proves discovery drove the read, not the conventional fallback paths.
+    expect(calls.some((c) => c.includes("/opt/custom/vhosts.conf"))).toBe(true);
+  });
+
+  test("no readable config at all is a warning, never a throw", async () => {
+    const res = await scanApache({ exec: async () => "" } as unknown as CommandExecutor);
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/adapters/src/system/proxy/import/apache.ts
+++ b/packages/adapters/src/system/proxy/import/apache.ts
@@ -11,7 +11,7 @@
 
 import type { CommandExecutor } from "../../../types";
 import type { ImportedSite, ProxyScanResult } from "../../types";
-import { sq, stripComments, tryExec } from "./parse-utils";
+import { collapseByHost, sq, stripComments, tryExec } from "./parse-utils";
 
 /** Files `apachectl -S` reports as holding vhost defs (Include-resolved). */
 async function vhostFilesFromDump(executor: CommandExecutor): Promise<string[]> {
@@ -56,14 +56,48 @@ function directiveAll(body: string, name: string): string[] {
   );
 }
 
-function parseVhost(body: string, portHint: string): ImportedSite | { warning: string } {
+/**
+ * Is this vhost nothing but an HTTP→HTTPS upgrade for its own hostname?
+ *
+ * Apache writes this two ways — `Redirect permanent / https://…` and a
+ * `RewriteRule … [R=301]` — and such a vhost very often ALSO carries a
+ * DocumentRoot, so it parsed as a real static site and then collided with the
+ * `:443` vhost for the same ServerName. That collision is how a live HTTPS site
+ * came back as an empty docroot. Openship's edge issues that redirect itself, so
+ * there is nothing here to carry.
+ */
+function isHttpsRedirectOnly(body: string): boolean {
+  const hasProxy = /(?:^|\n)\s*ProxyPass\s+\S+\s+(?!!)\S/i.test(body);
+  if (hasProxy) return false;
+  const redirects = [
+    ...body.matchAll(/(?:^|\n)\s*Redirect(?:Permanent|Match)?\s+(?:\d{3}\s+|permanent\s+|temp\s+)?\S*\s*(\S+)/gi),
+    ...body.matchAll(/(?:^|\n)\s*RewriteRule\s+\S+\s+(\S+)\s*\[[^\]]*R=?3\d\d[^\]]*\]/gi),
+  ].map((m) => m[1]);
+  return redirects.length > 0 && redirects.some((t) => /^https:\/\//i.test(t));
+}
+
+/** `ServerName example.com:443` is valid Apache — the port is NOT part of the
+ *  hostname, and carrying it through produced `server_name example.com:443`,
+ *  which matches nothing. */
+function hostOnly(name: string): string {
+  return name.trim().replace(/^https?:\/\//i, "").replace(/:\d+$/, "");
+}
+
+function parseVhost(body: string, portHint: string): ImportedSite | { warning: string } | null {
   const serverName = directive(body, "ServerName")?.split(/\s+/)[0];
   const aliases = directiveAll(body, "ServerAlias").flatMap((line) => line.split(/\s+/));
-  const names = [serverName, ...aliases].filter((n): n is string => Boolean(n));
+  const names = [serverName, ...aliases]
+    .filter((n): n is string => Boolean(n))
+    .map(hostOnly)
+    .filter(Boolean);
 
   if (names.length === 0) {
     return { warning: "apache: skipped a VirtualHost with no ServerName" };
   }
+
+  // Checked BEFORE DocumentRoot: a redirect vhost with a docroot is still a
+  // redirect vhost, and treating it as a static site is what lost the real one.
+  if (isHttpsRedirectOnly(body)) return null;
 
   // ProxyPass <path> http://upstream — keep ALL non-"!" mappings (path fan-out);
   // primary = the "/" mapping if present, else the first.
@@ -71,6 +105,9 @@ function parseVhost(body: string, portHint: string): ImportedSite | { warning: s
     .map((m) => ({ path: m[1], url: m[2] }))
     .filter((p) => p.url && p.url !== "!");
   const docRoot = directive(body, "DocumentRoot")?.replace(/^["']|["']$/g, "");
+  // `ProxyPassMatch … fcgi://` / `…php-fpm.sock` — a PHP application, whatever its
+  // DocumentRoot says.
+  const fcgiMatch = /(?:^|\n)\s*ProxyPassMatch\s+[^\n]*(fcgi:|php-fpm|php\d*-fpm|\.sock)/i.test(body);
   const certPath = directive(body, "SSLCertificateFile");
   const keyPath = directive(body, "SSLCertificateKeyFile");
   const ssl = /:443/.test(portHint) || /SSLEngine\s+on/i.test(body) || Boolean(certPath);
@@ -78,9 +115,30 @@ function parseVhost(body: string, portHint: string): ImportedSite | { warning: s
   let target: ImportedSite["target"];
   if (routes.length > 0) {
     const primary = routes.find((r) => r.path === "/") ?? routes[0];
+    // `balancer://cluster/` needs the matching <Proxy balancer://…> member list,
+    // which no single upstream can express — emitting it yields a vhost nginx
+    // can't resolve.
+    if (/^balancer:\/\//i.test(primary.url)) {
+      return {
+        warning: `apache: ${names[0]} proxies to an mod_proxy_balancer cluster (${primary.url}) — re-add its members manually`,
+      };
+    }
     target = { kind: "proxy", url: primary.url };
+  } else if (fcgiMatch) {
+    // Checked BEFORE DocumentRoot, and that order is a SECURITY property: the
+    // canonical PHP-FPM vhost is `DocumentRoot` + `ProxyPassMatch … fcgi://`, so
+    // treating it as static would serve .php files as plain text — source
+    // disclosure (credentials in config.php), not merely a broken site.
+    return {
+      warning: `apache: ${names[0]} is a PHP-FPM site (ProxyPassMatch → FastCGI) — not migratable as a static root; re-add it manually`,
+    };
   } else if (docRoot) {
     target = { kind: "static", root: docRoot };
+  } else if (/(?:^|\n)\s*ProxyPassMatch\s/i.test(body)) {
+    // Regex-keyed proxying with no docroot has no single upstream either.
+    return {
+      warning: `apache: ${names[0]} uses ProxyPassMatch (regex proxying) — re-add it manually`,
+    };
   } else {
     return { warning: `apache: ${names[0]} has neither ProxyPass nor DocumentRoot — skipped` };
   }
@@ -89,6 +147,13 @@ function parseVhost(body: string, portHint: string): ImportedSite | { warning: s
   if (routes.length > 0) site.routes = routes;
   if (certPath && keyPath) site.tls = { certPath, keyPath };
   return site;
+}
+
+/** ServerName + aliases of a vhost we're about to drop as a redirect half. */
+function redirectVhostNames(body: string): string[] {
+  const serverName = directive(body, "ServerName")?.split(/\s+/)[0];
+  const aliases = directiveAll(body, "ServerAlias").flatMap((l) => l.split(/\s+/));
+  return [serverName, ...aliases].filter((n): n is string => Boolean(n)).map(hostOnly).filter(Boolean);
 }
 
 /** Extract `<VirtualHost x>…</VirtualHost>` bodies + the opening-tag args. */
@@ -115,11 +180,43 @@ export async function scanApache(executor: CommandExecutor): Promise<ProxyScanRe
   const blocks = vhostBlocks(text);
   if (blocks.length === 0) warnings.push("apache: no <VirtualHost> blocks found");
 
+  /** Hostnames whose only vhost was an HTTP→HTTPS redirect. */
+  const redirectOnlyHosts: string[][] = [];
   for (const { args, body } of blocks) {
     const parsed = parseVhost(body, args);
+    if (parsed === null) {
+      redirectOnlyHosts.push(redirectVhostNames(body));
+      continue; // HTTP→HTTPS redirect half — the edge does that itself
+    }
     if ("warning" in parsed) warnings.push(parsed.warning);
     else sites.push(parsed);
   }
 
-  return { proxy: "apache", sites, warnings };
+  // Dropping the redirect half is right when the TLS vhost beside it carries the
+  // site. When there ISN'T one, the hostname would vanish without a word — so say
+  // it, rather than letting the operator discover a missing domain in production.
+  const served = new Set(sites.flatMap((s) => s.serverNames));
+  for (const names of redirectOnlyHosts) {
+    const orphaned = names.filter((n) => !served.has(n));
+    if (orphaned.length > 0) {
+      warnings.push(
+        `apache: ${orphaned.join(", ")} only redirected to HTTPS and has no TLS VirtualHost here — nothing to serve it after migration`,
+      );
+    }
+  }
+
+  // `<VirtualHost *:80>` and `<VirtualHost *:443>` for the same ServerName both
+  // reach here when the :80 half serves real content; TLS has to win.
+  const { kept, dropped } = collapseByHost(
+    sites,
+    (s) => s.serverNames,
+    (s) => (s.ssl ? 2 : 0) + (s.target.kind === "proxy" ? 1 : 0),
+  );
+  for (const d of dropped) {
+    warnings.push(
+      `apache: ${d.serverNames.join(", ")} had a second VirtualHost (${d.ssl ? "TLS" : "plain HTTP"}, ${d.target.kind}) — kept the TLS/proxy one`,
+    );
+  }
+
+  return { proxy: "apache", sites: kept, warnings };
 }

--- a/packages/adapters/src/system/proxy/import/caddy-edge-cases.test.ts
+++ b/packages/adapters/src/system/proxy/import/caddy-edge-cases.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "vitest";
+import type { CommandExecutor } from "../../../types";
+import { scanCaddy } from "./caddy";
+
+/**
+ * Caddy migration edge cases.
+ *
+ * The JSON fixtures below are the SHAPE `caddy adapt` really emits — captured from
+ * a `caddy:2` container, not hand-idealised. Two of these bugs were invisible to
+ * hand-written fixtures and only appeared against the real adapter:
+ *
+ *   • `handle_path /api/*` nests its proxy in a subroute whose matcher lives on the
+ *     nested route. Flattening handlers dropped that matcher, and since the scoped
+ *     proxy comes FIRST, the whole host was routed to its /api backend.
+ *   • `php_fastcgi` adapts to a `reverse_proxy` with `transport.protocol=fastcgi`.
+ *     Read as an HTTP upstream it produced a vhost where every request fails.
+ */
+
+/** Executor that answers `caddy adapt` with JSON, or the Caddyfile cat with text. */
+const exec = (opts: { adapt?: unknown; caddyfile?: string }): CommandExecutor =>
+  ({
+    exec: async (cmd: string) => {
+      if (cmd.includes("caddy adapt")) return opts.adapt ? JSON.stringify(opts.adapt) : "";
+      if (cmd.includes("Caddyfile")) return opts.caddyfile ?? "";
+      return "";
+    },
+  }) as unknown as CommandExecutor;
+
+const httpsServer = (routes: unknown[]) => ({
+  apps: { http: { servers: { srv0: { listen: [":443"], routes } } } },
+});
+
+const urlOf = (site: { target: unknown } | undefined) =>
+  (site?.target as { url?: string; root?: string } | undefined)?.url;
+
+describe("caddy adapt: subroute path scoping", () => {
+  // Verbatim structure of `handle_path /api/* { reverse_proxy api:9000 }` beside a
+  // top-level `reverse_proxy web:3000`.
+  const pathRoute = {
+    match: [{ host: ["paths.example.com"] }],
+    handle: [
+      {
+        handler: "subroute",
+        routes: [
+          {
+            match: [{ path: ["/api/*"] }],
+            handle: [
+              {
+                handler: "subroute",
+                routes: [
+                  { handle: [{ handler: "rewrite", strip_path_prefix: "/api" }] },
+                  { handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "api:9000" }] }] },
+                ],
+              },
+            ],
+          },
+          { handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "web:3000" }] }] },
+        ],
+      },
+    ],
+  };
+
+  test("uses the CATCH-ALL upstream, not the path-scoped one that comes first", async () => {
+    const res = await scanCaddy(exec({ adapt: httpsServer([pathRoute]) }));
+    expect(urlOf(res.sites[0])).toBe("http://web:3000");
+  });
+
+  test("warns that the path rules don't survive", async () => {
+    const res = await scanCaddy(exec({ adapt: httpsServer([pathRoute]) }));
+    expect(res.warnings.some((w) => w.includes("routes some paths"))).toBe(true);
+  });
+
+  test("a host with ONLY a path-scoped upstream is kept but flagged as a guess", async () => {
+    const onlyScoped = {
+      match: [{ host: ["api-only.example.com"] }],
+      handle: [
+        {
+          handler: "subroute",
+          routes: [
+            {
+              match: [{ path: ["/api/*"] }],
+              handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "api:9000" }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const res = await scanCaddy(exec({ adapt: httpsServer([onlyScoped]) }));
+    expect(urlOf(res.sites[0])).toBe("http://api:9000");
+    expect(res.warnings.some((w) => w.includes("no catch-all upstream"))).toBe(true);
+  });
+});
+
+describe("caddy adapt: handlers that aren't an HTTP upstream", () => {
+  test("php_fastcgi (fastcgi transport) is refused, not proxied over HTTP", async () => {
+    const res = await scanCaddy(
+      exec({
+        adapt: httpsServer([
+          {
+            match: [{ host: ["php.example.com"] }],
+            handle: [
+              {
+                handler: "subroute",
+                routes: [
+                  { handle: [{ handler: "vars", root: "/srv/php" }] },
+                  {
+                    handle: [
+                      {
+                        handler: "reverse_proxy",
+                        transport: { protocol: "fastcgi", split_path: [".php"] },
+                        upstreams: [{ dial: "php:9000" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]),
+      }),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => /PHP-FPM|FastCGI/i.test(w))).toBe(true);
+  });
+
+  test("a unix-socket upstream is refused rather than emitted as http://unix/…", async () => {
+    const res = await scanCaddy(
+      exec({
+        adapt: httpsServer([
+          {
+            match: [{ host: ["sock.example.com"] }],
+            handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "unix//run/app.sock" }] }],
+          },
+        ]),
+      }),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes("unix socket"))).toBe(true);
+  });
+
+  test("a respond-only site is named instead of silently vanishing", async () => {
+    const res = await scanCaddy(
+      exec({
+        adapt: httpsServer([
+          {
+            match: [{ host: ["ok.example.com"] }],
+            handle: [{ handler: "static_response", status_code: 200 }],
+          },
+        ]),
+      }),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes("ok.example.com"))).toBe(true);
+  });
+});
+
+describe("caddy adapt: load balancing and collisions", () => {
+  test("multiple upstreams → first is migrated, with a warning", async () => {
+    const res = await scanCaddy(
+      exec({
+        adapt: httpsServer([
+          {
+            match: [{ host: ["lb.example.com"] }],
+            handle: [
+              {
+                handler: "reverse_proxy",
+                upstreams: [{ dial: "app1:3000" }, { dial: "app2:3000" }],
+              },
+            ],
+          },
+        ]),
+      }),
+    );
+    expect(urlOf(res.sites[0])).toBe("http://app1:3000");
+    expect(res.warnings.some((w) => w.includes("load-balances across 2"))).toBe(true);
+  });
+
+  test("an http:// block beside the auto-HTTPS one keeps TLS", async () => {
+    // Both carry a real handler, so both reach the collapse — and one vhost file
+    // per host means the plain one could otherwise win.
+    const res = await scanCaddy(
+      exec({
+        adapt: {
+          apps: {
+            http: {
+              servers: {
+                srv0: {
+                  listen: [":443"],
+                  routes: [
+                    {
+                      match: [{ host: ["dual.example.com"] }],
+                      handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "secure:443" }] }],
+                    },
+                  ],
+                },
+                srv1: {
+                  listen: [":80"],
+                  routes: [
+                    {
+                      match: [{ host: ["dual.example.com"] }],
+                      handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "plain:80" }] }],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].ssl).toBe(true);
+    expect(urlOf(res.sites[0])).toBe("http://secure:443");
+  });
+});
+
+describe("caddy Caddyfile text fallback", () => {
+  const textOnly = (caddyfile: string) => scanCaddy(exec({ caddyfile }));
+
+  test("block-form reverse_proxy { to backend } — the idiomatic shape", async () => {
+    // No inline upstream, so the inline-only regex reported "no reverse_proxy"
+    // and dropped the site.
+    const res = await textOnly(`
+proxied.example.com {
+  reverse_proxy {
+    to backend:8080
+    header_up X-Real-IP {remote_host}
+  }
+}
+`);
+    expect(urlOf(res.sites[0])).toBe("http://backend:8080");
+  });
+
+  test("php_fastcgi is named, not reported as 'no reverse_proxy or root'", async () => {
+    const res = await textOnly(`
+php.example.com {
+  root * /srv/php
+  php_fastcgi php:9000
+}
+`);
+    // root+php_fastcgi: the root wins as a static site only when there's no PHP.
+    expect(res.warnings.some((w) => /php/i.test(w))).toBe(true);
+  });
+
+  test("unix socket upstream is refused", async () => {
+    const res = await textOnly("sock.example.com {\n  reverse_proxy unix//run/app.sock\n}\n");
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes("unix socket"))).toBe(true);
+  });
+
+  test("inline multi-upstream warns", async () => {
+    const res = await textOnly("lb.example.com {\n  reverse_proxy a:3000 b:3000\n}\n");
+    expect(urlOf(res.sites[0])).toBe("http://a:3000");
+    expect(res.warnings.some((w) => w.includes("load-balances"))).toBe(true);
+  });
+
+  test("handle_path in text mode warns that path rules are lost", async () => {
+    const res = await textOnly(`
+paths.example.com {
+  handle_path /api/* {
+    reverse_proxy api:9000
+  }
+  reverse_proxy web:3000
+}
+`);
+    expect(res.warnings.some((w) => w.includes("path"))).toBe(true);
+  });
+
+  test("http:// prefix and :80 address both mean not-TLS", async () => {
+    const res = await textOnly(
+      "http://a.example.com {\n reverse_proxy x:1\n}\nb.example.com:80 {\n reverse_proxy y:2\n}\n",
+    );
+    expect(res.sites.every((s) => s.ssl === false)).toBe(true);
+  });
+
+  test("brace-less single-site shorthand still migrates", async () => {
+    const res = await textOnly("example.com\nreverse_proxy localhost:8080\n");
+    expect(res.sites[0].serverNames).toEqual(["example.com"]);
+    expect(urlOf(res.sites[0])).toBe("http://localhost:8080");
+  });
+});

--- a/packages/adapters/src/system/proxy/import/caddy.ts
+++ b/packages/adapters/src/system/proxy/import/caddy.ts
@@ -11,7 +11,7 @@
 
 import type { CommandExecutor } from "../../../types";
 import type { ImportedSite, ProxyScanResult } from "../../types";
-import { stripComments, tryExec } from "./parse-utils";
+import { collapseByHost, stripComments, tryExec } from "./parse-utils";
 
 const CADDYFILE_PATHS = ["/etc/caddy/Caddyfile", "/etc/Caddyfile"];
 
@@ -21,10 +21,13 @@ interface CaddyHandler {
   handler?: string;
   upstreams?: Array<{ dial?: string }>;
   root?: string;
+  /** `php_fastcgi` adapts to a reverse_proxy whose transport is fastcgi — NOT an
+   *  HTTP upstream. Migrating it as one yields a vhost where every request fails. */
+  transport?: { protocol?: string };
   routes?: CaddyRoute[]; // subroute
 }
 interface CaddyRoute {
-  match?: Array<{ host?: string[] }>;
+  match?: Array<{ host?: string[]; path?: string[] }>;
   handle?: CaddyHandler[];
 }
 interface CaddyAdaptConfig {
@@ -40,26 +43,108 @@ async function loadCaddyJson(executor: CommandExecutor): Promise<string | null> 
   return null;
 }
 
-/** Flatten a route's handlers, descending into `subroute` routes, to leaf handlers. */
-function flattenHandlers(handlers: CaddyHandler[] | undefined, out: CaddyHandler[] = []): CaddyHandler[] {
+interface FlatHandler {
+  h: CaddyHandler;
+  /** The nested route this handler came from had its OWN matcher (a path, a file
+   *  test…), so it serves a SUBSET of the host — not the site's main upstream. */
+  scoped: boolean;
+}
+
+/**
+ * Flatten a route's handlers, descending into `subroute` routes, to leaf handlers.
+ *
+ * Carries each nested route's matcher down as `scoped`, which is load-bearing:
+ * flattening it away made a `handle_path /api/*` proxy indistinguishable from the
+ * site's catch-all, and since it comes FIRST in adapt output, `find()` picked it —
+ * silently routing an entire host to its /api backend. Caught against real
+ * `caddy adapt` output, not a fixture.
+ */
+function flattenHandlers(
+  handlers: CaddyHandler[] | undefined,
+  scoped = false,
+  out: FlatHandler[] = [],
+): FlatHandler[] {
   for (const h of handlers ?? []) {
     if (h.handler === "subroute") {
-      for (const r of h.routes ?? []) flattenHandlers(r.handle, out);
+      for (const r of h.routes ?? []) {
+        flattenHandlers(r.handle, scoped || (r.match?.length ?? 0) > 0, out);
+      }
     } else {
-      out.push(h);
+      out.push({ h, scoped });
     }
   }
   return out;
 }
 
+/** Handlers that mean "this route serves something we cannot express as one
+ *  upstream or docroot" — worth NAMING, because silently skipping them is how a
+ *  live PHP or `respond` site disappears from a migration without a word. */
+const UNMIGRATABLE_HANDLERS: Record<string, string> = {
+  php_fastcgi: "a PHP-FPM site (php_fastcgi)",
+  fastcgi: "a FastCGI backend",
+  static_response: "a static inline response (respond)",
+  templates: "Caddy templates",
+  encode: "",
+  headers: "",
+  authentication: "Caddy authentication",
+  rewrite: "",
+  acme_server: "an embedded ACME server",
+};
+
+interface RouteOutcome {
+  target?: ImportedSite["target"];
+  /** Set when the route carries something worth telling the operator about. */
+  note?: string;
+  /** More than one upstream — load balancing we can't reproduce with one target. */
+  extraUpstreams?: number;
+  /** The only upstream found was path-scoped, so using it as the host's upstream
+   *  is a guess the operator must check. */
+  pathScopedOnly?: boolean;
+  /** Some OTHER upstream on this host is path-scoped — those path rules don't survive. */
+  hasScopedSibling?: boolean;
+}
+
 /** A route's target: reverse_proxy upstream (first dial) or file_server + vars.root. */
-function targetFromRoute(route: CaddyRoute): ImportedSite["target"] | null {
+function targetFromRoute(route: CaddyRoute): RouteOutcome {
   const flat = flattenHandlers(route.handle);
-  const dial = flat.find((h) => h.handler === "reverse_proxy")?.upstreams?.find((u) => u.dial)?.dial;
-  if (dial) return { kind: "proxy", url: /^https?:\/\//.test(dial) ? dial : `http://${dial}` };
-  const root = flat.find((h) => h.handler === "vars" && typeof h.root === "string")?.root;
-  if (root && flat.some((h) => h.handler === "file_server")) return { kind: "static", root };
-  return null; // redirect-only (auto HTTP→HTTPS) or an unsupported handler
+  const proxies = flat.filter((f) => f.h.handler === "reverse_proxy");
+  // The CATCH-ALL proxy is the site's upstream; a path-scoped one only serves its
+  // own prefix. Prefer unscoped, and say so when only a scoped one exists.
+  const chosen = proxies.find((f) => !f.scoped) ?? proxies[0];
+  const proxy = chosen?.h;
+  if (proxy?.transport?.protocol === "fastcgi") {
+    return { note: "serves a PHP-FPM/FastCGI site (php_fastcgi) — not an HTTP upstream" };
+  }
+  const pathScopedOnly = Boolean(chosen?.scoped);
+  const hasScopedSibling = proxies.some((f) => f.scoped);
+  const dials = (proxy?.upstreams ?? []).map((u) => u.dial).filter((d): d is string => Boolean(d));
+  if (dials.length > 0) {
+    const dial = dials[0];
+    // A unix-socket upstream isn't an http URL; emitting `http://unix//run/x.sock`
+    // produces a vhost that can never connect.
+    if (/^unix\//i.test(dial)) {
+      return { note: `proxies to the unix socket "${dial}", which needs a manual upstream` };
+    }
+    return {
+      target: { kind: "proxy", url: /^https?:\/\//.test(dial) ? dial : `http://${dial}` },
+      extraUpstreams: dials.length - 1,
+      pathScopedOnly,
+      hasScopedSibling,
+    };
+  }
+  const root = flat.find((f) => f.h.handler === "vars" && typeof f.h.root === "string")?.h.root;
+  if (root && flat.some((f) => f.h.handler === "file_server")) {
+    return { target: { kind: "static", root } };
+  }
+
+  // Nothing we can serve. Say WHICH handler, when we recognise it.
+  for (const { h } of flat) {
+    const label = h.handler ? UNMIGRATABLE_HANDLERS[h.handler] : undefined;
+    if (label) return { note: `serves ${label}` };
+  }
+  // A bare `static_response`/`redir` route is Caddy's own auto HTTP→HTTPS half —
+  // the edge does that itself, so it is genuinely nothing to migrate.
+  return {};
 }
 
 /** Parse `caddy adapt` JSON. Returns null when it isn't the expected shape. */
@@ -74,6 +159,7 @@ function parseCaddyJson(raw: string): { sites: ImportedSite[]; warnings: string[
   if (!servers) return null;
 
   const sites: ImportedSite[] = [];
+  const warnings: string[] = [];
   for (const srv of Object.values(servers)) {
     // TLS iff this server listens on :443 (Caddy puts the real routes there; the
     // separate :80 server only carries the auto HTTP→HTTPS redirect).
@@ -81,14 +167,47 @@ function parseCaddyJson(raw: string): { sites: ImportedSite[]; warnings: string[
     for (const route of srv.routes ?? []) {
       const hosts = (route.match ?? []).flatMap((m) => m.host ?? []).filter((h) => h && h !== "*");
       if (hosts.length === 0) continue; // catch-all / no host matcher
-      const target = targetFromRoute(route);
-      if (!target) continue; // redirect-only or unsupported — nothing to migrate
+      const outcome = targetFromRoute(route);
+      if (outcome.note) {
+        warnings.push(`caddy: ${hosts.join(", ")} ${outcome.note} — re-add it manually`);
+        continue;
+      }
+      if (!outcome.target) continue; // auto HTTP→HTTPS half — the edge does that itself
+      if (outcome.extraUpstreams) {
+        warnings.push(
+          `caddy: ${hosts.join(", ")} load-balances across ${outcome.extraUpstreams + 1} upstreams — only the first is migrated`,
+        );
+      }
+      // Path routing doesn't survive a single-upstream vhost. Two flavours, and
+      // the second is a guess worth flagging harder than the first.
+      if (outcome.hasScopedSibling || (route.match ?? []).some((m) => m.path?.length)) {
+        warnings.push(
+          `caddy: ${hosts.join(", ")} routes some paths to other upstreams — only the catch-all is migrated; re-add path rules manually`,
+        );
+      }
+      if (outcome.pathScopedOnly) {
+        warnings.push(
+          `caddy: ${hosts.join(", ")} has no catch-all upstream — used its path-scoped one; verify the target`,
+        );
+      }
       // Certs: Caddy auto-provisions, and openship re-issues via Let's Encrypt on
       // takeover, so we carry only the ssl flag here (no fragile cert→SNI mapping).
-      sites.push({ serverNames: hosts, ssl, target, source: "caddy (adapt)" });
+      sites.push({ serverNames: hosts, ssl, target: outcome.target, source: "caddy (adapt)" });
     }
   }
-  return { sites, warnings: [] };
+  // An `http://host` block and the auto-HTTPS one for the same host both carry a
+  // real handler — TLS must win, or the site comes back plain HTTP.
+  const { kept, dropped } = collapseByHost(
+    sites,
+    (s) => s.serverNames,
+    (s) => (s.ssl ? 1 : 0),
+  );
+  for (const d of dropped) {
+    warnings.push(
+      `caddy: ${d.serverNames.join(", ")} had a second (non-TLS) block — kept the TLS one`,
+    );
+  }
+  return { sites: kept, warnings };
 }
 
 async function loadCaddyfile(executor: CommandExecutor): Promise<string> {
@@ -146,7 +265,11 @@ export async function scanCaddy(executor: CommandExecutor): Promise<ProxyScanRes
   const json = await loadCaddyJson(executor);
   if (json) {
     const parsed = parseCaddyJson(json);
-    if (parsed && parsed.sites.length > 0) {
+    // Sites OR warnings means adapt gave a real answer. Requiring sites > 0 meant
+    // a config we deliberately REFUSED (all php_fastcgi, all unix sockets) looked
+    // like "adapt found nothing", fell through to the text scan, and threw the
+    // refusal reasons away — the operator got "no readable Caddyfile" instead.
+    if (parsed && (parsed.sites.length > 0 || parsed.warnings.length > 0)) {
       return { proxy: "caddy", sites: parsed.sites, warnings: parsed.warnings };
     }
   }
@@ -188,19 +311,53 @@ async function scanCaddyText(executor: CommandExecutor): Promise<ProxyScanResult
       continue;
     }
 
-    const proxyMatch = body.match(/(?:^|\s)reverse_proxy\s+([^\n{]+)/);
+    const inlineProxy = body.match(/(?:^|\s)reverse_proxy\s+([^\n{]+)/);
+    // Block form — `reverse_proxy {\n  to backend:8080\n  header_up …\n}` — is
+    // idiomatic Caddy and has NO inline upstream, so the inline regex above missed
+    // it entirely and the site was reported as having no reverse_proxy at all.
+    const blockProxy = body.match(/(?:^|\s)reverse_proxy\s*\{([\s\S]*?)\}/);
+    const blockTo = blockProxy?.[1].match(/(?:^|\n)\s*to\s+([^\n]+)/);
     const rootMatch = body.match(/(?:^|\s)root\s+\*?\s*([^\n\s]+)/);
     const tlsMatch = body.match(/(?:^|\s)tls\s+(\S+)\s+(\S+)/); // tls <cert> <key>
 
+    const upstreams = (inlineProxy?.[1] ?? blockTo?.[1] ?? "").trim().split(/\s+/).filter(Boolean);
+    const host = addrs[0].host;
+
     let target: ImportedSite["target"];
-    if (proxyMatch) {
-      const upstream = proxyMatch[1].trim().split(/\s+/)[0];
+    if (upstreams.length > 0) {
+      const upstream = upstreams[0];
+      if (/^unix\//i.test(upstream)) {
+        warnings.push(
+          `caddy: ${host} proxies to the unix socket "${upstream}" — needs a manual upstream, skipped`,
+        );
+        continue;
+      }
+      if (upstreams.length > 1) {
+        warnings.push(
+          `caddy: ${host} load-balances across ${upstreams.length} upstreams — only the first is migrated`,
+        );
+      }
       target = { kind: "proxy", url: /^https?:\/\//.test(upstream) ? upstream : `http://${upstream}` };
+    } else if (/(?:^|\s)php_fastcgi\s/.test(body)) {
+      // BEFORE `root`, and that order is a SECURITY property: `root * /srv/php` +
+      // `php_fastcgi` is the standard PHP site, and migrating it as a static root
+      // serves .php files as plain text — source disclosure, not just a 500.
+      warnings.push(
+        `caddy: ${host} serves a PHP-FPM site (php_fastcgi) — not migratable as a static root; re-add it manually`,
+      );
+      continue;
     } else if (rootMatch) {
       target = { kind: "static", root: rootMatch[1] };
     } else {
-      warnings.push(`caddy: ${addrs[0].host} has no reverse_proxy or root — skipped`);
+      warnings.push(`caddy: ${host} has no reverse_proxy or root — skipped`);
       continue;
+    }
+    // A path-scoped handler means the upstream we found serves only part of the
+    // site; taking it as the whole host quietly rewires everything else.
+    if (/(?:^|\s)(handle_path|handle)\s+\//.test(body)) {
+      warnings.push(
+        `caddy: ${host} routes by path (handle/handle_path) — only one upstream is migrated; re-add path rules manually`,
+      );
     }
 
     const site: ImportedSite = {
@@ -215,5 +372,16 @@ async function scanCaddyText(executor: CommandExecutor): Promise<ProxyScanResult
     sites.push(site);
   }
 
-  return { proxy: "caddy", sites, warnings };
+  const { kept, dropped } = collapseByHost(
+    sites,
+    (s) => s.serverNames,
+    (s) => (s.ssl ? 1 : 0),
+  );
+  for (const d of dropped) {
+    warnings.push(
+      `caddy: ${d.serverNames.join(", ")} had a second (non-TLS) block — kept the TLS one`,
+    );
+  }
+
+  return { proxy: "caddy", sites: kept, warnings };
 }

--- a/packages/adapters/src/system/proxy/import/index.ts
+++ b/packages/adapters/src/system/proxy/import/index.ts
@@ -5,7 +5,8 @@
  */
 
 import type { CommandExecutor } from "../../../types";
-import type { ProxyKind, ProxyScanResult } from "../../types";
+import type { ImportedSite, ProxyKind, ProxyScanResult } from "../../types";
+import { EDGE_CONTAINER_MOUNTS } from "../../../infra/openresty-lua";
 import { scanNginx, scanOpenshipEdge } from "./nginx";
 import { scanCaddy } from "./caddy";
 import { scanApache } from "./apache";
@@ -123,3 +124,43 @@ export function canImportProxy(proxy: ProxyKind | undefined): boolean {
 }
 
 export { scanNginx, scanOpenshipEdge, scanCaddy, scanApache, scanTraefik };
+
+/** One adopted static site whose docroot the containerized edge cannot read. */
+export interface UnreachableStaticRoot {
+  /** Primary hostname (what the operator recognises). */
+  host: string;
+  /** The docroot as the foreign proxy declared it — a HOST path. */
+  root: string;
+}
+
+/**
+ * Adopted static sites whose docroot lives outside the edge container's bind
+ * mounts — i.e. the paths the edge simply cannot see.
+ *
+ * A bare host proxy could serve any directory on the box; the containerized edge
+ * only sees {@link EDGE_CONTAINER_MOUNTS}. Migrating `root /home/app/dist`
+ * verbatim therefore produces a vhost that answers **500** (`try_files` →
+ * `/index.html` → "rewrite or internal redirection cycle"), which reads as a
+ * broken site rather than a missing mount. Surfacing this BEFORE the cutover lets
+ * the caller offer the real choices: copy the tree under `/opt/openship/static`
+ * (already mounted), add a bind mount, or knowingly leave it.
+ *
+ * Returns [] for a bare-host edge, where every path is readable already.
+ */
+export function unreachableStaticRoots(
+  sites: ImportedSite[],
+  opts: { containerEdge: boolean },
+): UnreachableStaticRoot[] {
+  if (!opts.containerEdge) return [];
+  const visible = EDGE_CONTAINER_MOUNTS.map((m) => m.host.replace(/\/+$/, ""));
+  const out: UnreachableStaticRoot[] = [];
+  for (const site of sites) {
+    if (site.target.kind !== "static") continue;
+    const root = site.target.root.replace(/\/+$/, "");
+    // Prefix match on a path BOUNDARY — `/opt/openship/staticstuff` is not
+    // inside `/opt/openship/static`.
+    const reachable = visible.some((v) => root === v || root.startsWith(`${v}/`));
+    if (!reachable) out.push({ host: site.serverNames[0] ?? root, root: site.target.root });
+  }
+  return out;
+}

--- a/packages/adapters/src/system/proxy/import/nginx.ts
+++ b/packages/adapters/src/system/proxy/import/nginx.ts
@@ -11,7 +11,7 @@ import type { ImportedSite, ProxyScanResult } from "../../types";
 import { EDGE_HOST_PATHS, OPENRESTY_DEFAULT_PATHS } from "../../../infra/openresty-lua";
 import { containerCommand } from "../../edge-container-executor";
 import { resolveOurEdgeContainer } from "../detect";
-import { extractBlocks, stripComments, tryExec } from "./parse-utils";
+import { collapseByHost, extractBlocks, stripComments, tryExec } from "./parse-utils";
 
 async function loadNginxConfig(executor: CommandExecutor): Promise<string> {
   const dumped = await tryExec(executor, "nginx -T 2>/dev/null");
@@ -62,7 +62,15 @@ function resolveProxyTarget(
   const host = authority.replace(/:\d+$/, "");
   if (upstreams.has(host)) return { url: `${scheme}${upstreams.get(host)}` };
   const isIp = /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
-  if (isIp || host === "localhost" || host.includes(".")) return { url: raw };
+  // `localhost` is NOT safe to carry over verbatim: nginx resolves it to ::1
+  // first, and most app servers bind IPv4 only — so an adopted
+  // `proxy_pass http://localhost:4000` 502s with "connect() failed (111) …
+  // upstream: http://[::1]:4000". Pin the family the app actually listens on.
+  // (An app bound ONLY to ::1 is rare enough to be worth this trade.)
+  if (host === "localhost" || host === "ip6-localhost") {
+    return { url: raw.replace(/^(https?:\/\/)[^/:]+/i, "$1127.0.0.1") };
+  }
+  if (isIp || host.includes(".")) return { url: raw };
   return { reason: `proxy_pass host "${host}" is an undeclared upstream — not migratable` };
 }
 
@@ -127,6 +135,30 @@ function isHttpsUpgradeForSelf(body: string, names: string[]): boolean {
   });
 }
 
+/**
+ * Does every `location` in this block exist only to answer ACME challenges?
+ *
+ * certbot's `--webroot` leaves blocks whose sole content is
+ * `location /.well-known/acme-challenge/ { root /var/www/certbot; }` — and
+ * `--webroot-path` pointed at a deliberately nonexistent dir is a known certbot
+ * idiom too. Their `root` is NOT a site root: treating it as one produced a
+ * static vhost for a directory with no index, which the edge answers with a 500
+ * (`try_files` → `/index.html` → redirect cycle). Our edge answers ACME itself,
+ * so these carry nothing to migrate.
+ */
+function isAcmeWebrootOnly(body: string): boolean {
+  const paths = [...body.matchAll(/(?:^|[\s;}])location\s+([^{]+?)\s*\{/g)].map((m) =>
+    m[1].trim(),
+  );
+  if (paths.length === 0) {
+    // No locations at all — a bare `root` with nothing serving it is only ACME
+    // scaffolding when the path itself says so (certbot's nonexistent webroot).
+    const root = firstDirective(body, "root") ?? "";
+    return /letsencrypt|acme|certbot/i.test(root);
+  }
+  return paths.every((p) => /\.well-known\/acme-challenge/i.test(p));
+}
+
 function parseServer(
   body: string,
   source: string,
@@ -175,10 +207,21 @@ function parseServer(
     const primary = resolved.find((r) => r.path === "/") ?? resolved[0];
     target = { kind: "proxy", url: primary.url };
     routes = resolved;
-  } else if (root) {
-    target = { kind: "static", root: root.replace(/;$/, "") };
   } else if (isHttpsUpgradeForSelf(body, names)) {
-    return { warnings: [] }; // HTTPS-upgrade half of a certbot pair — nothing lost
+    // BEFORE the `root` fallback, deliberately. certbot's :80 half usually
+    // carries BOTH a redirect and an ACME webroot `root`, so checking `root`
+    // first classified it as a STATIC SITE — which then collided with the real
+    // :443 vhost for the same hostname downstream (one file per host) and
+    // overwrote it. The site vanished and its TLS with it: the host answered
+    // only on :80 serving an empty webroot.
+    return { warnings: [] };
+  } else if (root && !isAcmeWebrootOnly(body)) {
+    target = { kind: "static", root: root.replace(/;$/, "") };
+  } else if (root) {
+    // A root that exists ONLY to answer /.well-known/acme-challenge — certbot
+    // scaffolding, not a site. Our edge answers ACME itself (nginx.conf proxies
+    // the challenge to certbot's loopback port), so there's nothing to carry.
+    return { warnings: [] };
   } else {
     warnings.push(`nginx: ${names[0]} has neither proxy_pass nor root — skipped (${source})`);
     return { warnings };
@@ -215,9 +258,24 @@ function parseNginxConfig(raw: string): ProxyScanResult {
     if (site) sites.push(site);
   }
 
-  return { proxy: "nginx", sites, warnings };
+  const { kept } = collapseByHost(
+    sites,
+    (s) => s.serverNames,
+    (s) => (s.ssl ? 2 : 0) + (s.target.kind === "proxy" ? 1 : 0),
+  );
+  return { proxy: "nginx", sites: kept, warnings };
 }
 
+/**
+ * One vhost file per hostname downstream, so two parsed blocks sharing a
+ * `server_name` are a COLLISION — last write wins and the loser is gone. Decide
+ * the winner here instead of letting file-write order decide it.
+ *
+ * Precedence: TLS beats plain HTTP, and a proxy beats a static root. That's the
+ * certbot pair (`:80` helper + `:443` real site) resolved the right way round —
+ * previously the `:80` half could overwrite the real site, leaving the host
+ * answering only on port 80 with an empty webroot.
+ */
 export async function scanNginx(executor: CommandExecutor): Promise<ProxyScanResult> {
   return parseNginxConfig(await loadNginxConfig(executor));
 }

--- a/packages/adapters/src/system/proxy/import/parse-utils.test.ts
+++ b/packages/adapters/src/system/proxy/import/parse-utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { collapseByHost } from "./parse-utils";
+
+/**
+ * `collapseByHost` is the shared same-hostname dedup every importer (nginx,
+ * traefik, caddy, apache) funnels through. A wrong winner here is what took a
+ * customer's HTTPS site down to plain HTTP, so pin the invariants directly
+ * rather than only through the per-proxy importer tests.
+ */
+describe("collapseByHost", () => {
+  const hosts = (h: string[]) => h;
+
+  it("keeps every block when no two share a host set", () => {
+    const items = [
+      { id: "a", h: ["a.com"], s: 1 },
+      { id: "b", h: ["b.com"], s: 1 },
+    ];
+    const { kept, dropped } = collapseByHost(
+      items,
+      (i) => i.h,
+      (i) => i.s,
+    );
+    expect(kept.map((i) => i.id)).toEqual(["a", "b"]);
+    expect(dropped).toEqual([]);
+  });
+
+  it("keeps the highest score and drops the loser for a colliding host", () => {
+    const http = { id: "http", h: ["site.com"], s: 0 };
+    const https = { id: "https", h: ["site.com"], s: 2 };
+    const { kept, dropped } = collapseByHost(
+      [http, https],
+      (i) => i.h,
+      (i) => i.s,
+    );
+    expect(kept.map((i) => i.id)).toEqual(["https"]);
+    expect(dropped.map((i) => i.id)).toEqual(["http"]);
+  });
+
+  it("keeps the FIRST on a score tie (source order)", () => {
+    const first = { id: "first", h: ["site.com"], s: 1 };
+    const second = { id: "second", h: ["site.com"], s: 1 };
+    const { kept, dropped } = collapseByHost(
+      [first, second],
+      (i) => i.h,
+      (i) => i.s,
+    );
+    expect(kept.map((i) => i.id)).toEqual(["first"]);
+    expect(dropped.map((i) => i.id)).toEqual(["second"]);
+  });
+
+  it("treats a multi-name block as its own group, not merged per-name", () => {
+    const multi = { id: "multi", h: ["a.com", "b.com"], s: 5 };
+    const single = { id: "single", h: ["a.com"], s: 9 };
+    const { kept, dropped } = collapseByHost(
+      [multi, single],
+      (i) => i.h,
+      (i) => i.s,
+    );
+    // Different host SETS → different groups → both kept, despite sharing a.com.
+    expect(kept.map((i) => i.id).sort()).toEqual(["multi", "single"]);
+    expect(dropped).toEqual([]);
+  });
+
+  it("is order-insensitive to how the names within a block are listed", () => {
+    const ab = { id: "ab", h: ["a.com", "b.com"], s: 1 };
+    const ba = { id: "ba", h: ["b.com", "a.com"], s: 2 };
+    const { kept } = collapseByHost(
+      [ab, ba],
+      (i) => i.h,
+      (i) => i.s,
+    );
+    expect(kept.map((i) => i.id)).toEqual(["ba"]); // same group, higher score wins
+  });
+
+  it("keeps groups in first-seen source order", () => {
+    const items = [
+      { id: "z", h: ["z.com"], s: 1 },
+      { id: "a", h: ["a.com"], s: 1 },
+      { id: "z2", h: ["z.com"], s: 0 },
+    ];
+    const { kept } = collapseByHost(
+      items,
+      (i) => i.h,
+      (i) => i.s,
+    );
+    expect(kept.map((i) => i.id)).toEqual(["z", "a"]); // z group seen first
+  });
+
+  describe("traefik redirect-only semantics via score", () => {
+    // Mirrors the folded-in traefik winner rule: redirectOnly → 0, else ssl?2:1.
+    const score = (c: { redirectOnly: boolean; ssl: boolean }) =>
+      c.redirectOnly ? 0 : c.ssl ? 2 : 1;
+
+    it("a real TLS router beats the http→https redirect half", () => {
+      const redirect = { id: "redir", h: ["x.com"], redirectOnly: true, ssl: false };
+      const tls = { id: "tls", h: ["x.com"], redirectOnly: false, ssl: true };
+      const { kept, dropped } = collapseByHost([redirect, tls], (c) => c.h, score);
+      expect(kept.map((c) => c.id)).toEqual(["tls"]);
+      expect(dropped.map((c) => c.id)).toEqual(["redir"]);
+    });
+
+    it("an all-redirect group keeps the first by source order, ignoring ssl", () => {
+      // Both redirect-only → flat 0 → tie → first kept (NOT the ssl one).
+      const r1 = { id: "r1", h: ["y.com"], redirectOnly: true, ssl: false };
+      const r2 = { id: "r2", h: ["y.com"], redirectOnly: true, ssl: true };
+      const { kept, dropped } = collapseByHost([r1, r2], (c) => c.h, score);
+      expect(kept.map((c) => c.id)).toEqual(["r1"]);
+      expect(dropped.map((c) => c.id)).toEqual(["r2"]);
+    });
+  });
+});

--- a/packages/adapters/src/system/proxy/import/parse-utils.ts
+++ b/packages/adapters/src/system/proxy/import/parse-utils.ts
@@ -47,6 +47,50 @@ export function extractBlocks(text: string, keyword: string): string[] {
  * (wraps in `'…'` and escapes embedded quotes). Used to quote file paths fed to
  * `cat` when reading discovered vhost files.
  */
+/**
+ * Resolve same-hostname collisions before they reach disk.
+ *
+ * Every importer feeds one vhost FILE per hostname, so two parsed blocks sharing
+ * a `server_name`/address are a collision where last-write-wins and the loser is
+ * gone with no trace. Every proxy has a shape that produces this pair:
+ *
+ *   • nginx  — certbot's `:80` helper beside the real `:443` vhost
+ *   • traefik — the `web` redirect router beside the `websecure` router
+ *   • caddy  — an explicit `http://host` block beside the auto-HTTPS one
+ *   • apache — `<VirtualHost *:80>` with a Redirect beside `<VirtualHost *:443>`
+ *
+ * Observed live: the plain-HTTP half won and a customer's HTTPS site came back
+ * HTTP-only serving an empty ACME webroot. `score` decides the winner (higher
+ * wins); ties keep source order, and `dropped` is returned so the caller can say
+ * what it set aside rather than staying quiet.
+ */
+export function collapseByHost<T>(
+  items: T[],
+  hostsOf: (item: T) => string[],
+  score: (item: T) => number,
+): { kept: T[]; dropped: T[] } {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    // Keyed on the FULL name set: a multi-name block (`a.com b.com`) is one vhost
+    // and must not be compared against a single-name block for one of them.
+    const key = [...hostsOf(item)].sort().join(" ");
+    const bag = groups.get(key);
+    if (bag) bag.push(item);
+    else groups.set(key, [item]);
+  }
+
+  const kept: T[] = [];
+  const dropped: T[] = [];
+  // Map iteration follows first-insert order, so `kept` stays in source order.
+  for (const bag of groups.values()) {
+    let winner = bag[0];
+    for (const cand of bag) if (score(cand) > score(winner)) winner = cand;
+    kept.push(winner);
+    for (const loser of bag) if (loser !== winner) dropped.push(loser);
+  }
+  return { kept, dropped };
+}
+
 export function sq(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/packages/adapters/src/system/proxy/import/proxy-import.test.ts
+++ b/packages/adapters/src/system/proxy/import/proxy-import.test.ts
@@ -155,10 +155,74 @@ describe("scanNginx", () => {
     expect(res.sites).toHaveLength(hosts.length);
     for (const [host, up] of hosts) {
       const site = res.sites.find((s) => s.serverNames.includes(host));
-      expect(site?.target).toEqual({ kind: "proxy", url: up });
+      // `localhost` is pinned to IPv4 on the way in — see the normalization test
+      // below for why carrying it verbatim breaks.
+      expect(site?.target).toEqual({
+        kind: "proxy",
+        url: up.replace("//localhost:", "//127.0.0.1:"),
+      });
       expect(site?.ssl).toBe(true);
     }
     expect(res.warnings).toEqual([]);
+  });
+
+  test("pins a localhost upstream to IPv4 (nginx resolves localhost to ::1 first)", async () => {
+    // Carried verbatim, this 502s against any app bound to IPv4 only:
+    // `connect() failed (111: Connection refused) … upstream: http://[::1]:4000`.
+    const conf = `
+      server { listen 443 ssl; server_name a.example.com; location / { proxy_pass http://localhost:4000; } }
+      server { listen 443 ssl; server_name b.example.com; location / { proxy_pass http://localhost:5000/api/; } }
+      server { listen 443 ssl; server_name c.example.com; location / { proxy_pass http://127.0.0.1:6000; } }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+
+    const url = (host: string) =>
+      (res.sites.find((s) => s.serverNames.includes(host))?.target as { url: string }).url;
+    expect(url("a.example.com")).toBe("http://127.0.0.1:4000");
+    // The path suffix survives the host rewrite.
+    expect(url("b.example.com")).toBe("http://127.0.0.1:5000/api/");
+    expect(url("c.example.com")).toBe("http://127.0.0.1:6000");
+  });
+
+  test("a certbot :80 helper never overwrites the real :443 site for the same host", async () => {
+    // The shape that silently lost sites: the :80 half carries BOTH the ACME
+    // webroot `root` and the redirect, so it used to parse as a STATIC site and
+    // then win the one-file-per-host race against the real proxy vhost.
+    const conf = `
+      server {
+        listen 80;
+        server_name apistage.example.com;
+        location /.well-known/acme-challenge/ { root /var/www/certbot; }
+        return 301 https://$host$request_uri;
+      }
+      server {
+        listen 443 ssl;
+        server_name apistage.example.com;
+        ssl_certificate /etc/letsencrypt/live/apistage.example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/apistage.example.com/privkey.pem;
+        location / { proxy_pass http://127.0.0.1:5002; }
+      }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].ssl).toBe(true);
+    expect(res.sites[0].target).toEqual({ kind: "proxy", url: "http://127.0.0.1:5002" });
+    expect(res.sites[0].tls?.certPath).toContain("apistage.example.com");
+  });
+
+  test("an ACME-only webroot block is not migrated as a static site", async () => {
+    // certbot's `--webroot-path` pointed at a nonexistent dir. Imported as a
+    // static root it becomes a vhost whose try_files loops → 500.
+    const conf = `
+      server {
+        listen 80;
+        server_name www.example.com;
+        root /var/lib/letsencrypt/http_01_nonexistent;
+      }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+    expect(res.sites).toHaveLength(0);
   });
 
   test("a literal same-host HTTPS upgrade is silent, a cross-host redirect still warns", async () => {

--- a/packages/adapters/src/system/proxy/import/traefik-edge-cases.test.ts
+++ b/packages/adapters/src/system/proxy/import/traefik-edge-cases.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, test } from "vitest";
+import type { CommandExecutor } from "../../../types";
+import { parseTraefikLabels, scanTraefik, type TraefikContainer } from "./traefik";
+
+/**
+ * Traefik migration edge cases, written against the label sets real compose files
+ * actually carry (traefik.io docs examples, and the two-router redirect pattern
+ * every "Traefik + Let's Encrypt" tutorial teaches).
+ *
+ * The theme: a naive label read loses sites. Each test below is a shape that
+ * either dropped a live site, sent traffic to the wrong port, or produced an
+ * upstream reachable from nowhere.
+ */
+
+const box = (over: Partial<TraefikContainer> & { name: string }): TraefikContainer => ({
+  labels: {},
+  ip: "172.18.0.5",
+  ...over,
+});
+
+const urlOf = (site: { target: { kind: string } } | undefined) =>
+  (site?.target as { url?: string } | undefined)?.url;
+
+describe("traefik: the canonical two-router redirect pattern", () => {
+  // Straight out of every Traefik+ACME tutorial: a `web` router that redirects to
+  // https, and a `websecure` router with the real TLS + service. Both carry the
+  // SAME Host(), and one vhost file per host downstream means the plain-HTTP half
+  // could overwrite the TLS half — the site would come back HTTP-only.
+  const twoRouterLabels = {
+    "traefik.enable": "true",
+    "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme": "https",
+    "traefik.http.routers.blog.rule": "Host(`blog.example.com`)",
+    "traefik.http.routers.blog.entrypoints": "web",
+    "traefik.http.routers.blog.middlewares": "redirect-to-https",
+    "traefik.http.routers.blog-secure.rule": "Host(`blog.example.com`)",
+    "traefik.http.routers.blog-secure.entrypoints": "websecure",
+    "traefik.http.routers.blog-secure.tls.certresolver": "le",
+    "traefik.http.routers.blog-secure.service": "blog",
+    "traefik.http.services.blog.loadbalancer.server.port": "8080",
+  };
+
+  test("collapses to ONE site and keeps the TLS half", () => {
+    const res = parseTraefikLabels([box({ name: "blog", labels: twoRouterLabels })]);
+
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].serverNames).toEqual(["blog.example.com"]);
+    expect(res.sites[0].ssl).toBe(true);
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:8080");
+  });
+
+  test("says it recognised the redirect half rather than staying silent", () => {
+    const res = parseTraefikLabels([box({ name: "blog", labels: twoRouterLabels })]);
+    expect(res.warnings.some((w) => /redirect/i.test(w) && w.includes("blog.example.com"))).toBe(
+      true,
+    );
+    // …and does NOT nag about the redirect middleware as unmigrated config: the
+    // edge performs that redirect natively.
+    expect(res.warnings.some((w) => w.includes('middleware(s) "redirect-to-https"'))).toBe(false);
+  });
+
+  test("declaration order doesn't decide the winner — TLS does", () => {
+    // Same config with the secure router declared FIRST.
+    const flipped: Record<string, string> = {};
+    for (const k of Object.keys(twoRouterLabels).reverse()) {
+      flipped[k] = twoRouterLabels[k as keyof typeof twoRouterLabels];
+    }
+    const res = parseTraefikLabels([box({ name: "blog", labels: flipped })]);
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].ssl).toBe(true);
+  });
+
+  test("a host whose ONLY router is a redirect is still kept (never lose a hostname)", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "old",
+        labels: {
+          "traefik.http.middlewares.to-https.redirectscheme.scheme": "https",
+          "traefik.http.routers.old.rule": "Host(`old.example.com`)",
+          "traefik.http.routers.old.middlewares": "to-https",
+        },
+      }),
+    ]);
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].serverNames).toEqual(["old.example.com"]);
+  });
+});
+
+describe("traefik: port and scheme resolution", () => {
+  test("camelCase loadBalancer is the same knob as lowercase", () => {
+    // Traefik lowercases label keys; the docs write `loadBalancer`. Matching only
+    // the lowercase spelling silently fell back to :80 and every request 502'd.
+    const res = parseTraefikLabels([
+      box({
+        name: "api",
+        labels: {
+          "traefik.http.routers.api.rule": "Host(`api.example.com`)",
+          "traefik.http.routers.api.service": "api",
+          "traefik.http.services.api.loadBalancer.server.port": "9000",
+        },
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:9000");
+  });
+
+  test("scheme=https makes the UPSTREAM https, not just the listener", () => {
+    // Talking plaintext to a TLS backend fails every request.
+    const res = parseTraefikLabels([
+      box({
+        name: "sec",
+        labels: {
+          "traefik.http.routers.sec.rule": "Host(`sec.example.com`)",
+          "traefik.http.routers.sec.service": "sec",
+          "traefik.http.services.sec.loadbalancer.server.port": "8443",
+          "traefik.http.services.sec.loadbalancer.server.scheme": "https",
+        },
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("https://172.18.0.5:8443");
+  });
+
+  test("falls back to the container's single exposed port, like Traefik does", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "app",
+        labels: { "traefik.http.routers.app.rule": "Host(`app.example.com`)" },
+        exposedPorts: ["3000/tcp"],
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:3000");
+    expect(res.warnings).toEqual([]);
+  });
+
+  test("two exposed ports and no label is ambiguous — assumes :80 and SAYS so", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "app",
+        labels: { "traefik.http.routers.app.rule": "Host(`app.example.com`)" },
+        exposedPorts: ["3000/tcp", "9229/tcp"],
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:80");
+    expect(res.warnings.some((w) => w.includes("assumed :80"))).toBe(true);
+  });
+
+  test("a router names a service defined on ANOTHER container", () => {
+    // Traefik merges labels from every container into one config, so this is legal
+    // and common (a sidecar declaring the service for the app next to it).
+    const res = parseTraefikLabels([
+      box({
+        name: "router-box",
+        labels: {
+          "traefik.http.routers.web.rule": "Host(`split.example.com`)",
+          "traefik.http.routers.web.service": "elsewhere",
+        },
+      }),
+      box({
+        name: "svc-box",
+        ip: "172.18.0.9",
+        labels: { "traefik.http.services.elsewhere.loadbalancer.server.port": "7000" },
+      }),
+    ]);
+    // The upstream IP is the ROUTER's container (that's what Traefik dials for a
+    // docker-provider service), with the cross-container port applied.
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:7000");
+  });
+
+  test("a service@provider suffix on the router still resolves", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "app",
+        labels: {
+          "traefik.http.routers.app.rule": "Host(`s.example.com`)",
+          "traefik.http.routers.app.service": "app@docker",
+          "traefik.http.services.app.loadbalancer.server.port": "4321",
+        },
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:4321");
+  });
+
+  test("a non-numeric port label can't reach the generated config", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "evil",
+        labels: {
+          "traefik.http.routers.e.rule": "Host(`e.example.com`)",
+          "traefik.http.routers.e.service": "e",
+          "traefik.http.services.e.loadbalancer.server.port": "80; proxy_pass http://evil",
+        },
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.18.0.5:80");
+  });
+});
+
+describe("traefik: multi-network containers", () => {
+  test("traefik.docker.network decides which IP is dialled", () => {
+    // With two networks the wrong IP is an upstream reachable from nowhere, and
+    // Traefik's own answer to that ambiguity is this label.
+    const res = parseTraefikLabels([
+      box({
+        name: "app",
+        ip: undefined,
+        networks: { backend: "10.5.0.2", proxy: "172.20.0.7" },
+        labels: {
+          "traefik.docker.network": "proxy",
+          "traefik.http.routers.app.rule": "Host(`multi.example.com`)",
+          "traefik.http.routers.app.service": "app",
+          "traefik.http.services.app.loadbalancer.server.port": "3000",
+        },
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.20.0.7:3000");
+  });
+
+  test("an unknown network name falls back rather than dropping the site", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "app",
+        ip: undefined,
+        networks: { proxy: "172.20.0.7" },
+        labels: {
+          "traefik.docker.network": "does-not-exist",
+          "traefik.http.routers.app.rule": "Host(`fb.example.com`)",
+        },
+      }),
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://172.20.0.7:80");
+  });
+});
+
+describe("traefik: what we refuse to migrate, loudly", () => {
+  test("tcp and udp routers warn — the edge is HTTP(S) only", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "db",
+        labels: {
+          "traefik.tcp.routers.pg.rule": "HostSNI(`db.example.com`)",
+          "traefik.tcp.routers.pg.service": "pg",
+          "traefik.udp.routers.dns.rule": "HostSNI(`*`)",
+        },
+      }),
+    ]);
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes("tcp router") && w.includes("TCP/UDP"))).toBe(true);
+    expect(res.warnings.some((w) => w.includes("udp router"))).toBe(true);
+  });
+
+  test("a file provider is called out — its routes are in no label", () => {
+    // Otherwise a file-provider user migrates a subset and is told nothing.
+    const res = parseTraefikLabels([
+      box({
+        name: "traefik",
+        cmd: "--providers.docker=true --providers.file.directory=/etc/traefik/dynamic --entrypoints.web.address=:80",
+      }),
+      box({
+        name: "app",
+        labels: { "traefik.http.routers.app.rule": "Host(`labelled.example.com`)" },
+      }),
+    ]);
+    expect(res.sites).toHaveLength(1);
+    expect(res.warnings.some((w) => w.includes("file provider"))).toBe(true);
+  });
+
+  test("exposedByDefault=false: a container without traefik.enable=true is NOT served, so it doesn't migrate", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "traefik",
+        cmd: "--providers.docker --providers.docker.exposedByDefault=false",
+      }),
+      box({
+        name: "opted-in",
+        labels: {
+          "traefik.enable": "true",
+          "traefik.http.routers.in.rule": "Host(`in.example.com`)",
+        },
+      }),
+      box({
+        name: "not-opted-in",
+        labels: { "traefik.http.routers.out.rule": "Host(`out.example.com`)" },
+      }),
+    ]);
+    expect(res.sites.map((s) => s.serverNames[0])).toEqual(["in.example.com"]);
+  });
+});
+
+describe("traefik: rule parsing", () => {
+  test("Host() || Host() alternation collects both hostnames", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "a",
+        labels: {
+          "traefik.http.routers.r.rule": "Host(`a.example.com`) || Host(`b.example.com`)",
+        },
+      }),
+    ]);
+    expect(res.sites[0].serverNames).toEqual(["a.example.com", "b.example.com"]);
+  });
+
+  test("a hostname repeated across matchers isn't duplicated", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "a",
+        labels: {
+          "traefik.http.routers.r.rule":
+            "(Host(`a.example.com`) && PathPrefix(`/x`)) || (Host(`a.example.com`) && PathPrefix(`/y`))",
+        },
+      }),
+    ]);
+    expect(res.sites[0].serverNames).toEqual(["a.example.com"]);
+  });
+
+  test("uppercase HOST( and single quotes both parse", () => {
+    const res = parseTraefikLabels([
+      box({ name: "a", labels: { "traefik.http.routers.r.rule": "HOST('q.example.com')" } }),
+    ]);
+    expect(res.sites[0].serverNames).toEqual(["q.example.com"]);
+  });
+
+  test("tls=true (bare) counts as TLS, not just tls.certresolver", () => {
+    const res = parseTraefikLabels([
+      box({
+        name: "a",
+        labels: {
+          "traefik.http.routers.r.rule": "Host(`t.example.com`)",
+          "traefik.http.routers.r.tls": "true",
+        },
+      }),
+    ]);
+    expect(res.sites[0].ssl).toBe(true);
+  });
+});
+
+describe("scanTraefik: the real docker-inspect shape", () => {
+  const line = (
+    name: string,
+    labels: Record<string, string>,
+    nets: string,
+    ports = "",
+    cmd = "",
+  ) => `${name}\t${JSON.stringify(labels)}\t${nets}\t${ports}\t${cmd}`;
+
+  test("parses name=ip network pairs and honours traefik.docker.network", async () => {
+    const out = line(
+      "/app",
+      {
+        "traefik.enable": "true",
+        "traefik.docker.network": "proxy",
+        "traefik.http.routers.app.rule": "Host(`app.example.com`)",
+        "traefik.http.routers.app.service": "app",
+        "traefik.http.services.app.loadbalancer.server.port": "3000",
+      },
+      "backend=10.5.0.2 proxy=172.20.0.7 ",
+      "3000/tcp ",
+    );
+    const exec = {
+      exec: async (cmd: string) => (cmd.includes("docker inspect") ? out : ""),
+    } as unknown as CommandExecutor;
+
+    const res = await scanTraefik(exec);
+    expect(urlOf(res.sites[0])).toBe("http://172.20.0.7:3000");
+  });
+
+  test("tolerates a bare IP in the network column (no name= prefix)", async () => {
+    const out = line(
+      "/app",
+      { "traefik.http.routers.app.rule": "Host(`bare.example.com`)" },
+      "172.17.0.5 ",
+    );
+    const exec = {
+      exec: async () => out,
+    } as unknown as CommandExecutor;
+    const res = await scanTraefik(exec);
+    expect(urlOf(res.sites[0])).toBe("http://172.17.0.5:80");
+  });
+
+  test("keeps the traefik container itself (for its static flags) but emits no site for it", async () => {
+    const out = [
+      line("/traefik", {}, "proxy=172.20.0.2 ", "", "traefik --providers.file.directory=/dynamic"),
+      line(
+        "/app",
+        { "traefik.http.routers.app.rule": "Host(`app.example.com`)" },
+        "proxy=172.20.0.7 ",
+      ),
+    ].join("\n");
+    const exec = { exec: async () => out } as unknown as CommandExecutor;
+
+    const res = await scanTraefik(exec);
+    expect(res.sites.map((s) => s.serverNames[0])).toEqual(["app.example.com"]);
+    expect(res.warnings.some((w) => w.includes("file provider"))).toBe(true);
+  });
+
+  test("the authentic shape: labels captured from a live traefik v3.1 + compose stack", async () => {
+    // Verbatim from `docker inspect` against a real `traefik:v3.1` + `traefik/whoami`
+    // compose stack (19 compose-added labels alongside the traefik ones, two
+    // networks, camelCase loadBalancer). This is the shape unit fixtures tend to
+    // idealise away: compose label noise, `name=ip` pairs where the WRONG network
+    // sorts first, and a distinctive port to prove the label was really read.
+    const labels = {
+      "com.docker.compose.project": "traefik-real",
+      "com.docker.compose.service": "whoami",
+      "org.opencontainers.image.title": "Whoami",
+      "traefik.docker.network": "traefik-real_proxy",
+      "traefik.enable": "true",
+      "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme": "https",
+      "traefik.http.routers.whoami-secure.entrypoints": "websecure",
+      "traefik.http.routers.whoami-secure.rule": "Host(`whoami.example.com`)",
+      "traefik.http.routers.whoami-secure.service": "whoami",
+      "traefik.http.routers.whoami-secure.tls.certresolver": "le",
+      "traefik.http.routers.whoami.entrypoints": "web",
+      "traefik.http.routers.whoami.middlewares": "redirect-to-https",
+      "traefik.http.routers.whoami.rule": "Host(`whoami.example.com`)",
+      "traefik.http.services.whoami.loadBalancer.server.port": "9999",
+    };
+    const out = [
+      line("/traefik-real-traefik-1", { "com.docker.compose.service": "traefik" }, "traefik-real_proxy=172.23.0.2 ", "80/tcp 443/tcp ", "--providers.docker=true --providers.docker.exposedByDefault=false --providers.file.directory=/etc/traefik/dynamic --entrypoints.web.address=:80"),
+      // backend sorts BEFORE proxy, so a first-IP pick would take 172.22.0.2.
+      line("/traefik-real-whoami-1", labels, "traefik-real_backend=172.22.0.2 traefik-real_proxy=172.23.0.4 ", "80/tcp "),
+      line("/traefik-real-notexposed-1", { "traefik.http.routers.ghost.rule": "Host(`ghost.example.com`)" }, "traefik-real_proxy=172.23.0.5 ", "80/tcp "),
+    ].join("\n");
+    const exec = { exec: async () => out } as unknown as CommandExecutor;
+
+    const res = await scanTraefik(exec);
+
+    // One site, TLS kept, the PROXY network's IP, and the camelCase port.
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].serverNames).toEqual(["whoami.example.com"]);
+    expect(res.sites[0].ssl).toBe(true);
+    expect(urlOf(res.sites[0])).toBe("http://172.23.0.4:9999");
+    // exposedByDefault=false ⇒ the un-labelled container is not a site.
+    expect(res.sites.some((s) => s.serverNames.includes("ghost.example.com"))).toBe(false);
+    expect(res.warnings.some((w) => w.includes("file provider"))).toBe(true);
+  });
+
+  test("a label value containing a tab can't shift columns into a wrong IP", async () => {
+    const out = line(
+      "/app",
+      { "traefik.http.routers.app.rule": "Host(`safe.example.com`)", note: "a\\tb" },
+      "proxy=172.20.0.7 ",
+    );
+    const exec = { exec: async () => out } as unknown as CommandExecutor;
+    const res = await scanTraefik(exec);
+    expect(urlOf(res.sites[0])).toBe("http://172.20.0.7:80");
+  });
+});

--- a/packages/adapters/src/system/proxy/import/traefik.ts
+++ b/packages/adapters/src/system/proxy/import/traefik.ts
@@ -13,19 +13,51 @@
  * An OpenResty vhost carries ONE upstream per host, so only the Host() part
  * migrates; PathPrefix / Headers / Method / middlewares / HostRegexp are
  * surfaced as coverage warnings ("re-add manually"), never silently dropped.
+ *
+ * Three things here exist because the naive reading of labels loses sites:
+ *
+ *   1. The canonical compose pattern is TWO routers per host — a `web`
+ *      entrypoint one whose middleware redirects to https, and a `websecure` one
+ *      carrying the real TLS. Emitting both yields two sites with the SAME
+ *      hostname, and one-vhost-file-per-host downstream means the plain-HTTP half
+ *      can overwrite the TLS half. `collapseByHost` decides the winner here.
+ *   2. Label keys are case-INSENSITIVE to Traefik (`loadBalancer` ≡
+ *      `loadbalancer`), and both spellings are in the wild. Matching only the
+ *      lowercase form silently missed the port and fell back to :80.
+ *   3. Services and middlewares are resolved GLOBALLY across containers, because
+ *      Traefik merges every container's labels into one config — a router on
+ *      container A may legitimately name a service defined on container B.
  */
 
 import type { CommandExecutor } from "../../../types";
 import type { ImportedSite, ProxyScanResult } from "../../types";
-import { tryExec } from "./parse-utils";
+import { collapseByHost, tryExec } from "./parse-utils";
 
 export interface TraefikContainer {
   /** Container name — for the ImportedSite.source trace. */
   name: string;
   /** All docker labels on the container. */
   labels: Record<string, string>;
-  /** Resolved container IP (from docker inspect) for the upstream URL. */
+  /** Resolved container IP (from docker inspect) for the upstream URL. Kept for
+   *  the single-network case; `networks` wins when `traefik.docker.network` names one. */
   ip?: string;
+  /** network name → IP. Needed because a container on several networks has
+   *  several IPs and `traefik.docker.network` says which one Traefik dials. */
+  networks?: Record<string, string>;
+  /** Exposed container ports ("3000/tcp"). Traefik falls back to the single
+   *  exposed port when no service port label is given, so we must too. */
+  exposedPorts?: string[];
+  /** The container's command line — only read for the Traefik container itself,
+   *  to spot static-config flags that change what we're allowed to conclude. */
+  cmd?: string;
+}
+
+/** Traefik lowercases label keys before matching, so `loadBalancer` and
+ *  `loadbalancer` are the same knob. Compare on a lowercased copy. */
+function lowerKeys(labels: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(labels)) out[k.toLowerCase()] = v;
+  return out;
 }
 
 /** Pull backtick- (or quote-) quoted hostnames out of a `Host(...)` matcher. */
@@ -38,7 +70,7 @@ function extractHosts(rule: string): string[] {
       if (h) hosts.push(h);
     }
   }
-  return hosts;
+  return [...new Set(hosts)];
 }
 
 /** Matchers other than Host() that a single-upstream OpenResty vhost can't express. */
@@ -52,25 +84,115 @@ function extraMatchers(rule: string): string[] {
   return [...found];
 }
 
-export function parseTraefikLabels(containers: TraefikContainer[]): ProxyScanResult {
-  const sites: ImportedSite[] = [];
-  const warnings: string[] = [];
+interface ServiceDef {
+  port?: string;
+  /** `https` when the backend speaks TLS — the upstream URL scheme must follow,
+   *  or the proxy talks plaintext to a TLS port and every request fails. */
+  scheme?: string;
+}
+
+interface Definitions {
+  services: Map<string, ServiceDef>;
+  /** Middlewares that are a scheme redirect — the tell for the throwaway
+   *  http→https router half. */
+  redirectMiddlewares: Set<string>;
+  /** `tcp`/`udp` routers, which cannot become an HTTP vhost. */
+  streamRouters: string[];
+  /** True when Traefik also reads a file provider: those routes are NOT in any
+   *  label and would otherwise go missing without a word. */
+  fileProvider: boolean;
+  /** `--providers.docker.exposedByDefault=false` — containers without an
+   *  explicit `traefik.enable=true` are NOT served, so they must not migrate. */
+  exposedByDefault: boolean;
+}
+
+/** Pass 1 — everything that is global to the Traefik config, not per-container. */
+function collectDefinitions(containers: TraefikContainer[]): Definitions {
+  const services = new Map<string, ServiceDef>();
+  const redirectMiddlewares = new Set<string>();
+  const streamRouters: string[] = [];
+  let fileProvider = false;
+  let exposedByDefault = true;
 
   for (const c of containers) {
-    if (c.labels["traefik.enable"] === "false") continue; // opted out
-
-    const routers = new Map<string, Record<string, string>>();
-    const servicePorts = new Map<string, string>();
-    for (const [key, val] of Object.entries(c.labels)) {
-      const r = key.match(/^traefik\.http\.routers\.([^.]+)\.(.+)$/);
-      if (r) {
-        const bag = routers.get(r[1]) ?? {};
-        bag[r[2]] = val;
-        routers.set(r[1], bag);
+    const labels = lowerKeys(c.labels);
+    // A disabled container's SERVICE definitions still count — Traefik merges
+    // label config globally and `traefik.enable=false` only stops that container
+    // being exposed as a route target of its own.
+    for (const [k, v] of Object.entries(labels)) {
+      let m = k.match(/^traefik\.http\.services\.([^.]+)\.loadbalancer\.server\.(port|scheme)$/);
+      if (m) {
+        const def = services.get(m[1]) ?? {};
+        if (m[2] === "port") def.port = v;
+        else def.scheme = v;
+        services.set(m[1], def);
         continue;
       }
-      const s = key.match(/^traefik\.http\.services\.([^.]+)\.loadbalancer\.server\.port$/);
-      if (s) servicePorts.set(s[1], val);
+      m = k.match(/^traefik\.http\.middlewares\.([^.]+)\.redirectscheme\./);
+      if (m) {
+        redirectMiddlewares.add(m[1]);
+        continue;
+      }
+      m = k.match(/^traefik\.(tcp|udp)\.routers\.([^.]+)\.rule$/);
+      if (m) streamRouters.push(`${m[1]} router "${m[2]}"`);
+    }
+
+    // Static config lives on Traefik's own command line (or its env), not in
+    // labels. Both flags below change what the label set can be trusted to mean.
+    const cmd = c.cmd ?? "";
+    if (/--?providers\.file/i.test(cmd)) fileProvider = true;
+    if (/--?providers\.docker\.exposedbydefault[= ]?false/i.test(cmd)) exposedByDefault = false;
+  }
+
+  return { services, redirectMiddlewares, streamRouters, fileProvider, exposedByDefault };
+}
+
+/** Which IP Traefik would actually dial for this container. */
+function resolveIp(c: TraefikContainer, labels: Record<string, string>): string | undefined {
+  const wanted = labels["traefik.docker.network"];
+  // An explicit network is a hard choice: picking a different one produces an
+  // upstream that is reachable from nowhere.
+  if (wanted && c.networks?.[wanted]) return c.networks[wanted];
+  if (c.ip) return c.ip;
+  const first = Object.values(c.networks ?? {}).find(Boolean);
+  return first || undefined;
+}
+
+/** A route we might migrate, before same-host collisions are resolved. */
+interface Candidate {
+  hosts: string[];
+  ssl: boolean;
+  url: string;
+  container: string;
+  router: string;
+  rule: string;
+  middlewares: string[];
+  /** Every middleware on it is a scheme redirect → this is the throwaway
+   *  http→https half, not a site. */
+  redirectOnly: boolean;
+  /** Port had to be guessed — worth saying so, since a wrong port is a 502. */
+  portGuessed: boolean;
+}
+
+export function parseTraefikLabels(containers: TraefikContainer[]): ProxyScanResult {
+  const warnings: string[] = [];
+  const defs = collectDefinitions(containers);
+  const candidates: Candidate[] = [];
+
+  for (const c of containers) {
+    const labels = lowerKeys(c.labels);
+    if (labels["traefik.enable"] === "false") continue; // opted out
+    // With exposedByDefault=false, silence means "not served" — importing such a
+    // container would resurrect a route the operator had switched off.
+    if (!defs.exposedByDefault && labels["traefik.enable"] !== "true") continue;
+
+    const routers = new Map<string, Record<string, string>>();
+    for (const [key, val] of Object.entries(labels)) {
+      const r = key.match(/^traefik\.http\.routers\.([^.]+)\.(.+)$/);
+      if (!r) continue;
+      const bag = routers.get(r[1]) ?? {};
+      bag[r[2]] = val;
+      routers.set(r[1], bag);
     }
 
     for (const [rname, props] of routers) {
@@ -87,48 +209,116 @@ export function parseTraefikLabels(containers: TraefikContainer[]): ProxyScanRes
         continue;
       }
 
-      if (!c.ip) {
+      const ip = resolveIp(c, labels);
+      if (!ip) {
         warnings.push(
           `traefik: ${hosts.join(", ")} — couldn't resolve container ${c.name}'s IP; re-add the upstream manually`,
         );
         continue;
       }
 
-      // Upstream port: the router's service port → the only service → default 80.
-      const svc = props.service;
-      const rawPort =
-        (svc && servicePorts.get(svc)) ??
-        (servicePorts.size === 1 ? [...servicePorts.values()][0] : undefined) ??
-        "80";
+      // Port: the router's own service → the only service defined anywhere → the
+      // container's only exposed port (what Traefik itself falls back to) → 80.
+      const svc = props.service?.replace(/@.*$/, "");
+      const def =
+        (svc ? defs.services.get(svc) : undefined) ??
+        (defs.services.size === 1 ? [...defs.services.values()][0] : undefined);
+      const onlyExposed =
+        c.exposedPorts?.length === 1 ? c.exposedPorts[0].split("/")[0] : undefined;
+      const rawPort = def?.port ?? onlyExposed;
       // The port originates from a container label — accept only digits so it
       // can't inject characters into the generated proxy target (defence-in-depth;
       // the nginx layer rejects them too).
       const port = /^\d{1,5}$/.test(String(rawPort)) ? String(rawPort) : "80";
-      const url = `http://${c.ip}:${port}`;
+      const scheme = def?.scheme?.toLowerCase() === "https" ? "https" : "http";
 
-      const extras = extraMatchers(rule);
-      if (extras.length > 0) {
-        warnings.push(
-          `traefik: ${hosts.join(", ")} also matches ${extras.join(", ")} — only the Host() part is migrated; re-add path/header rules manually`,
-        );
-      }
-      if (props.middlewares) {
-        warnings.push(`traefik: ${hosts.join(", ")} uses middleware(s) "${props.middlewares}" — not migrated`);
-      }
+      const middlewares = (props.middlewares ?? "")
+        .split(",")
+        .map((m) => m.trim().replace(/@.*$/, ""))
+        .filter(Boolean);
 
-      const ssl = Object.keys(props).some((p) => p === "tls" || p.startsWith("tls."));
-      sites.push({
-        serverNames: hosts,
-        ssl,
-        target: { kind: "proxy", url },
-        source: `traefik container ${c.name}`,
+      candidates.push({
+        hosts,
+        ssl: Object.keys(props).some((p) => p === "tls" || p.startsWith("tls.")),
+        url: `${scheme}://${ip}:${port}`,
+        container: c.name,
+        router: rname,
+        rule,
+        middlewares,
+        redirectOnly:
+          middlewares.length > 0 && middlewares.every((m) => defs.redirectMiddlewares.has(m)),
+        portGuessed: rawPort === undefined,
       });
     }
   }
 
-  return { proxy: "traefik", sites, warnings };
+  // redirectOnly scores a flat 0 (never beats a real router, and among an
+  // all-redirect group the first is kept by source order — same as before);
+  // among real routers the TLS one wins, ties keep source order.
+  const { kept: sites, dropped } = collapseByHost(
+    candidates,
+    (c) => c.hosts,
+    (c) => (c.redirectOnly ? 0 : c.ssl ? 2 : 1),
+  );
+
+  // Warn only about SURVIVORS: a dropped redirect half would otherwise warn
+  // "uses middleware(s) redirect-to-https — not migrated", which is noise about
+  // config we reproduce natively.
+  for (const cand of sites) {
+    const extras = extraMatchers(cand.rule);
+    if (extras.length > 0) {
+      warnings.push(
+        `traefik: ${cand.hosts.join(", ")} also matches ${extras.join(", ")} — only the Host() part is migrated; re-add path/header rules manually`,
+      );
+    }
+    const carried = cand.middlewares.filter((m) => !defs.redirectMiddlewares.has(m));
+    if (carried.length > 0) {
+      warnings.push(
+        `traefik: ${cand.hosts.join(", ")} uses middleware(s) "${carried.join(", ")}" — not migrated`,
+      );
+    }
+    if (cand.portGuessed) {
+      warnings.push(
+        `traefik: ${cand.hosts.join(", ")} — no service port label and no single exposed port on ${cand.container}; assumed :80, check the upstream`,
+      );
+    }
+  }
+  for (const d of dropped) {
+    // Not silent: the operator should know we recognised it, not wonder if it
+    // was missed. Distinct wording from a real loss.
+    warnings.push(
+      `traefik: ${d.hosts.join(", ")} router "${d.router}" is an http→https redirect — Openship's edge does that itself (nothing to migrate)`,
+    );
+  }
+  for (const s of defs.streamRouters) {
+    warnings.push(`traefik: ${s} can't migrate — Openship's edge routes HTTP(S), not raw TCP/UDP`);
+  }
+  if (defs.fileProvider) {
+    warnings.push(
+      "traefik: a file provider is configured — routes defined in its YAML/TOML files are NOT read here, only container labels. Re-add those domains manually.",
+    );
+  }
+
+  return {
+    proxy: "traefik",
+    sites: sites.map((cand) => ({
+      serverNames: cand.hosts,
+      ssl: cand.ssl,
+      target: { kind: "proxy" as const, url: cand.url },
+      source: `traefik container ${cand.container}`,
+    })),
+    warnings,
+  };
 }
 
+/**
+ * One vhost per hostname downstream, so two routers sharing a Host() collide and
+ * the loser is silently gone. Resolve it here: drop the redirect-only halves when
+ * a real router exists for the same host, then prefer TLS.
+ *
+ * Keeps a redirect-only router if it is the ONLY thing serving that host —
+ * dropping it would lose the hostname entirely.
+ */
 /**
  * I/O wrapper: gather every running container's labels + IP via `docker inspect`
  * (traefik routers can live on ANY container, not just the traefik one), then
@@ -136,10 +326,16 @@ export function parseTraefikLabels(containers: TraefikContainer[]): ProxyScanRes
  * of a DockerRuntime dependency. Best-effort — never throws.
  */
 export async function scanTraefik(executor: CommandExecutor): Promise<ProxyScanResult> {
+  // Tab-delimited so a label value containing our separator can't shift columns.
+  // Networks are `name=ip` pairs (traefik.docker.network picks one) and Cmd is
+  // needed for the static-config flags read in collectDefinitions.
   const out = await tryExec(
     executor,
     "docker ps -q 2>/dev/null | xargs -r docker inspect " +
-      "--format '{{.Name}}\t{{json .Config.Labels}}\t{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' 2>/dev/null",
+      "--format '{{.Name}}\t{{json .Config.Labels}}\t" +
+      "{{range $n, $v := .NetworkSettings.Networks}}{{$n}}={{$v.IPAddress}} {{end}}\t" +
+      "{{range $p, $v := .Config.ExposedPorts}}{{$p}} {{end}}\t" +
+      "{{if .Config.Cmd}}{{join .Config.Cmd \" \"}}{{end}}' 2>/dev/null",
   );
   if (!out) {
     return { proxy: "traefik", sites: [], warnings: ["traefik: couldn't read container labels via docker inspect"] };
@@ -147,7 +343,7 @@ export async function scanTraefik(executor: CommandExecutor): Promise<ProxyScanR
 
   const containers: TraefikContainer[] = [];
   for (const line of out.split("\n")) {
-    const [rawName, rawLabels, rawIps] = line.split("\t");
+    const [rawName, rawLabels, rawNets, rawPorts, rawCmd] = line.split("\t");
     if (!rawName || !rawLabels) continue;
     let labels: Record<string, string>;
     try {
@@ -155,9 +351,39 @@ export async function scanTraefik(executor: CommandExecutor): Promise<ProxyScanR
     } catch {
       continue;
     }
-    if (!Object.keys(labels).some((k) => k.startsWith("traefik."))) continue; // only traefik-labeled
-    const ip = (rawIps ?? "").trim().split(/\s+/)[0] || undefined;
-    containers.push({ name: rawName.replace(/^\//, ""), labels, ip });
+
+    // `name=ip` pairs, but tolerate a bare IP: the format string above is the
+    // only producer today, yet a bare address is still a usable upstream and
+    // silently dropping it would cost the whole site.
+    const networks: Record<string, string> = {};
+    let bareIp: string | undefined;
+    for (const pair of (rawNets ?? "").trim().split(/\s+/)) {
+      if (!pair) continue;
+      const eq = pair.indexOf("=");
+      if (eq > 0) {
+        const ip = pair.slice(eq + 1);
+        if (ip) networks[pair.slice(0, eq)] = ip;
+      } else if (!bareIp) {
+        bareIp = pair;
+      }
+    }
+    const exposedPorts = (rawPorts ?? "").trim().split(/\s+/).filter(Boolean);
+
+    // Traefik's OWN container carries the static config we need (file provider,
+    // exposedByDefault) and usually no router labels, so it must survive the
+    // label filter below.
+    const hasTraefikLabels = Object.keys(labels).some((k) => k.toLowerCase().startsWith("traefik."));
+    const looksLikeTraefik = /traefik/i.test(rawCmd ?? "") || /--?providers\./i.test(rawCmd ?? "");
+    if (!hasTraefikLabels && !looksLikeTraefik) continue;
+
+    containers.push({
+      name: rawName.replace(/^\//, ""),
+      labels,
+      ip: Object.values(networks)[0] ?? bareIp,
+      networks,
+      exposedPorts,
+      cmd: rawCmd ?? undefined,
+    });
   }
   return parseTraefikLabels(containers);
 }

--- a/packages/adapters/src/system/proxy/import/unreachable-static-roots.test.ts
+++ b/packages/adapters/src/system/proxy/import/unreachable-static-roots.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { unreachableStaticRoots } from "./index";
+import type { ImportedSite } from "../../types";
+
+/**
+ * A bare host proxy can serve any directory on the box; the containerized edge
+ * only sees its bind mounts. Carrying `root /home/app/dist` across that boundary
+ * produced a vhost answering 500 ("rewrite or internal redirection cycle while
+ * internally redirecting to /index.html" — try_files with no index to find),
+ * which reads as a broken site instead of a missing mount. Observed on a live
+ * migration: 2 of 15 sites came up 500 for exactly this reason.
+ */
+
+const staticSite = (host: string, root: string): ImportedSite => ({
+  serverNames: [host],
+  ssl: true,
+  target: { kind: "static", root },
+});
+
+const proxySite = (host: string, url: string): ImportedSite => ({
+  serverNames: [host],
+  ssl: true,
+  target: { kind: "proxy", url },
+});
+
+describe("unreachableStaticRoots", () => {
+  test("flags a host docroot the edge container has no mount for", () => {
+    const sites = [
+      staticSite("front.example.com", "/home/App.Front/dist/site/browser"),
+      staticSite("stage.example.com", "/home/App.Stage/dist/site/browser"),
+    ];
+    expect(unreachableStaticRoots(sites, { containerEdge: true })).toEqual([
+      { host: "front.example.com", root: "/home/App.Front/dist/site/browser" },
+      { host: "stage.example.com", root: "/home/App.Stage/dist/site/browser" },
+    ]);
+  });
+
+  test("accepts a docroot already under a mounted path", () => {
+    const sites = [
+      staticSite("ok.example.com", "/opt/openship/static/ok"),
+      // The mount root itself, and a trailing slash, both count as inside.
+      staticSite("root.example.com", "/opt/openship/static"),
+      staticSite("slash.example.com", "/opt/openship/static/x/"),
+    ];
+    expect(unreachableStaticRoots(sites, { containerEdge: true })).toEqual([]);
+  });
+
+  test("matches on a path boundary, not a string prefix", () => {
+    // `/opt/openship/staticstuff` is NOT inside `/opt/openship/static`.
+    const sites = [staticSite("sneaky.example.com", "/opt/openship/staticstuff/dist")];
+    expect(unreachableStaticRoots(sites, { containerEdge: true })).toEqual([
+      { host: "sneaky.example.com", root: "/opt/openship/staticstuff/dist" },
+    ]);
+  });
+
+  test("ignores proxy sites — only a docroot has to be readable by the edge", () => {
+    const sites = [proxySite("api.example.com", "http://127.0.0.1:5002")];
+    expect(unreachableStaticRoots(sites, { containerEdge: true })).toEqual([]);
+  });
+
+  test("a bare-host edge can read every path, so nothing is flagged", () => {
+    const sites = [staticSite("front.example.com", "/home/App.Front/dist")];
+    expect(unreachableStaticRoots(sites, { containerEdge: false })).toEqual([]);
+  });
+});

--- a/packages/adapters/test/openresty-install-container-edge.test.ts
+++ b/packages/adapters/test/openresty-install-container-edge.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { installOpenResty, installCertbot } from "../src/system/installer";
+import type { CommandExecutor, SystemLog } from "../src/types";
+
+/**
+ * The edge container IS OpenResty and holds :80/:443 in host network mode, so the
+ * host package must never be installed alongside it (#288).
+ *
+ * This isn't "redundant work" — Debian's postinst STARTS openresty.service, the
+ * bind fails with "Address already in use", the postinst exits non-zero, and dpkg
+ * is left half-configured. That breaks EVERY later apt operation on the box, which
+ * is why the reporter's mail-server setup died mid-install.
+ *
+ * `installCertbot` already had this guard; `installOpenResty` did not.
+ */
+
+const noLog = (_l: SystemLog) => {};
+
+/** Executor that reports an openship-edge container and answers execs inside it. */
+const withEdge = (inContainer: Record<string, string>) => {
+  const seen: string[] = [];
+  const exec = {
+    exec: vi.fn(async (cmd: string) => {
+      seen.push(cmd);
+      // resolveOurEdgeContainer probes for our edge by name.
+      if (cmd.includes("docker ps") && cmd.includes("openship-edge")) return "openship-edge";
+      for (const [needle, out] of Object.entries(inContainer)) {
+        if (cmd.includes(needle)) return out;
+      }
+      return "";
+    }),
+    streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+  } as unknown as CommandExecutor;
+  return { exec, seen };
+};
+
+describe("installOpenResty with a container edge present", () => {
+  it("does NOT run the package manager — the edge already provides OpenResty", async () => {
+    const { exec, seen } = withEdge({
+      "openresty -v": "nginx version: openresty/1.27.1.1",
+    });
+
+    const res = await installOpenResty(exec, noLog);
+
+    expect(res.success).toBe(true);
+    expect(res.component).toBe("openresty");
+    // The whole point: nothing that could trip the postinst.
+    const apt = seen.filter((c) => /apt-get|apt |dnf|yum|apk add|zypper/.test(c));
+    expect(apt).toEqual([]);
+  });
+
+  it("never touches systemctl for a host openresty service that shouldn't exist", async () => {
+    const { exec, seen } = withEdge({ "openresty -v": "openresty/1.27.1.1" });
+    await installOpenResty(exec, noLog);
+    expect(seen.filter((c) => c.includes("systemctl"))).toEqual([]);
+  });
+
+  it("reports the version the CONTAINER provides", async () => {
+    const { exec } = withEdge({ "openresty -v": "nginx version: openresty/1.25.3.2" });
+    const res = await installOpenResty(exec, noLog);
+    expect(res.version).toContain("1.25.3.2");
+  });
+
+  it("falls through to a real install when the container has no openresty", async () => {
+    // A container that answers nothing for `openresty -v` isn't our edge providing
+    // it, so the guard must not swallow a genuinely needed install.
+    const { exec, seen } = withEdge({});
+    await installOpenResty(exec, noLog).catch(() => undefined);
+    // It got past the guard (privilege prep / catalog work happened).
+    expect(seen.some((c) => !c.includes("docker ps"))).toBe(true);
+  });
+
+  it("matches the guard installCertbot already had", async () => {
+    // Same box, same shape — the two components must agree, since they're both
+    // baked into the edge image.
+    const { exec, seen } = withEdge({
+      "certbot --version": "certbot 2.9.0",
+      "openresty -v": "openresty/1.27.1.1",
+    });
+
+    const certbot = await installCertbot(exec, noLog);
+    const openresty = await installOpenResty(exec, noLog);
+
+    expect(certbot.success).toBe(true);
+    expect(openresty.success).toBe(true);
+    expect(seen.filter((c) => /apt-get|dnf|yum|apk add/.test(c))).toEqual([]);
+  });
+});

--- a/packages/db/src/repos/domain.repo.ts
+++ b/packages/db/src/repos/domain.repo.ts
@@ -338,6 +338,37 @@ export function createDomainRepo(db: Database) {
      * immediate Verify click. Free-managed rows are excluded; they
      * don't go through DNS verification (we own the suffix).
      */
+    /**
+     * Custom domains that are DNS-VERIFIED but still have no usable certificate.
+     *
+     * The gap this closes: `findPendingVerification` only returns `verified: false`
+     * rows, and the renewal sweep only looks at certs that already exist (it needs an
+     * expiry to compare). A domain whose first issuance failed is verified with
+     * `sslStatus: "provisioning"` — too verified for one job, no cert for the other —
+     * so nothing retried it and the operator had to click Verify + Redeploy by hand.
+     */
+    async findPendingSsl(limit = 50, organizationId?: string): Promise<Domain[]> {
+      const conds = [
+        eq(domain.verified, true),
+        eq(domain.domainType, "custom"),
+        inArray(domain.sslStatus, ["provisioning", "none", "pending"]),
+        // Externally-terminated TLS is not ours to issue; certbot never will.
+        eq(domain.externalIngress, false),
+      ];
+      if (organizationId) {
+        conds.push(
+          inArray(
+            domain.projectId,
+            db
+              .select({ id: project.id })
+              .from(project)
+              .where(eq(project.organizationId, organizationId)),
+          ),
+        );
+      }
+      return db.select().from(domain).where(and(...conds)).limit(limit);
+    },
+
     async findPendingVerification(
       beforeDate: Date,
       limit = 100,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,7 +98,22 @@ if ! command -v node >/dev/null 2>&1; then
   fi
 fi
 
-# 5. Next steps.
+# 5. Docker is the CLI's job, not ours. `openship up` / the wizard install it via
+#    ensureDocker() only when they actually need the compose stack — this script also
+#    runs on laptops and CI that just manage REMOTE servers. (OPENSHIP_SKIP_DOCKER is
+#    still accepted; it no longer does anything.)
+#
+#    The one thing the CLI can't fix for you: group membership needs a new login.
+if [ "$(uname -s)" = "Linux" ] \
+  && command -v docker >/dev/null 2>&1 \
+  && ! docker info >/dev/null 2>&1 \
+  && [ "$(id -u)" -ne 0 ] \
+  && ! id -nG | tr ' ' '\n' | grep -qx docker; then
+  info "Docker is installed but your user can't reach the daemon."
+  info "Fix: sudo usermod -aG docker $(id -un) — then log out and back in (or: newgrp docker)."
+fi
+
+# 6. Next steps.
 cat <<EOF
 
 $(printf '\033[32m✔\033[0m') Openship installed.


### PR DESCRIPTION
<!--
Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
Fill in the sections below and delete any that genuinely don't apply.
-->

## Summary

<!-- What does this PR do, in one or two sentences? -->

## Motivation

<!-- What was broken, or what did the linked issue agree on? Why is this change needed? -->

## Related issue

<!--
New features, behavior changes, new dependencies, new endpoints, and schema/migration changes
need a maintainer to agree on scope *and* approach in an issue **before** the code is written —
link that issue here (for example: Closes #123).

Bug fixes, tests, docs, and small self-contained improvements don't need one. Write "None".
-->

## Changes

<!-- Bullet what changed, grouped by workspace (apps/api, apps/dashboard, packages/db, ...). -->

## Verification

<!--
How you actually verified this: the commands you ran and the before/after behavior.
Paste real output rather than describing what should happen.
-->

```bash

```

## Screenshots

<!-- Before/after for dashboard, web, or desktop changes. Delete this section if not applicable. -->

## Checklist

- [ ] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [ ] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [ ] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [ ] I understand every line of this diff and can explain it in review
