### PR TITLE
fix(api): normalize mail admin email input before validating it

### DIFF
--- a/apps/api/src/modules/mail/admin/aliases.service.ts
+++ b/apps/api/src/modules/mail/admin/aliases.service.ts
@@ -57,6 +57,15 @@ function validateEmail(email: string): void {
   }
 }
 
+/** Trim + lowercase an address, then validate it. Returns the normalized form. */
+function normalizeEmail(email: string): string {
+  const e = email.trim().toLowerCase();
+  if (!EMAIL_RE.test(e) || e.length > 255) {
+    throw new Error(`Invalid email: ${email}`);
+  }
+  return e;
+}
+
 function validateLocalPart(local: string): void {
   if (!LOCAL_PART_RE.test(local) || local.length === 0 || local.length > 64) {
     throw new Error(`Invalid local-part: ${local}`);
@@ -102,8 +111,7 @@ export async function createAlias(
 ): Promise<AliasRow> {
   const domain = input.domain.trim().toLowerCase();
   validateDomain(domain);
-  validateEmail(input.destination);
-  const destination = input.destination.trim().toLowerCase();
+  const destination = normalizeEmail(input.destination);
   const destDomain = destination.split("@")[1]!;
 
   const address = input.isCatchAll

--- a/apps/api/src/modules/mail/admin/mailboxes.service.ts
+++ b/apps/api/src/modules/mail/admin/mailboxes.service.ts
@@ -94,6 +94,15 @@ function validateEmail(email: string): void {
   }
 }
 
+/** Trim + lowercase an address, then validate it. Returns the normalized form. */
+function normalizeEmail(email: string): string {
+  const e = email.trim().toLowerCase();
+  if (!EMAIL_RE.test(e) || e.length > 255) {
+    throw new Error(`Invalid email: ${email}`);
+  }
+  return e;
+}
+
 function validateLocalPart(local: string): void {
   if (!LOCAL_PART_RE.test(local) || local.length === 0 || local.length > 64) {
     throw new Error(`Invalid local-part: ${local}`);
@@ -140,10 +149,10 @@ export async function listMailboxes(
 }
 
 export async function getMailbox(serverId: string, email: string): Promise<MailboxRow | null> {
-  validateEmail(email);
+  const username = normalizeEmail(email);
   return queryOne<MailboxRow>(
     serverId,
-    `SELECT${SELECT_COLUMNS} FROM mailbox WHERE username = ${q(email.toLowerCase())}`,
+    `SELECT${SELECT_COLUMNS} FROM mailbox WHERE username = ${q(username)}`,
   );
 }
 
@@ -225,8 +234,7 @@ export async function updateMailbox(
   email: string,
   patch: UpdateMailboxInput,
 ): Promise<MailboxRow> {
-  validateEmail(email);
-  const username = email.toLowerCase();
+  const username = normalizeEmail(email);
 
   const existing = await getMailbox(serverId, username);
   if (!existing) throw new MailboxNotFoundError(username);
@@ -289,8 +297,7 @@ export async function softDeleteMailbox(
   email: string,
   adminUsername: string,
 ): Promise<void> {
-  validateEmail(email);
-  const username = email.toLowerCase();
+  const username = normalizeEmail(email);
   const existing = await getMailbox(serverId, username);
   if (!existing) throw new MailboxNotFoundError(username);
 
@@ -320,8 +327,7 @@ export async function softDeleteMailbox(
  * additionally guards against any path outside /var/vmail/.
  */
 export async function hardDeleteMailbox(serverId: string, email: string): Promise<void> {
-  validateEmail(email);
-  const username = email.toLowerCase();
+  const username = normalizeEmail(email);
   const existing = await getMailbox(serverId, username);
   if (!existing) throw new MailboxNotFoundError(username);
 

--- a/apps/api/test/modules/mail/email-case.test.ts
+++ b/apps/api/test/modules/mail/email-case.test.ts
@@ -1,0 +1,224 @@
+import "./_setup-env";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  queryOne: vi.fn(),
+  transaction: vi.fn(),
+  readState: vi.fn(),
+  removeMaildirOnDisk: vi.fn(),
+  recountDomain: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: {
+    withExecutor: async (_serverId: string, fn: (exec: object) => unknown) => fn({}),
+  },
+}));
+
+vi.mock("../../../src/modules/mail/admin/psql-runner", () => ({
+  execute: mocks.execute,
+  queryOne: mocks.queryOne,
+  queryRows: vi.fn(),
+  q: (value: string) => `'${value}'`,
+  qInt: (value: number) => String(value),
+  transaction: mocks.transaction,
+}));
+
+vi.mock("../../../src/modules/mail/mail-state", () => ({
+  readState: mocks.readState,
+}));
+
+vi.mock("../../../src/modules/mail/admin/maildir", () => ({
+  createMaildirOnDisk: vi.fn(),
+  generateMaildir: vi.fn(),
+  removeMaildirOnDisk: mocks.removeMaildirOnDisk,
+  STORAGE_BASE: "/var/vmail",
+  STORAGE_NODE: "vmail1",
+}));
+
+vi.mock("../../../src/modules/mail/admin/domains.service", () => ({
+  recountDomain: mocks.recountDomain,
+  validateDomain: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/mail/admin/password", () => ({
+  hashPassword: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/mail/admin/platform-mailbox.service", () => ({
+  buildInsertMailboxSql: vi.fn(),
+  buildInsertSelfForwardingSql: vi.fn(),
+}));
+
+import { createAlias } from "../../../src/modules/mail/admin/aliases.service";
+import {
+  getMailbox,
+  hardDeleteMailbox,
+  softDeleteMailbox,
+  updateMailbox,
+} from "../../../src/modules/mail/admin/mailboxes.service";
+
+const INVALID_EMAILS = [
+  "not-an-email",
+  "ops@example",
+  "ops @example.com",
+  "@example.com",
+  `${"a".repeat(250)}@example.com`,
+];
+
+function alias(address: string, forwarding: string) {
+  return {
+    id: 1,
+    address,
+    forwarding,
+    domain: "example.com",
+    destDomain: forwarding.split("@")[1],
+    isCatchAll: false,
+    active: true,
+  };
+}
+
+function mailbox(username: string) {
+  return {
+    username,
+    name: "Ops",
+    domain: "example.com",
+    quotaMB: 0,
+    storagebasedirectory: "/var/vmail",
+    storagenode: "vmail1",
+    maildir: "example.com/o/p/s/ops-2026.07.31.00.00.00/",
+    active: true,
+    isAdmin: false,
+    isGlobalAdmin: false,
+    createdAt: "2026-07-31",
+    passwordLastChange: "2026-07-31",
+  };
+}
+
+function sqlOf(calls: unknown[][]): string {
+  return calls.map((args) => String(args[1])).join("\n");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.execute.mockResolvedValue(undefined);
+  mocks.transaction.mockResolvedValue(undefined);
+  mocks.recountDomain.mockResolvedValue(undefined);
+  mocks.removeMaildirOnDisk.mockResolvedValue(undefined);
+  mocks.readState.mockResolvedValue({ domain: "primary.example" });
+});
+
+describe("createAlias destination", () => {
+  beforeEach(() => {
+    mocks.queryOne.mockImplementation(async (_serverId: string, sql: string) =>
+      sql.includes("is_alias = 1") ? alias("sales@example.com", "ops@example.com") : null,
+    );
+  });
+
+  test("accepts a mixed-case destination and stores it lowercased", async () => {
+    const row = await createAlias("srv_test", {
+      domain: "example.com",
+      localPart: "sales",
+      isCatchAll: false,
+      destination: "Ops@Example.com",
+    });
+
+    expect(row.forwarding).toBe("ops@example.com");
+    expect(sqlOf(mocks.execute.mock.calls)).toContain("'ops@example.com'");
+    expect(sqlOf(mocks.execute.mock.calls)).not.toContain("Ops@Example.com");
+  });
+
+  test("accepts a destination whose domain part alone is mixed-case", async () => {
+    await expect(
+      createAlias("srv_test", {
+        domain: "example.com",
+        localPart: "sales",
+        isCatchAll: false,
+        destination: "ops@Example.COM",
+      }),
+    ).resolves.toMatchObject({ forwarding: "ops@example.com" });
+  });
+
+  test("accepts a whitespace-padded destination", async () => {
+    await createAlias("srv_test", {
+      domain: "example.com",
+      localPart: "sales",
+      isCatchAll: false,
+      destination: "  ops@example.com  ",
+    });
+
+    expect(sqlOf(mocks.execute.mock.calls)).toContain("'ops@example.com'");
+  });
+
+  test.each(INVALID_EMAILS)("still rejects the destination %j", async (destination) => {
+    await expect(
+      createAlias("srv_test", {
+        domain: "example.com",
+        localPart: "sales",
+        isCatchAll: false,
+        destination,
+      }),
+    ).rejects.toThrow(/^Invalid email:/);
+
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+});
+
+describe("mailbox lookup by address", () => {
+  beforeEach(() => {
+    mocks.queryOne.mockResolvedValue(mailbox("ops@example.com"));
+  });
+
+  test("getMailbox accepts a mixed-case address and queries the lowercased username", async () => {
+    await expect(getMailbox("srv_test", "Ops@Example.com")).resolves.toMatchObject({
+      username: "ops@example.com",
+    });
+
+    expect(sqlOf(mocks.queryOne.mock.calls)).toContain("username = 'ops@example.com'");
+  });
+
+  test("getMailbox accepts an address whose domain part alone is mixed-case", async () => {
+    await expect(getMailbox("srv_test", "ops@Example.COM")).resolves.toMatchObject({
+      username: "ops@example.com",
+    });
+
+    expect(sqlOf(mocks.queryOne.mock.calls)).toContain("username = 'ops@example.com'");
+  });
+
+  test("getMailbox accepts a whitespace-padded address", async () => {
+    await expect(getMailbox("srv_test", "  ops@example.com  ")).resolves.toMatchObject({
+      username: "ops@example.com",
+    });
+  });
+
+  test("updateMailbox accepts a mixed-case address", async () => {
+    await updateMailbox("srv_test", "Ops@Example.com", { active: false });
+
+    expect(sqlOf(mocks.execute.mock.calls)).toContain("username = 'ops@example.com'");
+  });
+
+  test("softDeleteMailbox accepts a mixed-case address", async () => {
+    await softDeleteMailbox("srv_test", "Ops@Example.com", "admin@example.com");
+
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+    expect(String(mocks.transaction.mock.calls[0]![1])).toContain("'ops@example.com'");
+  });
+
+  test("hardDeleteMailbox accepts a mixed-case address", async () => {
+    await hardDeleteMailbox("srv_test", "Ops@Example.com");
+
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+    expect(String(mocks.transaction.mock.calls[0]![1])).toContain("'ops@example.com'");
+  });
+
+  test.each(INVALID_EMAILS)("getMailbox still rejects %j", async (email) => {
+    await expect(getMailbox("srv_test", email)).rejects.toThrow(/^Invalid email:/);
+    expect(mocks.queryOne).not.toHaveBeenCalled();
+  });
+
+  test.each(INVALID_EMAILS)("hardDeleteMailbox still rejects %j", async (email) => {
+    await expect(hardDeleteMailbox("srv_test", email)).rejects.toThrow(/^Invalid email:/);
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Five mail-admin service entry points validated the caller's raw email string against a lowercase-only regex *before* lowercasing it for the SQL lookup, so a valid mixed-case address was rejected. This normalizes first, then validates.

## Motivation

`EMAIL_RE` in `aliases.service.ts` / `mailboxes.service.ts` is `/^[a-z0-9._+-]+@[a-z0-9.-]+\.[a-z]{2,}$/` — lowercase only. Against a mail server that has `ops@example.com`:

| Request | Status | Body |
|---|---|---|
| `GET /api/mail/admin/:serverId/mailboxes/ops@example.com` | 404 | `{"error":"Mailbox not found"}` |
| `GET /api/mail/admin/:serverId/mailboxes/Ops@Example.com` | **500** | `{"error":"Invalid email: Ops@Example.com"}` |
| `GET /api/mail/admin/:serverId/mailboxes/ops@Example.COM` | **500** | `{"error":"Invalid email: ops@Example.COM"}` |

The third row matters on its own: `ops@Example.COM` differs from the stored address only in the domain part, which RFC 5321 §2.4 makes explicitly case-insensitive.

`createAlias` rejects a mixed-case or whitespace-padded `destination` the same way (`Invalid email: Ops@Example.com`) before it ever reaches the INSERT.

Affected call sites: `createAlias` (the `destination` argument), `getMailbox`, `updateMailbox`, `softDeleteMailbox`, `hardDeleteMailbox`.

**Cause.** Each of the five does `validateEmail(email)` and then, on the very next line, `email.toLowerCase()` to build the query — so the code already means to be case-insensitive; only the order is wrong. Three siblings in the same folder do it the right way round: `validateDomain` (`domains.service.ts`) trims + lowercases then tests, `sendTestEmail` (`test-email.service.ts`) normalizes then tests, and `createMailbox` lowercases the composed username before validating it.

**Who hits it.** The dashboard is *not* affected — it lowercases before sending (`aliases-tab.tsx`, `mailboxes-tab.tsx`), and the `:email` path param it uses comes from a row the API returned. There is no CLI or MCP surface for these routes either (`apps/cli/src/commands/mail.ts` lists them in its header docstring but only implements `components/:key/logs`). The realistic caller is a direct API-token consumer of the routes documented in `apps/web/content/docs/api/mail.mdx`, where nothing says the address must be lowercase.

## Related issue

None.

## Changes

**apps/api**

- `modules/mail/admin/aliases.service.ts`, `modules/mail/admin/mailboxes.service.ts`: add a `normalizeEmail()` helper that trims + lowercases, validates, and returns the normalized form (the shape of the existing `validateDomain`), and use it at the five sites that take a caller-supplied address.
- `validateEmail()` is deliberately kept for the two *internally composed* addresses (`createAlias`'s `local@domain`, `createMailbox`'s `username`). In `createMailbox` the raw `input.domain` is also used for the `domain` column and the maildir path, and `validateDomain` trims before testing — so `validateEmail(username)` is currently the only thing rejecting a domain with trailing whitespace. Routing that site through the trimming helper would accept it and write an inconsistent row.
- `test/modules/mail/email-case.test.ts`: new, 24 tests.

This is pure widening. Every string `EMAIL_RE` accepts today is already lowercase and whitespace-free, so `trim().toLowerCase()` is the identity on it and the SQL parameter is byte-identical; I checked that over 3,000,000 random strings drawn from `abAB09._+-@ \t\n.` — 50 accepted by the old path, 0 divergences, 896 newly accepted, all of them case/whitespace variants. Genuinely invalid addresses still throw, still quoting the raw input in the message.

**Out of scope, on purpose:** the 500. Every plain validation error in this module returns 500 because `errorJson` in `admin.controller.ts` is `c.json({ error: message }, 500)` and only typed errors map to 4xx — `Invalid local-part` and `Invalid domain` behave the same way. Turning these into typed 4xx errors is a defensible alternative fix, but it is a deliberate decision about this module's error contract, so I kept it out to keep this PR to one concern. Happy to switch or follow up if you'd prefer that.

## Verification

```bash
# 1. The new test fails without the source change (test kept, fix stashed)
$ git stash push -- apps/api/src/modules/mail/admin/aliases.service.ts \
                    apps/api/src/modules/mail/admin/mailboxes.service.ts
$ cd apps/api && npx vitest run test/modules/mail/email-case.test.ts

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 9 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  > createAlias destination > accepts a mixed-case destination and stores it lowercased
 FAIL  > createAlias destination > accepts a destination whose domain part alone is mixed-case
       Caused by: Error: Invalid email: ops@Example.COM
 FAIL  > createAlias destination > accepts a whitespace-padded destination
 FAIL  > getMailbox accepts a mixed-case address and queries the lowercased username
       Caused by: Error: Invalid email: Ops@Example.com
 FAIL  > getMailbox accepts an address whose domain part alone is mixed-case
       Caused by: Error: Invalid email: ops@Example.COM
 FAIL  > getMailbox accepts a whitespace-padded address
       Caused by: Error: Invalid email:   ops@example.com
 FAIL  > updateMailbox accepts a mixed-case address
 FAIL  > softDeleteMailbox accepts a mixed-case address
 FAIL  > hardDeleteMailbox accepts a mixed-case address

 Test Files  1 failed (1)
      Tests  9 failed | 15 passed (24)

# 2. ...and passes with it
$ git stash pop
$ cd apps/api && npx vitest run test/modules/mail/email-case.test.ts

 ✓ test/modules/mail/email-case.test.ts (24 tests) 4ms

 Test Files  1 passed (1)
      Tests  24 passed (24)

# 3. Full suite, baseline on main @ 460b2547 vs. this branch
$ bun run test -- --continue
# main @ 460b2547:  Tasks 7 successful, 7 total
#                   2850 passed | 0 failed | 15 skipped
#                   @repo/api: 1524 passed | 0 failed | 15 skipped (152 files)
# this branch:      Tasks 7 successful, 7 total
#                   2874 passed | 0 failed | 15 skipped
#                   @repo/api: 1548 passed | 0 failed | 15 skipped (153 files)
# delta is exactly the 24 new tests in the 1 new file

$ bun run --cwd apps/api lint
$ tsc --noEmit
# clean
```

`main` CI at `460b2547` is green (run `30596928634`), so this branch starts from a green baseline and any red check here is mine.

The 15 tests that pass in both directions are the `test.each` rejection cases — `not-an-email`, `ops@example`, `ops @example.com`, `@example.com`, and a 262-character address. They pin the guard closed, so they must pass either way; the internal-space case is the one showing `trim()` did not open a hole.

Both service files already had pre-existing Prettier drift on `main`, so per CONTRIBUTING I did not run `bun format` over them — I hand-formatted my own lines and confirmed I added no new drift by comparing prettier-normalized `origin/main` against prettier-normalized branch (that diff is character-for-character the raw `git diff`). The new test file is Prettier-clean.

Written with AI assistance; I ran everything above myself and stand behind every line.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review
