### PR TITLE
fix: support monorepo sub-apps that have their own Dockerfile

### DIFF
--- a/apps/api/src/lib/project-root-detector.ts
+++ b/apps/api/src/lib/project-root-detector.ts
@@ -6,6 +6,7 @@ import {
   getBuildImage,
   parseVercelConfig,
   extractCdTargets,
+  slugify,
   type WorkspaceDetector,
 } from "@repo/core";
 import {
@@ -708,7 +709,9 @@ export interface MonorepoWorkspace {
 export interface MonorepoApp {
   /** Stable identifier for this sub-app (e.g. "apps/web"). */
   id: string;
-  /** Display name (last segment of rootDirectory, or package.json name). */
+  /** Display name AND infra identifier (container/network name) - last segment
+   *  of rootDirectory, or a Docker-safe slug of package.json name. Always
+   *  matches `[a-zA-Z0-9][a-zA-Z0-9_.-]*`; see `sanitizeAppName`. */
   name: string;
   rootDirectory: string;
   stack: StackResult["stack"];
@@ -828,12 +831,29 @@ function isIndependentlyDeployable(candidate: ProjectRootSnapshot): boolean {
   return false;
 }
 
+/**
+ * `MonorepoApp.name` isn't just a display label - it's persisted as
+ * `Service.name` and consumed verbatim as a Docker container/network name
+ * (see compose/build.service.ts, runtime/docker.ts's `createServiceContainer`),
+ * which only allows `[a-zA-Z0-9][a-zA-Z0-9_.-]*`. A `package.json` name is
+ * frequently npm-scoped ("@virtalio/saas" - the norm for pnpm/turborepo
+ * workspaces), and "@"/"/" both fail that pattern, so a raw scoped name
+ * deploys fine right up until container creation, which fails with a cryptic
+ * "Invalid container name" from the Docker daemon. Fold the scope into the
+ * name (rather than dropping it) so sibling apps under different scopes,
+ * or the same package name under different scopes, don't collide.
+ */
+function sanitizeAppName(raw: string): string {
+  return slugify(raw.replace(/^@/, "").replace(/\//g, "-"));
+}
+
 function toMonorepoApp(snapshot: ProjectRootSnapshot, overrides?: { id?: string; rootDirectory?: string }): MonorepoApp {
   const rootDirectory = overrides?.rootDirectory ?? snapshot.rootDirectory;
   const segments = snapshot.rootDirectory.split("/");
   const stack = snapshot.stack;
+  const packageName = (snapshot.packageJson?.name as string | undefined)?.trim();
   const name =
-    (snapshot.packageJson?.name as string | undefined)?.trim() ||
+    (packageName && sanitizeAppName(packageName)) ||
     segments.at(-1) ||
     rootDirectory ||
     "app";

--- a/apps/api/src/lib/project-root-detector.ts
+++ b/apps/api/src/lib/project-root-detector.ts
@@ -928,11 +928,22 @@ export function discoverMonorepoApps(
  * not the monorepo flow). Library directories under `packages/` are still
  * filtered out by `scoreCandidate`'s segment penalty; we additionally reject
  * `unknown` stacks so we don't list every directory containing a manifest.
+ *
+ * `projectType === "docker"` (a directory with its own Dockerfile) is
+ * ALSO accepted, not just "app": a Railway/per-service-Dockerfile-style
+ * monorepo (e.g. `apps/api/Dockerfile`, `apps/web/Dockerfile`) is exactly as
+ * deployable as a buildpack-detected app - the build pipeline already builds
+ * a "docker"-stack sub-app straight from its own Dockerfile at its
+ * `rootDirectory`, same as a standalone docker-stack project (see
+ * compose/build.service.ts's monorepo build path). Excluding these dropped
+ * every sub-app to 0 candidates for any monorepo built this way, so
+ * `discoverMonorepoApps` silently returned null instead of detecting it.
  */
 function isMonorepoAppCandidate(candidate: ProjectRootSnapshot): boolean {
   if (!candidate.rootDirectory) return false;
   if (candidate.stack.stack === "unknown") return false;
-  if (candidate.stack.projectType !== "app") return false;
+  if (candidate.stack.projectType !== "app" && candidate.stack.projectType !== "docker")
+    return false;
   // A .NET class library is not a deployable app — only web/service/exe projects are.
   if (isDotnetLibraryOnly(candidate)) return false;
   // Library segments first (packages/, libs/, shared/, …) are not deployable on their own.

--- a/apps/api/src/modules/deployments/compose/build.service.ts
+++ b/apps/api/src/modules/deployments/compose/build.service.ts
@@ -168,6 +168,11 @@ export async function buildComposeImages(opts: {
   //     buildCommand as long as it has something to CMD. Excluding them
   //     would drop them to neither bucket and they'd silently fail at
   //     deploy time with a misleading "No image available" error.
+  //   - A `framework === "docker"` sub-app ALWAYS counts too, even with both
+  //     commands empty: it builds from its own repo Dockerfile (the Dockerfile
+  //     owns install/build/start), so requiring a build or start command here
+  //     would drop every Dockerfile-based monorepo sub-app to neither bucket -
+  //     the same silent "No image available" failure.
   // External = compose rows with a pre-built image and no Dockerfile build.
   // ONE-TIME image handover (migration cutover): a service named here deploys
   // from an already-present image (a transferred / running container's image)
@@ -200,7 +205,8 @@ export async function buildComposeImages(opts: {
           // sub-app, or the #231 materialized app row) must be selected as
           // buildable HERE too. Keying off the raw row dropped it to neither
           // bucket → the misleading "No image available" the comment above warns of.
-          (!!(service.buildCommand ?? opts.snapshot.buildCommand) ||
+          ((service.framework ?? opts.snapshot.framework) === "docker" ||
+            !!(service.buildCommand ?? opts.snapshot.buildCommand) ||
             !!(service.startCommand ?? opts.snapshot.startCommand)))),
   );
   const external = enabled.filter(

--- a/apps/api/src/modules/deployments/preflight.ts
+++ b/apps/api/src/modules/deployments/preflight.ts
@@ -856,6 +856,12 @@ function checkConfig(snapshot: DeploymentConfigSnapshot, opts?: PreflightOptions
         subAppFailures.push(`sub-app "${svc.name}" missing rootDirectory`);
         continue;
       }
+      // A `docker` sub-app builds from its OWN Dockerfile under rootDirectory
+      // (its FROM is the image) — install/build/start commands are never
+      // consumed there, same as the single-project docker carve-out below.
+      // Requiring them here would block every Dockerfile-based monorepo
+      // sub-app (e.g. a Railway-style per-service-Dockerfile repo).
+      if (svc.framework === "docker") continue;
       const installFallback = svc.installCommand ?? snapshot.installCommand;
       const buildFallback = svc.buildCommand ?? snapshot.buildCommand;
       const startFallback = svc.startCommand ?? snapshot.startCommand;

--- a/apps/api/test/lib/project-root-detector.test.ts
+++ b/apps/api/test/lib/project-root-detector.test.ts
@@ -1012,3 +1012,76 @@ describe("discoverMonorepoApps - .NET class-library exclusion", () => {
     expect(result!.apps.map((app) => app.rootDirectory).sort()).toEqual([".", "ApiB"]);
   });
 });
+
+describe("discoverMonorepoApps - formal workspace monorepo with per-app Dockerfiles", () => {
+  // Mirrors a Railway-style pnpm/turbo monorepo where every sub-app carries its
+  // own Dockerfile (and often a railway.json) instead of being buildpack-
+  // detected. Each sub-app's stack therefore resolves to "docker"
+  // (projectType "docker"), not "app" - previously excluded entirely by
+  // isMonorepoAppCandidate, which dropped candidates to 0 and made
+  // discoverMonorepoApps return null for the whole repo.
+  const root = () => ({
+    rootDirectory: "",
+    files: [
+      { name: "package.json", type: "file" as const },
+      { name: "pnpm-workspace.yaml", type: "file" as const },
+      { name: "turbo.json", type: "file" as const },
+      { name: "apps", type: "dir" as const },
+    ],
+    packageJson: { packageManager: "pnpm@9.0.0" },
+    fileContents: { "pnpm-workspace.yaml": "packages:\n  - 'apps/*'\n" },
+  });
+
+  const dockerSubApp = (dir: string) => ({
+    rootDirectory: dir,
+    source: "workspace" as const,
+    files: [
+      { name: "package.json", type: "file" as const },
+      { name: "Dockerfile", type: "file" as const },
+      { name: "railway.json", type: "file" as const },
+    ],
+    packageJson: { name: dir.split("/").at(-1) },
+    fileContents: {},
+  });
+
+  it("detects a monorepo whose sub-apps each have their own Dockerfile", () => {
+    const result = discoverMonorepoApps(root(), [
+      dockerSubApp("apps/api"),
+      dockerSubApp("apps/saas"),
+      dockerSubApp("apps/marketing"),
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(result!.apps.map((app) => app.rootDirectory).sort()).toEqual([
+      "apps/api",
+      "apps/marketing",
+      "apps/saas",
+    ]);
+    for (const app of result!.apps) {
+      expect(app.stack).toBe("docker");
+      // The Dockerfile owns install/build/start - the runtime builds straight
+      // from it (requireRepositoryDockerfile), so these stay empty rather than
+      // being synthesized.
+      expect(app.installCommand).toBe("");
+      expect(app.buildCommand).toBe("");
+      expect(app.startCommand).toBe("");
+    }
+    expect(result!.workspace.packageManager).toBe("pnpm");
+  });
+
+  it("still excludes a services (docker-compose) candidate from the app list", () => {
+    const composeSubApp = {
+      rootDirectory: "apps/infra",
+      source: "workspace" as const,
+      files: [{ name: "docker-compose.yml", type: "file" as const }],
+      fileContents: {},
+    };
+    const result = discoverMonorepoApps(root(), [
+      dockerSubApp("apps/api"),
+      dockerSubApp("apps/saas"),
+      composeSubApp,
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.apps.map((app) => app.rootDirectory).sort()).toEqual(["apps/api", "apps/saas"]);
+  });
+});

--- a/apps/api/test/lib/project-root-detector.test.ts
+++ b/apps/api/test/lib/project-root-detector.test.ts
@@ -1084,4 +1084,34 @@ describe("discoverMonorepoApps - formal workspace monorepo with per-app Dockerfi
     expect(result).not.toBeNull();
     expect(result!.apps.map((app) => app.rootDirectory).sort()).toEqual(["apps/api", "apps/saas"]);
   });
+
+  it("sanitizes an npm-scoped package.json name into a Docker-safe service name", () => {
+    // pnpm/turborepo workspaces conventionally name sub-apps "@scope/pkg".
+    // That name is persisted as Service.name and used verbatim as a Docker
+    // container/network name downstream, which rejects "@" and "/" - this
+    // was the exact shape of the Virtalio repo that surfaced the bug.
+    const scopedSubApp = (dir: string, pkgName: string) => ({
+      rootDirectory: dir,
+      source: "workspace" as const,
+      files: [
+        { name: "package.json", type: "file" as const },
+        { name: "Dockerfile", type: "file" as const },
+      ],
+      packageJson: { name: pkgName },
+      fileContents: {},
+    });
+
+    const result = discoverMonorepoApps(root(), [
+      scopedSubApp("apps/api", "@virtalio/api"),
+      scopedSubApp("apps/saas", "@virtalio/saas"),
+      scopedSubApp("apps/marketing", "@virtalio/marketing"),
+    ]);
+
+    expect(result).not.toBeNull();
+    const names = result!.apps.map((app) => app.name).sort();
+    expect(names).toEqual(["virtalio-api", "virtalio-marketing", "virtalio-saas"]);
+    for (const name of names) {
+      expect(name).toMatch(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Monorepo detection silently failed for any repo whose sub-apps each carry their own `Dockerfile` instead of being buildpack-detected — a common layout for pnpm/turborepo workspaces (e.g. Railway-style `apps/api/Dockerfile`, `apps/saas/Dockerfile`, `apps/marketing/Dockerfile`). Verified against a real production turborepo with this exact shape.

- **Detection**: `isMonorepoAppCandidate` only accepted `projectType === "app"` (buildpack-detected apps), rejecting every directory whose stack resolved to `"docker"` (i.e. has its own Dockerfile). This dropped candidate count to 0 for such repos, so `discoverMonorepoApps` returned `null` for the whole repo instead of finding the sub-apps. Fixed by also accepting `"docker"`.
- **Build**: `compose/build.service.ts`'s `buildable` filter assumed every monorepo sub-app has buildpack-style build/start commands. A docker-stack sub-app has none of those by design (the Dockerfile owns everything), so it was silently dropped to neither the buildable nor external bucket. Added a `framework === "docker"` carve-out, mirroring the pattern.
- **Preflight**: `preflight.ts`'s sub-app sanity loop had the same assumption and would block the deploy with "sub-app X missing install command" for a valid Dockerfile-based sub-app. Added the same carve-out — mirrors the existing single-project docker carve-out already in the same file.
- **Naming**: Once detection worked, sub-app names fell back to `package.json`'s `name` field. npm-scoped names (`@scope/pkg`, the pnpm/turborepo convention) were used verbatim as the Docker container/network name downstream, which only allows `[a-zA-Z0-9][a-zA-Z0-9_.-]*` — deploy failed at container creation with `bad parameter - Invalid container name`. Fixed by slugifying the name (folding the scope in rather than dropping it, so sibling apps under different scopes don't collide).

## Test plan

- [x] `tsc --noEmit` passes clean on `apps/api`
- [x] New unit tests in `apps/api/test/lib/project-root-detector.test.ts` cover: a workspace monorepo whose sub-apps each have their own Dockerfile, that a docker-compose sub-app is still correctly excluded from the app list, and that npm-scoped package names sanitize to valid Docker service names
- [x] Verified end-to-end against a real production turborepo (3 apps, each with its own Dockerfile and an `@scope/name` package.json) — all 3 apps now detected and deployed correctly
- [ ] `bunx vitest run test/lib/project-root-detector.test.ts` could not be run to green locally — pre-existing, unrelated environmental failure (`TypeError: undefined is not an object (evaluating '__vite_ssr_import_0__.z.object')` in `packages/core/src/apps/schema.ts:38`, a vitest/zod SSR-transform issue). Confirmed pre-existing and unrelated to this change by running an untouched test file (`test/lib/stack-detector.test.ts`) and observing the identical failure.