### PR TITLE
fix(i18n): translate the 90 untranslated deploy-namespace keys, restore the parity ratchet

### DIFF
--- a/apps/dashboard/src/i18n/i18n-parity.test.ts
+++ b/apps/dashboard/src/i18n/i18n-parity.test.ts
@@ -33,7 +33,6 @@ const MISSING_BASELINE: Record<string, number> = {
   emails: 42,
   projectDetail: 42,
   brand: 40,
-  deploy: 18,
   library: 119,
   billing: 6,
 

--- a/apps/dashboard/src/i18n/locales/ar/deploy.json
+++ b/apps/dashboard/src/i18n/locales/ar/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " للتحقق من الملكية.",
     "cloudInfoPre": "أضف ",
     "recordCname": "سجل CNAME",
-    "cloudInfoMid": " للتوجيه، ثم أضف "
+    "cloudInfoMid": " للتوجيه، ثم أضف ",
+    "modalTitle": "وجّه نطاقك، ثم انشر",
+    "modalSubtitle": "يُصدر HTTPS عند أول عملية نشر بعد أن يشير نطاقك إلى هنا — أو تجاوز الخطوة وأضف DNS لاحقًا من تبويب النطاقات.",
+    "descCnameWww": "يوجّه www إلى نطاقك الرئيسي",
+    "autoConfigTitle": "الإعداد التلقائي عبر مزوّد DNS الخاص بي",
+    "autoConfigDesc": "اربط مُسجّل النطاق وسنضيف هذه السجلات نيابةً عنك.",
+    "comingSoon": "قريبًا",
+    "deployAction": "نشر",
+    "cancel": "إلغاء",
+    "loadingRecords": "جارٍ تحميل سجلات DNS…"
   },
   "buildSummary": {
     "title": "ملخص النشر",

--- a/apps/dashboard/src/i18n/locales/de/deploy.json
+++ b/apps/dashboard/src/i18n/locales/de/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " zur Besitzbestätigung hinzu.",
     "cloudInfoPre": "Fügen Sie den ",
     "recordCname": "CNAME-Eintrag",
-    "cloudInfoMid": " zum Routing hinzu und fügen Sie dann den "
+    "cloudInfoMid": " zum Routing hinzu und fügen Sie dann den ",
+    "modalTitle": "Ihre Domain verweisen, dann deployen",
+    "modalSubtitle": "HTTPS wird beim ersten Deployment ausgestellt, sobald Ihre Domain hierauf verweist — oder überspringen Sie den Schritt und fügen DNS später im Tab „Domains“ hinzu.",
+    "descCnameWww": "Verweist www auf Ihre Hauptdomain",
+    "autoConfigTitle": "Automatisch mit meinem DNS-Anbieter konfigurieren",
+    "autoConfigDesc": "Verbinden Sie Ihren Registrar und wir fügen diese Einträge für Sie hinzu.",
+    "comingSoon": "Demnächst verfügbar",
+    "deployAction": "Deployen",
+    "cancel": "Abbrechen",
+    "loadingRecords": "DNS-Einträge werden geladen…"
   },
   "buildSummary": {
     "title": "Deploy-Zusammenfassung",
@@ -312,6 +321,8 @@
     "startCommandLabel": "Start command",
     "startCommandPlaceholder": "npx serve -s dist -l $PORT",
     "startCommandHint": "The command that starts your server. For a static bundle, use a static file server (e.g. npx serve).",
+    "modeStatic": "Statisch",
+    "modeProcess": "Serverprozess",
     "portLabel": "Port"
   }
 }

--- a/apps/dashboard/src/i18n/locales/es/deploy.json
+++ b/apps/dashboard/src/i18n/locales/es/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " para la verificación de propiedad.",
     "cloudInfoPre": "Añade el ",
     "recordCname": "registro CNAME",
-    "cloudInfoMid": " para el enrutamiento, luego añade el "
+    "cloudInfoMid": " para el enrutamiento, luego añade el ",
+    "modalTitle": "Apunta tu dominio y luego despliega",
+    "modalSubtitle": "El HTTPS se emite en el primer despliegue una vez que tu dominio apunte aquí — o sáltalo y añade el DNS más tarde desde la pestaña Dominios.",
+    "descCnameWww": "Apunta www a tu dominio principal",
+    "autoConfigTitle": "Configurar automáticamente con mi proveedor de DNS",
+    "autoConfigDesc": "Conecta tu registrador y añadiremos estos registros por ti.",
+    "comingSoon": "Próximamente",
+    "deployAction": "Desplegar",
+    "cancel": "Cancelar",
+    "loadingRecords": "Cargando registros DNS…"
   },
   "buildSummary": {
     "title": "Resumen del despliegue",
@@ -312,6 +321,8 @@
     "startCommandLabel": "Start command",
     "startCommandPlaceholder": "npx serve -s dist -l $PORT",
     "startCommandHint": "The command that starts your server. For a static bundle, use a static file server (e.g. npx serve).",
+    "modeStatic": "Estático",
+    "modeProcess": "Proceso de servidor",
     "portLabel": "Port"
   }
 }

--- a/apps/dashboard/src/i18n/locales/fr/deploy.json
+++ b/apps/dashboard/src/i18n/locales/fr/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " pour la vérification de propriété.",
     "cloudInfoPre": "Ajoutez l'",
     "recordCname": "enregistrement CNAME",
-    "cloudInfoMid": " pour le routage, puis ajoutez l'"
+    "cloudInfoMid": " pour le routage, puis ajoutez l'",
+    "modalTitle": "Pointez votre domaine, puis déployez",
+    "modalSubtitle": "Le HTTPS est émis lors du premier déploiement dès que votre domaine pointe ici — ou passez cette étape et ajoutez le DNS plus tard depuis l’onglet Domaines.",
+    "descCnameWww": "Pointe www vers votre domaine principal",
+    "autoConfigTitle": "Configurer automatiquement avec mon fournisseur DNS",
+    "autoConfigDesc": "Connectez votre registraire et nous ajouterons ces enregistrements pour vous.",
+    "comingSoon": "Bientôt disponible",
+    "deployAction": "Déployer",
+    "cancel": "Annuler",
+    "loadingRecords": "Chargement des enregistrements DNS…"
   },
   "buildSummary": {
     "title": "Récapitulatif du déploiement",

--- a/apps/dashboard/src/i18n/locales/ja/deploy.json
+++ b/apps/dashboard/src/i18n/locales/ja/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " を追加してください。",
     "cloudInfoPre": "ルーティング用の ",
     "recordCname": "CNAMEレコード",
-    "cloudInfoMid": " を追加し、続けて "
+    "cloudInfoMid": " を追加し、続けて ",
+    "modalTitle": "ドメインを向けてからデプロイ",
+    "modalSubtitle": "ドメインがここを指すと、初回デプロイ時に HTTPS が発行されます — スキップして後から「ドメイン」タブで DNS を追加することもできます。",
+    "descCnameWww": "www を頂点ドメインに向けます",
+    "autoConfigTitle": "自分の DNS プロバイダーで自動設定する",
+    "autoConfigDesc": "レジストラーを接続すると、これらのレコードを代わりに追加します。",
+    "comingSoon": "近日公開",
+    "deployAction": "デプロイ",
+    "cancel": "キャンセル",
+    "loadingRecords": "DNS レコードを読み込み中…"
   },
   "buildSummary": {
     "title": "デプロイの概要",
@@ -312,6 +321,8 @@
     "startCommandLabel": "Start command",
     "startCommandPlaceholder": "npx serve -s dist -l $PORT",
     "startCommandHint": "The command that starts your server. For a static bundle, use a static file server (e.g. npx serve).",
+    "modeStatic": "静的",
+    "modeProcess": "サーバープロセス",
     "portLabel": "Port"
   }
 }

--- a/apps/dashboard/src/i18n/locales/pt/deploy.json
+++ b/apps/dashboard/src/i18n/locales/pt/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " para a verificação de propriedade.",
     "cloudInfoPre": "Adicione o ",
     "recordCname": "registro CNAME",
-    "cloudInfoMid": " para o roteamento e, em seguida, adicione o "
+    "cloudInfoMid": " para o roteamento e, em seguida, adicione o ",
+    "modalTitle": "Aponte o seu domínio e depois implante",
+    "modalSubtitle": "O HTTPS é emitido na primeira implantação assim que o seu domínio apontar para aqui — ou pule e adicione o DNS mais tarde na aba Domínios.",
+    "descCnameWww": "Aponta o www para o seu domínio principal",
+    "autoConfigTitle": "Configurar automaticamente com o meu provedor de DNS",
+    "autoConfigDesc": "Conecte o seu registrador e nós adicionaremos estes registros para você.",
+    "comingSoon": "Em breve",
+    "deployAction": "Implantar",
+    "cancel": "Cancelar",
+    "loadingRecords": "Carregando registros DNS…"
   },
   "buildSummary": {
     "title": "Resumo da implantação",
@@ -312,6 +321,8 @@
     "startCommandLabel": "Start command",
     "startCommandPlaceholder": "npx serve -s dist -l $PORT",
     "startCommandHint": "The command that starts your server. For a static bundle, use a static file server (e.g. npx serve).",
+    "modeStatic": "Estático",
+    "modeProcess": "Processo de servidor",
     "portLabel": "Port"
   }
 }

--- a/apps/dashboard/src/i18n/locales/tr/deploy.json
+++ b/apps/dashboard/src/i18n/locales/tr/deploy.json
@@ -17,7 +17,13 @@
   },
   "domainSettings": {
     "saveFailed": "Alan adları kaydedilemedi",
-    "toastTitle": "Alan Adları"
+    "toastTitle": "Alan Adları",
+    "routeFreeLabel": "Ücretsiz alt alan adı",
+    "routeFreeDesc": "Anında hazır, ücretsiz bir {domain} adresi.",
+    "routeCustomLabel": "Özel alan adı",
+    "routeCustomDesc": "Kendi alan adınızı bu dağıtıma yönlendirin.",
+    "routeNoneLabel": "Yok",
+    "routeNoneDesc": "Herkese açık adres yok — yalnızca dahili. Host üzerindeki port ile erişin."
   },
   "dns": {
     "title": "DNS Yapılandırması",
@@ -34,7 +40,16 @@
     "verifySuffix": " sahiplik doğrulaması için ekleyin.",
     "cloudInfoPre": "Yönlendirme için ",
     "recordCname": "CNAME kaydını",
-    "cloudInfoMid": " ekleyin, ardından "
+    "cloudInfoMid": " ekleyin, ardından ",
+    "modalTitle": "Alan adınızı yönlendirin, sonra dağıtın",
+    "modalSubtitle": "Alan adınız buraya yönlendiğinde HTTPS ilk dağıtımda verilir — ya da atlayıp DNS’i daha sonra Alan Adları sekmesinden ekleyin.",
+    "descCnameWww": "www’yi ana alan adınıza yönlendirir",
+    "autoConfigTitle": "DNS sağlayıcım ile otomatik yapılandır",
+    "autoConfigDesc": "Kayıt operatörünüzü bağlayın, bu kayıtları sizin için ekleyelim.",
+    "comingSoon": "Yakında",
+    "deployAction": "Dağıt",
+    "cancel": "İptal",
+    "loadingRecords": "DNS kayıtları yükleniyor…"
   },
   "buildSummary": {
     "title": "Dağıtım Özeti",
@@ -119,6 +134,8 @@
     "addServer": "Kendi sunucunuzu ekleyin",
     "continue": "Devam et",
     "chooseServer": "Bir sunucu seçin",
+    "thisServerBadge": "Bu Sunucu",
+    "thisServerHost": "Mevcut host — dağıtımlar burada çalışır",
     "searchPlaceholder": "Sunucularda ara…",
     "noServersMatch": "Aramanızla eşleşen sunucu bulunamadı.",
     "requireCloudFeature": "Openship Bulut'a Dağıtılıyor",

--- a/apps/dashboard/src/i18n/locales/zh/deploy.json
+++ b/apps/dashboard/src/i18n/locales/zh/deploy.json
@@ -40,7 +40,16 @@
     "verifySuffix": " 用于所有权验证。",
     "cloudInfoPre": "添加 ",
     "recordCname": "CNAME 记录",
-    "cloudInfoMid": " 用于路由，然后添加 "
+    "cloudInfoMid": " 用于路由，然后添加 ",
+    "modalTitle": "先将域名指向此处，然后部署",
+    "modalSubtitle": "域名指向此处后，首次部署时会自动签发 HTTPS — 也可以跳过，稍后在「域名」标签页添加 DNS。",
+    "descCnameWww": "将 www 指向你的主域名",
+    "autoConfigTitle": "使用我的 DNS 服务商自动配置",
+    "autoConfigDesc": "连接你的域名注册商，我们将为你添加这些记录。",
+    "comingSoon": "即将推出",
+    "deployAction": "部署",
+    "cancel": "取消",
+    "loadingRecords": "正在加载 DNS 记录…"
   },
   "buildSummary": {
     "title": "部署摘要",
@@ -312,6 +321,8 @@
     "startCommandLabel": "Start command",
     "startCommandPlaceholder": "npx serve -s dist -l $PORT",
     "startCommandHint": "The command that starts your server. For a static bundle, use a static file server (e.g. npx serve).",
+    "modeStatic": "静态",
+    "modeProcess": "服务器进程",
     "portLabel": "Port"
   }
 }


### PR DESCRIPTION
## Summary

Translates the 90 untranslated keys in the `deploy` namespace across all 8
locales and removes its `MISSING_BASELINE` entry, fixing the `i18n-parity` test
that currently fails on `main`.

## Motivation

`i18n-parity.test.ts` fails on `main` right now:

    deploy: 90 missing (baseline 18)

`MISSING_BASELINE` is a one-way ratchet — it never asks anyone to clear the
existing backlog, only to not add to it. That contract was broken: the
DNS-records modal landed 9 new English `deploy.dns.*` keys with no translations,
pushing the count from 18 to 90.

Nothing is functionally broken. `deepMerge` in `src/i18n/index.ts` falls back to
English, so no key renders blank. The costs are a red test that every unrelated
PR now inherits, and non-English users reading English mid-sentence in an
otherwise translated UI — #315 is a live example of the latter, a Chinese user
reporting raw English strings in the dashboard.

## Related issue

None — bug fix restoring a test that fails on `main`.

## Changes

Two commits, each green on its own.

**`fix(i18n)` — apps/dashboard/src/i18n/locales/{ar,de,es,fr,ja,pt,tr,zh}/deploy.json**

- `dns.*` — 9 keys × 8 locales (72), the DNS-records modal
- `serveMode.mode{Static,Process}` — 2 × 5 locales (10): de, es, ja, pt, zh
- `domainSettings.route{Free,Custom,None}{Label,Desc}` — 6, tr only
- `targetStep.thisServer{Badge,Host}` — 2, tr only

**`test(i18n)` — apps/dashboard/src/i18n/i18n-parity.test.ts**

- Deleted `deploy: 18` from `MISSING_BASELINE`, now that the namespace is at 0.

Translations reuse each locale's existing vocabulary rather than translating from
scratch, so the new strings read consistently beside their neighbours:
`despliegue` (es), `implantação` (pt), `alan adı` plus the file's own
untranslated `Host` (tr), `デプロイ` (ja), and 你 rather than 您 inside the `dns`
block (zh) to match the surrounding keys. The `{domain}` placeholder in
`domainSettings.routeFreeDesc` is preserved.

Keys are inserted in the English key order, so every locale diff is additive —
the only removed lines are 9 pre-existing lines that gained a trailing comma.

## Verification

```bash
# Before — on main
$ bun run --cwd apps/dashboard test
 ❯ src/i18n/i18n-parity.test.ts (2 tests | 1 failed)
   × introduces no NEW missing keys beyond the per-namespace baseline
AssertionError: New i18n drift vs English.
deploy: 90 missing (baseline 18)
 Test Files  1 failed | 7 passed (8)
      Tests  1 failed | 59 passed (60)

# After
$ bun run --cwd apps/dashboard test
 ✓ src/i18n/i18n-parity.test.ts (2 tests) 3ms
 Test Files  8 passed (8)
      Tests  60 passed (60)

# `deploy` is gone from the drift report; the total drops by exactly 90
$ bun run --cwd apps/dashboard i18n:check
i18n drift vs "en" — missing: 5571, extra: 14   # was 5661
# (no `deploy` line in the per-namespace breakdown)

# Interpolation placeholders match English in every locale; all 8 files parse
✓ all placeholders identical
✓ ar zh de es fr ja pt tr

# Diff is additive and scoped to i18n
$ git diff --numstat upstream/main..HEAD
+99 -10
```

I also checked the first commit in isolation: with the 72 `dns.*` keys translated
and the baseline still at 18, the count lands exactly on 18 and the test passes —
so that commit alone is enough to unblock CI if you'd rather take only part of
this.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

Two notes on that unchecked box — both reproduce on a clean `main` and are
untouched here:

- `bun run --cwd apps/dashboard lint` fails with `Invalid project directory
  provided, no such directory: apps/dashboard/lint`, from the `next lint`
  invocation itself.
- CONTRIBUTING asks for `bun format` before committing, but on a clean checkout it
  rewrites roughly 51k insertions / 58k deletions across the repo — the tree isn't
  Prettier-clean, so running it would bury this diff. I deliberately skipped it;
  the JSON here matches the surrounding 2-space style and parses clean. Happy to
  run it scoped to just these files if you'd prefer.

## Follow-ups I found but deliberately left out

- The ratchet counts key *presence*, not whether the value differs from English.
  The whole `serveMode` block (`heading`, `subtitle`, `staticLabel`, `serverDesc`,
  `startCommandHint`, …) is English in all 8 locales and the test is satisfied;
  `ar`/`fr`/`tr` literally carry `"modeStatic": "Static"`. Worth its own issue.
- `settings.methodToken` is missing from `zh`, which is the confirmed cause of one
  symptom in #315. Different namespace, doesn't affect this test — a natural next
  PR.
