### PR TITLE
fix(deploy): skip dead service rows in preflight, scope migration compose project

### DIFF
--- a/apps/api/src/lib/deployable-service.ts
+++ b/apps/api/src/lib/deployable-service.ts
@@ -71,6 +71,16 @@ export type DeployableService = ComposeService & MonorepoSubAppFields & {
     customDomain?: string | null;
     domainType?: string | null;
   }>;
+  /**
+   * Whether ANY service_deployment row has ever been recorded for this
+   * service. `undefined` means unknown (the caller supplied services
+   * directly, e.g. an in-flight wizard session, rather than projecting them
+   * from the project's saved `service` rows) — preflight treats that as "not
+   * provably dead" and keeps failing loudly. Only an explicit `false` — a
+   * saved row this project has never once deployed — is eligible for the
+   * dead-row carve-out.
+   */
+  everDeployed?: boolean;
 };
 
 /**

--- a/apps/api/src/modules/deployments/compose/project-services.ts
+++ b/apps/api/src/modules/deployments/compose/project-services.ts
@@ -51,9 +51,13 @@ export async function listProjectMonorepoApps(projectId: string): Promise<Servic
  * installCommand on a compose row" bug would surface immediately instead of
  * being silently masked here.
  */
-export function projectServicesToDeployableServices(services: Service[]): DeployableService[] {
+export function projectServicesToDeployableServices(
+  services: Service[],
+  everDeployedByServiceId?: Map<string, boolean>,
+): DeployableService[] {
   return services.map((s): DeployableService => ({
     kind: serviceKind(s),
+    everDeployed: everDeployedByServiceId?.get(s.id),
     enabled: s.enabled,
     name: s.name,
     image: s.image ?? undefined,
@@ -88,7 +92,18 @@ export async function resolveProjectServicePreflightServices(
 ): Promise<DeployableService[]> {
   if (requestServices?.length) return requestServices;
   const services = await listProjectComposeServices(projectId);
-  return projectServicesToDeployableServices(services.filter((service) => service.enabled));
+  // One round trip for "has this service EVER produced a service_deployment
+  // row" — distinguishes a saved row nobody has ever deployed (eligible for
+  // the dead-row preflight carve-out) from a fresh row about to be deployed
+  // for the first time (still an unknown until it either succeeds or fails).
+  const latestByService = await repos.serviceDeployment.latestByProject(projectId);
+  const everDeployedByServiceId = new Map(
+    services.map((s) => [s.id, latestByService.has(s.id)]),
+  );
+  return projectServicesToDeployableServices(
+    services.filter((service) => service.enabled),
+    everDeployedByServiceId,
+  );
 }
 
 export async function shouldUseProjectServicePipeline(

--- a/apps/api/src/modules/deployments/preflight.ts
+++ b/apps/api/src/modules/deployments/preflight.ts
@@ -845,6 +845,7 @@ function checkConfig(snapshot: DeploymentConfigSnapshot, opts?: PreflightOptions
     // value here so the operator sees "sub-app X has no install command"
     // before resources are provisioned.
     const subAppFailures: string[] = [];
+    const deadRowWarnings: string[] = [];
     for (const svc of opts.composeServices ?? []) {
       if (svc.kind !== "monorepo") continue;
       // Disabled sub-apps never run; skip. `enabled === false` is the
@@ -852,6 +853,23 @@ function checkConfig(snapshot: DeploymentConfigSnapshot, opts?: PreflightOptions
       // sub-app get a public URL) and conflating them lets enabled-but-
       // not-exposed sub-apps slip past this check with no install command.
       if (svc.enabled === false) continue;
+      // Dead/orphaned row: a saved sub-app this project has NEVER once
+      // deployed (confirmed, not just "not this deploy" — see `everDeployed`),
+      // carrying no install/build/start command at all. Nothing distinguishes
+      // that from stray leftover config (a duplicate/abandoned row from an
+      // earlier import or a half-finished "add service" that was never
+      // followed through) — and unlike a genuinely misconfigured LIVE
+      // service, hard-failing it blocks every future deploy of the WHOLE
+      // project indefinitely, with no route to recovery short of editing the
+      // DB by hand. Warn instead: surface it so the operator can clean it up,
+      // but let the rest of the project keep deploying.
+      const hasAnyCommand = !!(svc.installCommand || svc.buildCommand || svc.startCommand);
+      if (svc.everDeployed === false && !hasAnyCommand) {
+        deadRowWarnings.push(
+          `sub-app "${svc.name}" has never been deployed and has no install/build/start command — skipping (disable or configure it to silence this)`,
+        );
+        continue;
+      }
       if (!svc.rootDirectory) {
         subAppFailures.push(`sub-app "${svc.name}" missing rootDirectory`);
         continue;
@@ -894,6 +912,14 @@ function checkConfig(snapshot: DeploymentConfigSnapshot, opts?: PreflightOptions
         label: "Service configuration",
         status: "fail",
         message: subAppFailures.join("; "),
+      };
+    }
+    if (deadRowWarnings.length > 0) {
+      return {
+        id: "config",
+        label: "Service configuration",
+        status: "warn",
+        message: deadRowWarnings.join("; "),
       };
     }
 

--- a/apps/api/src/modules/migration/migrate.service.ts
+++ b/apps/api/src/modules/migration/migrate.service.ts
@@ -310,6 +310,16 @@ export async function adoptServerStack(opts: {
   /** Adopt in flat-docker mode — must match the scan the user selected from, or
    *  openship-labeled containers are treated as managed and none are found. */
   flatDocker?: boolean;
+  /** Restrict `serviceNames` resolution to ONE discovered group: the compose
+   *  project name, or `null` for the standalone (hand-run container) group.
+   *  Omit for the legacy server-wide match.
+   *
+   *  Service names are only unique WITHIN a compose project, so on a server
+   *  running several stacks a bare name like `app`/`db`/`redis` matches a
+   *  container in each of them. Unscoped, those extra matches are not dropped —
+   *  buildAdoptedServiceRows suffixes them (`app-2`, `redis-3`), silently
+   *  adopting another stack's containers into this project. */
+  composeProject?: string | null;
   /** Parsed repo compose services (name → spec). When present, adopted rows take
    *  their NATIVE build/image from the mapped repo service (Redeploy rebuilds),
    *  and the returned `handover` lets the first deploy reuse the running image. */
@@ -319,10 +329,23 @@ export async function adoptServerStack(opts: {
 
   const stack = await discoverServerStack(serverId, organizationId, undefined, { flatDocker });
   const selected = new Set(serviceNames);
+  // Resolve names within ONE group when the caller scoped the adopt — a bare
+  // service name is ambiguous across compose projects (see `composeProject`).
+  let pool = stack.services;
+  if (opts.composeProject !== undefined) {
+    const group = stack.groups.find((g) => g.project === opts.composeProject);
+    if (!group) {
+      const known = stack.groups.map((g) => g.project ?? "(standalone)").join(", ");
+      throw new Error(
+        `Compose project "${opts.composeProject ?? "(standalone)"}" was not found on the server. Found: ${known}.`,
+      );
+    }
+    pool = group.services;
+  }
   // Drop the edge proxy (traefik/nginx/… on 80/443): OpenResty replaces it, so
   // adopting it would just replay the 80/443 conflict. Defense-in-depth — the
   // wizard already marks it non-importable and the orchestrator filters it too.
-  const chosen = stack.services.filter((s) => selected.has(s.name) && !s.proxyKind);
+  const chosen = pool.filter((s) => selected.has(s.name) && !s.proxyKind);
   if (chosen.length === 0) {
     throw new Error("None of the selected services were found on the server.");
   }

--- a/apps/api/src/modules/migration/migration.controller.ts
+++ b/apps/api/src/modules/migration/migration.controller.ts
@@ -167,6 +167,10 @@ export async function adoptServer(c: Context) {
     volumeStrategies?: Record<string, "reuse" | "copy">;
     serviceSubpaths?: Record<string, string>;
     serviceEnv?: Record<string, Record<string, string>>;
+    /** Compose project to resolve `serviceNames` in (`null` = standalone group).
+     *  Omit for the legacy server-wide match — ambiguous when several stacks
+     *  share service names like `app`/`db`/`redis`. */
+    composeProject?: string | null;
   }>();
   const { serverId, projectName, serviceNames, flatDocker, volumeStrategies, serviceSubpaths, serviceEnv } = body;
   if (!serverId) return c.json({ error: "serverId is required" }, 400);
@@ -195,6 +199,7 @@ export async function adoptServer(c: Context) {
       volumeStrategies,
       serviceSubpaths,
       serviceEnv,
+      ...("composeProject" in body ? { composeProject: body.composeProject } : {}),
     });
     return c.json({ success: true, ...result });
   } catch (err) {

--- a/apps/api/test/modules/deployments/preflight.test.ts
+++ b/apps/api/test/modules/deployments/preflight.test.ts
@@ -177,4 +177,84 @@ describe("runPreflightChecks", () => {
     expect(result.checks.some((check) => check.message?.includes("install command"))).toBe(false);
     expect(result.checks.some((check) => check.message?.includes("start command"))).toBe(false);
   });
+
+  it("warns instead of failing on a monorepo sub-app that has never been deployed and has no commands", async () => {
+    const result = await runPreflightChecks(
+      {
+        repoUrl: "https://github.com/acme/monorepo.git",
+        branch: "main",
+        hasBuild: true,
+        hasServer: true,
+        deployTarget: "server",
+        organizationId: "org-1",
+      } as any,
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" } as any,
+        buildStrategy: "local",
+        multiService: true,
+        composeServices: [
+          {
+            kind: "monorepo",
+            name: "orphaned-app",
+            rootDirectory: ".",
+            enabled: true,
+            everDeployed: false,
+          },
+        ],
+      },
+    );
+
+    // "warn" is not "fail" — the deploy proceeds.
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "config",
+          label: "Service configuration",
+          status: "warn",
+        }),
+      ]),
+    );
+    expect(
+      result.checks.find((c) => c.id === "config")?.message,
+    ).toContain("orphaned-app");
+  });
+
+  it("still hard-fails a monorepo sub-app missing commands when it HAS been deployed before", async () => {
+    const result = await runPreflightChecks(
+      {
+        repoUrl: "https://github.com/acme/monorepo.git",
+        branch: "main",
+        hasBuild: true,
+        hasServer: true,
+        deployTarget: "server",
+        organizationId: "org-1",
+      } as any,
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" } as any,
+        buildStrategy: "local",
+        multiService: true,
+        composeServices: [
+          {
+            kind: "monorepo",
+            name: "live-app",
+            rootDirectory: ".",
+            enabled: true,
+            everDeployed: true,
+          },
+        ],
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "config",
+          label: "Service configuration",
+          status: "fail",
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## What / why

Two related deploy/migration robustness fixes.

### 1. Preflight hard-fails a whole project over one dead service row

The multi-service preflight's sub-app check hard-fails the **entire
project's** deploy when any enabled `monorepo`-kind service row lacks an
install/build/start command it's supposed to have. That's the right call
for a genuinely misconfigured, actively-used sub-app — but it applies just
as unconditionally to a saved row that has **never once been deployed**: a
duplicate/leftover row from an earlier import, or a half-finished "add
service" that was never followed through.

Hit this on a real self-hosted install: a docker-migration-imported project
accumulated a stray, never-deployed `monorepo`-kind service row alongside
its real (already-working, already-routed) compose services. That one dead
row's missing start command blocked **every subsequent deploy of the whole
project indefinitely** — including a plain git-push redeploy that touched
none of the project's actual services — with no way to recover short of an
operator finding and editing the row directly in the database.

**Fix:** track whether a service has ever produced a `service_deployment`
row (one extra round trip via the existing `serviceDeployment.latestByProject`
lookup — no new query shape, just reusing what's already there). A saved
row with no install/build/start command *and* no deployment history is
downgraded from a hard failure to a warning: the operator still sees it
flagged, but the rest of the project's services keep deploying. A row that
*has* been deployed before, or one that came from an explicit in-flight
request (not projected from the DB, so its history is unknown), is
unaffected and still fails exactly as before.

### 2. Adopted service-name resolution isn't scoped to a compose project

`adoptServerStack()` resolved the caller's `serviceNames` against every
service discovered on the server, server-wide. Service names are only
unique *within* a single compose project, so a server running several
stacks has a bare name like `app`/`db`/`redis` matching a container in
**each** of them — and those extra cross-stack matches weren't dropped:
`buildAdoptedServiceRows` suffixed them (`app-2`, `redis-3`) and silently
adopted another project's containers into the one being migrated.

**Fix:** accept an optional `composeProject` to restrict resolution to ONE
discovered group (the compose project name, or `null` for the standalone/
hand-run-container group). Omitting it keeps the legacy server-wide match
for existing callers, so this is purely additive.

## Test plan

- `tsc --noEmit` on `apps/api` — clean.
- Added two tests to `apps/api/test/modules/deployments/preflight.test.ts`:
  one confirming a never-deployed, commandless monorepo row now produces a
  `warn` (and `result.ok === true`), one confirming a row that *has* been
  deployed before still hard-fails exactly as before (no regression).
- No test hunk existed for the `composeProject` migration change; the
  existing `migrate.service.test.ts` suite is unaffected since the new
  parameter is optional and defaults to the prior server-wide behavior.
- Note: this sandbox's `vitest` run hits a pre-existing, unrelated failure
  (`TypeError: undefined is not an object (evaluating
  '__vite_ssr_import_0__.z.object')` in `packages/core/src/apps/schema.ts`)
  affecting every test file in `apps/api`/`packages/adapters` identically on
  a clean `origin/main` checkout with zero changes (confirmed via `git
  stash`), so it isn't introduced by this PR. I traced `runPreflightChecks`'s
  aggregation (`ok: checks.every(check => check.status !== "fail")`) by hand
  to confirm a `warn`-only result correctly leaves `ok: true`.