### PR TITLE
fix(mail): check spamd.service, not spamassassin.service

### DIFF
--- a/apps/api/src/modules/mail/mail-health.service.ts
+++ b/apps/api/src/modules/mail/mail-health.service.ts
@@ -58,7 +58,14 @@ export const MAIL_COMPONENTS: MailComponentDef[] = [
     key: "spamassassin",
     label: "SpamAssassin",
     description: "Spam scoring",
-    unit: "spamassassin",
+    // The Debian/Ubuntu spamassassin package (>=4.0) ships its systemd unit
+    // as `spamd.service`, not `spamassassin.service` — checking the latter
+    // always returned LoadState=not-found ("Missing") even on a fully
+    // installed, correctly-configured host. Note Amavis scores spam via its
+    // own in-process Mail::SpamAssassin integration regardless of this
+    // daemon's state; spamd is the standalone network-facing scorer other
+    // tools (spamc) can talk to — this check is about ITS state specifically.
+    unit: "spamd",
   },
   {
     key: "iredapd",


### PR DESCRIPTION
## What / why

The mail health check's `MailComponentDef` for spam scoring probed the
systemd unit `spamassassin.service`.

## Root cause

On Debian/Ubuntu, the `spamassassin` package (>=4.0, what our slimmed
iRedMail engine installs) ships its systemd unit as `spamd.service` — there
is no `spamassassin.service` unit at all. The health check's `systemctl`
lookup for the wrong unit name always came back `LoadState=not-found`, so
the dashboard reported spam scoring as "Missing" even on a host where
`spamassassin`/`spamc`/`spamd`/`sa-compile` were all correctly installed via
dpkg and fully functional.

Note Amavis actually scores spam via its own in-process
`Mail::SpamAssassin` integration, independent of `spamd`'s state — `spamd`
is the standalone network-facing daemon other tools (`spamc`) talk to. This
check is specifically about `spamd`'s own state, which is now what it
reports.

Hit this on a real self-hosted install: spam scoring showed "Missing" in
the dashboard on a box with a fully working, dpkg-verified SpamAssassin
install — the only thing wrong was the health check's unit name.

## Fix

Point the health check at `spamd.service` instead of `spamassassin.service`.

## Test plan

- `tsc --noEmit` on `apps/api` — clean.
- No existing test covers this specific `MailComponentDef` entry; this is a
  one-line unit-name correction with no behavior change to the check logic
  itself.
- Verified directly on a live self-hosted install: `systemctl status
  spamd.service` reports the correct active/running state, where
  `systemctl status spamassassin.service` returns "could not be found."