### PR TITLE
fix(api): rewrite SSH tunnel HTTP requests over raw duplex stream

### DIFF
--- a/apps/api/src/lib/ssh-tunnel.ts
+++ b/apps/api/src/lib/ssh-tunnel.ts
@@ -56,8 +56,41 @@ export interface TunnelResponse {
 }
 
 /**
+ * Parse a chunked-transfer-encoded body out of an accumulated buffer.
+ * Returns the decoded body, or `null` if the buffer doesn't yet contain a
+ * complete terminating chunk (0-length chunk + trailing CRLF).
+ */
+function decodeChunkedBody(buf: Buffer): Buffer | null {
+  const out: Buffer[] = [];
+  let offset = 0;
+  for (;;) {
+    const lineEnd = buf.indexOf("\r\n", offset);
+    if (lineEnd === -1) return null;
+    const sizeLine = buf.slice(offset, lineEnd).toString().split(";")[0].trim();
+    const size = parseInt(sizeLine, 16);
+    if (Number.isNaN(size)) return null;
+    const chunkStart = lineEnd + 2;
+    if (size === 0) return Buffer.concat(out);
+    const chunkEnd = chunkStart + size;
+    if (buf.length < chunkEnd + 2) return null; // chunk data + trailing CRLF not fully buffered yet
+    out.push(buf.slice(chunkStart, chunkEnd));
+    offset = chunkEnd + 2;
+  }
+}
+
+/**
  * Send a single HTTP request to `remoteHost:remotePort` through an SSH
  * tunnel.  Returns the full response (status, headers, body).
+ *
+ * Writes the request directly onto the tunnel's raw duplex and parses the
+ * response by hand (same approach as `tunnelStream` below) rather than
+ * going through `http.request({ createConnection })` — Bun's `node:http`
+ * polyfill does not honor a caller-supplied `createConnection` socket (it
+ * still attempts its own connection under the hood), which made every call
+ * through this path fail with ECONNREFUSED and get silently swallowed to
+ * `null`. Always sends `Connection: close` so the remote closes the socket
+ * once the response is flushed — the simplest unambiguous end-of-body
+ * signal alongside Content-Length/chunked framing.
  *
  * Returns `null` on connection error, timeout, or if the executor
  * doesn't support tunnelling.
@@ -82,43 +115,94 @@ export async function tunnelRequest(
     return null;
   }
 
+  const bodyBuf = body ? (Buffer.isBuffer(body) ? body : Buffer.from(body)) : undefined;
+  const headerLines = [
+    `${method} ${path} HTTP/1.1`,
+    `Host: 127.0.0.1:${remotePort}`,
+    "Connection: close",
+    ...(bodyBuf ? [`Content-Length: ${bodyBuf.length}`] : []),
+    ...Object.entries(headers).map(([k, v]) => `${k}: ${v}`),
+    "",
+    "",
+  ];
+
   return new Promise<TunnelResponse | null>((resolve) => {
-    const timer = setTimeout(() => {
-      tunnel.destroy();
-      resolve(null);
-    }, timeoutMs);
-
-    const req = http.request(
-      {
-        method,
-        path,
-        headers: {
-          Host: `127.0.0.1:${remotePort}`,
-          ...headers,
-        },
-        createConnection: () => tunnel as any,
-      },
-      (res) => {
-        const chunks: Buffer[] = [];
-        res.on("data", (chunk: Buffer) => chunks.push(chunk));
-        res.on("end", () => {
-          clearTimeout(timer);
-          resolve({
-            statusCode: res.statusCode ?? 0,
-            headers: res.headers,
-            body: Buffer.concat(chunks).toString(),
-          });
-        });
-      },
-    );
-
-    req.on("error", () => {
+    let settled = false;
+    const finish = (result: TunnelResponse | null) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
-      resolve(null);
+      tunnel.destroy();
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => finish(null), timeoutMs);
+
+    let buffer = Buffer.alloc(0);
+    let headerEnd = -1;
+    let statusCode = 0;
+    let parsedHeaders: http.IncomingHttpHeaders = {};
+
+    tunnel.on("data", (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk]);
+
+      if (headerEnd === -1) {
+        headerEnd = buffer.indexOf("\r\n\r\n");
+        if (headerEnd === -1) return;
+
+        const rawHead = buffer.slice(0, headerEnd).toString();
+        const [statusLine, ...headerLinesRaw] = rawHead.split("\r\n");
+        statusCode = parseInt(statusLine.split(" ")[1] ?? "0", 10);
+        for (const line of headerLinesRaw) {
+          const colon = line.indexOf(":");
+          if (colon > 0) {
+            parsedHeaders[line.slice(0, colon).trim().toLowerCase()] = line.slice(colon + 1).trim();
+          }
+        }
+      }
+
+      const bodyBytes = buffer.slice(headerEnd + 4);
+      const contentLength = parsedHeaders["content-length"]
+        ? parseInt(parsedHeaders["content-length"] as string, 10)
+        : null;
+      const isChunked = parsedHeaders["transfer-encoding"] === "chunked";
+
+      if (isChunked) {
+        const decoded = decodeChunkedBody(bodyBytes);
+        if (decoded !== null) {
+          finish({ statusCode, headers: parsedHeaders, body: decoded.toString() });
+        }
+      } else if (contentLength !== null) {
+        if (bodyBytes.length >= contentLength) {
+          finish({
+            statusCode,
+            headers: parsedHeaders,
+            body: bodyBytes.slice(0, contentLength).toString(),
+          });
+        }
+      }
+      // Neither content-length nor chunked: wait for the remote to close
+      // the connection (handled by the "close"/"end" listener below).
     });
 
-    if (body) req.write(body);
-    req.end();
+    tunnel.on("error", () => finish(null));
+    tunnel.on("close", () => {
+      if (settled) return;
+      // Connection closed before/without a recognized length framing —
+      // treat whatever body we've buffered as the complete response (the
+      // "Connection: close" no-content-length case).
+      if (headerEnd !== -1) {
+        finish({
+          statusCode,
+          headers: parsedHeaders,
+          body: buffer.slice(headerEnd + 4).toString(),
+        });
+      } else {
+        finish(null);
+      }
+    });
+
+    tunnel.write(Buffer.concat([Buffer.from(headerLines.join("\r\n")), bodyBuf ?? Buffer.alloc(0)]));
   });
 }
 


### PR DESCRIPTION
## What / why

`tunnelRequest()` in `apps/api/src/lib/ssh-tunnel.ts` used Node's `http.request()`
with a custom `createConnection` that returned the SSH tunnel's duplex stream
directly, instead of opening a real TCP socket.

## Root cause

Under Bun's `node:http` polyfill, a caller-supplied `createConnection` is not
honored — `http.request()` still attempts to open its own connection under the
hood regardless of what `createConnection` returns. Every request made through
this path failed with `ECONNREFUSED`, which the existing `req.on("error", ...)`
handler quietly resolved to `null`.

This was caught on a real self-hosted install: analytics scraping for a remote
server reached over an SSH-tunnel executor consistently returned zero data,
even though the target service was healthy and reachable by every other check.
Tracing `tunnelRequest()` directly (bypassing the higher-level analytics code)
reproduced the `ECONNREFUSED` immediately.

## Fix

Write the HTTP/1.1 request directly onto the tunnel's raw duplex stream and
parse the response by hand — status line, headers, `Content-Length`/chunked
transfer-encoding body framing, and a connection-close fallback for responses
with neither. This mirrors the approach this same file's `tunnelStream()`
already uses for streaming responses, so the file is now internally
consistent and no longer depends on `node:http` understanding a
non-standard socket.

## Test plan

- `tsc --noEmit` on `apps/api` — clean.
- Verified directly against a live self-hosted install: before the fix,
  `tunnelRequest()` against a real SSH-tunneled service returned `null` on
  every call; after the fix, it returns the correct status/headers/body, and
  analytics scraping for that server started reporting real data again.
- No existing unit test file covers this module; the fix is a drop-in
  replacement of the request/response mechanics with the same public
  signature (`tunnelRequest(...)`) and return type, so no callers change.