### PR TITLE
feat(email): alias, forwarding and catch-all management for mail server

### DIFF
--- a/apps/api/src/modules/mail/admin/admin.controller.ts
+++ b/apps/api/src/modules/mail/admin/admin.controller.ts
@@ -37,6 +37,15 @@ import {
   softDeleteMailbox,
   updateMailbox,
 } from "./mailboxes.service";
+import {
+  createAlias,
+  deleteAlias,
+  listAliases,
+  updateAliasActive,
+  AliasConflictsWithMailboxError,
+  AliasExistsError,
+  AliasNotFoundError,
+} from "./aliases.service";
 import { getMailServerStats } from "./stats.service";
 import { scanDns } from "./dns-scan.service";
 import { sendTestEmail, TestEmailError } from "./test-email.service";
@@ -532,6 +541,110 @@ export async function deleteMailboxHandler(c: Context) {
     return c.json({ ok: true, mode: hard ? "hard" : "soft" });
   } catch (err) {
     if (err instanceof MailboxNotFoundError) {
+      return c.json({ error: err.message }, 404);
+    }
+    return errorJson(c, err);
+  }
+}
+
+// ─── Admin panel - aliases / forwards / catch-all ────────────────────────────
+
+export async function listAliasesHandler(c: Context) {
+  const guard = assertNotCloud(c);
+  if (guard) return guard;
+  const serverId = param(c, "serverId");
+  await permission.assert(getRequestContext(c), { resourceType: "mail_server", resourceId: serverId, action: "read" });
+  const ctx = getRequestContext(c);
+  if (!(await isServerInOrg(ctx, serverId))) {
+    return c.json({ error: "Server not found" }, 404);
+  }
+  const domain = c.req.query("domain");
+  if (!domain) return c.json({ error: "domain query param required" }, 400);
+  try {
+    const rows = await listAliases(serverId, domain);
+    return c.json({ aliases: rows });
+  } catch (err) {
+    return errorJson(c, err);
+  }
+}
+
+export async function createAliasHandler(c: Context) {
+  const guard = assertNotCloud(c);
+  if (guard) return guard;
+  const serverId = param(c, "serverId");
+  await permission.assert(getRequestContext(c), { resourceType: "mail_server", resourceId: serverId, action: "write" });
+  const ctx = getRequestContext(c);
+  if (!(await isServerInOrg(ctx, serverId))) {
+    return c.json({ error: "Server not found" }, 404);
+  }
+  const body = await c.req.json().catch(() => ({}));
+  try {
+    const row = await createAlias(serverId, {
+      domain: String(body.domain ?? ""),
+      localPart: body.localPart ? String(body.localPart) : undefined,
+      isCatchAll: Boolean(body.isCatchAll),
+      destination: String(body.destination ?? ""),
+    });
+    return c.json({ alias: row }, 201);
+  } catch (err) {
+    if (err instanceof AliasExistsError) {
+      return c.json({ error: err.message }, 409);
+    }
+    if (err instanceof AliasConflictsWithMailboxError) {
+      return c.json({ error: err.message }, 409);
+    }
+    return errorJson(c, err);
+  }
+}
+
+export async function updateAliasHandler(c: Context) {
+  const guard = assertNotCloud(c);
+  if (guard) return guard;
+  const serverId = param(c, "serverId");
+  await permission.assert(getRequestContext(c), { resourceType: "mail_server", resourceId: serverId, action: "write" });
+  const ctx = getRequestContext(c);
+  if (!(await isServerInOrg(ctx, serverId))) {
+    return c.json({ error: "Server not found" }, 404);
+  }
+  const idParam = c.req.param("id");
+  const id = Number(idParam);
+  if (!idParam || !Number.isInteger(id)) {
+    return c.json({ error: "id must be an integer" }, 400);
+  }
+  const body = await c.req.json().catch(() => ({}));
+  if (body.active == null) {
+    return c.json({ error: "active is required" }, 400);
+  }
+  try {
+    const row = await updateAliasActive(serverId, id, Boolean(body.active));
+    return c.json({ alias: row });
+  } catch (err) {
+    if (err instanceof AliasNotFoundError) {
+      return c.json({ error: err.message }, 404);
+    }
+    return errorJson(c, err);
+  }
+}
+
+export async function deleteAliasHandler(c: Context) {
+  const guard = assertNotCloud(c);
+  if (guard) return guard;
+  const serverId = param(c, "serverId");
+  await permission.assert(getRequestContext(c), { resourceType: "mail_server", resourceId: serverId, action: "admin" });
+  const ctx = getRequestContext(c);
+  if (!(await isServerInOrg(ctx, serverId))) {
+    return c.json({ error: "Server not found" }, 404);
+  }
+  const idParam = c.req.param("id");
+  const id = Number(idParam);
+  if (!idParam || !Number.isInteger(id)) {
+    return c.json({ error: "id must be an integer" }, 400);
+  }
+  try {
+    await deleteAlias(serverId, id);
+    return c.json({ ok: true });
+  } catch (err) {
+    if (err instanceof AliasNotFoundError) {
       return c.json({ error: err.message }, 404);
     }
     return errorJson(c, err);

--- a/apps/api/src/modules/mail/admin/aliases.service.ts
+++ b/apps/api/src/modules/mail/admin/aliases.service.ts
@@ -1,0 +1,215 @@
+/**
+ * Alias / forward / catch-all CRUD for the mail admin panel.
+ *
+ * An "alias" here is a row in `vmail.forwardings` with `is_alias = 1` -
+ * distinct from a mailbox's own self-forwarding row (`is_forwarding = 1`,
+ * owned by mailboxes.service.ts). Postfix's virtual_alias_maps / catchall_maps
+ * read `forwardings` directly via live SQL lookup maps - no reload needed,
+ * a row is effective the instant it commits.
+ *
+ * Two shapes share this table:
+ *   - Per-address alias: address = "local@domain" - forwards ONE address to
+ *     another (a local mailbox or an external address).
+ *   - Catch-all: address = the BARE domain (no @). catchall_maps.cf's query
+ *     is `WHERE forwardings.address = domain.domain`, so a bare-domain
+ *     address IS the catch-all by construction - there's no separate flag.
+ *     Postfix takes the first match, so only one catch-all per domain makes
+ *     sense; createAlias replaces any existing one atomically.
+ */
+
+import { queryRows, queryOne, execute, transaction, q, qInt } from "./psql-runner";
+import { validateDomain, recountDomain } from "./domains.service";
+
+const EMAIL_RE = /^[a-z0-9._+-]+@[a-z0-9.-]+\.[a-z]{2,}$/;
+const LOCAL_PART_RE = /^[a-z0-9._+-]+$/;
+
+const SELECT_COLUMNS = `
+  id,
+  address,
+  forwarding,
+  domain,
+  dest_domain AS "destDomain",
+  (address = domain) AS "isCatchAll",
+  (active = 1) AS active
+`;
+
+export interface AliasRow {
+  id: number;
+  address: string;
+  forwarding: string;
+  domain: string;
+  destDomain: string;
+  isCatchAll: boolean;
+  active: boolean;
+}
+
+export interface CreateAliasInput {
+  domain: string;
+  /** Ignored when isCatchAll is true. */
+  localPart?: string;
+  isCatchAll: boolean;
+  destination: string;
+}
+
+function validateEmail(email: string): void {
+  if (!EMAIL_RE.test(email) || email.length > 255) {
+    throw new Error(`Invalid email: ${email}`);
+  }
+}
+
+function validateLocalPart(local: string): void {
+  if (!LOCAL_PART_RE.test(local) || local.length === 0 || local.length > 64) {
+    throw new Error(`Invalid local-part: ${local}`);
+  }
+}
+
+export async function listAliases(
+  serverId: string,
+  domain: string,
+): Promise<AliasRow[]> {
+  validateDomain(domain);
+  return queryRows<AliasRow>(
+    serverId,
+    `SELECT${SELECT_COLUMNS} FROM forwardings
+       WHERE domain = ${q(domain.toLowerCase())} AND is_alias = 1
+       ORDER BY (address = domain) DESC, address`,
+  );
+}
+
+export async function getAlias(serverId: string, id: number): Promise<AliasRow | null> {
+  return queryOne<AliasRow>(
+    serverId,
+    `SELECT${SELECT_COLUMNS} FROM forwardings WHERE id = ${qInt(id)} AND is_alias = 1`,
+  );
+}
+
+/**
+ * Create a per-address alias or a domain catch-all.
+ *
+ * Guards, in order:
+ *   1. destination must be a valid email address.
+ *   2. per-address: local-part must be valid; catch-all ignores localPart.
+ *   3. the resulting address must not already be a real mailbox - creating
+ *      an alias over a mailbox's own address would silently redirect that
+ *      mailbox's mail (postfix's virtual_alias_maps is checked before
+ *      virtual_mailbox_maps for a given address, so the alias would win).
+ *   4. catch-all: any existing catch-all row for the domain is replaced
+ *      (delete-then-insert in one transaction), so there's only ever one.
+ */
+export async function createAlias(
+  serverId: string,
+  input: CreateAliasInput,
+): Promise<AliasRow> {
+  const domain = input.domain.trim().toLowerCase();
+  validateDomain(domain);
+  validateEmail(input.destination);
+  const destination = input.destination.trim().toLowerCase();
+  const destDomain = destination.split("@")[1]!;
+
+  const address = input.isCatchAll
+    ? domain
+    : (() => {
+        const local = (input.localPart ?? "").trim().toLowerCase();
+        validateLocalPart(local);
+        const addr = `${local}@${domain}`;
+        validateEmail(addr);
+        return addr;
+      })();
+
+  // Guard 3: address must not collide with a real mailbox. Catch-all
+  // addresses are bare domains and can never match a mailbox username
+  // (always a full email), so this only applies to per-address aliases.
+  if (!input.isCatchAll) {
+    const mailboxHit = await queryOne<{ username: string }>(
+      serverId,
+      `SELECT username FROM mailbox WHERE username = ${q(address)}`,
+    );
+    if (mailboxHit) {
+      throw new AliasConflictsWithMailboxError(address);
+    }
+  }
+
+  if (input.isCatchAll) {
+    await transaction(serverId, [
+      `DELETE FROM forwardings WHERE domain = ${q(domain)} AND address = ${q(domain)} AND is_alias = 1`,
+      `INSERT INTO forwardings (address, forwarding, domain, dest_domain, is_maillist, is_list, is_forwarding, is_alias, active)
+         VALUES (${q(address)}, ${q(destination)}, ${q(domain)}, ${q(destDomain)}, 0, 0, 0, 1, 1)`,
+    ]);
+  } else {
+    // Friendlier than letting the (address, forwarding) unique index fire -
+    // matches the duplicate pre-check convention in mailboxes.service.ts.
+    // Different DESTINATIONS for the same source address are allowed
+    // (fan-out); only the exact pair is a duplicate.
+    const existing = await queryOne<{ id: number }>(
+      serverId,
+      `SELECT id FROM forwardings WHERE address = ${q(address)} AND forwarding = ${q(destination)}`,
+    );
+    if (existing) {
+      throw new AliasExistsError(address, destination);
+    }
+    await execute(
+      serverId,
+      `INSERT INTO forwardings (address, forwarding, domain, dest_domain, is_maillist, is_list, is_forwarding, is_alias, active)
+         VALUES (${q(address)}, ${q(destination)}, ${q(domain)}, ${q(destDomain)}, 0, 0, 0, 1, 1)`,
+    );
+  }
+
+  await recountDomain(serverId, domain);
+
+  const row = await queryOne<AliasRow>(
+    serverId,
+    `SELECT${SELECT_COLUMNS} FROM forwardings
+       WHERE address = ${q(address)} AND forwarding = ${q(destination)} AND is_alias = 1`,
+  );
+  if (!row) {
+    throw new Error("Alias was created but could not be re-read.");
+  }
+  return row;
+}
+
+export async function updateAliasActive(
+  serverId: string,
+  id: number,
+  active: boolean,
+): Promise<AliasRow> {
+  const existing = await getAlias(serverId, id);
+  if (!existing) throw new AliasNotFoundError(id);
+
+  await execute(
+    serverId,
+    `UPDATE forwardings SET active = ${active ? 1 : 0} WHERE id = ${qInt(id)} AND is_alias = 1`,
+  );
+  await recountDomain(serverId, existing.domain);
+
+  const row = await getAlias(serverId, id);
+  if (!row) throw new AliasNotFoundError(id);
+  return row;
+}
+
+export async function deleteAlias(serverId: string, id: number): Promise<void> {
+  const existing = await getAlias(serverId, id);
+  if (!existing) throw new AliasNotFoundError(id);
+
+  await execute(serverId, `DELETE FROM forwardings WHERE id = ${qInt(id)} AND is_alias = 1`);
+  await recountDomain(serverId, existing.domain);
+}
+
+// ─── Typed errors ────────────────────────────────────────────────────────────
+
+export class AliasNotFoundError extends Error {
+  constructor(public id: number) {
+    super(`Alias not found: ${id}`);
+  }
+}
+
+export class AliasExistsError extends Error {
+  constructor(public address: string, public forwarding: string) {
+    super(`Alias already exists: ${address} -> ${forwarding}`);
+  }
+}
+
+export class AliasConflictsWithMailboxError extends Error {
+  constructor(public address: string) {
+    super(`${address} is a real mailbox - creating an alias here would redirect its mail. Edit or delete the mailbox instead.`);
+  }
+}

--- a/apps/api/src/modules/mail/mail.routes.ts
+++ b/apps/api/src/modules/mail/mail.routes.ts
@@ -120,6 +120,28 @@ r.delete(
   admin.deleteMailboxHandler,
 );
 
+/* ── Admin panel - aliases / forwards / catch-all ─────────────────── */
+r.get(
+  "/admin/:serverId/aliases",
+  { tag: "mail_server:list" },
+  admin.listAliasesHandler,
+);
+r.post(
+  "/admin/:serverId/aliases",
+  { tag: "mail_server:write" },
+  admin.createAliasHandler,
+);
+r.patch(
+  "/admin/:serverId/aliases/:id",
+  { tag: "mail_server:write" },
+  admin.updateAliasHandler,
+);
+r.delete(
+  "/admin/:serverId/aliases/:id",
+  { tag: "mail_server:admin" },
+  admin.deleteAliasHandler,
+);
+
 /* ── Admin panel - aggregates ─────────────────────────────────────── */
 r.get(
   "/admin/:serverId/stats",

--- a/apps/dashboard/src/app/(dashboard)/emails/_components/admin/admin-panel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/emails/_components/admin/admin-panel.tsx
@@ -25,6 +25,7 @@ import {
   LayoutDashboard,
   Globe,
   UserRound,
+  Forward,
   FileText,
   HeartPulse,
   Send,
@@ -39,6 +40,7 @@ import { useI18n } from "@/components/i18n-provider";
 import { OverviewTab } from "./overview-tab";
 import { DomainsTab } from "./domains-tab";
 import { MailboxesTab } from "./mailboxes-tab";
+import { AliasesTab } from "./aliases-tab";
 import { DnsTab } from "./dns-tab";
 import { HealthTab } from "./health-tab";
 import { TestTab } from "./test-tab";
@@ -62,6 +64,7 @@ type TabKey =
   | "overview"
   | "domains"
   | "mailboxes"
+  | "aliases"
   | "dns"
   | "health"
   | "test"
@@ -78,6 +81,7 @@ const TABS: TabDef[] = [
   { key: "overview", icon: LayoutDashboard },
   { key: "domains", icon: Globe },
   { key: "mailboxes", icon: UserRound },
+  { key: "aliases", icon: Forward },
   { key: "dns", icon: FileText },
   { key: "health", icon: HeartPulse },
   { key: "test", icon: Send },
@@ -164,6 +168,14 @@ export function MailAdminPanel({ status, serverId, onRefresh, onForgotten }: Mai
         )}
         {tab === "mailboxes" && (
           <MailboxesTab
+            serverId={serverId}
+            primaryDomain={primaryDomain}
+            selectedDomain={selectedDomain}
+            onSelectDomain={(d) => setQuery({ domain: d })}
+          />
+        )}
+        {tab === "aliases" && (
+          <AliasesTab
             serverId={serverId}
             primaryDomain={primaryDomain}
             selectedDomain={selectedDomain}

--- a/apps/dashboard/src/app/(dashboard)/emails/_components/admin/aliases-tab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/emails/_components/admin/aliases-tab.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+/**
+ * Aliases tab - list + create/delete/toggle for vmail.forwardings rows with
+ * is_alias = 1 (per-address forwards and domain catch-alls). Mailbox
+ * self-forwarding rows (is_forwarding = 1) live in the Mailboxes tab, not
+ * here - see aliases.service.ts on the API side for the split.
+ *
+ * Same real-table layout as Mailboxes (DataTable primitive), scoped to one
+ * domain via the picker at the top. Unlike Mailboxes, the create dialog has
+ * its own domain select so an alias for any domain can be added without
+ * leaving the current view.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Forward, Plus, Power, Trash2 } from "lucide-react";
+import {
+  getApiErrorMessage,
+  mailAdminApi,
+  type AdminAlias,
+  type AdminDomain,
+} from "@/lib/api";
+import { useModal } from "@/context/ModalContext";
+import {
+  DataTable,
+  RowIconButton,
+  type DataTableColumn,
+} from "./_shared/data-table";
+import { StatusPill } from "./_shared/status-pill";
+import {
+  Field,
+  FormModalContent,
+  inputClassName,
+} from "./_shared/form-modal-content";
+import { useI18n, interpolate } from "@/components/i18n-provider";
+
+interface AliasesTabProps {
+  serverId: string;
+  primaryDomain: string;
+  selectedDomain: string;
+  onSelectDomain: (domain: string) => void;
+}
+
+export function AliasesTab({
+  serverId,
+  primaryDomain,
+  selectedDomain,
+  onSelectDomain,
+}: AliasesTabProps) {
+  const { showModal, hideModal } = useModal();
+  const { t } = useI18n();
+  const [domains, setDomains] = useState<AdminDomain[]>([]);
+  const [aliases, setAliases] = useState<AdminAlias[]>([]);
+  const [loadingDomains, setLoadingDomains] = useState(true);
+  const [loadingAliases, setLoadingAliases] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeDomain = selectedDomain || primaryDomain;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingDomains(true);
+    mailAdminApi.domains
+      .list(serverId)
+      .then((res) => {
+        if (cancelled) return;
+        setDomains(res.domains);
+        if (
+          selectedDomain &&
+          selectedDomain !== primaryDomain &&
+          !res.domains.some((d) => d.domain === selectedDomain)
+        ) {
+          onSelectDomain(primaryDomain);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(getApiErrorMessage(err, t.emailsAdmin.aliases.loadDomainsFailed));
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingDomains(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [serverId, selectedDomain, primaryDomain, onSelectDomain]);
+
+  const reloadAliases = useCallback(async () => {
+    if (!activeDomain) return;
+    setLoadingAliases(true);
+    setError(null);
+    try {
+      const res = await mailAdminApi.aliases.list(serverId, activeDomain);
+      setAliases(res.aliases);
+    } catch (err) {
+      setError(getApiErrorMessage(err, t.emailsAdmin.aliases.loadFailed));
+    } finally {
+      setLoadingAliases(false);
+    }
+  }, [serverId, activeDomain]);
+
+  useEffect(() => {
+    void reloadAliases();
+  }, [reloadAliases]);
+
+  const openCreate = () => {
+    const id = showModal({
+      maxWidth: "560px",
+      showCloseButton: false,
+      customContent: (
+        <CreateAliasForm
+          serverId={serverId}
+          domains={domains}
+          defaultDomain={activeDomain}
+          onCancel={() => hideModal(id)}
+          onCreated={() => {
+            hideModal(id);
+            void reloadAliases();
+          }}
+        />
+      ),
+    });
+  };
+
+  const openDelete = (row: AdminAlias) => {
+    const id = showModal({
+      maxWidth: "520px",
+      showCloseButton: false,
+      customContent: (
+        <DeleteAliasConfirm
+          serverId={serverId}
+          row={row}
+          onCancel={() => hideModal(id)}
+          onDeleted={() => {
+            hideModal(id);
+            void reloadAliases();
+          }}
+        />
+      ),
+    });
+  };
+
+  const toggleActive = async (row: AdminAlias) => {
+    setError(null);
+    try {
+      await mailAdminApi.aliases.setActive(serverId, row.id, !row.active);
+      void reloadAliases();
+    } catch (err) {
+      setError(getApiErrorMessage(err, t.emailsAdmin.aliases.loadFailed));
+    }
+  };
+
+  const columns: DataTableColumn<AdminAlias>[] = [
+    {
+      key: "source",
+      header: t.emailsAdmin.aliases.colSource,
+      width: "minmax(220px, 1.4fr)",
+      cell: (r) => (
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0">
+            <Forward className="size-4 text-muted-foreground" strokeWidth={2} />
+          </div>
+          <p className="text-sm font-medium text-foreground truncate font-mono">
+            {r.isCatchAll ? `*@${r.address}` : r.address}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: "destination",
+      header: t.emailsAdmin.aliases.colDestination,
+      width: "minmax(200px, 1.2fr)",
+      cell: (r) => (
+        <span className="text-sm text-foreground font-mono truncate">{r.forwarding}</span>
+      ),
+    },
+    {
+      key: "type",
+      header: t.emailsAdmin.aliases.colType,
+      width: "140px",
+      hideBelow: "md",
+      cell: (r) => (
+        <StatusPill tone={r.isCatchAll ? "info" : "neutral"}>
+          {r.isCatchAll ? t.emailsAdmin.aliases.typeCatchAll : t.emailsAdmin.aliases.typeAlias}
+        </StatusPill>
+      ),
+    },
+    {
+      key: "status",
+      header: t.emailsAdmin.aliases.colStatus,
+      width: "140px",
+      cell: (r) =>
+        r.active ? (
+          <StatusPill tone="success" dot>
+            {t.emailsAdmin.aliases.active}
+          </StatusPill>
+        ) : (
+          <StatusPill tone="neutral" dot>
+            {t.emailsAdmin.aliases.disabled}
+          </StatusPill>
+        ),
+    },
+  ];
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold text-foreground">{t.emailsAdmin.aliases.heading}</h2>
+          <p className="text-sm text-muted-foreground mt-0.5 max-w-2xl">
+            {t.emailsAdmin.aliases.description}
+          </p>
+        </div>
+        <button
+          onClick={openCreate}
+          disabled={domains.length === 0}
+          className="inline-flex items-center gap-2 px-4 py-2.5 bg-primary text-primary-foreground text-sm font-medium rounded-xl hover:bg-primary/90 transition-all hover:shadow-lg hover:shadow-primary/25 disabled:opacity-50 disabled:hover:shadow-none shrink-0"
+        >
+          <Plus className="size-4" />
+          {t.emailsAdmin.aliases.addAlias}
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-sm text-muted-foreground">{t.emailsAdmin.aliases.domainLabel}</span>
+        {loadingDomains ? (
+          <div className="px-3 py-2 rounded-xl border border-border bg-muted/30 flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">{t.emailsAdmin.aliases.loading}</span>
+          </div>
+        ) : (
+          <select
+            value={activeDomain}
+            onChange={(e) => onSelectDomain(e.target.value)}
+            className="px-3 py-2 text-sm rounded-xl border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 transition-colors min-w-[200px]"
+          >
+            {domains.map((d) => (
+              <option key={d.domain} value={d.domain}>
+                {d.domain}
+              </option>
+            ))}
+          </select>
+        )}
+        {!loadingAliases && aliases.length > 0 && (
+          <span className="ms-auto text-xs text-muted-foreground tabular-nums">
+            {interpolate(t.emailsAdmin.aliases.activeCount, {
+              active: String(aliases.filter((a) => a.active).length),
+              total: String(aliases.length),
+            })}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-danger-border bg-danger-bg px-4 py-3 text-sm text-danger">
+          {error}
+        </div>
+      )}
+
+      <DataTable
+        columns={columns}
+        rows={aliases}
+        rowKey={(r) => String(r.id)}
+        loading={loadingAliases}
+        rowActions={(row) => (
+          <>
+            <RowIconButton
+              icon={Power}
+              label={row.active ? t.emailsAdmin.aliases.deactivateAction : t.emailsAdmin.aliases.activateAction}
+              onClick={() => void toggleActive(row)}
+            />
+            <RowIconButton
+              icon={Trash2}
+              label={t.emailsAdmin.aliases.deleteAction}
+              variant="danger"
+              onClick={() => openDelete(row)}
+            />
+          </>
+        )}
+        empty={{
+          icon: Forward,
+          title: t.emailsAdmin.aliases.emptyTitle,
+          description: interpolate(t.emailsAdmin.aliases.emptyDesc, { domain: activeDomain }),
+          action: (
+            <button
+              onClick={openCreate}
+              disabled={domains.length === 0}
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-primary-foreground text-sm font-medium rounded-xl hover:bg-primary/90 transition-colors disabled:opacity-50"
+            >
+              <Plus className="size-4" />
+              {t.emailsAdmin.aliases.addAlias}
+            </button>
+          ),
+        }}
+      />
+    </div>
+  );
+}
+
+// ─── Create form ─────────────────────────────────────────────────────────────
+
+function CreateAliasForm({
+  serverId,
+  domains,
+  defaultDomain,
+  onCancel,
+  onCreated,
+}: {
+  serverId: string;
+  domains: AdminDomain[];
+  defaultDomain: string;
+  onCancel: () => void;
+  onCreated: () => void;
+}) {
+  const { t } = useI18n();
+  const [domain, setDomain] = useState(defaultDomain);
+  const [isCatchAll, setIsCatchAll] = useState(false);
+  const [localPart, setLocalPart] = useState("");
+  const [destination, setDestination] = useState("");
+
+  const submit = async () => {
+    try {
+      await mailAdminApi.aliases.create(serverId, {
+        domain,
+        localPart: isCatchAll ? undefined : localPart.trim().toLowerCase(),
+        isCatchAll,
+        destination: destination.trim().toLowerCase(),
+      });
+      onCreated();
+    } catch (err) {
+      // ApiError.message is just "API 409: Conflict" - the server's actual
+      // error string (e.g. AliasConflictsWithMailboxError's message) lives
+      // in the response body, which only getApiErrorMessage unwraps.
+      // FormModalContent's own catch just does `err.message`, so re-throw a
+      // plain Error carrying the unwrapped text.
+      throw new Error(getApiErrorMessage(err, t.emailsAdmin.aliases.loadFailed));
+    }
+  };
+
+  const canSubmit =
+    Boolean(domain) &&
+    Boolean(destination.trim()) &&
+    (isCatchAll || Boolean(localPart.trim()));
+
+  return (
+    <FormModalContent
+      title={interpolate(t.emailsAdmin.aliases.create.title, { domain: domain || "…" })}
+      description={t.emailsAdmin.aliases.create.description}
+      submitLabel={t.emailsAdmin.aliases.create.submit}
+      submittingLabel={t.emailsAdmin.aliases.create.submitting}
+      onSubmit={submit}
+      onCancel={onCancel}
+      disabled={!canSubmit}
+    >
+      <Field label={t.emailsAdmin.aliases.domainLabel}>
+        <select
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          className={inputClassName}
+        >
+          {domains.map((d) => (
+            <option key={d.domain} value={d.domain}>
+              {d.domain}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <label className="flex items-start gap-3 cursor-pointer p-3 -mx-1 rounded-xl hover:bg-muted/30 transition-colors">
+        <input
+          type="checkbox"
+          checked={isCatchAll}
+          onChange={(e) => setIsCatchAll(e.target.checked)}
+          className="rounded border-border mt-0.5"
+        />
+        <span>
+          <span className="block text-sm font-medium text-foreground">
+            {t.emailsAdmin.aliases.create.catchAllLabel}
+          </span>
+          <span className="block text-xs text-muted-foreground mt-0.5 leading-relaxed">
+            {interpolate(t.emailsAdmin.aliases.create.catchAllHint, { domain: domain || "…" })}
+          </span>
+        </span>
+      </label>
+
+      {!isCatchAll && (
+        <Field
+          label={t.emailsAdmin.aliases.create.localPartLabel}
+          hint={t.emailsAdmin.aliases.create.localPartHint}
+        >
+          <div className="flex items-stretch rounded-xl border border-border bg-background focus-within:ring-2 focus-within:ring-primary/40 focus-within:border-primary/60 transition-colors">
+            <input
+              type="text"
+              autoFocus
+              value={localPart}
+              onChange={(e) => setLocalPart(e.target.value)}
+              placeholder="shop"
+              className="flex-1 px-3 py-2 text-sm bg-transparent text-foreground placeholder:text-muted-foreground/60 focus:outline-none rounded-s-xl"
+            />
+            <span className="px-3 py-2 text-sm text-muted-foreground border-s border-border bg-muted/40 rounded-e-xl whitespace-nowrap">
+              @{domain || "…"}
+            </span>
+          </div>
+        </Field>
+      )}
+
+      <Field
+        label={t.emailsAdmin.aliases.create.destinationLabel}
+        hint={t.emailsAdmin.aliases.create.destinationHint}
+      >
+        <input
+          type="email"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          placeholder="you@gmail.com"
+          className={inputClassName}
+        />
+      </Field>
+    </FormModalContent>
+  );
+}
+
+// ─── Delete confirm ──────────────────────────────────────────────────────────
+
+function DeleteAliasConfirm({
+  serverId,
+  row,
+  onCancel,
+  onDeleted,
+}: {
+  serverId: string;
+  row: AdminAlias;
+  onCancel: () => void;
+  onDeleted: () => void;
+}) {
+  const { t } = useI18n();
+  const source = row.isCatchAll
+    ? interpolate(t.emailsAdmin.aliases.deleteForm.sourceCatchAll, { domain: row.domain })
+    : row.address;
+
+  const submit = async () => {
+    await mailAdminApi.aliases.delete(serverId, row.id);
+    onDeleted();
+  };
+
+  return (
+    <FormModalContent
+      title={t.emailsAdmin.aliases.deleteForm.title}
+      description={interpolate(t.emailsAdmin.aliases.deleteForm.description, {
+        source,
+      })}
+      submitLabel={t.emailsAdmin.aliases.deleteForm.submit}
+      submittingLabel={t.emailsAdmin.aliases.deleteForm.submitting}
+      submitVariant="danger"
+      onSubmit={submit}
+      onCancel={onCancel}
+    >
+      <div className="rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground font-mono">
+        {source} → {row.forwarding}
+      </div>
+    </FormModalContent>
+  );
+}

--- a/apps/dashboard/src/i18n/i18n-parity.test.ts
+++ b/apps/dashboard/src/i18n/i18n-parity.test.ts
@@ -23,7 +23,7 @@ const MISSING_BASELINE: Record<string, number> = {
   jobs: 876,
   migration: 1237,
   settings: 888,
-  emailsAdmin: 316,
+  emailsAdmin: 628,
   widgets: 138,
   misc: 123,
   overview: 120,

--- a/apps/dashboard/src/i18n/locales/en/emailsAdmin.json
+++ b/apps/dashboard/src/i18n/locales/en/emailsAdmin.json
@@ -4,6 +4,7 @@
       "overview": "Overview",
       "domains": "Domains",
       "mailboxes": "Mailboxes",
+      "aliases": "Aliases",
       "dns": "DNS",
       "health": "Health",
       "test": "Test",
@@ -241,6 +242,52 @@
       "hardDeleteLabel": "Hard delete",
       "hardDeleteDesc": "Remove DB rows and Maildir files immediately. Cannot be undone.",
       "postmasterNote": "The postmaster mailbox is hard-delete protected - only soft delete is available, so the mail server's bootstrap account stays intact."
+    }
+  },
+  "aliases": {
+    "heading": "Aliases",
+    "description": "Forward mail from one address to another, or catch every unmatched address at a domain. Live the moment you save - no restart needed.",
+    "addAlias": "Add alias",
+    "domainLabel": "Domain",
+    "loading": "Loading…",
+    "activeCount": "{active} of {total} active",
+    "colSource": "Source",
+    "colDestination": "Forwards to",
+    "colType": "Type",
+    "colStatus": "Status",
+    "typeAlias": "Alias",
+    "typeCatchAll": "Catch-all",
+    "active": "Active",
+    "disabled": "Disabled",
+    "activateAction": "Activate",
+    "deactivateAction": "Deactivate",
+    "deleteAction": "Delete",
+    "loadDomainsFailed": "Failed to load domains",
+    "loadFailed": "Failed to load aliases",
+    "emptyTitle": "No aliases yet",
+    "emptyDesc": "Forward an address, or set up a catch-all, for {domain}.",
+    "create": {
+      "title": "New alias · {domain}",
+      "description": "Creates a row in the mail server's forwarding table. Postfix reads it live - no restart needed.",
+      "submit": "Create alias",
+      "submitting": "Creating…",
+      "catchAllLabel": "Catch-all for this domain",
+      "catchAllHint": "Forwards every address at {domain} that doesn't match a real mailbox or another alias. Replaces any existing catch-all for this domain.",
+      "localPartLabel": "Local part",
+      "localPartHint": "The part before @. Lowercase, alphanumeric.",
+      "destinationLabel": "Forwards to",
+      "destinationHint": "Any valid email address - a mailbox on this server, or external (e.g. Gmail)."
+    },
+    "deleteForm": {
+      "title": "Delete this alias?",
+      "sourceCatchAll": "Catch-all for {domain}",
+      "description": "Removes the forwarding row immediately. Mail to {source} will bounce or fall through to the next matching rule, effective on the next message.",
+      "submit": "Delete alias",
+      "submitting": "Deleting…"
+    },
+    "toast": {
+      "mailboxConflict": "{address} is a real mailbox - creating an alias here would redirect its mail. Edit or delete the mailbox instead.",
+      "alreadyExists": "That exact forward already exists."
     }
   },
   "health": {

--- a/apps/dashboard/src/lib/api/endpoints.ts
+++ b/apps/dashboard/src/lib/api/endpoints.ts
@@ -330,6 +330,10 @@ export const endpoints = {
         `mail/admin/${encodeURIComponent(serverId)}/mailboxes`,
       mailbox: (serverId: string, email: string) =>
         `mail/admin/${encodeURIComponent(serverId)}/mailboxes/${encodeURIComponent(email)}`,
+      aliases: (serverId: string) =>
+        `mail/admin/${encodeURIComponent(serverId)}/aliases`,
+      alias: (serverId: string, id: number) =>
+        `mail/admin/${encodeURIComponent(serverId)}/aliases/${id}`,
       stats: (serverId: string) =>
         `mail/admin/${encodeURIComponent(serverId)}/stats`,
       dnsScan: (serverId: string) =>

--- a/apps/dashboard/src/lib/api/index.ts
+++ b/apps/dashboard/src/lib/api/index.ts
@@ -107,10 +107,12 @@ export { mailAdminApi } from "./mail-admin";
 export type {
   AdminDomain,
   AdminMailbox,
+  AdminAlias,
   CreateDomainPayload,
   UpdateDomainPayload,
   CreateMailboxPayload,
   UpdateMailboxPayload,
+  CreateAliasPayload,
   DomainDependents,
   AdditionalDomainDnsState,
   MailServerStats,

--- a/apps/dashboard/src/lib/api/mail-admin.ts
+++ b/apps/dashboard/src/lib/api/mail-admin.ts
@@ -134,6 +134,27 @@ export interface UpdateMailboxPayload {
   active?: boolean;
 }
 
+// ─── Aliases / forwards / catch-all ───────────────────────────────────────────
+
+export interface AdminAlias {
+  id: number;
+  address: string;
+  forwarding: string;
+  domain: string;
+  destDomain: string;
+  /** true when `address` is the bare domain (no @) - the domain's catch-all. */
+  isCatchAll: boolean;
+  active: boolean;
+}
+
+export interface CreateAliasPayload {
+  domain: string;
+  /** Ignored when isCatchAll is true. */
+  localPart?: string;
+  isCatchAll: boolean;
+  destination: string;
+}
+
 // ─── Stats ───────────────────────────────────────────────────────────────────
 
 export interface MailServerStats {
@@ -285,6 +306,24 @@ export const mailAdminApi = {
       api.delete<{ ok: boolean; mode: "soft" | "hard" }>(
         `${endpoints.mail.admin.mailbox(serverId, email)}?hard=true`,
       ),
+  },
+  aliases: {
+    list: (serverId: string, domain: string) =>
+      api.get<{ aliases: AdminAlias[] }>(
+        `${endpoints.mail.admin.aliases(serverId)}?domain=${encodeURIComponent(domain)}`,
+      ),
+    create: (serverId: string, payload: CreateAliasPayload) =>
+      api.post<{ alias: AdminAlias }>(
+        endpoints.mail.admin.aliases(serverId),
+        payload,
+      ),
+    setActive: (serverId: string, id: number, active: boolean) =>
+      api.patch<{ alias: AdminAlias }>(
+        endpoints.mail.admin.alias(serverId, id),
+        { active },
+      ),
+    delete: (serverId: string, id: number) =>
+      api.delete<{ ok: boolean }>(endpoints.mail.admin.alias(serverId, id)),
   },
   stats: {
     get: (serverId: string) =>


### PR DESCRIPTION
## Summary

The `/emails` admin panel manages domains and mailboxes, but the underlying
iRedMail-style mail stack already supports per-address forwarding and
domain catch-alls via the `vmail.forwardings` table — there was just no way
to manage them without SSHing in and writing SQL by hand. This adds an
**Aliases** tab (after Mailboxes) so admins can create/toggle/delete
forwards and catch-alls from the dashboard.

## Implementation notes

- **`apps/api/src/modules/mail/admin/aliases.service.ts`** (new) —
  `listAliases`/`createAlias`/`updateAliasActive`/`deleteAlias`, mirroring
  `mailboxes.service.ts` exactly: same `psql-runner.ts` (SSH+psql)
  execution path, same `q()`/`qInt()` quoting for injection safety, same
  validate-then-INSERT convention.
- A `forwardings` row with `is_alias = 1` is either a **per-address alias**
  (`address = local@domain`) or a **catch-all** (`address` = the bare
  domain, matching `catchall_maps.cf`'s `WHERE forwardings.address =
  domain.domain` join) — no separate flag needed, the shape of `address`
  disambiguates it.
- Guards:
  - destination / local-part email format validation
  - reject an alias address that's already a real mailbox — `409` (since
    `virtual_alias_maps` is checked before `virtual_mailbox_maps`, an alias
    over a mailbox address would silently redirect that mailbox's mail)
  - reject an exact duplicate `(address, forwarding)` pair — `409`
  - catch-all creation is a delete-existing-then-insert transaction, so
    there's only ever one per domain
- 4 REST endpoints under `/admin/:serverId/aliases[/:id]`
  (`GET`/`POST`/`PATCH`/`DELETE`), same permission-tag convention as the
  existing mailbox routes (list/write/write/admin).
- Frontend: `aliases-tab.tsx` mirrors `mailboxes-tab.tsx`'s
  `DataTable`/`FormModalContent` pattern. The create dialog has its own
  domain select (unlike Mailboxes) so an alias for any domain can be added
  without leaving the current view, plus a catch-all checkbox that swaps
  the local-part field for a domain-wide note.
- `vmail` SQL (`forwardings`/`mailbox`/`domain` tables) is the only state
  touched — no control-plane schema changes, no migration.
- i18n: English strings only for the new `aliases.*` / `panel.tabs.aliases`
  keys; `i18n-parity.test.ts`'s ratchet baseline bumped to match the exact
  new ​count (consistent with how every other namespace in that file
  already carries an English-first backlog).

## Test plan

Verified live on a self-hosted install running a fork of `0.4.5` (api
rebuilt from source with this change, dashboard likewise) against a real
iRedMail mail server:

- [x] Created an alias via the dashboard UI and via the raw API
      (`local@domain` → external address)
- [x] Confirmed the row lands correctly in `vmail.forwardings`
      (`is_alias=1`, `is_forwarding=0`, `dest_domain` derived from the
      destination)
- [x] Confirmed it's **live with no restart**:
      `postmap -q <alias> pgsql:/etc/postfix/pgsql/virtual_alias_maps.cf`
      resolves to the destination immediately after creation
- [x] Guard: alias address colliding with an existing mailbox → `409`,
      mailbox untouched
- [x] Guard: exact duplicate `(address, forwarding)` → `409`
- [x] Guard: invalid destination email format → rejected
- [x] Toggle active on/off via `PATCH`
- [x] Delete via UI and via `DELETE` — confirmed row removed from
      `vmail.forwardings` and gone from the list endpoint
- [x] `tsc --noEmit` clean on `apps/api` and `apps/dashboard`
- [x] `i18n-parity.test.ts` passes with the updated baseline
- [x] All other hosted sites / unrelated services on the box unaffected
      throughout