### PR TITLE
fix(api): declare the compose-sync body so its MCP tool can send one

### DIFF
--- a/apps/api/src/modules/services/service.routes.ts
+++ b/apps/api/src/modules/services/service.routes.ts
@@ -24,6 +24,7 @@ import * as ctrl from "./service.controller";
 import {
   CreateServiceBody,
   SetServiceEnvVarsBody,
+  SyncServicesBody,
   UpdateServiceBody,
 } from "./service.schema";
 
@@ -64,7 +65,14 @@ r.get(
 );
 r.post(
   "/sync",
-  { tag: "project:service:write", collection: true, mcp: { description: "Sync services from the project's docker-compose file into the service table." } },
+  {
+    tag: "project:service:write",
+    collection: true,
+    body: SyncServicesBody,
+    mcp: {
+      description: "Sync services from the project's docker-compose file into the service table.",
+    },
+  },
   cloudProjectProxy,
   ctrl.syncFromCompose,
 );

--- a/apps/api/src/modules/services/service.schema.ts
+++ b/apps/api/src/modules/services/service.schema.ts
@@ -148,6 +148,99 @@ export const UpdateServiceBody = Type.Object(
   { additionalProperties: false },
 );
 
+/**
+ * Reconcile a project's compose services against a parsed compose file.
+ *
+ * Entries carry every field `repos.service.syncFromCompose` consumes
+ * (`ParsedComposeService` in @repo/db): `name` keys the row, `kind` filters
+ * monorepo entries out, and the rest are the compose-owned and routing fields.
+ * Declaring all of them - rather than leaning on `additionalProperties` - is
+ * what lets an MCP agent discover the surface instead of guessing at it.
+ *
+ * Deliberately OPEN and unbounded, unlike Create/Update above: the payload is
+ * machine-produced from `docker compose config`, whose scalars carry no length
+ * limit and whose `restart` accepts forms outside the four-value enum
+ * (`on-failure:3`). `advanced` stays an open object because ComposeAdvanced
+ * grows per phase (healthcheck, files, ...) and this is an import path, not the
+ * curated Create/Update surface. Mass assignment isn't a concern either way:
+ * the repo layer rebuilds each row field-by-field through `toComposeSpec` +
+ * `normalizeRoutingFields` rather than spreading the entry.
+ *
+ * `services: []` is left to the handler, which rejects it with its own message.
+ */
+export const SyncServicesBody = Type.Object({
+  services: Type.Array(
+    Type.Object(
+      {
+        name: Type.String({
+          minLength: 1,
+          description: "Compose service name - keys the service row.",
+        }),
+        kind: Type.Optional(
+          Type.String({ description: 'Defaults to "compose"; "monorepo" entries are skipped.' }),
+        ),
+        image: Type.Optional(Type.String()),
+        build: Type.Optional(
+          Type.String({ description: "Build context, relative to the compose file." }),
+        ),
+        dockerfile: Type.Optional(Type.String()),
+        ports: Type.Optional(
+          Type.Array(Type.String(), { description: 'Compose port mappings, e.g. "8080:80".' }),
+        ),
+        dependsOn: Type.Optional(Type.Array(Type.String())),
+        environment: Type.Optional(Type.Record(Type.String(), Type.String())),
+        volumes: Type.Optional(Type.Array(Type.String())),
+        command: Type.Optional(Type.String()),
+        restart: Type.Optional(
+          Type.String({
+            description: 'Compose restart policy, e.g. "unless-stopped" or "on-failure:3".',
+          }),
+        ),
+        advanced: Type.Optional(
+          Type.Object(
+            {},
+            {
+              additionalProperties: true,
+              description: "Extended compose block stored as-is (healthcheck, files, ...).",
+            },
+          ),
+        ),
+        exposed: Type.Optional(Type.Boolean()),
+        exposedPort: Type.Optional(Type.String()),
+        domain: Type.Optional(Type.String()),
+        customDomain: Type.Optional(Type.String()),
+        domainType: Type.Optional(
+          Type.String({
+            description: '"custom" routes the custom domain; anything else is treated as "free".',
+          }),
+        ),
+        publicEndpoints: Type.Optional(
+          Type.Array(
+            Type.Object(
+              {
+                port: Type.Optional(Type.Union([Type.Number(), Type.String()])),
+                domain: Type.Optional(Type.String()),
+                customDomain: Type.Optional(Type.String()),
+                domainType: Type.Optional(Type.String()),
+                targetPath: Type.Optional(Type.String()),
+              },
+              { additionalProperties: true },
+            ),
+            {
+              description: "Additional public routes, one per port. Entry[0] mirrors the scalars.",
+            },
+          ),
+        ),
+      },
+      { additionalProperties: true },
+    ),
+    {
+      description:
+        "The full service list from the compose file - services missing from it are removed.",
+    },
+  ),
+});
+
 export const SetServiceEnvVarsBody = Type.Object(
   {
     environment: Type.Union([
@@ -172,4 +265,5 @@ export const SetServiceEnvVarsBody = Type.Object(
 
 export type TCreateServiceBody = Static<typeof CreateServiceBody>;
 export type TUpdateServiceBody = Static<typeof UpdateServiceBody>;
+export type TSyncServicesBody = Static<typeof SyncServicesBody>;
 export type TSetServiceEnvVarsBody = Static<typeof SetServiceEnvVarsBody>;

--- a/apps/api/test/modules/mcp/mcp-services-sync-body.test.ts
+++ b/apps/api/test/modules/mcp/mcp-services-sync-body.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { Value } from "@sinclair/typebox/value";
+import "../../../src/modules/services/service.routes";
+import { getMcpTools } from "../../../src/modules/mcp/mcp-tools";
+import { SyncServicesBody } from "../../../src/modules/services/service.schema";
+
+/**
+ * `spec.body` on the sync route drives BOTH the auto-wired request validator
+ * and the MCP tool's `body` parameter, so these cover the two sides together:
+ * the tool advertises the parameter, and the payloads the CLI and dashboard
+ * actually send still validate.
+ */
+
+const syncTool = () => getMcpTools().find((t) => t.name === "post_projects_by_id_services_sync");
+
+/** The shape `openship service sync` builds from `docker compose config` (apps/cli mapComposeService). */
+const cliPayload = {
+  services: [
+    {
+      name: "web",
+      build: "./web",
+      dockerfile: "Dockerfile.prod",
+      ports: ["8080:80", "9000:9000/udp"],
+      dependsOn: ["db"],
+      environment: { NODE_ENV: "production", EMPTY: "" },
+      volumes: ["./static:/srv/static:ro"],
+      command: "node server.js",
+      restart: "on-failure:3",
+    },
+    { name: "db", image: "postgres:16", volumes: ["pgdata:/var/lib/postgresql/data"] },
+  ],
+};
+
+/** The shape `servicesApi.sync` posts (apps/dashboard ServiceInput). */
+const dashboardPayload = {
+  services: [
+    {
+      name: "api",
+      kind: "compose",
+      image: "ghcr.io/acme/api:latest",
+      ports: ["3000:3000"],
+      environment: { PORT: "3000" },
+      command: "bun start",
+      restart: "unless-stopped",
+      advanced: {
+        healthcheck: { test: ["CMD", "curl", "-f", "http://localhost:3000"], retries: 3 },
+      },
+      exposed: true,
+      exposedPort: "3000",
+      domain: "api.example.com",
+      domainType: "free",
+      publicEndpoints: [{ port: 3000, domain: "api.example.com", domainType: "free" }],
+      enabled: true,
+      sortOrder: 0,
+    },
+  ],
+};
+
+describe("POST /projects/:id/services/sync body schema", () => {
+  it("advertises a body parameter on the MCP tool", () => {
+    const tool = syncTool();
+    expect(tool).toBeDefined();
+    expect(tool!.hasBody).toBe(true);
+
+    const props = (tool!.inputSchema as { properties: Record<string, unknown> }).properties;
+    expect(props.body).toBeDefined();
+    expect((props.body as { required?: string[] }).required).toEqual(["services"]);
+  });
+
+  it("accepts the payload the CLI builds from a compose file", () => {
+    expect(Value.Check(SyncServicesBody, cliPayload)).toBe(true);
+  });
+
+  it("accepts the payload the dashboard posts", () => {
+    expect(Value.Check(SyncServicesBody, dashboardPayload)).toBe(true);
+  });
+
+  it("accepts compose restart policies outside the four-value enum", () => {
+    expect(
+      Value.Check(SyncServicesBody, { services: [{ name: "web", restart: "on-failure:3" }] }),
+    ).toBe(true);
+    expect(Value.Check(SyncServicesBody, { services: [{ name: "web", restart: "no" }] })).toBe(
+      true,
+    );
+  });
+
+  it("keeps `advanced` open as ComposeAdvanced grows", () => {
+    expect(
+      Value.Check(SyncServicesBody, {
+        services: [{ name: "web", advanced: { files: [{ path: "/etc/kong.yml", content: "x" }] } }],
+      }),
+    ).toBe(true);
+  });
+
+  it("passes unknown per-service keys through", () => {
+    expect(Value.Check(SyncServicesBody, { services: [{ name: "web", labels: { a: "b" } }] })).toBe(
+      true,
+    );
+  });
+
+  it("leaves the empty-list rejection to the handler", () => {
+    expect(Value.Check(SyncServicesBody, { services: [] })).toBe(true);
+  });
+
+  it("requires compose scalars to be strings", () => {
+    const entry = (patch: Record<string, unknown>) => ({ services: [{ name: "web", ...patch }] });
+    expect(Value.Check(SyncServicesBody, entry({ environment: { PORT: 3000 } }))).toBe(false);
+    expect(Value.Check(SyncServicesBody, entry({ ports: [8080] }))).toBe(false);
+    expect(Value.Check(SyncServicesBody, entry({ command: ["node", "server.js"] }))).toBe(false);
+    expect(Value.Check(SyncServicesBody, entry({ exposed: "true" }))).toBe(false);
+    expect(Value.Check(SyncServicesBody, entry({ exposedPort: 3000 }))).toBe(false);
+    expect(Value.Check(SyncServicesBody, entry({ image: null }))).toBe(false);
+    expect(Value.Check(SyncServicesBody, { services: [{ name: "" }] })).toBe(false);
+  });
+
+  it("rejects a missing services array and unnamed entries", () => {
+    expect(Value.Check(SyncServicesBody, {})).toBe(false);
+    expect(Value.Check(SyncServicesBody, { services: {} })).toBe(false);
+    expect(Value.Check(SyncServicesBody, { services: [{ image: "nginx:1.27" }] })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/projects/:id/services/sync` has an `mcp` block but no `spec.body`, so the generated MCP tool advertises no `body` parameter and can never send the `services` array its handler requires. Every call to `post_projects_by_id_services_sync` comes back 400. This adds the missing `SyncServicesBody` — the same one-line-per-route change `3d6a68b3` made everywhere else.

## Motivation

`getMcpTools()` on the booted app, on `main` (6a677363):

```json
{
  "name": "post_projects_by_id_services_sync",
  "hasBody": true,
  "inputSchema": {
    "type": "object",
    "properties": {
      "id":    { "type": "string", "description": "Path parameter :id" },
      "query": { "type": "object", "description": "Optional query-string parameters", "additionalProperties": true }
    },
    "required": ["id"],
    "additionalProperties": false
  }
}
```

No `body` property, and `additionalProperties: false` forbids an agent inventing one. `dispatchTool` (`mcp-dispatch.ts:53`) attaches a body only when `args.body` is an object, so the request reaches the handler with no body at all:

| tool call | what the handler sees | result |
| --- | --- | --- |
| `{ id: "proj_123" }` — the only shape the schema allows | no request body → `c.req.json()` throws `SyntaxError` | `400 {"error":"Invalid JSON body","code":"INVALID_JSON"}` |
| `{ id: "proj_123", body: {…} }` | rejected by `additionalProperties: false` before dispatch | never sent |

Confirmed by mounting `ctrl.syncFromCompose` directly:

```
no body        -> SyntaxError: Unexpected end of JSON input   (→ 400 INVALID_JSON via handleApiError)
empty json obj -> 400 {"success":false,"error":"services array is required"}
```

**Cause.** `3d6a68b3` (merged as #321, the commit this branch is based on) changed `inputSchema` from `if (hasBody) properties.body = bodySchema ?? {permissive}` to `if (hasBody && bodySchema)`, establishing the convention its own comment states: *"a route with NO `spec.body` is a no-body action … So 'add a typed body to an MCP tool' == 'add spec.body to its route'."* That sweep covered 25+ routes across 8 modules; `POST /sync` was missed. I walked all 28 body-method tools that currently emit no `body` param — this is the only one whose handler reads a body. The other 27 (`/enable`, `/redeploy`, `/verify`, `/start`, `/rotate`, …) are genuinely no-body actions.

## Related issue

None — bug fix completing #321.

## Changes

**apps/api**

- `modules/services/service.schema.ts` — new `SyncServicesBody` + `TSyncServicesBody`. Entries declare all 18 fields `repos.service.syncFromCompose` consumes (`ParsedComposeService` in `@repo/db`).
- `modules/services/service.routes.ts` — `body: SyncServicesBody` on `POST /sync`.
- `test/modules/mcp/mcp-services-sync-body.test.ts` — new, 9 tests.

Nothing else is touched. The handler keeps its existing inline `c.req.json<{ services: … }>()`, matching how `3d6a68b3` left every other controller alone.

### Adding `spec.body` newly enforces validation — what I did about it

`secure-router.ts:170` auto-wires `tbValidator("json", spec.body)`, so this schema becomes real HTTP validation on a route that has never had any. I enumerated every caller first. `grep -rn "services/sync"` across the repo returns exactly: `apps/cli/src/commands/service.ts:412`, `apps/dashboard/src/lib/api/services.ts:267`, `apps/dashboard/src/lib/api/endpoints.ts:91` (URL only), and the docs page. `apps/desktop` has none, and `migrate.service.ts` / `build.service.ts` / `build-pipeline.ts` call `repos.service.syncFromCompose` directly, bypassing HTTP.

The schema is deliberately looser than `CreateServiceBody`/`UpdateServiceBody`:

- **`restart` is `Type.String()`, not `RestartEnum`.** The CLI forwards compose's value verbatim (`if (typeof d.restart === "string") svc.restart = d.restart`), and `docker compose config` emits forms like `on-failure:3`. The enum would have 400'd real compose files.
- **`domainType` is `Type.String()`.** `normalizeRoutingFields` already folds anything that isn't `"custom"` to `"free"`.
- **Entries stay `additionalProperties: true`**, so `enabled`, `sortOrder` and any future compose key still pass. Safe against mass assignment because `syncFromCompose` never spreads the entry — it rebuilds each row through `toComposeSpec` (a hard-coded 10-key whitelist) + `normalizeRoutingFields` (`packages/db/src/repos/service.repo.ts:28,165,410`).
- **No `maxLength` / `maxItems`** — the payload is machine-generated from a compose file, whose scalars have no length bound. (Same class of trap as the stale `minItems: 1` in #328.)
- **No `minItems`**, so `services: []` still reaches the handler and gets its own `"Refusing to sync an empty compose service list"` message.

### It does tighten the public API — please read this bit

This is the route's first validation, and the route is publicly documented (`apps/web/content/docs/api/services.mdx:140`). Neither in-repo caller can produce any of the shapes below — the CLI's `mapComposeService` emits strings, and the dashboard's `ServiceInput` types them as strings — but a hand-rolled API client could. Probed with `Value.Check`:

| payload | on `main` | with this PR |
| --- | --- | --- |
| `environment: { PORT: 3000 }` | stored as-is | **400** |
| `ports: [8080]` | stored as-is | **400** |
| `command: ["node", "x.js"]` | stored as-is | **400** |
| `exposed: "true"` | stored as-is | **400** |
| `exposedPort: 3000` | stored as-is | **400** |
| `name: ""` | creates a row named `""` | **400** |
| `services` missing / not an array | 400 (handler's message) | 400 (validator's message) |
| `services: []` | 400 "Refusing to sync an empty compose service list" | unchanged |

**Nullability.** The schema declares every field non-null, but `ParsedComposeService.kind` is `string | null` and all five `PublicEndpointInputLike` fields are `T | null` (`service.repo.ts:9-15`). So a direct caller sending an explicit `null` on a *declared* field now gets a 400 — `image`, `kind`, `advanced`, `publicEndpoints`, `environment`, `ports`, `restart`, `domainType`, and `publicEndpoints[].domain` / `.targetPath` all reject; an *undeclared* key with `null` is still accepted. Omitting the key behaves as before. Say the word and I'll wrap the affected fields in `Type.Union([…, Type.Null()])` for exact type parity.

An entry with no `name` is the one case that gets strictly better: `name` is `notNull` on the `service` table, so it could only ever fail at insert. That is now a 400 instead of a 500.

## Verification

```bash
# 1. MCP tool schema, on the booted app, after the change
BODY REQUIRED: ["services"]
ENTRY REQUIRED: ["name"]
ENTRY FIELDS: name, kind, image, build, dockerfile, ports, dependsOn, environment,
              volumes, command, restart, advanced, exposed, exposedPort, domain,
              customDomain, domainType, publicEndpoints
ENTRY additionalProperties: true
BODY-METHOD TOOLS STILL WITHOUT body: 27      # was 28

# 2. regression test, with the fix
$ npx vitest run test/modules/mcp/mcp-services-sync-body.test.ts
 ✓ test/modules/mcp/mcp-services-sync-body.test.ts (9 tests) 2ms
 Test Files  1 passed (1)
      Tests  9 passed (9)

# 3. same test with service.routes.ts reverted to 6a677363 (fix removed, schema + test kept)
 ❯ test/modules/mcp/mcp-services-sync-body.test.ts (9 tests | 1 failed) 3ms
   × advertises a body parameter on the MCP tool 2ms
   ✓ accepts the payload the CLI builds from a compose file
   ✓ accepts the payload the dashboard posts
   ✓ accepts compose restart policies outside the four-value enum
   ✓ keeps `advanced` open as ComposeAdvanced grows
   ✓ passes unknown per-service keys through
   ✓ leaves the empty-list rejection to the handler
   ✓ requires compose scalars to be strings
   ✓ rejects a missing services array and unnamed entries

 FAIL  … > advertises a body parameter on the MCP tool
AssertionError: expected undefined to be defined
 ❯ test/modules/mcp/mcp-services-sync-body.test.ts:66:24
     66|     expect(props.body).toBeDefined();

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)

# 4. typecheck
$ bun run --cwd apps/api lint
$ tsc --noEmit            # exit 0, no output
```

I confirmed the test fails without the fix and passes with it. The other eight tests pin the boundary in **both** directions: the exact payloads the CLI and dashboard send (including `restart: "on-failure:3"`, `advanced.files`, `publicEndpoints`) must validate, and the newly-rejected scalar shapes above must not — so a future tightening of this schema fails loudly instead of silently 400ing `openship service sync`.

Full suite, `bun run test -- --continue` (plain `bun run test` aborts sibling tasks on the first failure and never reaches `@repo/api`):

| workspace | on `main` (6a677363) | with this PR |
| --- | --- | --- |
| `@repo/api` | 1 failed, 1271 passed, 3 skipped (128 files) | 1 failed, **1280** passed, 3 skipped (129 files) |
| `@repo/dashboard` | 1 failed, 59 passed | 1 failed, 59 passed |
| `@repo/adapters` | 629 passed | 629 passed |
| `@repo/core` | 168 passed | 168 passed |
| `@repo/db` | 47 passed | 47 passed |
| `openship` | 178 passed | 178 passed |
| `@repo/desktop` | 3 passed | 3 passed |

+9 = exactly the new tests. Two failures are **pre-existing on pristine `main`** and unrelated to this change: `apps/dashboard/src/i18n/i18n-parity.test.ts` ("deploy: 90 missing, baseline 18") and `apps/api/test/lib/project-root-detector.test.ts` ("detects a monorepo whose sub-apps each have their own Dockerfile").

Formatting: `service.schema.ts` and the new test file pass `prettier --check`. `service.routes.ts` has pre-existing drift, so per CONTRIBUTING I hand-formatted only my own lines — diffing the file against its prettier output leaves hunks at lines 38, 59, 93 and 113 only, none overlapping the lines I touched.

## Alternatives, in the order you're most likely to want them

1. **Nullable fields.** As above — `Type.Union([…, Type.Null()])` on the declared fields would restore exact parity with `ParsedComposeService` / `PublicEndpointInputLike` and remove the explicit-`null` rejection entirely. One-line-per-field change; happy to do it.
2. **Strict `advanced`.** This is the single largest looseness in the diff, and it is deliberately looser than its neighbour: `CreateServiceBody` uses `AdvancedSchema` (`additionalProperties: false`, `healthcheck` only), whereas this path uses an open object. Reason: `advanced.files` is in live use (`ComposeAdvanced` in `packages/core/src/types.ts:122`) and is absent from `AdvancedSchema`, so reusing it here would 400 a real payload. Your `AdvancedSchema` comment says unknown keys should be "rejected rather than silently stored", and I'd rather follow that — but it needs `files` added to `AdvancedSchema` first. Tell me and I'll do both in this PR, or leave `AdvancedSchema` to a separate change.
3. **Cap `publicEndpoints`.** `CreateServiceBody` caps it at `maxItems: 20`; this schema has no cap. Neutral versus `main` (which validates nothing) and consistent with the no-bounds principle for machine-generated payloads, but the asymmetry is real — say the word and I'll add `maxItems: 20` to match.
4. **A fully permissive `Type.Object({ services: Type.Array(Type.Any()) })`** fixes the "tool can never be called" bug with zero new rejection surface, at the cost of giving the agent no field guidance at all. I don't think it's the right trade given `mcp-tools.ts:116` explicitly wants agents not to have to guess, but it is the smallest possible change.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

---

*AI-assisted: the analysis, the caller enumeration and the diff were produced with Claude and verified by me against the real codebase — every command and output above was actually run.*
