### PR TITLE
fix(domains): complete automatic SSL verification lifecycle

### DIFF
--- a/apps/api/src/lib/domain-ssl.ts
+++ b/apps/api/src/lib/domain-ssl.ts
@@ -244,13 +244,10 @@ async function executeSslAction(
 
 // NOTE on the toolchain (certbot/OpenResty): we deliberately do NOT install it
 // here. Installing certbot can take 30–90s, which blows the renew HTTP request's
-// timeout. Toolchain install lives in the DEPLOY step chain instead — the deploy
-// preflight runs `system.ensureFeature("ssl", …)` whenever a planned domain has
-// `provisionSsl` (see build-pipeline.ts), streaming the install logs into the
-// deploy output. So a custom domain gets certbot installed AND its cert issued
-// as part of a normal deploy; this on-demand path only issues/renews against an
-// already-provisioned host (and surfaces a clear error if the toolchain is
-// missing — i.e. "redeploy to set up SSL").
+// timeout. Toolchain install lives in the DEPLOY step chain instead. The first
+// deploy prepares it for every local-certbot custom route, including a pending
+// one whose certificate issuance is deferred until verification. This
+// on-demand path can therefore issue/renew later without requiring a redeploy.
 export async function manageDomainSsl(
   hostname: string,
   opts: DomainSslOptions,

--- a/apps/api/src/lib/routing-domains.ts
+++ b/apps/api/src/lib/routing-domains.ts
@@ -10,6 +10,13 @@ import { generateToken } from "./domain-token";
 export interface PlannedRouteDomain {
   hostname: string;
   tls: boolean;
+  /**
+   * The serving host must have the local TLS toolchain ready for this route.
+   * This is intentionally broader than `provisionSsl`: pending custom domains
+   * need certbot installed during their first deploy even though issuance waits
+   * for verification.
+   */
+  requiresSslTooling: boolean;
   provisionSsl: boolean;
   isCloud: boolean;
   targetPort?: number;
@@ -113,11 +120,18 @@ export function buildProjectRouteDomains(opts: {
     // uploaded cert and never run certbot, even behind an external edge.
     const manualSsl = !!domainRow?.manualSsl;
 
+    const requiresSslTooling =
+      usesCertbotSsl(runtimeName) &&
+      !managed.isManaged &&
+      !route.skipSsl &&
+      !external &&
+      !manualSsl;
+
     planned.push({
       hostname: normalized,
       tls: !external || manualSsl,
-      provisionSsl:
-        usesCertbotSsl(runtimeName) && !managed.isManaged && !route.skipSsl && !external && !manualSsl && isVerified,
+      requiresSslTooling,
+      provisionSsl: requiresSslTooling && isVerified,
       isCloud: managed.isManaged,
       ...(route.destination?.targetPort !== undefined
         ? { targetPort: route.destination.targetPort }
@@ -247,11 +261,17 @@ export function buildServiceRouteDomains(opts: {
     // When the domain map isn't supplied (edit/delete reconcile, which doesn't
     // provision SSL), this stays false and no cert work is attempted.
     const isVerified = managed.isManaged ? true : (domainRow?.verified ?? false);
+    const requiresSslTooling =
+      usesCertbotSsl(runtimeName) &&
+      endpoint.domainType === "custom" &&
+      !external &&
+      !manualSsl;
+
     planned.push({
       hostname,
       tls: !external || manualSsl,
-      provisionSsl:
-        usesCertbotSsl(runtimeName) && endpoint.domainType === "custom" && !external && !manualSsl && isVerified,
+      requiresSslTooling,
+      provisionSsl: requiresSslTooling && isVerified,
       isCloud: managed.isManaged,
       targetPort: endpoint.port,
       domainType: endpoint.domainType,
@@ -259,6 +279,7 @@ export function buildServiceRouteDomains(opts: {
       serviceId: service.id,
       isPrimary: false,
       createIfMissing: true,
+      verified: isVerified,
     });
   }
 

--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -1080,7 +1080,10 @@ function buildDeployEnvironment(
                   );
                 }
               }
-              if (plannedDomains.some((d) => d.provisionSsl)) {
+              // Prepare certbot for pending custom domains too. Issuance still
+              // waits for verification, but Verify/the background verifier must
+              // not require a second deploy merely to install the toolchain.
+              if (plannedDomains.some((d) => d.requiresSslTooling)) {
                 await system.ensureFeature("ssl", systemLog);
               }
             } catch (err) {

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -524,7 +524,10 @@ export async function deployComposeServices(
           await opts.system.ensureFeature("routing", systemLog);
         }
       }
-      if (plannedRoutes.some((route) => route.provisionSsl)) {
+      // Pending custom routes deliberately skip issuance, but their first
+      // deploy must still prepare certbot so automatic/manual verification can
+      // issue later without asking for a redeploy.
+      if (plannedRoutes.some((route) => route.requiresSslTooling)) {
         await opts.system.ensureFeature("ssl", systemLog);
       }
     } catch (err) {

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -983,10 +983,11 @@ function sslRetryCleared(id: string): void {
  * Phase 2 of the domain sweep: finish TLS for domains that are already verified but
  * never got a certificate.
  *
- * Reuses `verifyDomainSsl` — the exact call the dashboard's own retry makes — so
- * there is ONE issuance path, not a cron-flavoured copy of it. Best-effort per
- * domain, matching the golden rule: routing/TLS never fails anything, it only
- * reports. What changes is that it now self-heals instead of waiting for a human.
+ * Reuses `manageDomainSsl("provision")`, the same locked/persisted issuance
+ * primitive as the interactive flow. A read-only `verifyDomainSsl` recheck is
+ * insufficient here: when the first ACME order genuinely failed there is no
+ * certificate to discover. Best-effort per domain, matching the golden rule:
+ * routing/TLS never fails anything, it only reports.
  */
 async function issuePendingSsl(limit: number): Promise<{ issued: number; retrying: number }> {
   const rows = await repos.domain.findPendingSsl(limit).catch(() => []);
@@ -1004,14 +1005,10 @@ async function issuePendingSsl(limit: number): Promise<{ issued: number; retryin
     if (!project?.organizationId) continue;
 
     try {
-      await verifyDomainSsl(
-        buildBackgroundContext({
-          userId: "",
-          organizationId: project.organizationId,
-          label: "domains:verify-pending",
-        }),
-        d.id,
-      );
+      await manageDomainSsl(d.hostname, {
+        action: "provision",
+        projectId: d.projectId ?? undefined,
+      });
       const after = await repos.domain.findById(d.id).catch(() => null);
       if (after?.sslStatus === "active") {
         issued++;

--- a/apps/api/src/modules/jobs/job.registry.ts
+++ b/apps/api/src/modules/jobs/job.registry.ts
@@ -120,9 +120,10 @@ export const SYSTEM_JOB_DEFS: SystemJobDef[] = [
     // whose first issuance failed — those sat in `provisioning` forever, needing a
     // manual Verify + Redeploy (#289), because the verify sweep only selects
     // unverified rows and the renewal sweep only selects certs that already exist.
-    // Off the :00/:30 marks. Cloud verifies via Oblien too, so gate only desktop out.
+    // Off the :00/:30 marks. This also runs in Desktop: the local API resolves
+    // each project's active deployment and performs verification/cert work on
+    // that remote server over its stored SSH connection.
     defaultCron: "*/13 * * * *",
-    available: () => platform().target !== "desktop",
     run: async () => {
       const r = await verifyPendingDomains();
       return {

--- a/apps/api/test/lib/routing-domains.test.ts
+++ b/apps/api/test/lib/routing-domains.test.ts
@@ -72,6 +72,59 @@ describe("buildProjectRouteDomains", () => {
     const custom = planned.find((domain) => domain.hostname === "azharmedicinegirls.org");
     expect(custom?.domainType).toBe("custom");
     expect(custom?.isPrimary).toBe(true);
+    expect(custom?.requiresSslTooling).toBe(true);
+    expect(custom?.provisionSsl).toBe(false);
+  });
+
+  it("prepares SSL tooling for pending custom routes without issuing a certificate", () => {
+    const [route] = buildProjectRouteDomains({
+      project: { slug: "my-app" } as any,
+      projectDomains: [
+        {
+          hostname: "app.example.com",
+          verified: false,
+          externalIngress: false,
+          manualSsl: false,
+        } as any,
+      ],
+      publicEndpoints: [
+        { port: 3000, customDomain: "app.example.com", domainType: "custom" },
+      ],
+      runtimeName: "docker",
+      usesManagedRouting: true,
+    });
+
+    expect(route).toMatchObject({
+      hostname: "app.example.com",
+      requiresSslTooling: true,
+      provisionSsl: false,
+      verified: false,
+    });
+  });
+
+  it("does not prepare certbot for external-ingress custom routes", () => {
+    const [route] = buildProjectRouteDomains({
+      project: { slug: "my-app" } as any,
+      projectDomains: [
+        {
+          hostname: "app.example.com",
+          verified: false,
+          externalIngress: true,
+          manualSsl: false,
+        } as any,
+      ],
+      publicEndpoints: [
+        { port: 3000, customDomain: "app.example.com", domainType: "custom" },
+      ],
+      runtimeName: "docker",
+      usesManagedRouting: true,
+    });
+
+    expect(route).toMatchObject({
+      requiresSslTooling: false,
+      provisionSsl: false,
+      tls: false,
+    });
   });
 
   it("still attaches the free .opsh.io fallback when there is no custom domain", () => {
@@ -147,7 +200,9 @@ describe("buildServiceRouteDomains — custom-domain SSL gate", () => {
     });
     expect(route?.hostname).toBe("api.example.com");
     expect(route?.domainType).toBe("custom");
+    expect(route?.requiresSslTooling).toBe(true);
     expect(route?.provisionSsl).toBe(false);
+    expect(route?.verified).toBe(false);
   });
 
   it("provisions SSL only once the custom domain row is verified", () => {
@@ -161,7 +216,9 @@ describe("buildServiceRouteDomains — custom-domain SSL gate", () => {
       usesManagedRouting: true,
       domainByHostname,
     });
+    expect(route?.requiresSslTooling).toBe(true);
     expect(route?.provisionSsl).toBe(true);
+    expect(route?.verified).toBe(true);
   });
 
   it("canonicalizes a scheme/slash-dressed custom domain to the stored host", () => {

--- a/apps/api/test/modules/domains/domain-auto-ssl.test.ts
+++ b/apps/api/test/modules/domains/domain-auto-ssl.test.ts
@@ -1,0 +1,121 @@
+import "../mail/_setup-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const domainRepo = vi.hoisted(() => ({
+  findPendingVerification: vi.fn(),
+  findPendingSsl: vi.fn(),
+  findById: vi.fn(),
+}));
+const projectRepo = vi.hoisted(() => ({
+  findById: vi.fn(),
+}));
+const ssl = vi.hoisted(() => ({
+  manageDomainSsl: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    domain: domainRepo,
+    project: projectRepo,
+  },
+}));
+
+vi.mock("../../../src/lib/domain-ssl", () => ({
+  manageDomainSsl: ssl.manageDomainSsl,
+  tlsIssuedElsewhere: () => null,
+  installDomainCert: vi.fn(),
+  provisionDomainCertForVerify: vi.fn(),
+  verifyExistingCert: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/controller-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/lib/controller-helpers")>();
+  return {
+    ...actual,
+    platform: () => ({ target: "desktop", runtime: {} }),
+  };
+});
+
+vi.mock("../../../src/lib/route-apply.service", () => ({
+  reconcileProjectRoutes: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/server-target", () => ({
+  resolveProjectServerHost: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: {
+    probeReachable: vi.fn(),
+    withExecutor: vi.fn(),
+    withHostExecutor: vi.fn(),
+  },
+}));
+
+import { verifyPendingDomains } from "../../../src/modules/domains/domain.service";
+
+describe("automatic SSL completion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    domainRepo.findPendingVerification.mockResolvedValue([]);
+    projectRepo.findById.mockResolvedValue({
+      id: "proj_1",
+      organizationId: "org_1",
+    });
+  });
+
+  it("retries issuance for a verified domain whose first certificate attempt failed", async () => {
+    domainRepo.findPendingSsl.mockResolvedValue([
+      {
+        id: "dom_issue",
+        projectId: "proj_1",
+        hostname: "app.example.com",
+        domainType: "custom",
+        verified: true,
+        sslStatus: "provisioning",
+        externalIngress: false,
+        manualSsl: false,
+      },
+    ]);
+    ssl.manageDomainSsl.mockResolvedValue({
+      domain: "app.example.com",
+      verified: true,
+      expiresAt: "2026-10-01T00:00:00.000Z",
+      issuer: "Let's Encrypt",
+    });
+    domainRepo.findById.mockResolvedValue({
+      id: "dom_issue",
+      sslStatus: "active",
+    });
+
+    const result = await verifyPendingDomains();
+
+    expect(ssl.manageDomainSsl).toHaveBeenCalledWith("app.example.com", {
+      action: "provision",
+      projectId: "proj_1",
+    });
+    expect(result.sslIssued).toBe(1);
+    expect(result.sslRetrying).toBe(0);
+  });
+
+  it("backs off a failed automatic issuance instead of requiring a redeploy", async () => {
+    domainRepo.findPendingSsl.mockResolvedValue([
+      {
+        id: "dom_retry",
+        projectId: "proj_1",
+        hostname: "retry.example.com",
+        domainType: "custom",
+        verified: true,
+        sslStatus: "provisioning",
+        externalIngress: false,
+        manualSsl: false,
+      },
+    ]);
+    ssl.manageDomainSsl.mockRejectedValue(new Error("ACME temporarily unavailable"));
+
+    const result = await verifyPendingDomains();
+
+    expect(result.sslIssued).toBe(0);
+    expect(result.sslRetrying).toBe(1);
+  });
+});

--- a/apps/api/test/modules/jobs/domain-verification-registry.test.ts
+++ b/apps/api/test/modules/jobs/domain-verification-registry.test.ts
@@ -1,0 +1,44 @@
+import "../mail/_setup-env";
+import { describe, expect, it, vi } from "vitest";
+
+const verifyPendingDomains = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/modules/domains/domain.service", () => ({
+  verifyPendingDomains,
+}));
+
+import { SYSTEM_JOB_BY_KEY } from "../../../src/modules/jobs/job.registry";
+
+describe("domains:verify-pending system job", () => {
+  it("is available on Desktop and every other platform", () => {
+    const job = SYSTEM_JOB_BY_KEY.get("domains:verify-pending");
+
+    expect(job).toBeDefined();
+    expect(job?.available).toBeUndefined();
+    expect(job?.defaultCron).toBe("*/13 * * * *");
+  });
+
+  it("reports verification and SSL retry outcomes", async () => {
+    verifyPendingDomains.mockResolvedValueOnce({
+      verified: 2,
+      failed: 1,
+      stillPending: 3,
+      total: 6,
+      sslIssued: 4,
+      sslRetrying: 1,
+      details: [],
+    });
+
+    const result = await SYSTEM_JOB_BY_KEY.get("domains:verify-pending")!.run();
+
+    expect(verifyPendingDomains).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      verified: 2,
+      failed: 1,
+      pending: 3,
+      total: 6,
+      sslIssued: 4,
+      sslRetrying: 1,
+    });
+  });
+});

--- a/apps/web/content/docs/troubleshooting/domains-ssl.mdx
+++ b/apps/web/content/docs/troubleshooting/domains-ssl.mdx
@@ -98,9 +98,16 @@ hours to propagate globally."* Usually it's a few minutes; occasionally it's muc
 1. Double-check there are no typos in the **Host** field and no leftover conflicting record for the same name.
 2. Wait. Save the records, give it several minutes, then click **Verify** again — re-clicking once DNS
    resolves is the reliable path.
-3. Openship also ships a *pending-verification sweep* (`POST /api/domains/verify-pending`) that re-checks
-   still-**Pending** domains and flips them to **Verified** on their own. It isn't on by default — it only runs
-   if your operator has wired it to a scheduler (cron / systemd timer) — so don't wait on it; re-click Verify.
+3. Openship's enabled-by-default **Domain DNS verification** job runs every 13 minutes. Once a pending
+   domain is at least 10 minutes old, the job retries verification and certificate issuance automatically.
+   This also runs in Openship Desktop against the project's connected deployment server. Clicking
+   **Verify** is the faster, explicit retry; it is not required for the normal background lifecycle.
+
+<Callout title="What the first deployment does" type="info">
+A new custom domain starts **Pending**, so its initial deployment creates the HTTP route and prepares the
+server's SSL toolchain, but deliberately does not open an ACME order yet. Certificate issuance begins only
+after verification succeeds, either from the scheduled job or from **Verify**.
+</Callout>
 
 <Callout title="Confirm propagation yourself" type="info">
 To check what the world currently sees, look the record up directly — e.g. `dig TXT _openship-challenge.app.example.com`
@@ -115,9 +122,10 @@ The domain is **Verified**, but the **SSL** pill stays on **Provisioning** inste
 so `https://` doesn't work yet.
 </Callout>
 
-**What it means.** Verifying a domain kicks off certificate issuance from Let's Encrypt **in the background** —
-the verify response comes back fast and the SSL status catches up on its own. **Provisioning** means the
-certificate is still being requested (or a request hasn't finished). It normally clears within a minute or two.
+**What it means.** On a self-hosted or Desktop-connected server, **Verify** obtains the certificate before
+reporting success and rewrites the existing route with TLS. On Openship Cloud, verification can start
+certificate issuance in the background. **Provisioning** means issuance is still in progress, its result has
+not been observed yet, or the first attempt failed.
 
 **How to fix**
 
@@ -127,8 +135,9 @@ certificate is still being requested (or a request hasn't finished). It normally
 2. If Recheck reports *"No valid certificate found for \{hostname} yet. If you just deployed, give Let's Encrypt
    a moment, then recheck."* — the certificate genuinely isn't there yet. Wait a little longer and recheck
    again.
-3. If it never provisions, click **Renew SSL** to force a fresh issuance attempt. Any real failure reason
-   (rate limit, ACME outage) surfaces on that action.
+3. The same scheduled domain job retries incomplete issuance with backoff. If you want an immediate retry,
+   click **Renew SSL**; any real failure reason (DNS, blocked ports, rate limit, ACME outage) surfaces on
+   that action.
 
 <Callout title="Renewing certificates" type="info">
 Once a certificate is **Active** you normally never touch it again. Renewal targets certificates within about
@@ -143,11 +152,11 @@ SSL actions require a **verified** domain — attempting them on a pending one r
 certificate.
 </Callout>
 
-<Callout title="If SSL was never set up on this host" type="warn">
-The certificate toolchain (certbot) is installed during a **deploy**, not by the on-demand Renew/Recheck
-buttons. If a host has never provisioned SSL for any custom domain, **redeploy the project** — the deploy
-preflight installs the toolchain and issues the certificate as part of the build, with the progress in the
-deploy logs. See [Troubleshooting → Deployments](/docs/troubleshooting/deployments).
+<Callout title="Verify should not require a redeploy" type="warn">
+The first deployment prepares certbot even while the domain is pending. After a successful **Verify**, the
+certificate provider re-registers the existing route with TLS, so no redeploy is expected. If a current
+deployment only starts serving HTTPS after redeploying, preserve both the deployment log and the Verify log;
+that indicates a separate edge/route reconciliation failure.
 </Callout>
 
 ## External ingress: your edge terminates TLS (TXT only)


### PR DESCRIPTION
## Summary

Completes the custom-domain SSL lifecycle so a pending domain can move from its initial HTTP-only deployment to a verified HTTPS route without requiring another deployment.

The initial deployment still does **not** open an ACME order for an unverified domain. It now prepares the SSL toolchain, the scheduled verifier runs in Desktop mode, and incomplete certificate issuance is retried through the real provisioning path.

## Problem

The intended lifecycle and the implementation had three gaps:

1. A new custom domain starts pending, so `provisionSsl` is false during its first deployment. Deployment preflight used that issuance flag to decide whether to install certbot, which meant the later Verify action could reach a fresh server with no SSL toolchain and require a redeploy.
2. The built-in `domains:verify-pending` job was explicitly unavailable when the control plane ran in Desktop mode, even though Desktop can resolve the project's active remote deployment and perform certificate work over SSH.
3. Phase two of the scheduled sweep used the read-only SSL recheck path. That can discover a certificate that already exists, but it cannot recover when the first ACME attempt genuinely produced no certificate.

## Changes

### Prepare SSL tooling without issuing early

- Adds `requiresSslTooling` to planned route domains.
- Keeps `provisionSsl` gated on successful domain verification.
- Marks pending certbot-managed custom routes as requiring tooling.
- Uses the new tooling flag in both single-app and Compose deployment preflight.
- Keeps external-ingress, managed/free, and manually managed TLS routes out of certbot setup.

This preserves the security boundary: an unverified hostname does not trigger ACME, while its first deployment still leaves the server ready for a later verification.

### Enable automatic verification in Desktop

- Removes the Desktop availability gate from `domains:verify-pending`.
- The existing in-process Desktop job runner now schedules the same 13-minute verifier used by other targets.
- Verification and certificate operations continue to resolve the project's active deployment server rather than running against the laptop.

### Retry actual certificate issuance

- Changes the verified-but-incomplete SSL sweep from read-only `verifyDomainSsl` to locked `manageDomainSsl(..., action: "provision")`.
- Retains the existing per-domain ACME lock, persistence rules, and exponential retry backoff.
- A missing certificate can now self-heal automatically instead of waiting for Renew or Redeploy.

### Documentation

Updates domain/SSL troubleshooting to describe the actual lifecycle:

- Initial deployment creates the pending HTTP route and prepares tooling, but does not issue a certificate.
- The enabled job checks eligible pending domains every 13 minutes after the 10-minute minimum age.
- Verify accelerates that lifecycle but is not normally required.
- Successful Verify re-registers the existing route with TLS; a redeploy is not expected.

## Expected lifecycle

1. Add a custom domain.
2. First deployment installs routing and SSL tooling and serves the pending HTTP route.
3. Once DNS is ready, either:
   - the scheduled verifier processes the domain automatically, or
   - the user clicks Verify for an immediate attempt.
4. Successful issuance rewrites/reloads the existing route with TLS.
5. If issuance is incomplete, the scheduled sweep retries it with backoff.

## Tests

- `bun run lint` in `apps/api` — passed (`tsc --noEmit`).
- Full API suite — **118 files passed; 1214 tests passed; 3 skipped**.
- Focused SSL lifecycle suite — **4 files passed; 35 tests passed**:
  - pending route tooling vs certificate issuance gating;
  - external-ingress exclusion;
  - Desktop job registration and 13-minute schedule;
  - real automatic provisioning retry and backoff;
  - existing SSL gate coverage.

## Risk and safeguards

- SSL tooling setup remains best-effort and cannot fail an application deployment.
- No ACME order is opened for an unverified hostname.
- External ingress and manually supplied certificates remain excluded from certbot management.
- Automatic retries use the existing per-hostname provisioning lock to avoid concurrent ACME orders and rate-limit pressure.

## Out of scope

- No `www` routing, toggle, or domain-variant changes are included in this PR.
- This does not issue SSL during the initial deployment; that remains intentionally gated by verification.
