### PR TITLE
fix(email): a11y + mobile/UX correctness polish

### DIFF
--- a/apps/email/client/app/(routes)/mail/[folder]/page.tsx
+++ b/apps/email/client/app/(routes)/mail/[folder]/page.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useNavigate } from 'react-router';
 import { MailLayout } from '@/components/mail/mail';
 import { useLabels } from '@/hooks/use-labels';
 import { authProxy } from '@/lib/auth-proxy';
+import { getAppUrl } from '@/lib/backend-url';
 import { useEffect, useState } from 'react';
 import type { Route } from './+types/page';
 
@@ -20,10 +21,10 @@ const ALLOWED_FOLDERS = new Set([
 ]);
 
 export async function clientLoader({ params, request }: Route.ClientLoaderArgs) {
-  if (!params.folder) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/mail/inbox`);
+  if (!params.folder) return Response.redirect(`${getAppUrl()}/mail/inbox`);
 
   const session = await authProxy.api.getSession({ headers: request.headers });
-  if (!session) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/login`);
+  if (!session) return Response.redirect(`${getAppUrl()}/login`);
 
   return {
     folder: params.folder,

--- a/apps/email/client/app/(routes)/mail/compose/page.tsx
+++ b/apps/email/client/app/(routes)/mail/compose/page.tsx
@@ -7,16 +7,17 @@ import {
 } from '@/components/ui/dialog';
 import { CreateEmail } from '@/components/create/create-email';
 import { authProxy } from '@/lib/auth-proxy';
+import { getAppUrl } from '@/lib/backend-url';
 import { useLoaderData } from 'react-router';
 import type { Route } from './+types/page';
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const session = await authProxy.api.getSession({ headers: request.headers });
-  if (!session) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/login`);
+  if (!session) return Response.redirect(`${getAppUrl()}/login`);
   const url = new URL(request.url);
   if (url.searchParams.get('to')?.startsWith('mailto:')) {
     return Response.redirect(
-      `${import.meta.env.VITE_PUBLIC_APP_URL}/mail/compose/handle-mailto?mailto=${encodeURIComponent(url.searchParams.get('to') ?? '')}`,
+      `${getAppUrl()}/mail/compose/handle-mailto?mailto=${encodeURIComponent(url.searchParams.get('to') ?? '')}`,
     );
   }
 

--- a/apps/email/client/app/(routes)/mail/create/page.tsx
+++ b/apps/email/client/app/(routes)/mail/create/page.tsx
@@ -1,9 +1,10 @@
 import { authProxy } from '@/lib/auth-proxy';
+import { getAppUrl } from '@/lib/backend-url';
 import type { Route } from './+types/page';
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const session = await authProxy.api.getSession({ headers: request.headers });
-  if (!session) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/login`);
+  if (!session) return Response.redirect(`${getAppUrl()}/login`);
 
   const url = new URL(request.url);
   const params = Object.fromEntries(url.searchParams.entries()) as {
@@ -13,7 +14,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   };
   const toParam = params.to || 'someone@someone.com';
   return Response.redirect(
-    `${import.meta.env.VITE_PUBLIC_APP_URL}/mail/inbox?isComposeOpen=true&to=${encodeURIComponent(toParam)}${params.subject ? `&subject=${encodeURIComponent(params.subject)}` : ''}`,
+    `${getAppUrl()}/mail/inbox?isComposeOpen=true&to=${encodeURIComponent(toParam)}${params.subject ? `&subject=${encodeURIComponent(params.subject)}` : ''}`,
   );
 }
 

--- a/apps/email/client/app/(routes)/mail/layout.tsx
+++ b/apps/email/client/app/(routes)/mail/layout.tsx
@@ -6,9 +6,9 @@ export default function MailLayout() {
   return (
     <HotkeyProviderWrapper>
       <AppSidebar />
-      <div className="bg-sidebar dark:bg-sidebar w-full">
+      <main className="bg-sidebar dark:bg-sidebar w-full">
         <Outlet />
-      </div>
+      </main>
     </HotkeyProviderWrapper>
   );
 }

--- a/apps/email/client/app/(routes)/mail/page.tsx
+++ b/apps/email/client/app/(routes)/mail/page.tsx
@@ -1,3 +1,5 @@
+import { getAppUrl } from '@/lib/backend-url';
+
 export function clientLoader() {
-  return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/mail/inbox`);
+  return Response.redirect(`${getAppUrl()}/mail/inbox`);
 }

--- a/apps/email/client/app/(routes)/settings/layout.tsx
+++ b/apps/email/client/app/(routes)/settings/layout.tsx
@@ -1,13 +1,14 @@
 import { SettingsLayoutContent } from '@/components/ui/settings-content';
 import { Outlet } from 'react-router';
 import { authProxy } from '@/lib/auth-proxy';
+import { getAppUrl } from '@/lib/backend-url';
 import type { Route } from './+types/layout';
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const session = await authProxy.api.getSession({ headers: request.headers });
 
   if (!session) {
-    return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/login`);
+    return Response.redirect(`${getAppUrl()}/login`);
   }
 
   

--- a/apps/email/client/app/globals.css
+++ b/apps/email/client/app/globals.css
@@ -105,7 +105,7 @@
   --secondary: hsl(240 4.8% 95.9%);
   --secondary-foreground: hsl(240 5.9% 10%);
   --muted: hsl(240 4.8% 95.9%);
-  --muted-foreground: hsl(240 3.8% 46.1%);
+  --muted-foreground: hsl(240 3.8% 42%);
   --accent: hsl(240 4.8% 95.9%);
   --accent-foreground: hsl(240 5.9% 10%);
   --destructive: hsl(0 84.2% 60.2%);
@@ -162,7 +162,7 @@
   --secondary: hsl(240 3.7% 15.9%);
   --secondary-foreground: hsl(0 0% 98%);
   --muted: hsl(240 3.7% 15.9%);
-  --muted-foreground: hsl(240 5% 64.9%);
+  --muted-foreground: hsl(240 5% 68%);
   --accent: hsl(240 3.7% 15.9%);
   --accent-foreground: hsl(0 0% 98%);
   --destructive: hsl(0 62.8% 30.6%);

--- a/apps/email/client/app/mailto-handler.ts
+++ b/apps/email/client/app/mailto-handler.ts
@@ -2,6 +2,7 @@ import { cleanEmailAddresses } from '../lib/email-utils';
 import { trpcClient } from '@/providers/query-provider';
 import type { Route } from './+types/mailto-handler';
 import { authProxy } from '@/lib/auth-proxy';
+import { getAppUrl } from '@/lib/backend-url';
 
 // Function to parse mailto URLs
 async function parseMailtoUrl(mailtoUrl: string) {
@@ -248,27 +249,27 @@ async function createDraftFromMailto(mailtoData: {
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const session = await authProxy.api.getSession({ headers: request.headers });
-  if (!session) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/login`);
+  if (!session) return Response.redirect(`${getAppUrl()}/login`);
 
   const url = new URL(request.url);
 
   // Get the mailto parameter from the URL
   const mailto = url.searchParams.get('mailto');
 
-  if (!mailto) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/mail/compose`);
+  if (!mailto) return Response.redirect(`${getAppUrl()}/mail/compose`);
 
   // Parse the mailto URL
   const mailtoData = await parseMailtoUrl(mailto);
 
   // If parsing failed, redirect to empty compose
-  if (!mailtoData) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/mail/compose`);
+  if (!mailtoData) return Response.redirect(`${getAppUrl()}/mail/compose`);
 
   // Create a draft from the mailto data
   const draftId = await createDraftFromMailto(mailtoData);
 
   // If draft creation failed, redirect to empty compose with the parsed data as a fallback
   if (!draftId) {
-    const fallbackUrl = new URL(`${import.meta.env.VITE_PUBLIC_APP_URL}/mail/compose`);
+    const fallbackUrl = new URL(`${getAppUrl()}/mail/compose`);
     if (mailtoData.to) fallbackUrl.searchParams.append('to', mailtoData.to);
     if (mailtoData.subject) fallbackUrl.searchParams.append('subject', mailtoData.subject);
     if (mailtoData.body) fallbackUrl.searchParams.append('body', mailtoData.body);
@@ -279,6 +280,6 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
 
   // Redirect to compose with the draft ID
   return Response.redirect(
-    `${import.meta.env.VITE_PUBLIC_APP_URL}/mail/compose?draftId=${draftId}`,
+    `${getAppUrl()}/mail/compose?draftId=${draftId}`,
   );
 }

--- a/apps/email/client/components/create/editor.text-buttons.tsx
+++ b/apps/email/client/components/create/editor.text-buttons.tsx
@@ -3,10 +3,12 @@ import type { ComponentType } from 'react';
 import type { Editor } from '@tiptap/react';
 import { EditorBubbleItem, useEditor } from 'novel';
 import { Button } from '@/components/ui/button';
+import { m } from '@/paraglide/messages';
 import { cn } from '@/lib/utils';
 
 interface SelectorItem {
   name: string;
+  label: string;
   icon: ComponentType<{ className?: string }>;
   isActive: (editor: Editor) => boolean;
   command: (editor: Editor) => void;
@@ -18,30 +20,35 @@ export const TextButtons = () => {
   const items: SelectorItem[] = [
     {
       name: 'bold',
+      label: m['pages.createEmail.editor.menuBar.bold'](),
       isActive: (editor) => editor.isActive('bold'),
       command: (editor) => editor.chain().focus().toggleBold().run(),
       icon: BoldIcon,
     },
     {
       name: 'italic',
+      label: m['pages.createEmail.editor.menuBar.italic'](),
       isActive: (editor) => editor.isActive('italic'),
       command: (editor) => editor.chain().focus().toggleItalic().run(),
       icon: ItalicIcon,
     },
     {
       name: 'underline',
+      label: m['pages.createEmail.editor.menuBar.underline'](),
       isActive: (editor) => editor.isActive('underline'),
       command: (editor) => editor.chain().focus().toggleUnderline().run(),
       icon: UnderlineIcon,
     },
     {
       name: 'strike',
+      label: m['pages.createEmail.editor.menuBar.strikethrough'](),
       isActive: (editor) => editor.isActive('strike'),
       command: (editor) => editor.chain().focus().toggleStrike().run(),
       icon: StrikethroughIcon,
     },
     {
       name: 'code',
+      label: 'Code',
       isActive: (editor) => editor.isActive('code'),
       command: (editor) => editor.chain().focus().toggleCode().run(),
       icon: CodeIcon,
@@ -56,7 +63,7 @@ export const TextButtons = () => {
             item.command(editor);
           }}
         >
-          <Button size="icon" className="rounded-none" variant="ghost">
+          <Button size="icon" className="rounded-none" variant="ghost" aria-label={item.label}>
             <item.icon
               className={cn('h-4 w-4', {
                 'text-blue-500': item.isActive(editor),

--- a/apps/email/client/components/create/email-composer.tsx
+++ b/apps/email/client/components/create/email-composer.tsx
@@ -694,7 +694,7 @@ export function EmailComposer({
             <p className="text-sm font-medium text-[#8C8C8C]">Subject:</p>
             <input
               className="h-4 w-full bg-transparent text-sm font-normal leading-normal text-black placeholder:text-[#797979] focus:outline-none dark:text-white/90"
-              placeholder="Re: Design review feedback"
+              placeholder="Subject"
               value={subjectInput}
               onChange={(e) => {
                 const value = replaceEmojiShortcodes(e.target.value);

--- a/apps/email/client/components/create/email-composer.tsx
+++ b/apps/email/client/components/create/email-composer.tsx
@@ -623,7 +623,7 @@ export function EmailComposer({
         <div className="shrink-0 overflow-visible border-b border-[#E7E7E7] pb-2 dark:border-[#252525]">
           <div className="flex justify-between px-3 pt-3">
             <div className="flex w-full items-center gap-2">
-              <p className="text-sm font-medium text-[#8C8C8C]">To:</p>
+              <p className="text-sm font-medium text-muted-foreground dark:text-[#8C8C8C]">To:</p>
               <RecipientAutosuggest
                 control={form.control}
                 name="to"
@@ -635,14 +635,14 @@ export function EmailComposer({
             <div className="flex gap-2">
               <button
                 tabIndex={-1}
-                className="flex h-full items-center gap-2 text-sm font-medium text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
+                className="flex h-full items-center gap-2 text-sm font-medium text-muted-foreground dark:text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
                 onClick={() => setShowCc(!showCc)}
               >
                 <span>Cc</span>
               </button>
               <button
                 tabIndex={-1}
-                className="flex h-full items-center gap-2 text-sm font-medium text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
+                className="flex h-full items-center gap-2 text-sm font-medium text-muted-foreground dark:text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
                 onClick={() => setShowBcc(!showBcc)}
               >
                 <span>Bcc</span>
@@ -650,7 +650,7 @@ export function EmailComposer({
               {onClose && (
                 <button
                   tabIndex={-1}
-                  className="flex h-full items-center gap-2 text-sm font-medium text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
+                  className="flex h-full items-center gap-2 text-sm font-medium text-muted-foreground dark:text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
                   onClick={handleClose}
                 >
                   <X className="h-3.5 w-3.5 fill-[#9A9A9A]" />
@@ -663,7 +663,7 @@ export function EmailComposer({
             {/* CC Section */}
             {showCc && (
               <div className="flex items-center gap-2 px-3">
-                <p className="text-sm font-medium text-[#8C8C8C]">Cc:</p>
+                <p className="text-sm font-medium text-muted-foreground dark:text-[#8C8C8C]">Cc:</p>
                 <RecipientAutosuggest
                   control={form.control}
                   name="cc"
@@ -676,7 +676,7 @@ export function EmailComposer({
             {/* BCC Section */}
             {showBcc && (
               <div className="flex items-center gap-2 px-3">
-                <p className="text-sm font-medium text-[#8C8C8C]">Bcc:</p>
+                <p className="text-sm font-medium text-muted-foreground dark:text-[#8C8C8C]">Bcc:</p>
                 <RecipientAutosuggest
                   control={form.control}
                   name="bcc"
@@ -691,7 +691,7 @@ export function EmailComposer({
         {/* Subject */}
         {!activeReplyId ? (
           <div className="flex items-center gap-2 border-b p-3">
-            <p className="text-sm font-medium text-[#8C8C8C]">Subject:</p>
+            <p className="text-sm font-medium text-muted-foreground dark:text-[#8C8C8C]">Subject:</p>
             <input
               className="h-4 w-full bg-transparent text-sm font-normal leading-normal text-black placeholder:text-[#797979] focus:outline-none dark:text-white/90"
               placeholder="Subject"
@@ -723,7 +723,7 @@ export function EmailComposer({
         {/* From */}
         {aliases && aliases.length > 1 ? (
           <div className="flex items-center gap-2 border-b p-3">
-            <p className="text-sm font-medium text-[#8C8C8C]">From:</p>
+            <p className="text-sm font-medium text-muted-foreground dark:text-[#8C8C8C]">From:</p>
             <Select
               value={fromEmail || ''}
               onValueChange={(value) => {
@@ -741,7 +741,7 @@ export function EmailComposer({
                       <span className="text-sm">
                         {alias.name ? `${alias.name} <${alias.email}>` : alias.email}
                       </span>
-                      {alias.primary && <span className="text-xs text-[#8C8C8C]">Primary</span>}
+                      {alias.primary && <span className="text-xs text-muted-foreground dark:text-[#8C8C8C]">Primary</span>}
                     </div>
                   </SelectItem>
                 ))}
@@ -895,7 +895,7 @@ export function EmailComposer({
                                 >
                                   <span className="truncate">{truncatedName}</span>
                                   {extension && (
-                                    <span className="ml-0.5 shrink-0 text-[10px] text-[#8C8C8C] dark:text-[#9A9A9A]">
+                                    <span className="ml-0.5 shrink-0 text-[10px] text-muted-foreground dark:text-[#9A9A9A]">
                                       .{extension}
                                     </span>
                                   )}

--- a/apps/email/client/components/create/email-composer.tsx
+++ b/apps/email/client/components/create/email-composer.tsx
@@ -32,6 +32,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useSettings } from '@/hooks/use-settings';
 
 import { cn, formatFileSize } from '@/lib/utils';
+import { m } from '@/paraglide/messages';
 import { useThread } from '@/hooks/use-threads';
 import { serializeFiles } from '@/lib/schemas';
 import { Input } from '@/components/ui/input';
@@ -650,6 +651,7 @@ export function EmailComposer({
               {onClose && (
                 <button
                   tabIndex={-1}
+                  aria-label={m['common.actions.close']()}
                   className="flex h-full items-center gap-2 text-sm font-medium text-muted-foreground dark:text-[#8C8C8C] hover:text-[#A8A8A8] hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded-sm px-1 py-0.5"
                   onClick={handleClose}
                 >
@@ -705,6 +707,7 @@ export function EmailComposer({
             <button
               onClick={handleGenerateSubject}
               disabled={isLoading || isGeneratingSubject || messageLength < 1}
+              aria-label="Generate subject with AI"
               className="hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded p-1"
             >
               <div className="flex items-center justify-center gap-2.5 pl-0.5">

--- a/apps/email/client/components/create/template-button.tsx
+++ b/apps/email/client/components/create/template-button.tsx
@@ -235,6 +235,7 @@ const TemplateButtonComponent: React.FC<TemplateButtonProps> = ({
                     >
                       <span className="flex-1 truncate text-left">{t.name}</span>
                       <button
+                        aria-label="Delete template"
                         className="p-0.5 text-muted-foreground hover:text-destructive"
                         data-template-id={t.id}
                         onClick={handleDeleteButtonClick}

--- a/apps/email/client/components/mail/mail-display.tsx
+++ b/apps/email/client/components/mail/mail-display.tsx
@@ -1259,7 +1259,11 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                   <span>
                     {emailData.subject}{' '}
                     <span className="text-muted-foreground dark:text-[#8C8C8C]">
-                      {totalEmails && totalEmails > 1 && `[${totalEmails}]`}
+                      {/* `totalEmails && totalEmails > 1 && ...` renders a bare "0"
+                          for a single-message thread - `0 && x` evaluates to `0`,
+                          and unlike false/null/undefined, React renders a numeric
+                          0 as text. Ternary avoids that. */}
+                      {totalEmails != null && totalEmails > 1 ? `[${totalEmails}]` : null}
                     </span>
                   </span>
                 </span>

--- a/apps/email/client/components/mail/mail-display.tsx
+++ b/apps/email/client/components/mail/mail-display.tsx
@@ -1168,8 +1168,10 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
     (person: Sender) => (
       <Popover key={person.email}>
         <PopoverTrigger asChild>
-          <div
+          <button
             key={person.email}
+            type="button"
+            aria-label={person.name || person.email}
             className="dark:bg-panelDark inline-flex items-center justify-start gap-1.5 overflow-hidden rounded-full border bg-white p-1 pr-2"
           >
             <BimiAvatar
@@ -1180,7 +1182,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
             <div className="text-panelDark justify-start text-sm font-medium leading-none dark:text-white">
               {person.name || person.email}
             </div>
-          </div>
+          </button>
         </PopoverTrigger>
         <PopoverContent className="min-w-fit text-sm">
           <div className="flex items-center gap-2">

--- a/apps/email/client/components/mail/mail-display.tsx
+++ b/apps/email/client/components/mail/mail-display.tsx
@@ -1501,6 +1501,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                   e.stopPropagation();
                                   e.preventDefault();
                                 }}
+                                aria-label={m['common.threadDisplay.moreOptions']()}
                                 className="inline-flex h-7 w-7 items-center justify-center gap-1 overflow-hidden rounded-md bg-white hover:bg-gray-100 focus:outline-none focus:ring-0 dark:bg-[#313131] dark:hover:bg-[#3d3d3d] cursor-pointer transition-colors"
                               >
                                 <ThreeDots className="fill-iconLight dark:fill-iconDark" />
@@ -1684,6 +1685,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                         </button>
                         <button
                           onClick={() => downloadAttachment(attachment)}
+                          aria-label="Download attachment"
                           className="flex cursor-pointer items-center gap-1 rounded-[5px] px-1.5 py-1 text-sm"
                         >
                           <HardDriveDownload className="text-muted-foreground dark:text-muted-foreground h-4 w-4 fill-[#FAFAFA] dark:fill-[#262626]" />

--- a/apps/email/client/components/mail/mail-list.tsx
+++ b/apps/email/client/components/mail/mail-list.tsx
@@ -488,7 +488,7 @@ const Thread = memo(
                     {isFolderSent ? (
                       <p
                         className={cn(
-                          'mt-1 line-clamp-1 max-w-[50ch] overflow-hidden text-sm text-[#8C8C8C] md:max-w-[25ch]',
+                          'mt-1 line-clamp-1 max-w-[50ch] overflow-hidden text-sm text-muted-foreground dark:text-[#8C8C8C] md:max-w-[25ch]',
                         )}
                       >
                         {latestMessage.to.map((e) => e.email).join(', ')}
@@ -496,7 +496,7 @@ const Thread = memo(
                     ) : (
                       <p
                         className={cn(
-                          'mt-1 line-clamp-1 w-[95%] min-w-0 overflow-hidden text-sm text-[#8C8C8C]',
+                          'mt-1 line-clamp-1 w-[95%] min-w-0 overflow-hidden text-sm text-muted-foreground dark:text-[#8C8C8C]',
                         )}
                       >
                         {highlightText(latestMessage.subject, searchValue.highlight)}
@@ -691,7 +691,7 @@ const Draft = memo(({ message, index }: { message: DraftListRow; index: number }
               <div className="flex justify-between">
                 <p
                   className={cn(
-                    'mt-1 line-clamp-1 max-w-[50ch] text-sm text-[#8C8C8C] md:max-w-[30ch]',
+                    'mt-1 line-clamp-1 max-w-[50ch] text-sm text-muted-foreground dark:text-[#8C8C8C] md:max-w-[30ch]',
                   )}
                 >
                   {message.subject}

--- a/apps/email/client/components/mail/mail-list.tsx
+++ b/apps/email/client/components/mail/mail-list.tsx
@@ -1044,7 +1044,7 @@ export const MailList = memo(
           type="button"
           onClick={openCompose}
           aria-label={m['common.commandPalette.commands.newEmail']()}
-          className="fixed bottom-6 right-4 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-[#006FFE] text-white shadow-lg transition-colors hover:bg-[#0056CC] md:hidden"
+          className="fixed bottom-6 right-4 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-[#006FFE] text-white shadow-lg transition-colors hover:bg-[#0056CC] lg:hidden"
         >
           <PencilCompose className="h-5 w-5 fill-white" />
         </button>

--- a/apps/email/client/components/mail/mail-list.tsx
+++ b/apps/email/client/components/mail/mail-list.tsx
@@ -261,6 +261,11 @@ const Thread = memo(
                   <Button
                     variant="ghost"
                     size="icon"
+                    aria-label={
+                      displayStarred
+                        ? m['common.threadDisplay.unstar']()
+                        : m['common.threadDisplay.star']()
+                    }
                     className="h-6 w-6 overflow-visible [&_svg]:size-3.5"
                     onClick={handleToggleStar}
                   >
@@ -288,6 +293,7 @@ const Thread = memo(
                   <Button
                     variant="ghost"
                     size="icon"
+                    aria-label={m['common.mail.toggleImportant']()}
                     className={cn(
                       'h-6 w-6 [&_svg]:size-3.5',
                       displayImportant ? 'hover:bg-orange-200/70 dark:hover:bg-orange-800/40' : '',
@@ -311,6 +317,7 @@ const Thread = memo(
                   <Button
                     variant="ghost"
                     size="icon"
+                    aria-label={m['common.threadDisplay.archive']()}
                     className="h-6 w-6 [&_svg]:size-3.5"
                     onClick={(e) => {
                       e.stopPropagation();
@@ -333,6 +340,7 @@ const Thread = memo(
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label={m['common.actions.Bin']()}
                       className="h-6 w-6 hover:bg-[#FDE4E9] dark:hover:bg-[#411D23] [&_svg]:size-3.5"
                       onClick={(e: React.MouseEvent) => {
                         e.stopPropagation();
@@ -476,7 +484,11 @@ const Thread = memo(
                     {latestMessage.receivedOn ? (
                       <p
                         className={cn(
-                          'text-muted-foreground text-nowrap text-xs font-normal opacity-70 transition-opacity group-hover:opacity-100 dark:text-[#8C8C8C]',
+                          // opacity-70 dropped: at rest (not hovered/selected) it dimmed
+                          // text-muted-foreground below 4.5:1 against both panel
+                          // backgrounds (~2.7:1 light, ~4.0:1 dark) - the base
+                          // token alone already clears 4.5:1 in both themes.
+                          'text-muted-foreground text-nowrap text-xs font-normal dark:text-[#8C8C8C]',
                           isMailSelected && 'opacity-100',
                         )}
                       >
@@ -681,7 +693,11 @@ const Draft = memo(({ message, index }: { message: DraftListRow; index: number }
                 {dateMs != null && (
                   <p
                     className={cn(
-                      'text-muted-foreground text-nowrap text-xs font-normal opacity-70 transition-opacity group-hover:opacity-100 dark:text-[#8C8C8C]',
+                      // opacity-70 dropped: at rest (not hovered/selected) it dimmed
+                      // text-muted-foreground below 4.5:1 against both panel
+                      // backgrounds (~2.7:1 light, ~4.0:1 dark) - the base
+                      // token alone already clears 4.5:1 in both themes.
+                      'text-muted-foreground text-nowrap text-xs font-normal dark:text-[#8C8C8C]',
                     )}
                   >
                     {formatDate(dateMs)}

--- a/apps/email/client/components/mail/mail-list.tsx
+++ b/apps/email/client/components/mail/mail-list.tsx
@@ -44,6 +44,7 @@ import { Button } from '../ui/button';
 import { Avatar } from '../ui/avatar';
 import { useQueryState } from 'nuqs';
 import { useAtom } from 'jotai';
+import { CreateEmail } from '../create/create-email';
 
 const Thread = memo(
   function Thread({
@@ -715,6 +716,23 @@ export const MailList = memo(
     const [searchValue, setSearchValue] = useSearchValue();
     const [anchorIndex, setAnchorIndex] = useState<number | null>(null);
 
+    // Mobile compose FAB - the "New email" trigger otherwise lives inside the
+    // sidebar, which on mobile is a Sheet that's unmounted (not just hidden)
+    // while closed. That was 2 taps to compose (open drawer, then New email).
+    // Query-state is shared/URL-synced (nuqs) with the sidebar's own trigger,
+    // so setting it here opens the exact same compose dialog.
+    const [isComposeOpen, setComposeOpen] = useQueryState('isComposeOpen');
+    const [, setComposeTo] = useQueryState('to');
+    const [, setComposeReplyId] = useQueryState('activeReplyId');
+    const [, setComposeMode] = useQueryState('mode');
+    const openCompose = useCallback(() => {
+      setComposeOpen('true');
+      setDraftId(null);
+      setComposeTo(null);
+      setComposeReplyId(null);
+      setComposeMode(null);
+    }, [setComposeOpen, setDraftId, setComposeTo, setComposeReplyId, setComposeMode]);
+
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
         if (event.key === 'Escape') {
@@ -1016,6 +1034,21 @@ export const MailList = memo(
             <div className="h-2" />
           )}
         </div>
+
+        {/* Mobile compose FAB - see the hook comment above for why this
+            can't just reuse the sidebar's trigger. CreateEmail wraps its own
+            Dialog keyed off the same isComposeOpen query state, so mounting
+            it here is enough for the dialog to actually open - no separate
+            Dialog/DialogTrigger needed on this end. */}
+        <button
+          type="button"
+          onClick={openCompose}
+          aria-label={m['common.commandPalette.commands.newEmail']()}
+          className="fixed bottom-6 right-4 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-[#006FFE] text-white shadow-lg transition-colors hover:bg-[#0056CC] md:hidden"
+        >
+          <PencilCompose className="h-5 w-5 fill-white" />
+        </button>
+        {isComposeOpen === 'true' && <CreateEmail />}
       </>
     );
   },

--- a/apps/email/client/components/mail/mail.tsx
+++ b/apps/email/client/components/mail/mail.tsx
@@ -514,6 +514,7 @@ export function MailLayout() {
                     onClick={handleRefetchThreads}
                     variant="ghost"
                     size="icon"
+                    aria-label={m['common.actions.refresh']()}
                     className="border-none bg-transparent hover:bg-accent/50 h-10 w-10 rounded-lg backdrop-blur-sm"
                   >
                     <RefreshCcw className="text-muted-foreground h-4 w-4" />

--- a/apps/email/client/components/mail/mail.tsx
+++ b/apps/email/client/components/mail/mail.tsx
@@ -637,7 +637,10 @@ export const Categories = () => {
             />
           ),
           colors:
-            'border-0 bg-[#006FFE] text-white dark:bg-[#006FFE] dark:text-white dark:hover:bg-[#006FFE]/90',
+            // #006FFE with white text is ~4.46:1, just under the 4.5:1 text
+            // minimum - darkened to #0062D4 (still the same brand blue family,
+            // ~5.7:1) so white text passes in both themes.
+            'border-0 bg-[#0062D4] text-white dark:bg-[#0062D4] dark:text-white dark:hover:bg-[#0062D4]/90',
         };
       case 'Personal':
         return {

--- a/apps/email/client/components/mail/note-panel.tsx
+++ b/apps/email/client/components/mail/note-panel.tsx
@@ -124,7 +124,7 @@ function SortableNote({
             {note.content}
           </p>
 
-          <div className="mt-2 flex cursor-default items-center text-xs text-[#8C8C8C]">
+          <div className="mt-2 flex cursor-default items-center text-xs text-muted-foreground dark:text-[#8C8C8C]">
             <Clock className="mr-1 h-3 w-3" />
             <span>{formatRelativeTime(note.createdAt)}</span>
           </div>
@@ -579,7 +579,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
                       <p className="text-sm text-black dark:text-white/90">
                         {m['common.notes.empty']()}
                       </p>
-                      <p className="mb-4 mt-1 max-w-[80%] text-xs text-[#8C8C8C]">
+                      <p className="mb-4 mt-1 max-w-[80%] text-xs text-muted-foreground dark:text-[#8C8C8C]">
                         {m['common.notes.emptyDescription']()}
                       </p>
                       <Button
@@ -696,7 +696,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
 
                             <div className="mt-2 flex flex-wrap items-center justify-between gap-y-2 px-3 py-2">
                               <div className="flex items-center gap-2">
-                                <span className="text-xs text-[#8C8C8C]">
+                                <span className="text-xs text-muted-foreground dark:text-[#8C8C8C]">
                                   {m['common.notes.label']()}
                                 </span>
                                 <div className="flex flex-wrap gap-1.5">
@@ -737,7 +737,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
                               <Button
                                 variant="ghost"
                                 size="xs"
-                                className="text-[#8C8C8C] hover:bg-white/10 hover:text-[#a0a0a0]"
+                                className="text-muted-foreground dark:text-[#8C8C8C] hover:bg-white/10 hover:text-[#a0a0a0]"
                                 onClick={() => {
                                   setIsAddingNewNote(false);
                                   setNewNoteContent('');
@@ -790,7 +790,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
             {editingNoteId && (
               <div className="dark:bg-panelDark border-t border-[#E7E7E7] bg-[#FAFAFA] p-3 dark:border-[#252525]">
                 <div className="space-y-2">
-                  <div className="mb-1 text-xs font-medium text-[#8C8C8C]">
+                  <div className="mb-1 text-xs font-medium text-muted-foreground dark:text-[#8C8C8C]">
                     {m['common.notes.editNote']()}:
                   </div>
                   <Textarea
@@ -806,7 +806,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
                     <Button
                       variant="ghost"
                       size="xs"
-                      className="text-[#8C8C8C] hover:bg-white/10 hover:text-[#a0a0a0]"
+                      className="text-muted-foreground dark:text-[#8C8C8C] hover:bg-white/10 hover:text-[#a0a0a0]"
                       onClick={() => {
                         setEditingNoteId(null);
                         setEditContent('');

--- a/apps/email/client/components/mail/render-labels.tsx
+++ b/apps/email/client/components/mail/render-labels.tsx
@@ -51,7 +51,7 @@ export const RenderLabels = ({ count = 1, labels }: { count?: number; labels: La
       {hiddenLabels.length > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-+            <button type="button" className="text-foreground dark:bg-subtleBlack bg-subtleWhite inline-block overflow-hidden truncate rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer">
+            <button type="button" className="text-foreground dark:bg-subtleBlack bg-subtleWhite inline-block overflow-hidden truncate rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer">
               +{hiddenLabels.length}
             </button>
           </TooltipTrigger>

--- a/apps/email/client/components/mail/thread-display.tsx
+++ b/apps/email/client/components/mail/thread-display.tsx
@@ -782,6 +782,7 @@ export function ThreadDisplay() {
                     <TooltipTrigger asChild>
                       <button
                         onClick={handleClose}
+                        aria-label={m['common.actions.close']()}
                         className="inline-flex h-7 w-7 items-center justify-center gap-1 overflow-hidden rounded-md hover:bg-white md:hidden dark:hover:bg-[#313131]"
                       >
                         <X className="fill-iconLight dark:fill-iconDark h-3.5 w-3.5" />
@@ -825,6 +826,11 @@ export function ThreadDisplay() {
                     <TooltipTrigger asChild>
                       <button
                         onClick={handleToggleStar}
+                        aria-label={
+                          isStarred
+                            ? m['common.threadDisplay.unstar']()
+                            : m['common.threadDisplay.star']()
+                        }
                         className="inline-flex h-7 w-7 items-center justify-center gap-1 overflow-hidden rounded-lg bg-white dark:bg-[#313131] hover:bg-gray-100 dark:hover:bg-[#404040] transition-colors cursor-pointer"
                       >
                         <Star
@@ -850,6 +856,7 @@ export function ThreadDisplay() {
                     <TooltipTrigger asChild>
                       <button
                         onClick={() => moveThreadTo('archive')}
+                        aria-label={m['common.threadDisplay.archive']()}
                         className="inline-flex h-7 w-7 items-center justify-center gap-1 overflow-hidden rounded-lg bg-white dark:bg-[#313131] hover:bg-gray-100 dark:hover:bg-[#404040] transition-colors cursor-pointer"
                       >
                         <Archive className="fill-iconLight dark:fill-iconDark" />
@@ -867,6 +874,7 @@ export function ThreadDisplay() {
                       <TooltipTrigger asChild>
                         <button
                           onClick={() => moveThreadTo('bin')}
+                          aria-label={m['common.mail.moveToBin']()}
                           className="inline-flex h-7 w-7 items-center justify-center gap-1 overflow-hidden rounded-lg border border-[#FCCDD5] bg-[#FDE4E9] hover:bg-[#fccdd5]/70 dark:border-[#6E2532] dark:bg-[#411D23] dark:hover:bg-[#6E2532]/70 cursor-pointer transition-colors"
                         >
                           <Trash className="fill-[#F43F5E]" />

--- a/apps/email/client/components/mail/thread-display.tsx
+++ b/apps/email/client/components/mail/thread-display.tsx
@@ -799,17 +799,21 @@ export function ThreadDisplay() {
                   className="hidden md:flex"
                 />
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 overflow-x-auto">
+                {/* Text label only from md up - this row has no wrap/scroll,
+                    and the label was the one item wide enough to push the
+                    "..." menu off the right edge on a phone-width screen. */}
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
                     setMode('replyAll');
                     setActiveReplyId(emailData?.latest?.id ?? '');
                   }}
+                  title={m['common.threadDisplay.replyAll']()}
                   className="inline-flex h-7 items-center justify-center gap-1 overflow-hidden rounded-lg border bg-white px-1.5 dark:border-none dark:bg-[#313131] hover:bg-gray-100 dark:hover:bg-[#404040] transition-colors cursor-pointer"
                 >
                   <Reply className="fill-muted-foreground dark:fill-[#9B9B9B]" />
-                  <div className="flex items-center justify-center gap-2.5 pl-0.5 pr-1">
+                  <div className="hidden items-center justify-center gap-2.5 pl-0.5 pr-1 md:flex">
                     <div className="justify-start whitespace-nowrap text-sm leading-none text-black dark:text-white">
                       {m['common.threadDisplay.replyAll']()}
                     </div>

--- a/apps/email/client/components/ui/app-sidebar.tsx
+++ b/apps/email/client/components/ui/app-sidebar.tsx
@@ -150,7 +150,14 @@ function ComposeButton() {
       <DialogDescription></DialogDescription>
 
       <DialogTrigger asChild>
-        <button type="button" className="relative mb-1.5 inline-flex h-8 w-full items-center justify-center gap-1 self-stretch overflow-hidden rounded-lg border border-gray-200 bg-[#006FFE] text-black dark:border-none dark:text-white cursor-pointer hover:bg-[#0056CC] dark:hover:bg-[#0056CC] transition-colors">
+        {/* Light mode: black text on #006FFE is ~4.7:1, fine. Dark mode: white
+            text on the same blue is ~4.46:1, just under 4.5:1 - dark:bg
+            overrides to #0062D4 (~5.7:1) so the white text passes too. */}
+        <button
+          type="button"
+          aria-label={m['common.commandPalette.commands.newEmail']()}
+          className="relative mb-1.5 inline-flex h-8 w-full items-center justify-center gap-1 self-stretch overflow-hidden rounded-lg border border-gray-200 bg-[#006FFE] text-black dark:border-none dark:bg-[#0062D4] dark:text-white cursor-pointer hover:bg-[#0056CC] dark:hover:bg-[#0056CC] transition-colors"
+        >
           {state === 'collapsed' && !isMobile ? (
             <PencilCompose className="mt-0.5 fill-white text-black" />
           ) : (

--- a/apps/email/client/components/ui/nav-main.tsx
+++ b/apps/email/client/components/ui/nav-main.tsx
@@ -228,6 +228,7 @@ export function NavMain({ items }: NavMainProps) {
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label={m['common.threadDisplay.addLabel']()}
                       className="mr-1 h-4 w-4 p-0 hover:bg-transparent"
                     >
                       <Plus className="text-muted-foreground h-3 w-3 dark:text-[#898989]" />

--- a/apps/email/client/components/ui/nav-main.tsx
+++ b/apps/email/client/components/ui/nav-main.tsx
@@ -1,5 +1,4 @@
 import { SidebarGroup, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from './sidebar';
-import { Collapsible, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { useCommandPalette } from '../context/command-palette-context.js';
 import { LabelDialog } from '@/components/labels/label-dialog';
 import { useActiveConnection } from '@/hooks/use-connections';
@@ -174,46 +173,41 @@ export function NavMain({ items }: NavMainProps) {
     <SidebarGroup className={`${state !== 'collapsed' ? '' : 'mt-1'} space-y-2.5 py-0 md:px-0`}>
       <SidebarMenu>
         {isBottomNav ? (
-          <NavItem
-            key={'feedback'}
-            isActive={isUrlActive('https://github.com/oblien/openship/issues')}
-            href={'https://github.com/oblien/openship/issues'}
-            url={'https://github.com/oblien/openship/issues'}
-            icon={MessageSquare}
-            target={'_blank'}
-            title={m['navigation.sidebar.feedback']()}
-          />
+          <SidebarMenuItem key={'feedback'}>
+            <NavItem
+              isActive={isUrlActive('https://github.com/oblien/openship/issues')}
+              href={'https://github.com/oblien/openship/issues'}
+              url={'https://github.com/oblien/openship/issues'}
+              icon={MessageSquare}
+              target={'_blank'}
+              title={m['navigation.sidebar.feedback']()}
+            />
+          </SidebarMenuItem>
         ) : null}
         {items.map((section) => (
-          <Collapsible
-            key={section.title}
-            defaultOpen={section.isActive}
-            className="group/collapsible"
-          >
-            <SidebarMenuItem>
-              {state !== 'collapsed' ? (
-                section.title ? (
-                  <p className="text-muted-foreground mx-2 mb-2 text-[13px] dark:text-[#898989]">
-                    {section.title}
-                  </p>
-                ) : null
-              ) : (
-                <div className="bg-muted-foreground/50 mx-2 mb-4 mt-2 h-[0.5px] dark:bg-[#262626]" />
-              )}
-              <div className="z-20 space-y-1 pb-2">
-                {section.items.map((item) => (
-                  <NavItem
-                    key={item.url}
-                    {...item}
-                    isActive={isUrlActive(item.url)}
-                    href={getHref(item)}
-                    target={item.target}
-                    title={item.title}
-                  />
-                ))}
-              </div>
-            </SidebarMenuItem>
-          </Collapsible>
+          <SidebarMenuItem key={section.title}>
+            {state !== 'collapsed' ? (
+              section.title ? (
+                <p className="text-muted-foreground mx-2 mb-2 text-[13px] dark:text-[#898989]">
+                  {section.title}
+                </p>
+              ) : null
+            ) : (
+              <div className="bg-muted-foreground/50 mx-2 mb-4 mt-2 h-[0.5px] dark:bg-[#262626]" />
+            )}
+            <div className="z-20 space-y-1 pb-2">
+              {section.items.map((item) => (
+                <NavItem
+                  key={item.url}
+                  {...item}
+                  isActive={isUrlActive(item.url)}
+                  href={getHref(item)}
+                  target={item.target}
+                  title={item.title}
+                />
+              ))}
+            </div>
+          </SidebarMenuItem>
         ))}
         {!pathname.includes('/settings') &&
           !isBottomNav &&
@@ -223,31 +217,29 @@ export function NavMain({ items }: NavMainProps) {
           // something to show - otherwise this was rendering a "Folders"
           // header over a permanently empty body.
           (userLabels.length > 0 || activeAccount?.providerId === 'google') && (
-          <Collapsible defaultOpen={true} className="group/collapsible flex-col">
-            <SidebarMenuItem className="mb-4" style={{ height: 'auto' }}>
-              <div className="mx-2 mb-4 flex items-center justify-between">
-                <span className="text-muted-foreground text-[13px] dark:text-[#898989]">
-                  {activeAccount?.providerId === 'google' ? 'Labels' : 'Folders'}
-                </span>
-                {activeAccount?.providerId === 'google' ? (
-                  <LabelDialog
-                    trigger={
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="mr-1 h-4 w-4 p-0 hover:bg-transparent"
-                      >
-                        <Plus className="text-muted-foreground h-3 w-3 dark:text-[#898989]" />
-                      </Button>
-                    }
-                    onSubmit={onSubmit}
-                  />
-                ) : activeAccount?.providerId === 'microsoft' ? null : null}
-              </div>
+          <SidebarMenuItem className="mb-4 flex-col" style={{ height: 'auto' }}>
+            <div className="mx-2 mb-4 flex items-center justify-between">
+              <span className="text-muted-foreground text-[13px] dark:text-[#898989]">
+                {activeAccount?.providerId === 'google' ? 'Labels' : 'Folders'}
+              </span>
+              {activeAccount?.providerId === 'google' ? (
+                <LabelDialog
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="mr-1 h-4 w-4 p-0 hover:bg-transparent"
+                    >
+                      <Plus className="text-muted-foreground h-3 w-3 dark:text-[#898989]" />
+                    </Button>
+                  }
+                  onSubmit={onSubmit}
+                />
+              ) : activeAccount?.providerId === 'microsoft' ? null : null}
+            </div>
 
-              {activeAccount ? <SidebarLabels data={userLabels ?? []} /> : null}
-            </SidebarMenuItem>
-          </Collapsible>
+            {activeAccount ? <SidebarLabels data={userLabels ?? []} /> : null}
+          </SidebarMenuItem>
         )}
       </SidebarMenu>
     </SidebarGroup>
@@ -282,33 +274,29 @@ function NavItem(item: NavItemProps & { href: string }) {
   };
 
   return (
-    <Collapsible defaultOpen={item.isActive}>
-      <CollapsibleTrigger asChild>
-        <SidebarMenuButton
-          asChild
-          tooltip={state === 'collapsed' ? item.title : undefined}
-          className={cn(
-            'hover:bg-subtleWhite flex items-center dark:hover:bg-[#202020]',
-            item.isActive && 'bg-subtleWhite text-accent-foreground dark:bg-[#202020]',
+    <SidebarMenuButton
+      asChild
+      tooltip={state === 'collapsed' ? item.title : undefined}
+      className={cn(
+        'hover:bg-subtleWhite flex items-center dark:hover:bg-[#202020]',
+        item.isActive && 'bg-subtleWhite text-accent-foreground dark:bg-[#202020]',
+      )}
+      onClick={handleClick}
+    >
+      <Link target={item.target} to={item.href}>
+        {item.icon && <item.icon ref={iconRef} className="mr-2 shrink-0" />}
+        <p className="relative bottom-px mt-0.5 min-w-0 flex-1 truncate text-[13px]">
+          {item.title}
+        </p>
+        {stats &&
+          stats.some((stat) => stat.label?.toLowerCase() === item.id?.toLowerCase()) && (
+            <Badge className="text-muted-foreground ml-auto shrink-0 rounded-full border-none bg-transparent">
+              {stats
+                .find((stat) => stat.label?.toLowerCase() === item.id?.toLowerCase())
+                ?.count?.toLocaleString() || '0'}
+            </Badge>
           )}
-          onClick={handleClick}
-        >
-          <Link target={item.target} to={item.href}>
-            {item.icon && <item.icon ref={iconRef} className="mr-2 shrink-0" />}
-            <p className="relative bottom-px mt-0.5 min-w-0 flex-1 truncate text-[13px]">
-              {item.title}
-            </p>
-            {stats &&
-              stats.some((stat) => stat.label?.toLowerCase() === item.id?.toLowerCase()) && (
-                <Badge className="text-muted-foreground ml-auto shrink-0 rounded-full border-none bg-transparent">
-                  {stats
-                    .find((stat) => stat.label?.toLowerCase() === item.id?.toLowerCase())
-                    ?.count?.toLocaleString() || '0'}
-                </Badge>
-              )}
-          </Link>
-        </SidebarMenuButton>
-      </CollapsibleTrigger>
-    </Collapsible>
+      </Link>
+    </SidebarMenuButton>
   );
 }

--- a/apps/email/client/components/ui/nav-main.tsx
+++ b/apps/email/client/components/ui/nav-main.tsx
@@ -215,7 +215,14 @@ export function NavMain({ items }: NavMainProps) {
             </SidebarMenuItem>
           </Collapsible>
         ))}
-        {!pathname.includes('/settings') && !isBottomNav && state !== 'collapsed' && (
+        {!pathname.includes('/settings') &&
+          !isBottomNav &&
+          state !== 'collapsed' &&
+          // Google always gets the section (it has an inline "add label"
+          // action even at zero); everyone else only gets it once there's
+          // something to show - otherwise this was rendering a "Folders"
+          // header over a permanently empty body.
+          (userLabels.length > 0 || activeAccount?.providerId === 'google') && (
           <Collapsible defaultOpen={true} className="group/collapsible flex-col">
             <SidebarMenuItem className="mb-4" style={{ height: 'auto' }}>
               <div className="mx-2 mb-4 flex items-center justify-between">

--- a/apps/email/client/components/ui/nav-user.tsx
+++ b/apps/email/client/components/ui/nav-user.tsx
@@ -116,7 +116,11 @@ export function NavUser() {
           activeAccount && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <div className="flex cursor-pointer items-center">
+                <button
+                  type="button"
+                  aria-label={m['common.navUser.accounts']()}
+                  className="flex cursor-pointer items-center"
+                >
                   <div className="relative">
                     <Avatar className="relative left-0.5 size-7 rounded-[5px]">
                       <AvatarImage
@@ -135,7 +139,7 @@ export function NavUser() {
                       </AvatarFallback>
                     </Avatar>
                   </div>
-                </div>
+                </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent
                 className="w-(--radix-dropdown-menu-trigger-width) ml-3 min-w-56 bg-white font-medium dark:bg-[#131313]"
@@ -384,7 +388,10 @@ export function NavUser() {
               )}
 
               <AddConnectionDialog>
-                <Button className="hover:bg-offsetLight/80 dark:hover:bg-offsetDark/80 flex h-7 w-7 cursor-pointer items-center justify-center rounded-[5px] border border-dashed bg-transparent px-0 text-black dark:bg-[#262626] dark:text-[#929292]">
+                <Button
+                  aria-label={m['pages.settings.connections.addEmail']()}
+                  className="hover:bg-offsetLight/80 dark:hover:bg-offsetDark/80 flex h-7 w-7 cursor-pointer items-center justify-center rounded-[5px] border border-dashed bg-transparent px-0 text-black dark:bg-[#262626] dark:text-[#929292]"
+                >
                   <Plus className="size-4" />
                 </Button>
               </AddConnectionDialog>
@@ -398,7 +405,11 @@ export function NavUser() {
               )} */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className={cn('md:h-fit md:px-2')}>
+                  <Button
+                    variant="ghost"
+                    aria-label={m['common.threadDisplay.moreOptions']()}
+                    className={cn('md:h-fit md:px-2')}
+                  >
                     <ThreeDots className="fill-iconLight dark:fill-iconDark" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/apps/email/client/components/ui/nav-user.tsx
+++ b/apps/email/client/components/ui/nav-user.tsx
@@ -440,20 +440,36 @@ export function NavUser() {
         )}
       </div>
 
-      {state !== 'collapsed' && (
-        <div className="mt-2 flex items-center justify-between gap-2">
-          <div className="mt-[2px] flex flex-col items-start gap-1 space-y-1">
-            <div className="flex items-center gap-1 text-[13px] leading-none text-black dark:text-white">
-              <p className={cn('max-w-[14.5ch] truncate text-[13px]')}>
-                {activeAccount?.name || session.user.name || 'User'}
-              </p>
+      {state !== 'collapsed' &&
+        (() => {
+          const accountEmail = activeAccount?.email || session.user.email;
+          const displayName = activeAccount?.name || session.user.name;
+          // A mailbox with no display name set falls back to the email for
+          // BOTH the name line and the email line below it - same string
+          // twice, one truncated harder than the other. Show just the one
+          // line when there's nothing besides the email to show.
+          const hasDistinctName =
+            !!displayName && displayName.trim().toLowerCase() !== accountEmail?.trim().toLowerCase();
+          return (
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <div className="mt-[2px] flex flex-col items-start gap-1 space-y-1">
+                {hasDistinctName && (
+                  <div className="flex items-center gap-1 text-[13px] leading-none text-black dark:text-white">
+                    <p className={cn('max-w-[14.5ch] truncate text-[13px]')} title={displayName}>
+                      {displayName}
+                    </p>
+                  </div>
+                )}
+                <div
+                  className="h-5 max-w-[200px] overflow-hidden truncate text-xs font-normal leading-none text-[#898989]"
+                  title={accountEmail}
+                >
+                  {accountEmail}
+                </div>
+              </div>
             </div>
-            <div className="h-5 max-w-[200px] overflow-hidden truncate text-xs font-normal leading-none text-[#898989]">
-              {activeAccount?.email || session.user.email}
-            </div>
-          </div>
-        </div>
-      )}
+          );
+        })()}
     </div>
   );
 }

--- a/apps/email/client/components/ui/prompts-dialog.tsx
+++ b/apps/email/client/components/ui/prompts-dialog.tsx
@@ -132,7 +132,7 @@ export function PromptsDialog() {
         <Tooltip>
           <TooltipTrigger asChild>
             <DialogTrigger asChild>
-              <Button variant="ghost" className="md:h-fit md:px-2">
+              <Button variant="ghost" aria-label="Prompts" className="md:h-fit md:px-2">
                 <Paper className="dark:fill-iconDark fill-iconLight h-3.5 w-3.5" />
               </Button>
             </DialogTrigger>

--- a/apps/email/client/components/ui/sidebar-toggle.tsx
+++ b/apps/email/client/components/ui/sidebar-toggle.tsx
@@ -9,7 +9,12 @@ export function SidebarToggle({ className }: ComponentProps<typeof SidebarTrigge
   const { toggleSidebar } = useSidebar();
 
   return (
-    <Button onClick={toggleSidebar} variant="ghost" className={cn('h-10 w-10 md:px-2', className)}>
+    <Button
+      onClick={toggleSidebar}
+      variant="ghost"
+      aria-label="Toggle Sidebar"
+      className={cn('h-10 w-10 md:px-2', className)}
+    >
       <PanelLeftOpen className="dark:fill-iconDark fill-iconLight" />
     </Button>
   );

--- a/apps/email/client/lib/backend-url.ts
+++ b/apps/email/client/lib/backend-url.ts
@@ -42,6 +42,26 @@ export function getTrpcUrl(): string {
 }
 
 /**
+ * Origin to redirect TO (login, inbox, compose, etc.) from a clientLoader.
+ * These loaders only ever run in the browser (this app is SPA-mode, no
+ * SSR), so `window` is always available here - no build-time env needed,
+ * no risk of baking in a dev default. Same reasoning as getBackendUrl,
+ * just for outbound navigation instead of API calls.
+ *
+ * `VITE_PUBLIC_APP_URL` used to be read directly at each redirect call
+ * site. When unset it silently became the literal string "undefined" in
+ * the built bundle (a relative-looking path that happened to still land
+ * on the right origin); when a dev default WAS present at build time
+ * (`.env.development`'s `http://localhost:3000`), a self-hosted release
+ * build baked that in as an absolute URL and redirected real users to
+ * localhost. This sidesteps the env dependency entirely.
+ */
+export function getAppUrl(): string {
+  if (isBrowser()) return window.location.origin;
+  return '';
+}
+
+/**
  * Legacy const exports - module-load-time values. Browser builds get the
  * runtime origin; SSR/Node builds get '' (or the dev override). New code
  * should call the getter functions above so a same-page navigation can't

--- a/apps/email/client/providers/query-provider.tsx
+++ b/apps/email/client/providers/query-provider.tsx
@@ -134,6 +134,14 @@ export function QueryProvider({
         // and connection data are slow-changing and safe to persist.
         dehydrateOptions: {
           shouldDehydrateQuery: (query) => {
+            // Match the library default (only persist settled/successful
+            // queries). Without this, a query that's still pending when the
+            // debounced persist fires gets dehydrated with its live in-flight
+            // `promise` attached (see dehydrateQuery in @tanstack/query-core),
+            // and idb-keyval's IndexedDB put() throws a DataCloneError trying
+            // to structured-clone that Promise - surfacing as a generic
+            // "Uncaught (in promise)" console error on nearly every persist.
+            if (query.state.status !== 'success') return false;
             const head = query.queryKey?.[0];
             const path = Array.isArray(head) ? head : [];
             const root = typeof path[0] === 'string' ? path[0] : '';


### PR DESCRIPTION
A batch of small, independent a11y and correctness fixes to the webmail client, verified live via a headless login + screenshot pass at 1280px and 390px before/after each change.

## Mobile / correctness
- Compose FAB: a floating action button on mobile mail-list views opens the same compose dialog. Previously only reachable through the sidebar, which on mobile is a Sheet that unmounts (not just hides) while closed - 2 taps to compose. Hidden on desktop (`lg:hidden`) to avoid overlapping the sidebar's own persistent "New email" trigger.
- Thread toolbar: Reply-all drops its text label below `md` and the action row gets `overflow-x-auto` - the label was the one item wide enough to push the "..." menu off the right edge on a phone-width screen.
- Fixed a bare `0` rendering next to the subject on a single-message thread: `totalEmails && totalEmails > 1 && ...` - `0 && x` evaluates to `0`, and unlike `false`/`null`/`undefined`, React renders a numeric `0` as text. Switched to a ternary.
- Sidebar Folders/Labels section: hidden when there are no folders instead of showing a permanently empty section header.
- Sidebar account block: was showing the account email twice (once as the name-line fallback, once as the email line) for a mailbox with no display name set.
- Compose subject placeholder: `"Re: Design review feedback"` -> `"Subject"`.
- Hardened redirect URLs against being baked in at build time (`getAppUrl()` now reads `window.location.origin` at runtime consistently across all redirect call sites) - the client is an SPA served same-origin, so there's no reason a redirect should ever reference a build-time value.
- Removed a stray literal `+` character sitting before a `<button>` tag in `render-labels.tsx` (pre-existing, not introduced by this PR) - valid JSX syntax so it doesn't break the build, but it gives a `TooltipTrigger asChild` two children instead of one, which Radix's `Slot` (`React.Children.only`) will throw on at runtime for any label with a visible tooltip.

## Accessibility (Lighthouse-driven)
- Removed a dead Radix `Collapsible` wrapper around sidebar nav items that never had a matching `CollapsibleContent` - left a dangling `aria-controls` reference (`aria-valid-attr-value`) and put a non-`<li>` wrapper directly inside `<ul data-sidebar="menu">` (invalid list semantics, `aria-required-children`).
- Added a `<main>` landmark around the mail app's primary content region.
- `aria-allowed-attr`: two `*Trigger asChild` sites were injecting `type="button"`/`aria-haspopup` onto bare `<div>`s with no interactive role - invalid. Converted to real `<button>`s.
- `button-name`: added `aria-label` to icon-only buttons across the mail list, thread view, sidebar, and composer (mostly reusing existing tooltip copy).
- Contrast: unscoped `text-[#8C8C8C]` (fails ~3.36:1 on light backgrounds) now falls back through `text-muted-foreground` with `dark:text-[#8C8C8C]` for the dark-mode accent. Darkened the `#006FFE` brand blue to `#0062D4` for the two buttons pairing it with white text (was ~4.46:1, just under the 4.5:1 minimum). Dropped an `opacity-70` utility on list-row timestamps that diluted `text-muted-foreground` below 4.5:1 at rest in both themes (full opacity only kicked in on hover/select).
- Fixed a real bug found while investigating a recurring `Uncaught (in promise)` console error (12-17x per session): the IndexedDB query-persister's `shouldDehydrateQuery` had dropped TanStack Query's default "only persist settled queries" check. In-flight queries still carry a live `Promise` field when dehydrated, which `IndexedDB`'s structured-clone `put()` cannot serialize - throwing `DataCloneError` on nearly every persist right after login. Restored the missing status check.

## Note on CI

Recent merged PRs against `main` (#322, #327) show `Typecheck: SUCCESS` / `Test: FAILURE` on their PR-context runs. Flagging in case it reproduces here too - doesn't look related to this change.