### PR TITLE
fix(docker): don't purge shared image tags, silence backup executor logs

### DIFF
--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -1927,6 +1927,30 @@ export class DockerRuntime implements RuntimeAdapter {
     }
   }
 
+  /**
+   * True if some container OTHER than `excludeContainerId` was created from
+   * this exact image tag. A locally-built image with no registry behind it
+   * (e.g. a docker-migration import, tagged once and reused verbatim) is
+   * shared across every deployment row ever generated from it — there is no
+   * per-deployment digest, just one mutable tag string. Best-effort: if the
+   * check itself fails, treat the tag as in-use (skip the removal) rather
+   * than risk deleting something a sibling deployment still needs.
+   */
+  private async imageTagInUseElsewhere(
+    imageRef: string,
+    excludeContainerId: string | null,
+  ): Promise<boolean> {
+    try {
+      const containers = await this.docker.listContainers({
+        all: true,
+        filters: { ancestor: [imageRef] },
+      });
+      return containers.some((c) => c.Id !== excludeContainerId);
+    } catch {
+      return true;
+    }
+  }
+
   async purge(deployment: DeploymentRef): Promise<void> {
     // Purge order: remove container first (best-effort), then image.
     // Container removal silently no-ops if already gone — keeps purge
@@ -1940,7 +1964,14 @@ export class DockerRuntime implements RuntimeAdapter {
     }
     if (deployment.imageRef) {
       try {
-        await this.removeImage(deployment.imageRef);
+        // Untagging a mutable, registry-less tag here would strand any
+        // SIBLING deployment/service whose container was created from that
+        // same tag — a later recreate against the tag then fails with
+        // "repository does not exist" even though the image is still very
+        // much in use elsewhere.
+        if (!(await this.imageTagInUseElsewhere(deployment.imageRef, deployment.containerId))) {
+          await this.removeImage(deployment.imageRef);
+        }
       } catch {
         // image already removed / not present locally
       }

--- a/packages/adapters/test/docker-container-status.test.ts
+++ b/packages/adapters/test/docker-container-status.test.ts
@@ -131,3 +131,80 @@ describe("DockerRuntime container status normalization", () => {
     expect(c.state).toBe("exited");
   });
 });
+
+describe("DockerRuntime.purge() shared-tag safety", () => {
+  it("does NOT untag the image when another container still runs it", async () => {
+    const runtime = await DockerRuntime.create();
+
+    // Simulate a mutable, registry-less tag (docker-migration import) shared
+    // by three sibling containers — "app" is being purged, "horizon" and
+    // "scheduler" are still running from the exact same tag.
+    runtime.docker.listContainers = (async () => [
+      { Id: "horizon-id", Image: "migration-360p-app:latest" },
+      { Id: "scheduler-id", Image: "migration-360p-app:latest" },
+    ]) as any;
+
+    let destroyCalled = false;
+    runtime.destroy = async () => {
+      destroyCalled = true;
+    };
+    let removeImageCalled = false;
+    runtime.removeImage = async () => {
+      removeImageCalled = true;
+    };
+
+    await runtime.purge({
+      id: "dep1",
+      projectId: "proj1",
+      imageRef: "migration-360p-app:latest",
+      containerId: "app-id",
+    } as any);
+
+    expect(destroyCalled).toBe(true);
+    expect(removeImageCalled).toBe(false);
+  });
+
+  it("removes the image when no other container references the tag", async () => {
+    const runtime = await DockerRuntime.create();
+
+    runtime.docker.listContainers = (async () => []) as any;
+
+    let removeImageCalled = false;
+    runtime.removeImage = async () => {
+      removeImageCalled = true;
+    };
+    runtime.destroy = async () => {};
+
+    await runtime.purge({
+      id: "dep1",
+      projectId: "proj1",
+      imageRef: "some-app:latest",
+      containerId: "app-id",
+    } as any);
+
+    expect(removeImageCalled).toBe(true);
+  });
+
+  it("treats a listContainers failure as in-use (safer default: skip removal)", async () => {
+    const runtime = await DockerRuntime.create();
+
+    runtime.docker.listContainers = (async () => {
+      throw new Error("daemon unreachable");
+    }) as any;
+
+    let removeImageCalled = false;
+    runtime.removeImage = async () => {
+      removeImageCalled = true;
+    };
+    runtime.destroy = async () => {};
+
+    await runtime.purge({
+      id: "dep1",
+      projectId: "proj1",
+      imageRef: "some-app:latest",
+      containerId: "app-id",
+    } as any);
+
+    expect(removeImageCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## What / why

`DockerRuntime.purge(deployment)` unconditionally calls `removeImage(deployment.imageRef)` — a forced `docker rmi` by tag string — whenever a deployment row carries an `imageRef`, with no check for whether that tag is still load-bearing elsewhere.

## Root cause

For a registry-backed image this is harmless (the tag can always be re-pulled). But a **locally-built image with no registry behind it** — e.g. a docker-migration import, built once and reused verbatim across every service in a compose project — has exactly ONE mutable tag string shared by every sibling container. Purging any single deployment row referencing that tag (a failed "update"-triggered redeploy being rolled back, for example) untags the image out from under still-running sibling containers.

Docker itself keeps those siblings running fine — a running container holds its image by resolved ID internally, not by tag — but any *subsequent* `docker run`/recreate against that tag then fails with `pull access denied ... repository does not exist`, since the tag no longer resolves to anything and there's no registry to pull it from. The image effectively becomes unrecoverable through the normal deploy path.

Hit exactly this on a real self-hosted install: rolling back a failed "update" deploy for a multi-service docker-migration project (an `app` + `horizon` + `scheduler` set sharing one image tag) deleted the tag while `horizon`/`scheduler` were still running from it, leaving the crashed `app` service unrecoverable without a manual rebuild.

## Fix

Before removing the image in `purge()`, check whether any container *other than* the deployment's own was created from that same tag (`docker ps -a --filter ancestor=<tag>`). Skip the removal if one exists. Best-effort: if the check itself fails (daemon hiccup), treat the tag as in-use and skip the removal — the safer default over risking an unrecoverable delete.

## Test plan

- `tsc --noEmit` on `packages/adapters` — clean.
- Added 3 unit tests to `packages/adapters/test/docker-container-status.test.ts` following the existing `DockerRuntime.create()` + mocked-`docker` pattern in that file:
  - a sibling container still referencing the tag → image is **not** removed (container is still destroyed as before)
  - no other container references the tag → image **is** removed
  - `listContainers` itself fails → treated as in-use, removal skipped
- Note: this sandbox's `vitest` run hits a pre-existing, unrelated failure (`TypeError: undefined is not an object (evaluating '__vite_ssr_import_0__.z.object')` in `packages/core/src/apps/schema.ts`) that affects ~45 test files identically on a clean `origin/main` checkout with zero changes (confirmed via `git stash`), so it isn't something this PR introduces. To get real signal on the fix itself, I ran the exact same three scenarios directly through `bun` against the compiled logic (mocking `docker.listContainers`/`destroy`/`removeImage` the same way the added tests do) and confirmed all three pass as expected.