### PR TITLE
fix: surface compose parser errors during prepare

### DIFF
--- a/apps/api/src/modules/deployments/prepare.service.ts
+++ b/apps/api/src/modules/deployments/prepare.service.ts
@@ -542,8 +542,9 @@ function toProjectInfo(
     try {
       const parsed = parseComposeFile(composeContent, { envFileContent: composeEnvContent });
       services = parsed.services;
-    } catch {
-      // Invalid YAML - continue without services.
+    } catch (err) {
+      const detail = err instanceof Error && err.message ? err.message : "Unknown parser error";
+      throw new Error(`Could not parse the Docker Compose file: ${detail}`, { cause: err });
     }
   }
 

--- a/apps/api/test/modules/deployments/prepare.service.test.ts
+++ b/apps/api/test/modules/deployments/prepare.service.test.ts
@@ -12,6 +12,37 @@ describe("resolveProjectInfo", () => {
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
+  it("reports missing required Compose variables instead of returning no services", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
+    tempDirs.push(tempDir);
+
+    await writeFile(
+      join(tempDir, "compose.yaml"),
+      [
+        "services:",
+        "  web:",
+        "    image: nginx:alpine",
+        "    environment:",
+        "      API_PASSWORD: ${API_PASSWORD:?Set API_PASSWORD}",
+      ].join("\n"),
+    );
+
+    await expect(resolveProjectInfo({ source: "local", path: tempDir })).rejects.toThrow(
+      "Could not parse the Docker Compose file: Set API_PASSWORD",
+    );
+  });
+
+  it("reports invalid Compose YAML instead of returning no services", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
+    tempDirs.push(tempDir);
+
+    await writeFile(join(tempDir, "compose.yaml"), "services:\n  web: [unterminated\n");
+
+    await expect(resolveProjectInfo({ source: "local", path: tempDir })).rejects.toThrow(
+      "Could not parse the Docker Compose file:",
+    );
+  });
+
   it("reads compose files from the selected nested root for local projects", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary

Surface Docker Compose parser errors instead of returning zero services.

## Motivation

OpenShip Desktop could stay loading when Compose parsing failed, such as for a missing `${VAR:?message}` value. The API swallowed the error, so the UI received no actionable failure.

## Related issue

None.

## Changes

### `apps/api`

- Return a contextual Compose parser error.
- Add tests for missing required variables and invalid YAML.

## Verification

```bash
bun run --cwd apps/api test -- test/modules/deployments/prepare.service.test.ts
# 3 tests passed

bun run --cwd apps/api lint
# passed

git diff --check
# passed
```

## Checklist

- [x] One change per PR
- [x] The diff is scoped
- [x] A regression test covers the bug
- [ ] Full monorepo tests and formatting pass
- [x] I understand the diff