### PR TITLE
fix(edge): use GeoLite2's latest-release download URL, not a pinned date tag

### DIFF
--- a/packages/adapters/src/infra/openresty-lua.ts
+++ b/packages/adapters/src/infra/openresty-lua.ts
@@ -327,7 +327,7 @@ http {
 const GEOIP_DIR = "/usr/share/GeoIP";
 const GEOIP_DB_PATH = `${GEOIP_DIR}/GeoLite2-Country.mmdb`;
 const GEOIP_DB_URL =
-  "https://github.com/P3TERX/GeoLite.mmdb/releases/download/2026.04.07/GeoLite2-Country.mmdb";
+  "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-Country.mmdb";
 
 // ── Local Lua source directory ───────────────────────────────────────────────
 


### PR DESCRIPTION
## What / why

`GEOIP_DB_URL` in `packages/adapters/src/infra/openresty-lua.ts` points at a
specific dated release tag of `P3TERX/GeoLite.mmdb`
(`releases/download/2026.04.07/GeoLite2-Country.mmdb`).

## Root cause

That repo publishes a new dated release on every scheduled MaxMind database
refresh and does not keep old release tags around — so a URL pinned to a
specific date 404s as soon as a newer release replaces it. The GeoIP database
install step then fails outright on any fresh setup, and country-lookup
features that depend on the downloaded `.mmdb` file existing never get data.

Hit this on a real self-hosted install: the GeoIP install step failed with a
404 against the pinned date URL.

## Fix

Point at the repo's `/releases/latest/download/` path instead, which always
redirects to whatever the current release actually is, instead of a fixed
date that inevitably goes stale.

## Test plan

- `tsc --noEmit` on `packages/adapters` — clean.
- No existing test references the pinned URL or date; this is a one-line,
  self-contained URL change with no other callers to update.
- Verified the new URL resolves (302 → current release asset) where the old
  pinned-date URL now 404s.