### PR TITLE
fix(cli): run smoke tests under Bun and Node

### DIFF
--- a/apps/cli/test/e2e/smoke.test.ts
+++ b/apps/cli/test/e2e/smoke.test.ts
@@ -18,10 +18,15 @@ const inject = join(here, "..", "helpers", "inject-version.mjs");
 const entry = join(cliRoot, "src", "index.ts");
 
 function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  const bunVersion = (process.versions as NodeJS.ProcessVersions & { bun?: string }).bun;
+  const runtimeArgs = bunVersion
+    ? ["--preload", inject, entry, ...args]
+    : ["--import", "tsx", "--import", inject, entry, ...args];
+
   return new Promise((resolve) => {
     execFile(
       process.execPath,
-      ["--import", "tsx", "--import", inject, entry, ...args],
+      runtimeArgs,
       { cwd: cliRoot, env: { ...process.env } },
       (error, stdout, stderr) => {
         const code = error && typeof (error as { code?: number }).code === "number"


### PR DESCRIPTION
## Summary

Make the CLI smoke-test launcher select the correct preload arguments for the runtime executing Vitest.

## Motivation

When the CLI suite runs directly on Bun 1.3.10, `process.execPath` points to Bun, but the smoke helper passes Node's `--import tsx --import ...` arguments to that executable. The real CLI process exits before rendering version or help output, causing three black-box smoke tests to fail.

The harness now uses Bun's supported `--preload` path when `process.versions.bun` is present and preserves the existing `tsx` loader path under Node.

## Related issue

None.

## Changes

- `apps/cli`: detect the active runtime in the E2E smoke helper.
- Use `--preload` for Bun and retain `--import tsx --import` for Node.
- No production CLI, dependency, lockfile, API, or generated-file changes.

## Verification

Before the change in a Bun-only Linux environment:

```text
$ bun run --cwd apps/cli test
Test Files  1 failed | 21 passed (22)
Tests       3 failed | 175 passed (178)
```

After the change:

```text
$ bun run --cwd apps/cli test
Test Files  22 passed (22)
Tests       178 passed (178)

$ node /workspace/node_modules/vitest/vitest.mjs run  # Node 24
Test Files  22 passed (22)
Tests       178 passed (178)

$ bun run --cwd apps/cli lint
$ tsc --noEmit

$ bun run --cwd apps/cli build
ESM Build success
DTS Build success
[stage-server] staged API bundle + pglite + migrations + engine + lua
```

I also ran the root test command in Linux Docker. The CLI suite passed, but the root command is not green in a container because existing `@repo/adapters` and `@repo/db` tests assume `/.dockerenv` is absent and `/etc/machine-id` is stable. Root lint also stops in the existing `apps/email` script because its nested server package has no `lint` script.

`prettier --check apps/cli/test/e2e/smoke.test.ts` reports an existing formatting mismatch on both untouched `main` and this branch. `git diff --check` passes, and I left the unrelated formatting untouched.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — targeted lint/tests/build pass; root/container and pre-existing formatting limitations are documented above
- [x] I understand every line of this diff and can explain it in review
