### PR TITLE
fix(core): keep single-quoted backslashes and empty quoted args in shellSplitWords

### DIFF
--- a/packages/core/src/shell-split.ts
+++ b/packages/core/src/shell-split.ts
@@ -17,6 +17,7 @@
 export function shellSplitWords(value: string): string[] {
   const words: string[] = [];
   let current = "";
+  let quoted = false;
   let inSingle = false;
   let inDouble = false;
   let escaped = false;
@@ -27,22 +28,25 @@ export function shellSplitWords(value: string): string[] {
       escaped = false;
       continue;
     }
-    if (char === "\\") {
+    if (char === "\\" && !inSingle) {
       escaped = true;
       continue;
     }
     if (char === "'" && !inDouble) {
       inSingle = !inSingle;
+      quoted = true;
       continue;
     }
     if (char === '"' && !inSingle) {
       inDouble = !inDouble;
+      quoted = true;
       continue;
     }
     if (/\s/.test(char) && !inSingle && !inDouble) {
-      if (current) {
+      if (current || quoted) {
         words.push(current);
         current = "";
+        quoted = false;
       }
       continue;
     }
@@ -50,7 +54,7 @@ export function shellSplitWords(value: string): string[] {
   }
 
   if (escaped) current += "\\";
-  if (current) words.push(current);
+  if (current || quoted) words.push(current);
   return words;
 }
 

--- a/packages/core/test/shell-split.test.ts
+++ b/packages/core/test/shell-split.test.ts
@@ -12,6 +12,23 @@ describe("shellSplitWords", () => {
   it("honors backslash escapes", () => {
     expect(shellSplitWords("a\\ b c")).toEqual(["a b", "c"]);
   });
+  it("keeps backslashes literal inside single quotes", () => {
+    expect(shellSplitWords(`awk '{ gsub(/\\r/, ""); print }' /data/in`)).toEqual([
+      "awk",
+      `{ gsub(/\\r/, ""); print }`,
+      "/data/in",
+    ]);
+    expect(shellSplitWords(`grep -E '\\d+' file.txt`)).toEqual(["grep", "-E", "\\d+", "file.txt"]);
+  });
+  it("keeps an empty quoted word as an empty argument", () => {
+    expect(shellSplitWords(`node app.js --base-href ""`)).toEqual([
+      "node",
+      "app.js",
+      "--base-href",
+      "",
+    ]);
+    expect(shellSplitWords("echo '' end")).toEqual(["echo", "", "end"]);
+  });
   it("empty / whitespace-only → []", () => {
     expect(shellSplitWords("")).toEqual([]);
     expect(shellSplitWords("   ")).toEqual([]);


### PR DESCRIPTION
## Summary

`shellSplitWords` — the shared tokenizer that turns a compose `command:` string into argv — eats backslashes inside single quotes and drops explicitly quoted empty arguments. Both make it disagree with docker compose's own tokenizer, so a service can be started with different argv than `docker compose up` would give it. This aligns both cases.

## Motivation

The function's contract is its own JSDoc: it tokenizes "matching how docker-compose turns a string `command` into argv" (added in #332). Oracle for everything below is real `docker compose config --format json` (Docker 29.6.1, Compose 5.2.0).

| compose `command:` | `docker compose` | openship on `main` |
| --- | --- | --- |
| `redis-server --appendonly yes --save ""` | `["redis-server","--appendonly","yes","--save",""]` | `["redis-server","--appendonly","yes","--save"]` |
| `awk '{ gsub(/\r/, ""); print }' /data/in` | `["awk","{ gsub(/\\r/, \"\"); print }","/data/in"]` | `["awk","{ gsub(/r/, \"\"); print }","/data/in"]` |
| `grep -E '\d+' file.txt` | `["grep","-E","\\d+","file.txt"]` | `["grep","-E","d+","file.txt"]` |
| `sed 's/\\/\//g' input` | `["sed","s/\\\\/\\//g","input"]` | `["sed","s/\\///g","input"]` |
| `celery -A app worker -Q "" -l info` | `["celery","-A","app","worker","-Q","","-l","info"]` | `["celery","-A","app","worker","-Q","-l","info"]` |
| `node app.js --base-href ""` | `["node","app.js","--base-href",""]` | `["node","app.js","--base-href"]` |

The single-quote half is the one that hurts, because the container still starts and the program still runs — it just means something else. Same busybox image, the two argvs above, same CRLF input:

```
$ printf 'carrot\r\nbird\r\n' | docker run --rm -i busybox awk '{ gsub(/\r/, ""); print }' | od -c
0000000    c   a   r   r   o   t  \n   b   i   r   d  \n
0000014
$ printf 'carrot\r\nbird\r\n' | docker run --rm -i busybox awk '{ gsub(/r/, ""); print }' | od -c
0000000    c   a   o   t  \r  \n   b   i   d  \r  \n
0000013
```

The line-ending fixer deletes every letter `r` and leaves the CRs. The same applies to any `\d`, `\.`, `\s`, `\\` inside a single-quoted awk/sed/grep program.

The empty-argument half shifts everything after it: in the `celery` row, `-Q` is handed `-l` instead of the empty string, and `info` becomes a positional. I checked the `redis-server` case at runtime and redis 7 happens to treat a bare `--save` the same as `--save ""` (both leave `CONFIG GET save` empty), so that particular argv still behaves — but it is only luck that the flag is last and that redis tolerates it.

## Related issue

None — bug fix. Context is #332, which introduced this tokenizer.

## Changes

**`packages/core/src/shell-split.ts`** (7 lines)

- The `char === "\\"` branch ran before the `inSingle` check, so a backslash inside single quotes was consumed as an escape. It is now `char === "\\" && !inSingle`, which is what POSIX and compose's shlex do.
- A word was only pushed when `current` was non-empty, so an explicitly quoted empty argument was dropped instead of becoming an empty argv element. A `quoted` flag now records that the current word was opened by a quote, and the two push sites accept `current || quoted`.

**`packages/core/test/shell-split.test.ts`** — two cases, one per half.

One clarification, because the JSDoc line reads `` `""` → [] ``: that is still true and still tested — a zero-length `command:` yields `[]` (clear the image CMD), which is also what compose does. What changes is the *literal two-character* input `""`, which used to yield `[]` and now yields `[""]`. Compose agrees (`[""]`), and `commandToArgv` still returns `null` for `undefined`/`null`, so the "no override" path is untouched.

## Blast radius: this also feeds the Dockerfile compiler

`shellSplitWords` is aliased as `splitWords` in `packages/adapters/src/dockerfile/compiler.ts` and used there for `FROM`, `ENV`/`LABEL` (`parseKeyValueList`), `COPY`/`ADD` and `EXPOSE` — so this is not a compose-only change and it deserves saying out loud.

For that consumer the single-quote change also moves toward the reference implementation. BuildKit, on a real build:

```
$ cat Dockerfile
FROM busybox
ENV RE='\d+'
EXPOSE 8080
$ docker build -q -t openship-splitcheck . && docker inspect -f '{{json .Config.Env}}' openship-splitcheck
["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","RE=\\d+"]
```

`main`'s compiler produces `RE=d+` for that line; with this change it produces `RE=\d+`, matching the image BuildKit builds.

The one consequence there that is *not* an improvement is on degenerate input. `FROM ''` used to tokenize to `[]` and hit the `parts.length === 0` arm at `compiler.ts:173-179`, which emits the `FROM is missing a base image.` error diagnostic. It now tokenizes to `[""]`, so `baseImage` is silently `""` and no diagnostic is emitted. Both tokenizers run through `compileDockerfileToWorkspacePlan` on `FROM ''` + `ENV RE='\d+'`:

```
before  baseImage ""  env {"RE":"d+"}    diagnostics [{"severity":"error","instruction":"FROM","line":1,"message":"FROM is missing a base image."}]
after   baseImage ""  env {"RE":"\\d+"}  diagnostics []
```

BuildKit rejects that Dockerfile (`base name ('') should not be blank`), so losing the diagnostic is a small step backwards on input nobody writes deliberately. I left it out of this PR to keep the diff to the tokenizer, but if you would rather keep the diagnostic, the guard at `compiler.ts:174` becomes `if (parts.length === 0 || parts[0] === "")` — say the word and I will add it here.

Also visible in the harness output below: for an unterminated quote (`foo "`), which compose rejects outright as an invalid command line, `main` returned `["foo"]` and this returns `["foo",""]`. Neither matches compose; it is malformed input either way.

## Verification

Differential harness: 34 compose `command:` strings, each fed to `docker compose config --format json` for the oracle and to the `main` and patched tokenizers. Batch 1 is the realistic-command set, batch 2 is degenerate/edge input. Every case the fix changes moves toward compose and none moves away.

```bash
$ bun run harness.ts
--- batch 1 (16 cases) ---
before BAD after ok  * "awk '{ gsub(/\\r/, \"\"); print }' /data/in"
    compose  ["awk","{ gsub(/\\r/, \"\"); print }","/data/in"]
    before   ["awk","{ gsub(/r/, \"\"); print }","/data/in"]
    after    ["awk","{ gsub(/\\r/, \"\"); print }","/data/in"]
before BAD after ok  * "node app.js --base-href \"\""
    compose  ["node","app.js","--base-href",""]
    before   ["node","app.js","--base-href"]
    after    ["node","app.js","--base-href",""]
before BAD after ok  * "sh -c 'printf \"%s\\n\" \"x\"'"
    compose  ["sh","-c","printf \"%s\\n\" \"x\""]
    before   ["sh","-c","printf \"%sn\" \"x\""]
    after    ["sh","-c","printf \"%s\\n\" \"x\""]
before ok  after ok    "serve --host 0.0.0.0"
    compose  ["serve","--host","0.0.0.0"]
before ok  after ok    "node -e \"console.log('a b')\""
    compose  ["node","-e","console.log('a b')"]
before ok  after ok    "--msg 'hello world'"
    compose  ["--msg","hello world"]
before ok  after ok    "a\\ b c"
    compose  ["a b","c"]
before BAD after BAD   "a && b"
    compose  ["a"]
    before   ["a","&&","b"]
    after    ["a","&&","b"]
before ok  after ok    "sh -c \"a && b\""
    compose  ["sh","-c","a && b"]
before BAD after ok  * "grep -E '\\d+' file.txt"
    compose  ["grep","-E","\\d+","file.txt"]
    before   ["grep","-E","d+","file.txt"]
    after    ["grep","-E","\\d+","file.txt"]
before BAD after ok  * "python -c 'import sys; print(\"\\t\".join(sys.argv))'"
    compose  ["python","-c","import sys; print(\"\\t\".join(sys.argv))"]
    before   ["python","-c","import sys; print(\"t\".join(sys.argv))"]
    after    ["python","-c","import sys; print(\"\\t\".join(sys.argv))"]
before BAD after ok  * "echo '' end"
    compose  ["echo","","end"]
    before   ["echo","end"]
    after    ["echo","","end"]
before ok  after ok    "bash -lc \"exec node server.js --tag=''\""
    compose  ["bash","-lc","exec node server.js --tag=''"]
before BAD after ok  * "sed 's/\\\\/\\//g' input"
    compose  ["sed","s/\\\\/\\//g","input"]
    before   ["sed","s/\\///g","input"]
    after    ["sed","s/\\\\/\\//g","input"]
before BAD after BAD   "printf \"a\\tb\\n\""
    compose  ["printf","a\tb\n"]
    before   ["printf","atbn"]
    after    ["printf","atbn"]
before BAD after ok  * "celery -A app worker -Q \"\" -l info"
    compose  ["celery","-A","app","worker","-Q","","-l","info"]
    before   ["celery","-A","app","worker","-Q","-l","info"]
    after    ["celery","-A","app","worker","-Q","","-l","info"]
batch 1: matches compose 6/16 before -> 14/16 after; 8 cases changed, 0 moved away from compose

--- batch 2 (18 cases) ---
before BAD after ok  * "redis-server --appendonly yes --save \"\""
    compose  ["redis-server","--appendonly","yes","--save",""]
    before   ["redis-server","--appendonly","yes","--save"]
    after    ["redis-server","--appendonly","yes","--save",""]
before BAD after BAD * "foo \""
    compose  "ERROR: 'services[app].command' invalid command line string"
    before   ["foo"]
    after    ["foo",""]
before BAD after BAD   "foo 'bar"
    compose  "ERROR: 'services[app].command' invalid command line string"
    before   ["foo","bar"]
    after    ["foo","bar"]
before BAD after BAD   "foo \\"
    compose  "ERROR: 'services[app].command' invalid command line string"
    before   ["foo","\\"]
    after    ["foo","\\"]
before ok  after ok    "   "
    compose  []
before BAD after ok  * "''''"
    compose  [""]
    before   []
    after    [""]
before BAD after ok  * "a '' '' b"
    compose  ["a","","","b"]
    before   ["a","b"]
    after    ["a","","","b"]
before ok  after ok    "--flag= --other"
    compose  ["--flag=","--other"]
before BAD after ok  * "sh -c ''"
    compose  ["sh","-c",""]
    before   ["sh","-c"]
    after    ["sh","-c",""]
before BAD after ok  * "npm run start -- --port \"\""
    compose  ["npm","run","start","--","--port",""]
    before   ["npm","run","start","--","--port"]
    after    ["npm","run","start","--","--port",""]
before ok  after ok    "sed -e 's|/usr/local|/opt|g' f"
    compose  ["sed","-e","s|/usr/local|/opt|g","f"]
before ok  after ok    "find . -name '*.log' -exec rm {} \\;"
    compose  ["find",".","-name","*.log","-exec","rm","{}",";"]
before ok  after ok    "sh -c 'exit 0'"
    compose  ["sh","-c","exit 0"]
before ok  after ok    "celery -A app worker --loglevel=info"
    compose  ["celery","-A","app","worker","--loglevel=info"]
before ok  after ok    "postgres -c 'shared_buffers=256MB'"
    compose  ["postgres","-c","shared_buffers=256MB"]
before ok  after ok    "sh -c \"trap 'exit 0' TERM; sleep 1\""
    compose  ["sh","-c","trap 'exit 0' TERM; sleep 1"]
before ok  after ok    "java -jar app.jar --spring.config.location=''"
    compose  ["java","-jar","app.jar","--spring.config.location="]
before BAD after ok  * "\"\""
    compose  [""]
    before   []
    after    [""]
batch 2: matches compose 9/18 before -> 15/18 after; 7 cases changed, 0 moved away from compose
```

The two batch-1 cases that still differ are deliberately out of scope: compose expands ANSI-C escapes outside single quotes (`printf "a\tb\n"`) and we do not, and compose's shlex truncates `a && b` at the operator while this module documents *and tests* operators as literal argv ("does NOT interpret shell operators"). Changing either is a behaviour change, not a fix, and belongs in its own discussion.

The two new tests fail on `main`'s tokenizer and pass with the change — with the `shell-split.ts` hunk reverted and the test file kept:

```bash
$ npx vitest run test/shell-split.test.ts     # fix reverted, test kept
     ✓ splits on unquoted whitespace 1ms
     ✓ keeps quoted spans intact 0ms
     ✓ honors backslash escapes 0ms
     × keeps backslashes literal inside single quotes 2ms
     × keeps an empty quoted word as an empty argument 0ms
     ✓ empty / whitespace-only → [] 0ms
     ✓ does NOT interpret shell operators (they become literal argv) 0ms
     ✓ null/undefined → null (keep image CMD) 0ms
     ✓ string → tokenized argv 0ms
     ✓ empty string → [] (clear image CMD) 0ms
     ✓ array → argv verbatim (stringified) 0ms
     ✓ explicit shell stays a shell invocation 0ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  test/shell-split.test.ts > shellSplitWords > keeps backslashes literal inside single quotes
AssertionError: expected [ 'awk', …(2) ] to deeply equal [ 'awk', …(2) ]
 FAIL  test/shell-split.test.ts > shellSplitWords > keeps an empty quoted word as an empty argument
AssertionError: expected [ 'node', 'app.js', '--base-href' ] to deeply equal [ 'node', 'app.js', '--base-href', '' ]
 Test Files  1 failed (1)
      Tests  2 failed | 10 passed (12)

$ npx vitest run test/shell-split.test.ts     # with the fix
 ✓ test/shell-split.test.ts (12 tests) 2ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Full suite, uncached, rebased onto `c017c231`:

```bash
$ bun run test -- --continue --force
@repo/desktop:test:  Test Files  1 passed (1)
@repo/desktop:test:       Tests  3 passed (3)
@repo/core:test:  Test Files  28 passed (28)
@repo/core:test:       Tests  300 passed (300)
@repo/dashboard:test:  Test Files  18 passed (18)
@repo/dashboard:test:       Tests  228 passed (228)
@repo/adapters:test:  Test Files  84 passed (84)
@repo/adapters:test:       Tests  721 passed (721)
openship:test:  Test Files  22 passed (22)
openship:test:       Tests  181 passed (181)
@repo/db:test:  Test Files  11 passed (11)
@repo/db:test:       Tests  55 passed (55)
@repo/api:test:  Test Files  163 passed | 4 skipped (167)
@repo/api:test:       Tests  1722 passed | 15 skipped (1737)
 Tasks:    7 successful, 7 total
Cached:    0 cached, 7 total
  Time:    17.81s

$ bun run --cwd packages/core lint        # tsc --noEmit, exit 0
$ bun run --cwd packages/adapters lint    # tsc --noEmit, exit 0
$ bun run --cwd apps/api lint             # tsc --noEmit, exit 0
```

3210 tests pass, 15 skipped, 0 fail. `main` CI is green at `c017c231` (run 30629413294), so there is no inherited red here.

Formatting note: both files already fail `prettier --check` on `main` — `commandToArgv`'s signature in the source and line 9 of the test file. Running `bun format --write` over them would rewrite those two unrelated spots, which CONTRIBUTING asks contributors not to do, so I hand-formatted my own lines instead; `prettier` reports no change on any line this PR adds.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally (see the formatting note above for the pre-existing drift in these two files)
- [x] I understand every line of this diff and can explain it in review
