### PR TITLE
fix(api): tunnel HTTP response framing — Transfer-Encoding casing, truncation, byte relay, CRLF

### DIFF
--- a/apps/api/src/lib/ssh-tunnel.ts
+++ b/apps/api/src/lib/ssh-tunnel.ts
@@ -105,8 +105,9 @@ function decodeChunkedBody(buf: Buffer): Buffer | null {
  * once the response is flushed — the simplest unambiguous end-of-body
  * signal alongside Content-Length/chunked framing.
  *
- * Returns `null` on connection error, timeout, or if the executor
- * doesn't support tunnelling.
+ * Returns `null` on connection error, timeout, a response truncated before
+ * its declared framing completed, or if the executor doesn't support
+ * tunnelling.
  */
 export async function tunnelRequest(
   serverId: string,
@@ -155,6 +156,8 @@ export async function tunnelRequest(
     let headerEnd = -1;
     let statusCode = 0;
     let parsedHeaders: http.IncomingHttpHeaders = {};
+    let contentLength: number | null = null;
+    let isChunked = false;
 
     tunnel.on("data", (chunk: Buffer) => {
       buffer = Buffer.concat([buffer, chunk]);
@@ -172,13 +175,13 @@ export async function tunnelRequest(
             parsedHeaders[line.slice(0, colon).trim().toLowerCase()] = line.slice(colon + 1).trim();
           }
         }
+        contentLength = parsedHeaders["content-length"]
+          ? parseInt(parsedHeaders["content-length"] as string, 10)
+          : null;
+        isChunked = isChunkedEncoding(parsedHeaders["transfer-encoding"]);
       }
 
       const bodyBytes = buffer.slice(headerEnd + 4);
-      const contentLength = parsedHeaders["content-length"]
-        ? parseInt(parsedHeaders["content-length"] as string, 10)
-        : null;
-      const isChunked = isChunkedEncoding(parsedHeaders["transfer-encoding"]);
 
       if (isChunked) {
         const decoded = decodeChunkedBody(bodyBytes);
@@ -201,10 +204,11 @@ export async function tunnelRequest(
     tunnel.on("error", () => finish(null));
     tunnel.on("close", () => {
       if (settled) return;
-      // Connection closed before/without a recognized length framing —
-      // treat whatever body we've buffered as the complete response (the
-      // "Connection: close" no-content-length case).
-      if (headerEnd !== -1) {
+      // Only a response with no length framing at all is terminated by the
+      // close itself ("Connection: close" with no Content-Length) — any other
+      // framing would already have resolved above, so reaching here means the
+      // remote hung up mid-response.
+      if (headerEnd !== -1 && !isChunked && contentLength === null) {
         finish({
           statusCode,
           headers: parsedHeaders,

--- a/apps/api/src/lib/ssh-tunnel.ts
+++ b/apps/api/src/lib/ssh-tunnel.ts
@@ -56,6 +56,16 @@ export interface TunnelResponse {
 }
 
 /**
+ * Whether any component of a request head contains a bare CR or LF.  The
+ * request line and header lines below are assembled by hand, so a component
+ * carrying one would terminate its own line and inject arbitrary extra
+ * headers - or an entire second request - onto the tunnel.
+ */
+function hasCrlf(parts: string[]): boolean {
+  return parts.some((part) => /[\r\n]/.test(part));
+}
+
+/**
  * Whether a `Transfer-Encoding` header value applies the chunked coding.
  * Transfer-coding names are case-insensitive and the header carries the
  * applied codings as a comma-separated list, chunked always last.
@@ -106,8 +116,8 @@ function decodeChunkedBody(buf: Buffer): Buffer | null {
  * signal alongside Content-Length/chunked framing.
  *
  * Returns `null` on connection error, timeout, a response truncated before
- * its declared framing completed, or if the executor doesn't support
- * tunnelling.
+ * its declared framing completed, a method/path/header containing CR or LF,
+ * or if the executor doesn't support tunnelling.
  */
 export async function tunnelRequest(
   serverId: string,
@@ -121,6 +131,10 @@ export async function tunnelRequest(
     body,
     timeoutMs = 10_000,
   } = opts;
+
+  if (hasCrlf([method, path, ...Object.entries(headers).flat()])) {
+    return null;
+  }
 
   let tunnel: Duplex;
   try {
@@ -250,7 +264,8 @@ export interface TunnelStreamHandle {
  * ```
  *
  * Sends `Accept: text/event-stream` and `Connection: keep-alive` by default.
- * Returns `null` on connection error, timeout, or non-2xx status.
+ * Returns `null` on connection error, timeout, non-2xx status, or a
+ * path/header containing CR or LF.
  */
 export async function tunnelStream(
   serverId: string,
@@ -258,6 +273,10 @@ export async function tunnelStream(
   path: string,
   extraHeaders: Record<string, string> = {},
 ): Promise<TunnelStreamHandle | null> {
+  if (hasCrlf([path, ...Object.entries(extraHeaders).flat()])) {
+    return null;
+  }
+
   let tunnel: Duplex;
   try {
     tunnel = await tunnelConnect(serverId, "127.0.0.1", remotePort);

--- a/apps/api/src/lib/ssh-tunnel.ts
+++ b/apps/api/src/lib/ssh-tunnel.ts
@@ -279,28 +279,27 @@ export async function tunnelStream(
 
   // Wait for response headers, then hand the stream back
   return new Promise<TunnelStreamHandle | null>((resolve) => {
-    let buffer = "";
+    let buffer = Buffer.alloc(0);
     const timeout = setTimeout(() => {
       tunnel.destroy();
       resolve(null);
     }, 10_000);
 
     const onData = (chunk: Buffer) => {
-      buffer += chunk.toString();
+      buffer = Buffer.concat([buffer, chunk]);
       const headerEnd = buffer.indexOf("\r\n\r\n");
       if (headerEnd === -1) return;
 
       clearTimeout(timeout);
       tunnel.removeListener("data", onData);
 
-      // Parse status line
-      const statusLine = buffer.slice(0, buffer.indexOf("\r\n"));
+      // Parse status line and headers
+      const rawHead = buffer.slice(0, headerEnd).toString();
+      const [statusLine, ...rawHeaderLines] = rawHead.split("\r\n");
       const statusCode = parseInt(statusLine.split(" ")[1] ?? "0", 10);
 
-      // Parse headers
-      const rawHeaders = buffer.slice(buffer.indexOf("\r\n") + 2, headerEnd);
       const headers: Record<string, string> = {};
-      for (const line of rawHeaders.split("\r\n")) {
+      for (const line of rawHeaderLines) {
         const colon = line.indexOf(":");
         if (colon > 0) {
           headers[line.slice(0, colon).trim().toLowerCase()] =
@@ -317,7 +316,7 @@ export async function tunnelStream(
       // Re-emit leftover body bytes so the caller sees them
       const body = buffer.slice(headerEnd + 4);
       if (body.length > 0) {
-        process.nextTick(() => tunnel.emit("data", Buffer.from(body)));
+        process.nextTick(() => tunnel.emit("data", body));
       }
 
       resolve({

--- a/apps/api/src/lib/ssh-tunnel.ts
+++ b/apps/api/src/lib/ssh-tunnel.ts
@@ -56,6 +56,19 @@ export interface TunnelResponse {
 }
 
 /**
+ * Whether a `Transfer-Encoding` header value applies the chunked coding.
+ * Transfer-coding names are case-insensitive and the header carries the
+ * applied codings as a comma-separated list, chunked always last.
+ */
+function isChunkedEncoding(value: string | string[] | undefined): boolean {
+  if (typeof value !== "string") return false;
+  return value
+    .toLowerCase()
+    .split(",")
+    .some((coding) => coding.trim() === "chunked");
+}
+
+/**
  * Parse a chunked-transfer-encoded body out of an accumulated buffer.
  * Returns the decoded body, or `null` if the buffer doesn't yet contain a
  * complete terminating chunk (0-length chunk + trailing CRLF).
@@ -165,7 +178,7 @@ export async function tunnelRequest(
       const contentLength = parsedHeaders["content-length"]
         ? parseInt(parsedHeaders["content-length"] as string, 10)
         : null;
-      const isChunked = parsedHeaders["transfer-encoding"] === "chunked";
+      const isChunked = isChunkedEncoding(parsedHeaders["transfer-encoding"]);
 
       if (isChunked) {
         const decoded = decodeChunkedBody(bodyBytes);

--- a/apps/api/test/lib/ssh-tunnel-http.test.ts
+++ b/apps/api/test/lib/ssh-tunnel-http.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../src/lib/ssh-manager", () => ({
   },
 }));
 
-import { tunnelRequest } from "../../src/lib/ssh-tunnel";
+import { tunnelRequest, tunnelStream } from "../../src/lib/ssh-tunnel";
 
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -127,5 +127,61 @@ describe("tunnelRequest truncated responses", () => {
     await reply(tunnel, 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"a":1}');
 
     expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+});
+
+const SSE_HEAD = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n";
+
+describe("tunnelStream byte relay", () => {
+  it("relays a multi-byte character split across the header boundary intact", async () => {
+    const frame = Buffer.from('data: {"city":"München"}\n\n', "utf8");
+    const cut = frame.indexOf(Buffer.from("ü", "utf8")) + 1;
+
+    const tunnel = openTunnel();
+    const pending = tunnelStream("srv_1", 9145, "/logs/stream");
+    await awaitRequest(tunnel);
+    tunnel.push(Buffer.concat([Buffer.from(SSE_HEAD), frame.subarray(0, cut)]));
+
+    const handle = await pending;
+    const relayed: Buffer[] = [];
+    handle!.stream.on("data", (c: Buffer) => relayed.push(Buffer.from(c)));
+    await tick();
+    tunnel.push(frame.subarray(cut));
+    await tick();
+    handle!.destroy();
+
+    expect(Buffer.concat(relayed).equals(frame)).toBe(true);
+  });
+
+  it("relays an ASCII leftover body after the headers unchanged", async () => {
+    const frame = 'event: request\ndata: {"n":1}\n\n';
+
+    const tunnel = openTunnel();
+    const pending = tunnelStream("srv_1", 9145, "/logs/stream");
+    await awaitRequest(tunnel);
+    tunnel.push(Buffer.from(SSE_HEAD + frame));
+
+    const handle = await pending;
+    const relayed: Buffer[] = [];
+    handle!.stream.on("data", (c: Buffer) => relayed.push(Buffer.from(c)));
+    await tick();
+    handle!.destroy();
+
+    expect(Buffer.concat(relayed).toString()).toBe(frame);
+  });
+
+  it("parses the status line and headers of the stream response", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelStream("srv_1", 9145, "/logs/stream");
+    await awaitRequest(tunnel);
+    tunnel.push(Buffer.from(SSE_HEAD));
+
+    const handle = await pending;
+
+    expect(handle).toMatchObject({
+      statusCode: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+    handle!.destroy();
   });
 });

--- a/apps/api/test/lib/ssh-tunnel-http.test.ts
+++ b/apps/api/test/lib/ssh-tunnel-http.test.ts
@@ -87,3 +87,45 @@ describe("tunnelRequest chunked framing", () => {
     expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
   });
 });
+
+describe("tunnelRequest truncated responses", () => {
+  it("fails a chunked body cut before the terminating chunk", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n7\r\n{"a":1}\r\n');
+
+    expect(await pending).toBeNull();
+  });
+
+  it("fails a response that delivers fewer bytes than Content-Length", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, 'HTTP/1.1 200 OK\r\nContent-Length: 20\r\n\r\n{"a":1}');
+
+    expect(await pending).toBeNull();
+  });
+
+  it("fails a connection that closes before the response head is complete", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, "HTTP/1.1 200 OK\r\nContent-Len");
+
+    expect(await pending).toBeNull();
+  });
+
+  it("returns the body of a complete chunked response", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, `HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n${CHUNKED_BODY}`);
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+
+  it("returns the buffered body when the response has no length framing", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"a":1}');
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+});

--- a/apps/api/test/lib/ssh-tunnel-http.test.ts
+++ b/apps/api/test/lib/ssh-tunnel-http.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { Duplex } from "node:stream";
+
+class FakeTunnel extends Duplex {
+  readonly written: Buffer[] = [];
+
+  _read() {}
+
+  _write(chunk: Buffer, _enc: BufferEncoding, done: () => void) {
+    this.written.push(Buffer.from(chunk));
+    done();
+  }
+
+  /** Everything the caller wrote onto the tunnel, byte for byte. */
+  get sent(): string {
+    return Buffer.concat(this.written).toString("latin1");
+  }
+}
+
+const active = vi.hoisted(() => ({ tunnel: null as FakeTunnel | null }));
+
+vi.mock("../../src/lib/ssh-manager", () => ({
+  sshManager: {
+    acquire: async () => ({ forwardPort: async () => active.tunnel }),
+  },
+}));
+
+import { tunnelRequest } from "../../src/lib/ssh-tunnel";
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function openTunnel(): FakeTunnel {
+  const tunnel = new FakeTunnel();
+  active.tunnel = tunnel;
+  return tunnel;
+}
+
+/** Resolves once the caller has written its request head onto the tunnel. */
+async function awaitRequest(tunnel: FakeTunnel): Promise<string> {
+  for (let i = 0; i < 100 && tunnel.written.length === 0; i++) await tick();
+  await tick();
+  return tunnel.sent;
+}
+
+/** Reply to the pending request with `raw`, then close the connection. */
+async function reply(tunnel: FakeTunnel, raw: string, close = true) {
+  await awaitRequest(tunnel);
+  tunnel.push(Buffer.from(raw, "latin1"));
+  if (close) tunnel.destroy();
+}
+
+const CHUNKED_BODY = '7\r\n{"a":1}\r\n0\r\n\r\n';
+
+describe("tunnelRequest chunked framing", () => {
+  it("decodes a lowercase chunked body", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, `HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n${CHUNKED_BODY}`);
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+
+  it("decodes a chunked body announced with different casing", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, `HTTP/1.1 200 OK\r\nTransfer-Encoding: Chunked\r\n\r\n${CHUNKED_BODY}`);
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+
+  it("strips the chunk framing when chunked is listed after another coding", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(
+      tunnel,
+      `HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n${CHUNKED_BODY}`,
+    );
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+
+  it("leaves a body with no transfer-encoding untouched", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, "/health");
+    await reply(tunnel, 'HTTP/1.1 200 OK\r\nContent-Length: 7\r\n\r\n{"a":1}');
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+  });
+});

--- a/apps/api/test/lib/ssh-tunnel-http.test.ts
+++ b/apps/api/test/lib/ssh-tunnel-http.test.ts
@@ -185,3 +185,103 @@ describe("tunnelStream byte relay", () => {
     handle!.destroy();
   });
 });
+
+describe("tunnel request head injection", () => {
+  const CRLF_PATH = "/health\r\nX-Injected: yes\r\n\r\nGET /rules HTTP/1.1";
+
+  it("refuses a tunnelRequest path containing CRLF", async () => {
+    const tunnel = openTunnel();
+
+    expect(await tunnelRequest("srv_1", 9145, CRLF_PATH)).toBeNull();
+    expect(tunnel.sent).toBe("");
+  });
+
+  it("refuses a tunnelRequest header value containing CRLF", async () => {
+    const tunnel = openTunnel();
+
+    const result = await tunnelRequest("srv_1", 9145, "/health", {
+      headers: { "X-Trace": "abc\r\nX-Injected: yes" },
+    });
+
+    expect(result).toBeNull();
+    expect(tunnel.sent).toBe("");
+  });
+
+  it("refuses a tunnelRequest header name containing CRLF", async () => {
+    const tunnel = openTunnel();
+
+    const result = await tunnelRequest("srv_1", 9145, "/health", {
+      headers: { "X-Trace\r\nX-Injected": "yes" },
+    });
+
+    expect(result).toBeNull();
+    expect(tunnel.sent).toBe("");
+  });
+
+  it("refuses a tunnelRequest method containing CRLF", async () => {
+    const tunnel = openTunnel();
+
+    const result = await tunnelRequest("srv_1", 9145, "/health", {
+      method: "GET /rules HTTP/1.1\r\nHost: 127.0.0.1:9145\r\n\r\nGET",
+    });
+
+    expect(result).toBeNull();
+    expect(tunnel.sent).toBe("");
+  });
+
+  it("refuses a tunnelStream path containing CRLF", async () => {
+    const tunnel = openTunnel();
+
+    expect(await tunnelStream("srv_1", 9145, CRLF_PATH)).toBeNull();
+    expect(tunnel.sent).toBe("");
+  });
+
+  it("refuses a tunnelStream header containing CRLF", async () => {
+    const tunnel = openTunnel();
+
+    const result = await tunnelStream("srv_1", 9145, "/logs/stream", {
+      "X-Trace": "abc\r\nX-Injected: yes",
+    });
+
+    expect(result).toBeNull();
+    expect(tunnel.sent).toBe("");
+  });
+
+  it("sends a percent-encoded path and a plain header through unchanged", async () => {
+    const path = `/logs?domain=${encodeURIComponent("app.example.com\r\nX-Injected: yes")}`;
+
+    const tunnel = openTunnel();
+    const pending = tunnelRequest("srv_1", 9145, path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: '{"a":1}',
+    });
+    const sent = await awaitRequest(tunnel);
+    await reply(tunnel, 'HTTP/1.1 200 OK\r\nContent-Length: 7\r\n\r\n{"a":1}');
+
+    expect(await pending).toMatchObject({ statusCode: 200, body: '{"a":1}' });
+    expect(sent).toBe(
+      `POST ${path} HTTP/1.1\r\n` +
+        "Host: 127.0.0.1:9145\r\n" +
+        "Connection: close\r\n" +
+        "Content-Length: 7\r\n" +
+        "Content-Type: application/json\r\n" +
+        '\r\n{"a":1}',
+    );
+  });
+
+  it("sends a tunnelStream request head unchanged for a safe path", async () => {
+    const tunnel = openTunnel();
+    const pending = tunnelStream("srv_1", 9145, "/logs/stream?domain=app.example.com");
+    const sent = await awaitRequest(tunnel);
+    tunnel.destroy();
+    await pending;
+
+    expect(sent).toBe(
+      "GET /logs/stream?domain=app.example.com HTTP/1.1\r\n" +
+        "Host: 127.0.0.1:9145\r\n" +
+        "Accept: text/event-stream\r\n" +
+        "Connection: keep-alive\r\n\r\n",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This is items 1, 2 and 3 from your own review on #322, plus the CRLF nit from the same
comment. #322 was merged as a single commit (`31cd4ab0`) with no follow-up, so all four
still reproduce on `main` at `460b2547`. `apps/api/src/lib/ssh-tunnel.ts` had no test file
at all; this adds one.

Three things stated up front so you can weigh them before reading the diff:

- **The `Transfer-Encoding` casing bug is not observed against our own edge.** OpenResty
  emits lowercase `chunked`. This is robustness on a general-purpose HTTP/1.1 parser, not
  a fix for a reported outage.
- **The CRLF item has no reachable exploit today, and you said so yourself** in the #322
  review: *"no CRLF validation now that http.request isn't doing it (not reachable today —
  all callers encodeURIComponent)"*. I re-walked every mgmt path builder at this tip to
  confirm it still holds: each one is a string literal, or `encodeURIComponent(domain)`
  plus a derived number (`from`/`to` minutes, a `YYYYMMDD` string, `limit` clamped to
  1..200). The only `headers` object ever passed is the literal
  `{"Content-Type": "application/json"}`, and `method` is only ever `"GET"` or `"POST"`. It
  is here because `http.request` *was* enforcing this for free and the rewrite dropped it.
- **`main` CI is green** (run [30596928634](https://github.com/oblien/openship/actions/runs/30596928634),
  success at `460b2547`), so unlike my last few PRs there is no inherited red here — a red
  check on this one would be mine.

## Motivation

All four executed against the real parser with a stubbed `Duplex` in place of the SSH
channel.

| # | Input on the wire | Before | Expected |
|---|---|---|---|
| 1 | `Transfer-Encoding: chunked` + `7\r\n{"a":1}\r\n0\r\n\r\n` | `body '{"a":1}'` | same (control) |
| 1 | `Transfer-Encoding: Chunked` + same body | `200, body '7\r\n{"a":1}\r\n0\r\n\r\n'` | `body '{"a":1}'` |
| 1 | `Transfer-Encoding: gzip, chunked` + same body | `200, body '7\r\n{"a":1}\r\n0\r\n\r\n'` | chunk framing stripped |
| 2 | `Transfer-Encoding: chunked` + `7\r\n{"a":1}\r\n`, socket closes (no `0` chunk) | `200, body '7\r\n{"a":1}\r\n'` | `null` |
| 2 | `Content-Length: 20` + 7 bytes, socket closes | `200, body '{"a":1}'` | `null` |
| 3 | SSE frame `data: {"city":"München"}\n\n` cut inside the two bytes of `ü` | relayed as `data: {"city":"M<ef bf bd><ef bf bd>nchen"}\n\n`, `Buffer.equals` false | byte-identical |
| 4 | path `/health\r\nX-Injected: yes\r\n\r\nGET /rules HTTP/1.1\r\nHost: 127.0.0.1:9145` | two complete HTTP requests written onto one socket | refused |
| 4 | header `{"X-Trace": "abc\r\nX-Injected: yes"}` | `...Connection: close\r\nX-Trace: abc\r\nX-Injected: yes\r\n\r\n` | refused |

Why each one matters:

1 and 2 both land the caller back in the exact silent-no-data symptom #322 was opened to
fix: `fetchMgmt` calls `JSON.parse(res.body)`, which throws on chunk framing or on a
truncated object, and the `catch` returns `null`. Case 2 is the realistic one — the SSH
channel dropping mid-scrape now yields a 200 with a partial body instead of an error, and
`mgmtRequest` never falls through to the exec transport because it got a truthy result.

3 is a transport-level correctness fix, and I want to be precise about what it does and
does not buy. `apps/api/test/lib/server-log-stream-framing.test.ts` already pins byte-exact
SSE relay for the **exec** transport ("Decoding each chunk as a string first would replace
the halves with U+FFFD"). The **tunnel** transport violated the same invariant, and after
this PR it doesn't: the bytes `tunnelStream` hands its caller are the bytes the edge sent.

**It does not fix the end-to-end live log tail on its own, and I don't want to imply it
does.** `serverLogStream` (`modules/projects/project.controller.ts:1236-1237`) is the sole
consumer of `mgmtStream`, and it does:

```ts
conn.stream.on("data", (chunk: Buffer) => {
  sseStream.write(chunk.toString()).catch(() => conn.destroy());
});
```

That `chunk.toString()` re-decodes every chunk and re-introduces exactly the same
corruption, on every mid-character chunk boundary for the life of the stream, and on the
**exec** transport too — so it is a strict superset of the site fixed here. I verified this
end to end through the patched transport into a real Hono `StreamingApi` (`write(string)`
runs the input back through `TextEncoder`); the browser still receives
`data: {"city":"M<ef bf bd><ef bf bd>nchen"}`.

One correction to something I'd assumed: the symptom is **silent corruption, not a dropped
frame**. U+FFFD is a legal character inside a JSON string, so the browser's `JSON.parse`
succeeds and returns `{"city":"M��nchen"}` — the log line renders with
replacement characters rather than failing loudly. So today, any hostname, path or
user-agent in a live tail containing a non-ASCII byte can render mangled, and nothing
reports an error.

4 is defence in depth only, per the disclaimer above.

One scoping note on the `gzip, chunked` row: this fixes the *framing* layer only. Nothing
here gunzips, so a genuinely gzipped body would still come back as gzip bytes rather than
JSON. That is not a regression — today it comes back as chunk framing wrapped around gzip
bytes — and adding content-coding support is a separate question I did not want to answer
unasked.

## Related issue

None — these are review comments on a merged PR.

## Changes

`apps/api/src/lib/ssh-tunnel.ts`, four commits, one per item:

- `isChunkedEncoding()` — lowercase, split on `,`, match any coding equal to `chunked`.
  Transfer-coding names are case-insensitive tokens and the header is a list
  (RFC 9110 §10.1.4). This is the shape you suggested.
- `contentLength`/`isChunked` hoisted out of the `data` handler (they derive from the head
  and never change), so `close` can tell the framings apart. Your gate verbatim: only a
  response with *no* length framing is terminated by the close itself; anything with a
  declared framing that hasn't already resolved is incomplete and returns `null`.
- `tunnelStream` accumulates a `Buffer` and slices bytes instead of `buffer += chunk.toString()`,
  mirroring the `Buffer.concat` head parser `tunnelRequest` already uses. Only the head is
  decoded to a string, which is ASCII by definition.
- `hasCrlf()` — both entry points return `null` before opening the SSH channel if the
  method, path, or any header name or value contains CR or LF. `null` is the failure mode
  both functions already document for a request they cannot make, and it lets `mgmtRequest`
  fall through to the exec transport, which `sq()`-quotes the URL.

**On the request head, nothing currently accepted changes behaviour** — two tests pin that
direction explicitly: a percent-encoded path plus a `Content-Type` header still goes out
byte-identical, and so does a normal `tunnelStream` head.

On the **response** side item 2 narrows what resolves, by design — that is the whole point
of it. One narrowing beyond the two truncation cases is worth calling out because it isn't
obvious from the diff: a malformed non-numeric `Content-Length` (e.g. `Content-Length: abc`)
makes `parseInt` return `NaN`, and `NaN !== null` holds, so `close` now takes the `else`
branch. Executed, same input either side:

| `Content-Length: abc` + `{"a":1}`, socket closes | `main` | this branch |
|---|---|---|
| | `{statusCode: 200, headers: {…}, body: '{"a":1}'}` | `null` |

I think `null` is right — a response whose framing header is unparseable is a response we
can't trust the length of, and `null` sends `mgmtRequest` to the exec transport rather than
handing `JSON.parse` a body of unknown completeness. But it is a behaviour change beyond
the two cases in the table above, it has no test of its own, and if you'd rather treat an
unparseable `Content-Length` as "no framing" (i.e. fall back to the close-terminated path)
that is a one-line change to `contentLength`'s initialiser: `Number.isNaN` → `null`.

**Deliberately not included**, to keep this to one concern:

- **The downstream `chunk.toString()` at `project.controller.ts:1237`** described above.
  Hono's `StreamingApi.write` is typed `(input: Uint8Array | string)`, so passing `chunk`
  straight through is a one-liner — but it is a different module and it changes the exec
  path as well, so it deserves its own test rather than riding along here. Say the word and
  I'll send it as a follow-up; without it the live tail stays corrupted, so I'd suggest
  taking both.
- Your item 3's shared `parseHttpHead()` — the UTF-8 corruption it was going to fix is
  fixed here, but de-duplicating the two head parsers is a `refactor:` on its own. Say the
  word and I'll fold it in or send it separately.
- The three remaining nits: a caller-passed `Content-Length` duplicating the computed one,
  the comment referring to an `end` listener that isn't registered, and a malformed chunk
  size hanging to timeout rather than failing fast. Happy to take any of them.

## Verification

New file `apps/api/test/lib/ssh-tunnel-http.test.ts`, 20 tests in four `describe` blocks,
one per item. Each block was verified to fail with only its own source change reverted and
the others in place (`git stash push -- apps/api/src/lib/ssh-tunnel.ts` at that commit's
parent, then `vitest -t "<block>"`), and to pass with it restored.

```bash
# 1. Transfer-Encoding — without the fix
× decodes a chunked body announced with different casing
× strips the chunk framing when chunked is listed after another coding
  - Expected  "{\"a\":1}"
  + Received  "7\r\n{\"a\":1}\r\n0\r\n\r\n"
  Tests  2 failed | 2 passed (4)
# with the fix:  Tests  4 passed (4)

# 2. Truncation — without the fix
× fails a chunked body cut before the terminating chunk
    expected { statusCode: 200, body: '7\r\n{"a":1}\r\n' } to be null
× fails a response that delivers fewer bytes than Content-Length
    expected { statusCode: 200, body: '{"a":1}' } to be null
  Tests  2 failed | 3 passed | 4 skipped (9)
# with the fix:  Tests  9 passed (9)

# 3. Byte relay — without the fix
× relays a multi-byte character split across the header boundary intact
    Buffer.concat(relayed).equals(frame): expected false to be true
  Tests  1 failed | 2 passed | 9 skipped (12)
# with the fix:  Tests  12 passed (12)

# 4. CRLF — without the fix
× refuses a tunnelRequest path containing CRLF
    expected 'GET /health\r\nX-Injected: yes\r\n\r\…' to be ''
× refuses a tunnelRequest header value containing CRLF
× refuses a tunnelRequest header name containing CRLF
× refuses a tunnelRequest method containing CRLF
× refuses a tunnelStream path containing CRLF
× refuses a tunnelStream header containing CRLF
✓ sends a percent-encoded path and a plain header through unchanged
✓ sends a tunnelStream request head unchanged for a safe path
  Tests  6 failed | 2 passed | 12 skipped (20)
# with the fix:  Tests  20 passed (20)
```

Full suite and typecheck on the branch:

```bash
$ bun run --cwd apps/api lint
$ tsc --noEmit          # clean

$ bun run test -- --continue --force
@repo/desktop:test    Tests  3 passed (3)
@repo/core:test       Tests  257 passed (257)
@repo/dashboard:test  Tests  121 passed (121)
@repo/adapters:test   Tests  712 passed (712)
openship:test         Tests  178 passed (178)
@repo/db:test         Tests  55 passed (55)
@repo/api:test        Tests  1544 passed | 15 skipped (1559)
 Tasks:    7 successful, 7 total
```

`@repo/api` on pristine `460b2547` is 1524 passed / 15 skipped / 152 files; this branch is
1544 / 15 / 153 — the delta is exactly the 20 new tests, nothing else moved.

`ssh-tunnel.ts` has pre-existing Prettier drift on `main`, so I did not run the formatter
over it — I hand-formatted my own lines and confirmed the file's `prettier --check` diff is
byte-identical to `main`'s. The new test file is formatter-clean.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test` and `bun run --cwd apps/api lint` pass locally. I did **not** run
      `bun format` over `ssh-tunnel.ts` — see the Prettier note above; my own lines are
      formatter-clean and the file's drift is unchanged from `main`.
- [x] I understand every line of this diff and can explain it in review

---

**The defensible alternative**, if you'd rather:

Item 2 could return the partial body with a flag (e.g. `{ …, truncated: true }`) instead of
`null`, letting `mgmtRequest` decide. I chose `null` because it restores exactly what
`http.request` did — it surfaced both truncations as errors — and because `mgmtRequest`
already treats `null` as "try the exec transport", which is the better outcome for a
dropped SSH channel. Happy to switch to the flag if you'd rather keep the bytes.

AI-assisted: the analysis, patch and tests were developed with Claude; I ran every command
quoted above and reviewed every line.
