### PR TITLE
fix(core): support Zod imports under Bun Vitest

### DIFF
--- a/packages/core/src/apps/schema.ts
+++ b/packages/core/src/apps/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 import { compareSemver } from "../updates/semver";
 
 /**


### PR DESCRIPTION
## Summary

Use Zod's namespace import in the core app-catalog schema so the schema loads when Vitest runs directly on Bun.

## Motivation

The repository pins Bun 1.3.10. In a Bun-only Linux environment, Vitest 4.0.18 resolves Zod's named `z` export as `undefined`, so `catalog.test.ts` aborts during module evaluation at `z.object()` and none of its 20 tests run.

Zod's namespace export works in that same environment and under Node. The runtime schema behavior is unchanged; this only uses the interoperable ESM import form.

## Related issue

None.

## Changes

- `packages/core`: import Zod as a namespace in `src/apps/schema.ts`.
- No dependency, lockfile, schema, API, or generated-file changes.

## Verification

Before the change, using the repository's pinned Bun version:

```text
$ bun run --cwd packages/core test
Test Files  1 failed | 26 passed (27)
Tests       237 passed (237)
TypeError: undefined is not an object (evaluating '__vite_ssr_import_0__.z.object')
```

After the change:

```text
$ bun run --cwd packages/core test
Test Files  27 passed (27)
Tests       257 passed (257)

$ bun run --cwd packages/core lint
$ tsc --noEmit

$ node /workspace/node_modules/vitest/vitest.mjs run  # Node 24
Test Files  27 passed (27)
Tests       257 passed (257)

$ bun run --cwd apps/api test  # Node 24 + Bun 1.3.10
Test Files  148 passed | 4 skipped (152)
Tests       1524 passed | 15 skipped (1539)
```

I also ran the root test command in Linux Docker. The changed core suite passed, but the root command is not green in a container because existing `@repo/adapters` and `@repo/db` tests assume `/.dockerenv` is absent and `/etc/machine-id` is stable. Those failures reproduce independently of this one-line change.

`prettier --check packages/core/src/apps/schema.ts` reports an existing formatting mismatch on both untouched `main` and this branch. `git diff --check` passes, and I left the unrelated formatting untouched.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — targeted lint/tests pass; root/container and pre-existing formatting limitations are documented above
- [x] I understand every line of this diff and can explain it in review
