### PR TITLE
fix(core): commented-out gems and mix deps are read as real dependencies

### DIFF
--- a/apps/api/test/lib/language-detectors.test.ts
+++ b/apps/api/test/lib/language-detectors.test.ts
@@ -284,3 +284,39 @@ describe("PHP fpm+nginx recipe", () => {
     expect(getRuntimeImage("symfony")).toBe("php:8.3-fpm");
   });
 });
+
+describe("commented-out entries in dependency manifests", () => {
+  const gemfile = (sinatra: string) =>
+    `source "https://rubygems.org"\ngem "puma"\ngem "rake"\n${sinatra}`;
+  const mixExs = (phoenix: string) =>
+    `defmodule App.MixProject do\n  defp deps do\n    [\n      {:jason, "~> 1.4"},\n${phoenix}    ]\n  end\nend\n`;
+
+  it("a commented gem does not select the Sinatra recipe", () => {
+    const r = detectStack([{ name: "Gemfile" }, { name: "main.rb" }], undefined, {
+      Gemfile: gemfile('# gem "sinatra"\n'),
+    });
+    expect(r.stack).toBe("unknown");
+  });
+
+  it("a declared gem still selects the Sinatra recipe", () => {
+    const r = detectStack([{ name: "Gemfile" }, { name: "main.rb" }], undefined, {
+      Gemfile: gemfile('gem "sinatra"\n'),
+    });
+    expect(r.stack).toBe("sinatra");
+  });
+
+  it("a commented mix.exs dep tuple does not select the Phoenix recipe", () => {
+    const r = detectStack([{ name: "mix.exs" }, { name: "lib", type: "dir" }], undefined, {
+      "mix.exs": mixExs('      # {:phoenix, "~> 1.7"},\n'),
+    });
+    expect(r.stack).not.toBe("phoenix");
+  });
+
+  it("a declared mix.exs dep tuple still selects the Phoenix recipe", () => {
+    const r = detectStack([{ name: "mix.exs" }, { name: "lib", type: "dir" }], undefined, {
+      "mix.exs": mixExs('      {:phoenix, "~> 1.7"},\n'),
+    });
+    expect(r.stack).toBe("phoenix");
+    expect(r.startCommand).toBe("_build/prod/rel/app/bin/app start");
+  });
+});

--- a/packages/core/src/languages/elixir.ts
+++ b/packages/core/src/languages/elixir.ts
@@ -5,14 +5,20 @@ import type { LanguageDetector } from "./types";
  * `deps/0` function. We extract every `{:atom,` occurrence; the version
  * constraint that follows is ignored (we only need presence).
  *
+ * `#`-commented lines are skipped, so a dep left in the file as a comment is
+ * not reported as installed.
+ *
  * (Umbrella-project root detection - `apps_path: "apps"` - lives under
  * `workspaces/elixir.ts`. They read the same file but answer different
  * questions.)
  */
 function parseMixExs(content: string): Record<string, string> {
   const deps: Record<string, string> = {};
-  for (const m of content.matchAll(/\{:([\w]+),/g)) {
-    deps[m[1]] = "*";
+  for (const line of content.split("\n")) {
+    if (line.trim().startsWith("#")) continue;
+    for (const m of line.matchAll(/\{:([\w]+),/g)) {
+      deps[m[1]] = "*";
+    }
   }
   return deps;
 }

--- a/packages/core/src/languages/ruby.ts
+++ b/packages/core/src/languages/ruby.ts
@@ -4,11 +4,17 @@ import type { LanguageDetector } from "./types";
  * Ruby - `Gemfile` lists gems via `gem 'name', '~> X.Y'` directives.
  * We extract the first quoted argument from each `gem` call and ignore the
  * version constraint (we only need presence for stack detection).
+ *
+ * `#`-commented lines are skipped, so a gem left in the file as a comment is
+ * not reported as installed.
  */
 function parseGemfile(content: string): Record<string, string> {
   const deps: Record<string, string> = {};
-  for (const m of content.matchAll(/gem\s+['"]([^'"]+)['"]/g)) {
-    deps[m[1].toLowerCase()] = "*";
+  for (const line of content.split("\n")) {
+    if (line.trim().startsWith("#")) continue;
+    for (const m of line.matchAll(/gem\s+['"]([^'"]+)['"]/g)) {
+      deps[m[1].toLowerCase()] = "*";
+    }
   }
   return deps;
 }


### PR DESCRIPTION
## Problem

`parseGemfile` and `parseMixExs` scan the whole manifest with one global regex and never skip comment lines. A dependency someone commented out is reported as installed.

```ruby
# Gemfile
source "https://rubygems.org"
gem "puma"
gem "rake"
# gem "sinatra"
```

```elixir
# mix.exs
[
  {:jason, "~> 1.4"},
  # {:phoenix, "~> 1.7"},
]
```

| manifest | deps (before) | after |
|---|---|---|
| Gemfile above | `puma, rake, `**`sinatra`** | `puma, rake` |
| mix.exs above | `jason, `**`phoenix`** | `jason` |

Stack detection is the only consumer of this map, so a phantom dependency selects a framework recipe the project cannot run:

| repo | stack | start command |
|---|---|---|
| Gemfile above + `main.rb`, before | `sinatra` | `ruby app.rb` |
| after | `unknown` | — |

There is no `app.rb` in that repo, so the deploy starts and dies. `unknown` is the correct outcome — it prompts the operator to configure the commands instead of guessing wrong.

Same shape for Elixir: `mix.exs` + `lib/` with Phoenix only mentioned in a comment resolves to the `phoenix` recipe and its full `mix do deps.get, compile, assets.deploy, release` build.

This is not a hypothetical style of manifest — commented-out dependencies are how both ecosystems ship their generated files (`rails new` leaves `# gem "bcrypt"`, `# gem "image_processing"`; `mix phx.new` leaves commented optional deps).

## Fix

Both parsers now iterate lines and skip those whose trimmed form starts with `#`. That is exactly what `parseCargoToml` in the same directory already does:

```ts
const trimmed = line.trim();
if (!trimmed || trimmed.startsWith("#")) continue;
```

so this makes Ruby and Elixir consistent with Rust rather than introducing a new convention. The extraction regexes are unchanged.

Deliberately left alone, since neither can produce a phantom entry:
- **trailing comments** on a real declaration (`gem "puma" # web server`) — the regex already captures the first quoted argument before the comment
- **Ruby `=begin`/`=end` blocks** — vanishingly rare in a Gemfile, and handling them would need real block-state tracking for no observed benefit

## Tests

Four cases in `apps/api/test/lib/language-detectors.test.ts`, pinning **both** directions so the fix can't over-correct into dropping real deps:

- a commented gem must **not** select the Sinatra recipe
- a declared gem must **still** select it
- a commented `mix.exs` dep tuple must **not** select the Phoenix recipe
- a declared dep tuple must **still** select it, with its start command intact

Verified the two negative cases **fail** with `ruby.ts` and `elixir.ts` stashed (2 failed / 26 passed) and pass with them restored. The two positive cases pass either way, deliberately — they exist to pin the behaviour the fix must preserve.

`bun run test` → 7/7 turbo tasks successful, `apps/api` 1186 passed. `bun run --cwd apps/api lint` clean.

`ruby.ts` and `elixir.ts` are prettier-clean. `language-detectors.test.ts` has pre-existing prettier drift on `main`; my additions are formatted to prettier's shape and the pre-existing lines are untouched.

## Note

Independent of #300 (also open, PEP 621 array parsing) — different files, and the test additions are at opposite ends of the file, so the two merge cleanly in either order.

While tracing this I noticed the same gap in the PEP 621 `dependencies` array scan — a `# "psycopg2",` line inside the array is picked up as a dep. That one lives in the function #300 rewrites, so I've left it out to keep these diffs from overlapping; happy to send it as a follow-up once #300 lands.
