### PR TITLE
fix(cli): give the LocalExecutor test mock a working exec()

### DIFF
--- a/apps/cli/test/e2e/up.test.ts
+++ b/apps/cli/test/e2e/up.test.ts
@@ -54,7 +54,19 @@ vi.mock("@repo/adapters/proxy", async (importOriginal) => ({
   edgeIsBroken: async () => e.edgeBroken,
   edgeCrashReason: async () => e.edgeCrashReason,
 }));
-vi.mock("@repo/adapters", () => ({ LocalExecutor: class {} }));
+// waitForEdgeRunning (edge-import.ts) does `new LocalExecutor().exec("docker
+// inspect …")` to confirm the edge container is actually up before importing
+// migrated sites — mirror `e.edgeBroken` so it resolves the same way the rest
+// of the edge-chain fixtures already do, instead of the class being callable
+// but exec-less (that threw "exec.exec is not a function" the instant any
+// test's flow reached this check).
+vi.mock("@repo/adapters", () => ({
+  LocalExecutor: class {
+    async exec() {
+      return e.edgeBroken ? "false" : "true";
+    }
+  },
+}));
 
 vi.mock("../../src/lib/edge-preflight", () => ({
   planAndApplyHostEdge: async () => {


### PR DESCRIPTION
## Summary

`main`'s CI is currently red (confirmed on the tip commit itself,
[run 30474891407](https://github.com/oblien/openship/actions/runs/30474891407)),
unconditionally, for everyone — this un-breaks it.

## Root cause

`1ea849a1` ("wait for edge container check") added `waitForEdgeRunning` to
`apps/cli/src/lib/edge-import.ts`, which does
`new LocalExecutor().exec("docker inspect ...")` to confirm the edge
container is actually running before importing migrated sites. It didn't
update `up.test.ts`'s blanket
`vi.mock("@repo/adapters", () => ({ LocalExecutor: class {} }))`, so the
first (and only) test whose flow actually reaches that check — *"imports
migrated sites into the edge after the stack is healthy"* — throws:

```
TypeError: exec.exec is not a function
  ❯ waitForEdgeRunning src/lib/edge-import.ts:46:8
```

Every other test in the file exits before reaching this code path (cancelled
takeover, missing docker, image-fetch failure, etc.), so the gap was never
exercised until CI ran the full suite against the "happy path" test.

## Fix

Give the mocked `LocalExecutor` a real `exec()` that mirrors `e.edgeBroken`
— the same fixture the file already uses one mock block above for
`edgeIsBroken`/`edgeCrashReason` — returning `"true"` (container running)
when healthy and `"false"` when the fixture marks the edge broken. No
production code changed, test-only.

## Test plan

- [x] `tsc --noEmit` clean on `apps/cli`
- [x] Verified the fix in isolation, outside the full monorepo suite (which
      hits an unrelated pre-existing `zod`/`packages/core/src/apps/schema.ts`
      resolution issue in my local sandbox, reproducible identically with or
      without this change — not something this PR touches or fixes): the
      *old* mock reproduces the CI error message byte-for-byte; the *new*
      one makes `waitForEdgeRunning` resolve `true` on the first attempt,
      no error, no retry delay.
- [x] This is the same failure referenced in [#305](https://github.com/oblien/openship/pull/305#issuecomment-5121979181) — once this merges, that PR's `Test` check should go green too.