### PR TITLE
fix(api): accept an empty publicEndpoints array on project create/update/ensure

### DIFF
--- a/apps/api/src/modules/projects/project.schema.test.ts
+++ b/apps/api/src/modules/projects/project.schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { UpdateProjectBody } from "./project.schema";
+import { Value } from "@sinclair/typebox/value";
+import { CreateProjectBody, EnsureProjectBody, UpdateProjectBody } from "./project.schema";
 
 /**
  * Mass-assignment guard: `updateProject` builds its DB patch ONLY from the keys
@@ -33,5 +34,35 @@ describe("UpdateProjectBody — mass-assignment allow-list", () => {
     for (const allowed of ["name", "gitBranch", "port", "publicEndpoints", "routingConfig"]) {
       expect(keys).toContain(allowed);
     }
+  });
+});
+
+/**
+ * `publicEndpoints: []` is the wire value for "no public route": `updateProject`
+ * gates route reconciliation on `data.publicEndpoints !== undefined`, so an
+ * explicit empty array has to reach the service to clear a project's routes.
+ * All three bodies are wired as `spec.body`, so the schema is what decides.
+ */
+describe("publicEndpoints — empty set", () => {
+  const endpoint = { domain: "my-app", domainType: "free" as const, port: 3000 };
+  const create = (endpoints: unknown[]) =>
+    Value.Check(CreateProjectBody, { name: "my-app", publicEndpoints: endpoints });
+  const update = (endpoints: unknown[]) =>
+    Value.Check(UpdateProjectBody, { publicEndpoints: endpoints });
+  const ensure = (endpoints: unknown[]) =>
+    Value.Check(EnsureProjectBody, { name: "my-app", publicEndpoints: endpoints });
+
+  it("accepts an explicit empty array on create, update, and ensure", () => {
+    expect(create([])).toBe(true);
+    expect(update([])).toBe(true);
+    expect(ensure([])).toBe(true);
+  });
+
+  it("still accepts a populated array and rejects more than 20 entries", () => {
+    const tooMany = Array.from({ length: 21 }, () => endpoint);
+    expect(create([endpoint])).toBe(true);
+    expect(create(tooMany)).toBe(false);
+    expect(update(tooMany)).toBe(false);
+    expect(ensure(tooMany)).toBe(false);
   });
 });

--- a/apps/api/src/modules/projects/project.schema.ts
+++ b/apps/api/src/modules/projects/project.schema.ts
@@ -207,7 +207,8 @@ export const CreateProjectBody = Type.Object({
     Type.Union([Type.Literal("host"), Type.Literal("static"), Type.Literal("standalone")]),
   ),
   port: Type.Optional(Type.Number({ minimum: 1, maximum: 65535 })),
-  publicEndpoints: Type.Optional(Type.Array(PublicEndpointSchema, { minItems: 1, maxItems: 20 })),
+  /** Public routes for the project. An explicit `[]` clears them (no public route). */
+  publicEndpoints: Type.Optional(Type.Array(PublicEndpointSchema, { maxItems: 20 })),
   hasServer: Type.Optional(Type.Boolean({ default: true })),
   hasBuild: Type.Optional(Type.Boolean({ default: true })),
   rollbackWindow: Type.Optional(Type.Number({ minimum: 0, maximum: 20 })),


### PR DESCRIPTION
## Summary

`publicEndpoints: []` — the wire value for "no public route" — is rejected with a 400 by
`POST /api/projects`, `POST /api/projects/ensure`, and `PATCH /api/projects/:id`. This drops
`minItems: 1` from the array in `CreateProjectBody` so an explicit empty set is accepted.
`maxItems: 20` is unchanged.

## Motivation

Sending `publicEndpoints: []` to any of the three project bodies returns 400 before the handler runs:

```
{"success":false,"errors":[{"type":4,"path":"/publicEndpoints","value":[],
  "message":"Expected array length to be greater or equal to 1"}]}
```

Three dashboard flows send exactly that, and all three are broken today:

| Flow | Client call | Expected | Actual |
| --- | --- | --- | --- |
| Deploy wizard → **select Routing = None** (two clicks, no deploy needed) | `projectsApi.update(projectId, { publicEndpoints: [] })` fired immediately from `handleModeChange("none")` — `deploy/[slug]/components/DomainSettings.tsx:115-135` | routes cleared silently | 400 → error toast the moment the radio is clicked |
| Deploy wizard, Routing = **None**, press Deploy | `projectsApi.ensure({…, publicEndpoints: []})` → `POST /api/projects/ensure` — `useDeploymentBuild.tsx:708` | project ensured, deploy proceeds | 400 → "Failed to create project", deploy aborts at STEP 3 |
| Project Settings → Domains → remove the **last** route | `projectsApi.update(id, { publicEndpoints: [] })` → `PATCH /api/projects/:id` — `projects/[id]/components/DomainSettings.tsx:1094` | route removed | 400 → routing-update-failed toast, route stays |

`[]` is unambiguously the intended wire value — the codebase says so in five places, including the
distinction between `[]` and `undefined`:

- `routing/RoutingModePicker.tsx:12` — "'None' = no public route … the backend treats an empty publicEndpoints set as no route"
- `deploy/[slug]/components/DomainSettings.tsx:125` — "An explicit `[]` makes the API drop the domain rows and deregister the live route (undefined would make it auto-derive the free subdomain again)."
- `useDeploymentBuild.tsx:705` — "'None' routing → explicit [] so ensure() doesn't PERSIST a stale free subdomain"
- `projects/[id]/components/DomainSettings.tsx:1080` — "ALLOW an empty set — removing every domain is a valid 'internal-only / no public route' state"
- `apps/api/src/lib/public-endpoints.ts:335` — `syncStoredPublicEndpoints` keys on `const nextProvided = opts.next !== undefined`, so `[]` is a first-class input distinct from `undefined` in the library layer; `project-crud.service.ts:1015` gates route reconciliation the same way.

### Cause

`minItems: 1` on `project.schema.ts:210` dates to f3095f10 (2026-05-15), when these schemas were
documentation-only (`mcp.body`) and had no runtime HTTP effect. 57ffebef — shipped in #320, the
current `main` tip — promoted `CreateProjectBody` / `UpdateProjectBody` / `EnsureProjectBody` to
`spec.body`, and `secureRouter` auto-wires `tbValidator("json", spec.body)` from that
(`secure-router.ts:175`), so the constraint silently became an enforced 400. `UpdateProjectBody`
(`Type.Partial`) and `EnsureProjectBody` (`Type.Composite`) both inherit it from `CreateProjectBody`.

So this is a ~12-hour-old regression, not long-standing behaviour.

## Related issue

None. Per CONTRIBUTING — "Bug fixes, tests, docs, and small self-contained improvements are welcome
as direct pull requests." This restores behaviour the dashboard and the service layer already
document and depend on; it is not a new endpoint, a new dependency, or a schema/migration change,
so the issue-first gate doesn't apply. Happy to move it to an issue if you'd rather steer it there.

## Changes

**apps/api**

- `src/modules/projects/project.schema.ts` — drop `minItems: 1` from `CreateProjectBody.publicEndpoints`;
  it propagates to `UpdateProjectBody` and `EnsureProjectBody`. `maxItems: 20` kept.
- `src/modules/projects/project.schema.test.ts` — assert `[]` is accepted on all three bodies, and
  that >20 entries is still rejected on all three.

## Verification

The new test fails without the schema change and passes with it. Stashing **only**
`project.schema.ts` and keeping the test:

```bash
$ git stash push -- apps/api/src/modules/projects/project.schema.ts
$ npx vitest run src/modules/projects/project.schema.test.ts

 ❯ src/modules/projects/project.schema.test.ts (4 tests | 1 failed) 4ms
   ✓ excludes internal/state columns that would enable cross-tenant escalation
   ✓ still allows the documented editable fields (no accidental over-restriction)
   × accepts an explicit empty array on create, update, and ensure 2ms
   ✓ still accepts a populated array and rejects more than 20 entries

 FAIL  src/modules/projects/project.schema.test.ts > publicEndpoints — empty set >
       accepts an explicit empty array on create, update, and ensure
 AssertionError: expected false to be true // Object.is equality
 - Expected
 + Received
 - true
 + false
   ❯ src/modules/projects/project.schema.test.ts:56:24
      56|     expect(create([])).toBe(true);

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)

$ git stash pop
$ npx vitest run src/modules/projects/project.schema.test.ts

 ✓ src/modules/projects/project.schema.test.ts (4 tests) 2ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

I also reproduced the original 400 end to end, by mounting the real `CreateProjectBody` /
`UpdateProjectBody` / `EnsureProjectBody` on a real `secureRouter` route (same harness as
`test/lib/secure-router-body-validation.test.ts`) and posting the exact payloads the dashboard sends:

```
ensure status: 400 body: {"success":false,"errors":[{"type":4,
  "schema":{"minItems":1,"maxItems":20,...},"path":"/publicEndpoints","value":[],
  "message":"Expected array length to be greater or equal to 1","errors":[]}]}
update status: 400 body: {... "path":"/publicEndpoints","value":[],
  "message":"Expected array length to be greater or equal to 1" ...}
create status: 400 body: {... "path":"/publicEndpoints","value":[],
  "message":"Expected array length to be greater or equal to 1" ...}
```

All three return 200 after the change. That scratch harness is not part of this diff.

Typecheck:

```bash
$ bun run --cwd apps/api lint
$ tsc --noEmit
# exit 0
```

Full suite — note `bun run test` alone is misleading here: turbo aborts sibling tasks on the first
failure (exit 130), so it never reaches `@repo/api`. With `-- --continue`:

- `@repo/core` 20/20 files, `@repo/adapters` 76/76, `@repo/db` 9/9, `@repo/desktop` 1/1, root 22/22 — green
- `@repo/api` 127/128 files — 1273 passed / 1 failed / 3 skipped
- `@repo/dashboard` 7/8 files — 59 passed / 1 failed

**Both failures are already present on pristine `main` and are unrelated to this change.** I verified
by checking out `main` and re-running:

- `apps/dashboard/src/i18n/i18n-parity.test.ts` — `deploy: 90 missing (baseline 18)`
- `apps/api/test/lib/project-root-detector.test.ts:1065` — "detects a monorepo whose sub-apps each have their own Dockerfile"

`apps/api` on pristine `main` (6a677363): 1271 passed / 1 failed / 3 skipped. On this branch:
1273 passed / 1 failed / 3 skipped — the delta is exactly the two new tests, same single pre-existing failure.

`project.schema.ts` has pre-existing Prettier drift on `main`, so rather than running `--write` over
it and churning unrelated lines I hand-formatted and confirmed my two changed lines are
byte-identical to Prettier's output. `project.schema.test.ts` passes `prettier --check`.

## Alternative considered

Keep `minItems: 1` on `CreateProjectBody` and override it only on the update and ensure bodies. I
rejected it: `EnsureProjectBody` is `Type.Composite([CreateProjectBody, …])`, so it needs its own
explicit override anyway, and the wizard's Routing = None path goes through `/projects/ensure` — so
create-with-`[]` has to be legal regardless. It would also leave the project bodies inconsistent with
`BuildAccessBody` (`deployment.schema.ts:101`) and `UpdateServiceBody` (`service.schema.ts:92`), both
of which already accept `[]` with no `minItems`, and `BuildAccessBody` is the very next call in the
same deploy chain. Say the word and I'll switch to the narrower version.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — with the two pre-existing `main` failures noted above
- [x] I understand every line of this diff and can explain it in review

