### PR TITLE
fix(api): password-reset route compat with better-auth 1.5.4, container-bridge SMTP transport

### DIFF
--- a/apps/api/src/lib/mail.ts
+++ b/apps/api/src/lib/mail.ts
@@ -1,3 +1,4 @@
+import { lookup as dnsLookup } from "node:dns/promises";
 import nodemailer, { type Transporter } from "nodemailer";
 import { env } from "../config/env";
 import { safeErrorMessage, withTimeout } from "@repo/core";
@@ -98,6 +99,38 @@ const PLATFORM_ENSURE_TIMEOUT_MS = 8_000;
 const platformTransportFailures = new Map<string, number>();
 
 /**
+ * `ensureOpenshipPlatformMailbox` reports `mail.<domain>` as the platform
+ * mailbox's SMTP host - correct for an external mail client, and correct
+ * for THIS process too when the api runs bare on the mail server box. But
+ * when containerized, that hostname commonly resolves to a loopback address
+ * via the HOST's own `/etc/hosts` self-entry (e.g. Ubuntu's default
+ * `127.0.1.1 <hostname>`) - meaningful only in the host's network
+ * namespace, not the container's. Connecting there fails immediately with
+ * ECONNREFUSED before ever reaching Postfix.
+ *
+ * Detected generically (not by hardcoding any domain): resolve the reported
+ * host and check if it's loopback. If so, and we have a working container
+ * -> host bridge address (the same one the SSH manager already uses to
+ * reach this box from inside a container), reconnect through that instead.
+ * A genuinely remote mail server resolves to a real address and is passed
+ * through untouched.
+ */
+async function resolveContainerReachableSmtpHost(reportedHost: string): Promise<string> {
+  const bridgeHost = process.env.OPENSHIP_HOST_SSH_HOST?.trim();
+  if (!bridgeHost) return reportedHost;
+  try {
+    const { address } = await dnsLookup(reportedHost);
+    const isLoopback = address === "::1" || address.startsWith("127.");
+    if (!isLoopback) return reportedHost;
+  } catch {
+    // Unresolvable - fall through and let nodemailer's own lookup fail with
+    // its normal error rather than silently substituting a guess.
+    return reportedHost;
+  }
+  return bridgeHost;
+}
+
+/**
  * Locate the active mail server and (re)build its platform-mailbox
  * transport. Returns null if no mail server is provisioned, or if the
  * ensure*-call throws (we don't want a transient mail-server fault to
@@ -152,14 +185,22 @@ async function getPlatformTransport(): Promise<{
       PLATFORM_ENSURE_TIMEOUT_MS,
       `platform mailbox lookup on ${installed.serverId}`,
     );
+    const smtpHost = await resolveContainerReachableSmtpHost(creds.smtpHost);
     const transport = nodemailer.createTransport({
-      host: creds.smtpHost,
+      host: smtpHost,
       port: creds.smtpPort,
       secure: creds.secure,
       auth: {
         user: creds.email,
         pass: creds.password,
       },
+      // When smtpHost got rewritten to the container->host bridge address,
+      // the TCP connection no longer matches the certificate's name (it's
+      // issued for the mail server's real hostname, e.g. mail.<domain>) -
+      // pin SNI/cert verification to the ORIGINAL hostname so TLS still
+      // validates against the right name while the socket itself reaches a
+      // container-routable address.
+      ...(smtpHost !== creds.smtpHost ? { tls: { servername: creds.smtpHost } } : {}),
     });
     const entry: CachedPlatformTransport = {
       transport,

--- a/apps/dashboard/src/lib/auth-client.ts
+++ b/apps/dashboard/src/lib/auth-client.ts
@@ -55,7 +55,15 @@ export const emailOtp = (authClient as any).emailOtp as {
  * the client object so TypeScript doesn't complain about missing
  * static properties.
  */
-export const forgetPassword = (authClient as any).forgetPassword as (
+// Better Auth's client proxy (better-auth/dist/client/proxy.mjs) derives the
+// HTTP path straight from the accessed property name via camelCase ->
+// kebab-case, with no check that the server actually registered a matching
+// route - an accessed property that doesn't exist just silently builds a
+// 404. The server-side endpoint (better-auth/dist/api/routes/password.mjs)
+// is `requestPasswordReset` -> POST /request-password-reset; `forgetPassword`
+// was a stale property name from an older Better Auth version that never
+// reaches the handler.
+export const forgetPassword = (authClient as any).requestPasswordReset as (
   opts: { email: string; redirectTo?: string },
 ) => Promise<{ error?: { message?: string } }>;
 


### PR DESCRIPTION
## Route: forgot-password silently 404s

`apps/dashboard/src/lib/auth-client.ts` accesses `authClient.forgetPassword`. Better Auth's client proxy derives the HTTP path straight from the accessed property name (camelCase -> kebab-case), with no check that the server actually registered a matching route - an accessed property that doesn't exist just silently builds a 404 instead of throwing. `better-auth@1.5.4` (both `apps/api` and `apps/dashboard` pin `^1.5.4` - confirmed not a lockfile skew) renamed this endpoint from `forget-password` to `requestPasswordReset` -> `POST /request-password-reset`. Fixed the property access to match.

## Transport: platform-mailbox SMTP unreachable from inside the api container

The platform-mailbox SMTP host is reported as `mail.<domain>` - correct for an external mail client, and correct when the api process runs bare on the mail server box. When containerized, that hostname commonly resolves to a loopback address via the host's own `/etc/hosts` self-entry (e.g. Debian/Ubuntu's default `127.0.1.1 <hostname>`) - meaningful only in the HOST's network namespace, not the container's, so connecting fails immediately with `ECONNREFUSED` before ever reaching Postfix.

Added `resolveContainerReachableSmtpHost()`: detects a loopback-resolving host generically (no hardcoded domain) and substitutes the existing container -> host SSH bridge address (`OPENSHIP_HOST_SSH_HOST`, already used for the SSH executor) before connecting; a genuinely remote mail server resolves to a real address and passes through untouched. Pins TLS `servername` to the original hostname when substituted, so certificate verification still matches `mail.<domain>` rather than the bridge address.

Verified end-to-end on a self-hosted instance: `POST /request-password-reset` returns 200, and the reset email is sent from the platform mailbox and accepted by the recipient's mail server.

## Note on CI

Recent merged PRs against `main` (#322, #327) show `Typecheck: SUCCESS` / `Test: FAILURE` on their PR-context runs. Flagging in case it reproduces here too - doesn't look related to this change.