### PR TITLE
fix(api): relay server-log stream chunks as bytes, not re-decoded strings

### DIFF
--- a/apps/api/src/modules/projects/project.controller.ts
+++ b/apps/api/src/modules/projects/project.controller.ts
@@ -1234,7 +1234,7 @@ export async function serverLogStream(c: Context) {
 
       await new Promise<void>((resolve) => {
         conn.stream.on("data", (chunk: Buffer) => {
-          sseStream.write(chunk.toString()).catch(() => conn.destroy());
+          sseStream.write(chunk).catch(() => conn.destroy());
         });
         conn.stream.on("close", () => resolve());
         conn.stream.on("end", () => resolve());

--- a/apps/api/test/modules/projects/server-log-stream-relay.test.ts
+++ b/apps/api/test/modules/projects/server-log-stream-relay.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from "vitest";
+import { Hono } from "hono";
+import type { CommandExecutor, LogEntry } from "@repo/adapters";
+
+/**
+ * `serverLogStream` relays the EDGE's SSE frames to the browser. The frames are
+ * the edge's, so the relay must be byte-exact: `pipe_stream.lua` emits UTF-8, and
+ * both transports hand the controller arbitrary byte slices of it, so a chunk
+ * boundary can land in the MIDDLE of a multi-byte character.
+ *
+ * These drive the exec transport (`execMgmtStream` → `streamChunkBytes` → the
+ * controller) through a real Hono SSE stream and compare the bytes the client
+ * receives with the bytes the edge emitted.
+ */
+
+const h = vi.hoisted(() => ({
+  executor: null as CommandExecutor | null,
+}));
+
+vi.mock("../../../src/lib/request-context", () => ({
+  getRequestContext: () => ({ userId: "user_1", organizationId: "org_1" }),
+}));
+
+vi.mock("../../../src/lib/permission", () => ({
+  permission: { assert: vi.fn(async () => {}) },
+}));
+
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: {
+    retain: vi.fn(),
+    release: vi.fn(),
+    acquire: vi.fn(async () => h.executor),
+  },
+}));
+
+vi.mock("@/lib/openresty-paths", () => ({
+  getOpenRestyPaths: vi.fn(async () => ({})),
+}));
+
+vi.mock("@repo/adapters", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/adapters")>();
+  return { ...actual, deployLuaScripts: vi.fn(async () => {}) };
+});
+
+vi.mock("@repo/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/db")>();
+  return {
+    ...actual,
+    repos: {
+      ...actual.repos,
+      project: {
+        ...actual.repos.project,
+        findById: vi.fn(async (id: string) => ({ id, organizationId: "org_1" })),
+      },
+    },
+  };
+});
+
+vi.mock("../../../src/lib/project-analytics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/lib/project-analytics")>();
+  return {
+    ...actual,
+    resolveProjectTrafficSource: vi.fn(async () => ({
+      kind: "self-hosted" as const,
+      domain: "app.example.com",
+      serverId: "srv_1",
+    })),
+  };
+});
+
+import { serverLogStream } from "../../../src/modules/projects/project.controller";
+
+/**
+ * An executor with no `forwardPort`, which is what selects the exec transport,
+ * running an edge container whose `curl -N` emits `chunks`.
+ */
+function edgeExecutor(chunks: Buffer[]): CommandExecutor {
+  return {
+    exec: async (command: string) => (command.includes("docker ps") ? "openship-edge\n" : ""),
+    streamExec: async (_command: string, onLog: (log: LogEntry) => void) => {
+      for (const chunk of chunks) {
+        onLog({
+          timestamp: "2026-07-31T00:00:00.000Z",
+          message: chunk.toString(),
+          level: "info",
+          rawData: chunk.toString("base64"),
+        });
+      }
+      return { code: 0, output: "" };
+    },
+  } as unknown as CommandExecutor;
+}
+
+/** What the browser receives when the edge emits `chunks`. */
+async function relay(chunks: Buffer[]): Promise<Buffer> {
+  h.executor = edgeExecutor(chunks);
+
+  const app = new Hono();
+  app.get("/projects/:id/server-logs/stream", serverLogStream);
+
+  const res = await app.request("/projects/proj_1/server-logs/stream");
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/** Split `frame` inside the multi-byte character `at`. */
+function splitMidCharacter(frame: string, at: string): Buffer[] {
+  const bytes = Buffer.from(frame, "utf8");
+  const cut = bytes.indexOf(Buffer.from(at, "utf8")) + 1;
+  return [bytes.subarray(0, cut), bytes.subarray(cut)];
+}
+
+describe("serverLogStream relay", () => {
+  it("relays a frame split mid-character byte-for-byte", async () => {
+    const frame = `event: request\ndata: {"path":"/café","status":200}\n\n`;
+
+    const relayed = await relay(splitMidCharacter(frame, "é"));
+
+    expect(relayed.toString("hex")).toBe(Buffer.from(frame, "utf8").toString("hex"));
+  });
+
+  it("keeps a payload parseable AND unmangled across a mid-character split", async () => {
+    // U+FFFD is legal inside a JSON string, so parsing alone says nothing about
+    // the bytes; the decoded value is what has to match.
+    const frame = `event: request\ndata: {"path":"/日本語/index","ua":"Mozilla"}\n\n`;
+
+    const relayed = await relay(splitMidCharacter(frame, "本"));
+
+    const data = relayed
+      .toString()
+      .split("\n")
+      .find((l) => l.startsWith("data: "))!
+      .slice(6);
+    expect(JSON.parse(data)).toEqual({ path: "/日本語/index", ua: "Mozilla" });
+  });
+
+  it("relays several frames split at successive mid-character boundaries", async () => {
+    const frame = `event: request\ndata: {"host":"münchen.example"}\n\nevent: request\ndata: {"host":"café.example"}\n\n`;
+    const bytes = Buffer.from(frame, "utf8");
+    const cuts = [
+      bytes.indexOf(Buffer.from("ü", "utf8")) + 1,
+      bytes.indexOf(Buffer.from("é", "utf8")) + 1,
+    ];
+
+    const relayed = await relay([
+      bytes.subarray(0, cuts[0]),
+      bytes.subarray(cuts[0], cuts[1]),
+      bytes.subarray(cuts[1]),
+    ]);
+
+    expect(relayed.toString("hex")).toBe(bytes.toString("hex"));
+  });
+
+  it("relays an ASCII frame unchanged", async () => {
+    const frame = `event: request\ndata: {"ip":"203.0.113.7"}\n\n: ping\n\n`;
+
+    const relayed = await relay([Buffer.from(frame, "utf8")]);
+
+    expect(relayed.toString()).toBe(frame);
+  });
+});


### PR DESCRIPTION
## Summary

`serverLogStream` re-decodes every chunk of the edge's SSE stream with `chunk.toString()`, which destroys any multi-byte UTF-8 character that lands on a chunk boundary. Pass the `Buffer` through instead.

This is the follow-up I offered in the "Deliberately not included" section of #344 — you merged that one without a steer either way, so here it is.

## Motivation

`apps/api/src/modules/projects/project.controller.ts:1237`:

```ts
conn.stream.on("data", (chunk: Buffer) => {
  sseStream.write(chunk.toString()).catch(() => conn.destroy());
});
```

Both transports behind `mgmtStream` hand the controller arbitrary byte slices — `streamExec` is a raw passthrough ("Do NOT split on `\n` or trim here"), and the tunnel emits whatever the socket delivered. So a chunk boundary can land in the middle of a multi-byte character. `chunk.toString()` decodes each chunk in isolation, both halves become U+FFFD, and Hono's `StreamingApi.write` re-encodes them with its `TextEncoder` and ships them.

Edge frame `event: request\ndata: {"path":"/café","status":200}\n\n`, cut inside the `é`:

| | bytes at `/caf…` |
|---|---|
| edge emitted | `2f 63 61 66 **c3 a9**` |
| browser received | `2f 63 61 66 **ef bf bd ef bf bd**` |

The corruption is **silent**. U+FFFD is legal inside a JSON string, so the dashboard's `JSON.parse` succeeds and just renders `/caf��`. Nothing throws, no event is dropped, and nobody will ever file a bug for it. Any request-log line whose path, `Host` or user-agent is non-ASCII is exposed, on every mid-character boundary, for the life of the stream.

#344 fixed the same defect one layer down, in `tunnelStream`'s `buffer += chunk.toString()`. `serverLogStream` is the sole consumer of `mgmtStream` and re-corrupted the identical bytes immediately afterwards — and on the **exec** transport too, which #344 did not touch. So the end-to-end live tail stayed broken after that PR; this closes it. The tunnel path shares this exact line, and #344's `ssh-tunnel-http.test.ts` already pins that `tunnelStream` hands over the edge's bytes unchanged — so exec is the half worth an end-to-end test here, and that is what the new test drives.

## Related issue

None. Follow-up to #344.

## Changes

**apps/api**

- `src/modules/projects/project.controller.ts` — `sseStream.write(chunk)` instead of `sseStream.write(chunk.toString())`. `StreamingApi.write` is typed `(input: Uint8Array | string)` (`hono/dist/types/utils/stream.d.ts:20`), so a `Buffer` goes straight to `writer.write` and no decode happens at all.
- `test/modules/projects/server-log-stream-relay.test.ts` — new. Drives the exec transport end to end (`execMgmtStream` → `streamChunkBytes` → the controller → a real Hono SSE stream via `app.request`) and compares the bytes the client receives against the bytes the edge emitted.

## Verification

Four cases; **three fail without the one-line change** and all four pass with it.

```bash
$ git stash push -- apps/api/src/modules/projects/project.controller.ts
$ cd apps/api && npx vitest run test/modules/projects/server-log-stream-relay.test.ts

 ❯ test/modules/projects/server-log-stream-relay.test.ts (4 tests | 3 failed)
   × relays a frame split mid-character byte-for-byte
   × keeps a payload parseable AND unmangled across a mid-character split
   × relays several frames split at successive mid-character boundaries
   ✓ relays an ASCII frame unchanged

 FAIL  serverLogStream relay > relays a frame split mid-character byte-for-byte
 AssertionError: expected '…' to be '…'
 Expected: "…646174613a207b2270617468223a222f636166c3a9222c22737461747573223a3230307d0a0a"
 Received: "…646174613a207b2270617468223a222f636166efbfbdefbfbd222c22737461747573223a3230307d0a0a"

 FAIL  serverLogStream relay > keeps a payload parseable AND unmangled across a mid-character split
 AssertionError: expected { …(2) } to deeply equal { path: '/日本語/index', ua: 'Mozilla' }
 - Expected
 + Received
   {
 -   "path": "/日本語/index",
 +   "path": "/日���語/index",
     "ua": "Mozilla",
   }

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

```bash
$ git stash pop
$ cd apps/api && npx vitest run test/modules/projects/server-log-stream-relay.test.ts

 ✓ test/modules/projects/server-log-stream-relay.test.ts (4 tests) 6ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full suite, rebased onto `0e42ccb7`:

| | `0e42ccb7` (main) | this branch |
|---|---|---|
| `@repo/api` | 1746 passed / 15 skipped | 1750 passed / 15 skipped |
| `@repo/adapters` | 730 | 730 |
| `@repo/core` | 307 | 307 |
| `@repo/dashboard` | 228 | 228 |
| `openship` (cli) | 181 | 181 |
| `@repo/db` | 55 | 55 |
| `@repo/desktop` | 3 | 3 |
| **total** | **3250 passed / 15 skipped / 0 failed** | **3254 passed / 15 skipped / 0 failed** |

```bash
$ bun run test -- --continue     # 7 tasks successful, 0 failed
$ bun run --cwd apps/api lint    # tsc --noEmit, exit 0
$ npx prettier --check apps/api/test/modules/projects/server-log-stream-relay.test.ts
All matched files use Prettier code style!
```

`project.controller.ts` has pre-existing Prettier drift on `main` (631 diff lines), so I hand-formatted my single line rather than running `--write` over the file and burying the fix.

`main` CI is green at `0e42ccb7` (run `30633859700`), so there is nothing inherited to disclose here — a red check on this one would be mine.

## Alternative

The other defensible fix is to keep the string write and decode the stream statefully — pipe `conn.stream` through a `StringDecoder` (or a `TextDecoder` with `{ stream: true }`) so partial sequences are held over to the next chunk. It produces identical output here, but adds a buffer and a decode step to a path whose only job is to relay the edge's bytes untouched. Happy to switch if you prefer it.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review
