### PR TITLE
fix(api): resolve nested Compose interpolation like ${A:-${B}}

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -484,19 +484,60 @@ function findClosingQuote(value: string, quote: '"' | "'"): number {
   return -1;
 }
 
+const BARE_VARIABLE_RE = /^[A-Za-z_][A-Za-z0-9_]*/;
+
+/**
+ * Reads the `${...}` expression opening at `start`, counting nested `${` so the
+ * matching close brace is found. Returns null when the expression is never closed.
+ */
+function readBracedExpression(
+  input: string,
+  start: number,
+): { expression: string; end: number } | null {
+  let depth = 1;
+  for (let i = start + 2; i < input.length; i++) {
+    if (input[i] === "$" && input[i + 1] === "{") {
+      depth++;
+      i++;
+    } else if (input[i] === "}" && --depth === 0) {
+      return { expression: input.slice(start + 2, i), end: i + 1 };
+    }
+  }
+  return null;
+}
+
 function interpolateComposeString(input: string, env: Record<string, string>): string {
   const escapedDollar = "\0COMPOSE_ESCAPED_DOLLAR\0";
   const protectedInput = input.replace(/\$\$/g, escapedDollar);
 
-  return protectedInput
-    .replace(
-      /\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
-      (_match, braced: string | undefined, bare: string | undefined) =>
-        braced !== undefined
-          ? resolveInterpolationExpression(braced, env).value
-          : (env[bare!] ?? ""),
-    )
-    .replaceAll(escapedDollar, "$");
+  let out = "";
+  let cursor = 0;
+  while (cursor < protectedInput.length) {
+    const dollar = protectedInput.indexOf("$", cursor);
+    if (dollar < 0) break;
+    out += protectedInput.slice(cursor, dollar);
+    cursor = dollar + 1;
+
+    if (protectedInput[dollar + 1] === "{") {
+      const braced = readBracedExpression(protectedInput, dollar);
+      if (braced && braced.expression) {
+        out += resolveInterpolationExpression(braced.expression, env).value;
+        cursor = braced.end;
+        continue;
+      }
+    } else {
+      const bare = protectedInput.slice(dollar + 1).match(BARE_VARIABLE_RE);
+      if (bare) {
+        out += env[bare[0]] ?? "";
+        cursor = dollar + 1 + bare[0].length;
+        continue;
+      }
+    }
+
+    out += "$";
+  }
+
+  return (out + protectedInput.slice(cursor)).replaceAll(escapedDollar, "$");
 }
 
 function resolveComposeValue(
@@ -504,9 +545,9 @@ function resolveComposeValue(
   env: Record<string, string>,
 ): { value: string; meta?: ComposeEnvironmentMeta } {
   const trimmed = input.trim();
-  const directBraced = trimmed.match(/^\$\{([^}]+)\}$/s);
-  if (directBraced) {
-    const resolved = resolveInterpolationExpression(directBraced[1]!, env);
+  const directBraced = trimmed.startsWith("${") ? readBracedExpression(trimmed, 0) : null;
+  if (directBraced?.expression && directBraced.end === trimmed.length) {
+    const resolved = resolveInterpolationExpression(directBraced.expression, env);
     return {
       value: resolved.value,
       meta: {

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -656,6 +656,67 @@ services:
   });
 });
 
+describe("parseComposeFile - nested interpolation expressions", () => {
+  const env = (expr: string) => `
+services:
+  app:
+    environment:
+      VAL: '${expr}'
+`;
+  const value = (expr: string, envFileContent = "") =>
+    parseComposeFile(env(expr), { envFileContent }).services[0]?.environment.VAL;
+
+  it("uses the variable when it is set, without leaking the nested closing brace", () => {
+    expect(value("${SET:-${OTHER}}", "SET=sv\nOTHER=ov\n")).toBe("sv");
+  });
+
+  it("resolves a nested default instead of emitting it literally", () => {
+    expect(value("${MISSING:-${OTHER}}", "OTHER=ov\n")).toBe("ov");
+    expect(value("${EMPTY:-${OTHER}}", "EMPTY=\nOTHER=ov\n")).toBe("ov");
+    expect(value("${MISSING-${OTHER}}", "OTHER=ov\n")).toBe("ov");
+    expect(value("${EMPTY-${OTHER}}", "EMPTY=\nOTHER=ov\n")).toBe("");
+  });
+
+  it("resolves a nested alternate for the :+ and + operators", () => {
+    expect(value("${SET:+${OTHER}}", "SET=sv\nOTHER=ov\n")).toBe("ov");
+    expect(value("${MISSING:+${OTHER}}", "OTHER=ov\n")).toBe("");
+  });
+
+  it("resolves defaults nested more than one level deep", () => {
+    expect(value("${A:-${B:-${C}}}", "C=cv\n")).toBe("cv");
+    expect(value("${A:-${B:-${C}}}", "B=bv\nC=cv\n")).toBe("bv");
+    expect(value("${A:-${B:-fallback}}")).toBe("fallback");
+  });
+
+  it("resolves nested expressions embedded in a larger string", () => {
+    expect(value("pre-${MISSING:-${OTHER}}-post", "OTHER=ov\n")).toBe("pre-ov-post");
+    expect(value("${A:-${X}}/${B:-${Y}}", "X=xv\nY=yv\n")).toBe("xv/yv");
+    expect(value("${MISSING:-${OTHER}/sub}", "OTHER=ov\n")).toBe("ov/sub");
+  });
+
+  it("treats a bare '{' in a default as a literal, not a nesting level", () => {
+    expect(value("${A:-{literal}}")).toBe("{literal}");
+    expect(value("${A:-x}y}")).toBe("xy}");
+    expect(value("${A:-}}")).toBe("}");
+  });
+
+  it("interpolates a nested variable inside a :? message", () => {
+    expect(() => parseComposeFile(env("${A:?need ${B}}"), { envFileContent: "B=bv\n" })).toThrow(
+      "need bv",
+    );
+  });
+
+  it("reports the outer variable in environmentMeta for a nested default", () => {
+    const parsed = parseComposeFile(env("${MISSING:-${OTHER}}"), { envFileContent: "OTHER=ov\n" });
+    expect(parsed.services[0]?.environmentMeta?.VAL).toMatchObject({
+      source: "default",
+      variable: "MISSING",
+      defaultValue: "ov",
+      resolvedValue: "ov",
+    });
+  });
+});
+
 // #333: an uploaded compose file's own limits were parsed nowhere and silently
 // dropped — a service asking for 4 GB got whatever the project was set to.
 describe("parseComposeFile — service resource limits", () => {


### PR DESCRIPTION
## Summary

The Compose interpolation scanner is not brace-aware, so a variable whose default or
alternate contains another `${...}` is cut at the first `}` — the value either carries a
stray `}` or ships the literal string `${OTHER}` into the container environment. This
replaces the regex scan with a balanced-brace reader.

## Motivation

Measured against the real `docker compose` binary (Docker 29.6.1 / Compose 5.2.0) by
writing the same `compose.yaml` and `.env` to disk and running
`docker compose config --format json`:

| `environment:` value | `.env` | `docker compose` | `main` |
|---|---|---|---|
| `${SET:-${OTHER}}` | `SET=sv`, `OTHER=ov` | `sv` | `sv}` |
| `${MISSING:-${OTHER}}` | `OTHER=ov` | `ov` | `${OTHER}` |
| `${EMPTY:-${OTHER}}` | `EMPTY=`, `OTHER=ov` | `ov` | `${OTHER}` |
| `${MISSING-${OTHER}}` | `OTHER=ov` | `ov` | `${OTHER}` |
| `${A:-${B:-${C}}}` | `C=cv` | `cv` | `${B:-${C}}` |
| `${SET:+${OTHER}}` | `SET=sv`, `OTHER=ov` | `ov` | `${OTHER}` |
| `pre-${MISSING:-${OTHER}}-post` | `OTHER=ov` | `pre-ov-post` | `pre-${OTHER}-post` |
| `${MISSING:-${OTHER}/sub}` | `OTHER=ov` | `ov/sub` | `${OTHER/sub}` |
| `${A:?need ${B}}` | `B=bv` | error `need bv` | error `need ${B` |

`${A:-${DEFAULT_REGISTRY}/img}` and `${PORT:-${DEFAULT_PORT}}` are ordinary shapes in
published compose files, so this reaches real uploads rather than being a synthetic edge
case.

**Cause.** `interpolateComposeString` (`apps/api/src/lib/compose-parser.ts:493`) scanned
with `/\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g`. `[^}]+` cannot cross a `}`, so
`${SET:-${OTHER}}` matches only `${SET:-${OTHER}` — the outer expression is truncated
and the surplus `}` falls through as literal text. When the variable is unset, the
truncated default `${OTHER` is not a valid expression either, so it survives verbatim.

`resolveComposeValue` (`:507`) used the same non-brace-aware pattern
(`/^\$\{([^}]+)\}$/s`) to decide whether a value is one whole expression, so a nested
default also lost its `environmentMeta` — reported as `source: "interpolated"` instead of
`source: "default"` with the outer variable name.

## Related issue

None.

## Changes

`apps/api`

- `compose-parser.ts`: new `readBracedExpression(input, start)` walks the string counting
  `${` and returns the expression plus its end offset, or `null` when it is never closed.
  `interpolateComposeString` scans with it instead of the regex.
  `resolveInterpolationExpression` already re-interpolated the default word recursively,
  so nothing about the operators changed — the whole defect was in *finding the matching
  close brace*.
- `compose-parser.ts`: `resolveComposeValue` shares the same reader, restoring the correct
  `environmentMeta` for a nested default.
- `compose-parser.test.ts`: new `parseComposeFile - nested interpolation expressions`
  block, 8 tests.

Deliberate details:

- Only `${` opens a nesting level. A bare `{` stays literal — `${A:-{literal}` resolves
  to `{literal` on `docker compose` and here, and `${A:-{}}` to `{}` on both.
- An unclosed `${` returns `null` and the `$` is emitted verbatim, which is what the
  parser already did for `${A`.
- `$$` protection, bare `$VAR`, and every operator (`-`, `:-`, `+`, `:+`, `?`, `:?`) are
  untouched.

## Verification

**Differential against the real binary.** 70 expressions were run through both
`docker compose config` and this parser, before and after. Cases covered: plain `${A}` /
`$A`; `${A:-d}`, `${A-d}`, `${A:+alt}`, `${A+alt}`, `${A:?err}`, `${A?err}` each across
set / set-empty / unset; `$$` escaping including `$${A}` and `$${A:-${B}}`; adjacent and
embedded expressions; defaults containing `:`, `/`, `{`, `}` and quoted shell text;
unmatched and surplus braces; and nesting one, two and three deep.

| | |
|---|---|
| Accepted by `docker compose` (the other 11 are files it rejects) | **59 of 70** |
| Of those 59, `main` agrees with `docker compose` | **41** |
| Of those 59, this branch agrees with `docker compose` | **58** |
| Cases where `main` agreed and this branch does not | **0** |
| Cases whose output changed at all | **22 of 70** — every one contains a `${` nested inside a `${...}` |

The single accepted case still divergent has nothing to do with braces and is unchanged
by this PR: a `.env` line referencing a key defined later in the same file (`A=${B}` then
`B=bv`). Compose resolves `.env` sequentially and yields `""`; this parser resolves in a
second pass and yields `bv`. Pre-existing on both sides.

On files `docker compose` rejects outright, behaviour shifts but stays lenient rather
than throwing, as before:

| malformed input | `main` | this branch |
|---|---|---|
| `${A:-${B}` | `${B` | `${A:-bv` |
| `${A ${B}` | `` (empty) | `${A bv` |
| `${A ${B}}` | `}` | `` (empty) |

**Regression test proof.** With only `compose-parser.ts` stashed and the new tests kept,
7 of the 8 fail:

```bash
$ git stash push -- apps/api/src/lib/compose-parser.ts
$ cd apps/api && npx vitest run test/lib/compose-parser.test.ts -t "nested interpolation expressions"

FAIL uses the variable when it is set, without leaking the nested closing brace
     AssertionError: expected 'sv}' to be 'sv'
FAIL resolves a nested default instead of emitting it literally
     AssertionError: expected '${OTHER}' to be 'ov'
FAIL resolves a nested alternate for the :+ and + operators
     AssertionError: expected '${OTHER}' to be 'ov'
FAIL resolves defaults nested more than one level deep
     AssertionError: expected '${B:-${C}}' to be 'cv'
FAIL resolves nested expressions embedded in a larger string
     AssertionError: expected 'pre-${OTHER}-post' to be 'pre-ov-post'
FAIL interpolates a nested variable inside a :? message
     AssertionError: expected [Function] to throw error including 'need bv' but got 'need ${B'
FAIL reports the outer variable in environmentMeta for a nested default
     AssertionError: expected { source: 'interpolated', …(2) } to match object { source: 'default', …(3) }

 Tests  7 failed | 1 passed | 63 skipped (71)
```

The 8th (`treats a bare '{' in a default as a literal, not a nesting level`) passes both
ways by design — it pins behaviour the new scanner must not regress.

Restored:

```bash
$ git stash pop
$ cd apps/api && npx vitest run test/lib/compose-parser.test.ts -t "nested interpolation expressions"

 ✓ test/lib/compose-parser.test.ts (71 tests | 63 skipped) 6ms
 Tests  8 passed | 63 skipped (71)
```

**Full suite**, re-measured on pristine `main` at `0e42ccb7` this session
(`bun run test -- --continue --force`):

| workspace | `main` | this branch |
|---|---|---|
| `@repo/api` | 1746 passed / 15 skipped | 1754 passed / 15 skipped |
| `@repo/adapters` | 730 | 730 |
| `@repo/core` | 307 | 307 |
| `@repo/dashboard` | 228 | 228 |
| `openship` (cli) | 181 | 181 |
| `@repo/db` | 55 | 55 |
| `@repo/desktop` | 3 | 3 |
| **total** | **3250 passed / 15 skipped / 0 failed** | **3258 passed / 15 skipped / 0 failed** |

```bash
$ bun run --cwd apps/api lint
$ tsc --noEmit
# exit 0, before and after
```

`main` is green, so there is nothing inherited to disclose.

On `bun format`: it rewrites 1571 files repo-wide from pre-existing drift, so per
CONTRIBUTING ("review the resulting diff so unrelated files are not included") the two
touched files were hand-formatted instead. Both carry exactly the same prettier drift as
on `main` (68 and 23 lines respectively) — this PR adds none.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

---

## Alternative

The `:?` / `?` message could be brought in line with Compose's own wording
(`required variable A is missing a value: <msg>`) at the same time — right now only the
author's word is thrown. That is a separate user-visible change to an error string, so it
is deliberately not bundled here. Happy to add it in this PR if you would rather have it
in one go.

