### PR TITLE
fix(api): don't synthesize an install command for Dockerfile-owned sub-apps

### DIFF
--- a/apps/api/src/lib/stack-detector.ts
+++ b/apps/api/src/lib/stack-detector.ts
@@ -473,13 +473,22 @@ export function detectStack(
     }
   }
 
+  // A Dockerfile owns its own build — the runtime builds straight from it
+  // (requireRepositoryDockerfile), so nothing is synthesized around it.
+  // buildCommand/startCommand already come out empty via the registry defaults
+  // on the `docker` stack, but installCommand is derived from the package
+  // manager alone, which has no way to know that. A Dockerfile sub-app that
+  // also carries a package.json for workspace membership (the Railway-style
+  // monorepo layout) would otherwise be handed a bogus `npm i --force`.
+  const projectType = getProjectType(matched);
+
   const result: StackResult = {
     stack: matched,
-    projectType: getProjectType(matched),
+    projectType,
     category: stackDef.category,
     dependencies: deps,
     packageManager: pm,
-    installCommand: getInstallCommand(pm),
+    installCommand: projectType === "docker" ? "" : getInstallCommand(pm),
     buildCommand: getBuildCommand(pm, matched, packageJson, files),
     startCommand,
     buildImage: getBuildImage(matched, pm),


### PR DESCRIPTION
## Summary

`apps/api/test/lib/project-root-detector.test.ts` fails on `main`. A monorepo
sub-app that carries its own Dockerfile is handed a synthesized
`installCommand` of `npm i --force`, where the test expects `""` because the
Dockerfile owns the build. One line in `detectStack` fixes it.

## Motivation

The failure on `main` today:

    FAIL test/lib/project-root-detector.test.ts > discoverMonorepoApps -
      formal workspace monorepo with per-app Dockerfiles
    AssertionError: expected 'npm i --force' to be ''
    → test/lib/project-root-detector.test.ts:1065

I ran that one test file at four refs to place it:

| ref | result |
| --- | --- |
| `6a677363` (`main`) | fail |
| `0b9f4b3f` (merge of #307) | fail |
| `d3b111a1` (#307 branch tip, pre-merge) | fail |
| this branch | pass |

So it has been red since 2026-07-29, and #307 was merged already failing — it
fails at its own branch tip, so this isn't a semantic merge conflict. The test
itself is right; the detector is wrong.

## Root cause

The three command fields in `detectStack` don't resolve symmetrically:

- `getBuildCommand()` and `getStartCommand()` both end in
  `return STACKS[stack].defaultBuildCommand` / `defaultStartCommand`, and the
  `docker` stack declares both as `""` — so those two already come out empty.
- `getInstallCommand(pm)` takes only the package manager. There is no
  `defaultInstallCommand` anywhere in the registry, so it has no way to know the
  Dockerfile owns the build, and returns the package manager's default.

That asymmetry is why a **Dockerfile-only** directory was already correct: with
no `package.json` the package manager stays unknown and the switch's `default`
returns `""`. The bug only surfaces when the sub-app *also* carries a
`package.json` for workspace membership — exactly the Railway-style layout the
test models, where `pm` resolves to `npm` and `npm i --force` gets synthesized
for a build the Dockerfile owns.

Probing `detectStack` directly with the test's own sub-app shape:

```
stack: "docker"  projectType: "docker"  packageManager: "npm"
installCommand: "npm i --force"   ← wrong
buildCommand: ""                  ← already correct
startCommand: ""                  ← already correct
```

## Changes

**apps/api/src/lib/stack-detector.ts** — hoist `getProjectType(matched)` into a
local (it was already being computed for the `projectType` field) and skip the
install-command synthesis for a Dockerfile-owned stack:

```ts
installCommand: projectType === "docker" ? "" : getInstallCommand(pm),
```

Gated on `projectType` rather than the stack id: `docker` is the only stack with
`category: "docker"`, so the two are equivalent today, and `projectType` states
the intent — the Dockerfile owns the build.

Deliberately narrow:

- Compose (`projectType: "services"`) is left alone. It's a separate question
  and not what this failure is about.
- No new `defaultInstallCommand` registry field. Making `getInstallCommand`
  stack-aware would be the symmetric fix, but it changes an exported signature
  with other callers and touches every stack definition — more surface than a
  red-test fix needs. Happy to do it that way instead if you'd prefer the
  symmetry.

## Verification

```bash
# The previously failing file
$ bun run --cwd apps/api test test/lib/project-root-detector.test.ts
 Test Files  1 passed (1)
      Tests  49 passed (49)
# before: 1 failed | 48 passed (49)

# Whole api package
$ bun run --cwd apps/api test
 Test Files  128 passed (128)
      Tests  1272 passed | 3 skipped (1275)
# before: 1 failed | 1271 passed | 3 skipped

# Same command CI runs for the api typecheck
$ bun run --cwd apps/api lint     # tsc --noEmit
$ echo $?
0

# Diff
$ git diff --stat upstream/main..HEAD
 apps/api/src/lib/stack-detector.ts | 13 +++++++++++--
 1 file changed, 11 insertions(+), 2 deletions(-)
```

I also checked that no existing test asserts a non-empty `installCommand` for a
`docker` stack, so nothing was relying on the old behaviour.

## Note on the red CI here

`main` currently has **two** independent test failures. This PR fixes the
`@repo/api` one; the `@repo/dashboard` one is an i18n-parity regression fixed
separately in #331. Each branch therefore still inherits the other's failure:

| PR | fixes | still shows red |
| --- | --- | --- |
| #331 | `@repo/dashboard` | `@repo/api` |
| this one | `@repo/api` | `@repo/dashboard` |

Together they take `main` fully green. Independent changes in different
workspaces, so they're kept as separate PRs — merge order doesn't matter.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

On that unchecked box: `bun run --cwd apps/api lint` passes (exit 0). `bun run
test` at the repo root still fails on `@repo/dashboard` for the unrelated i18n
reason above. `bun format` rewrites roughly 51k insertions / 58k deletions across
the repo on a clean checkout — the tree isn't Prettier-clean, so running it would
bury this one-line diff; I skipped it deliberately.
