### PR TITLE
fix(api): parse multi-line quoted values in .env files

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -427,8 +427,9 @@ export function parseComposeEnvFile(content: string): Record<string, string> {
   const result: Record<string, string> = {};
   const literalKeys = new Set<string>();
 
-  for (const rawLine of content.replace(/^\uFEFF/, "").split(/\r?\n/)) {
-    let line = rawLine.trim();
+  const lines = content.replace(/^\uFEFF/, "").split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].trim();
     if (!line || line.startsWith("#")) continue;
     if (line.startsWith("export ")) line = line.slice("export ".length).trimStart();
 
@@ -438,7 +439,14 @@ export function parseComposeEnvFile(content: string): Record<string, string> {
     const key = line.slice(0, eqIdx).trim();
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
 
-    const parsed = parseEnvValue(line.slice(eqIdx + 1));
+    let rawValue = line.slice(eqIdx + 1);
+    const continued = joinQuotedContinuation(rawValue, lines, i);
+    if (continued) {
+      rawValue = continued.value;
+      i = continued.endLine;
+    }
+
+    const parsed = parseEnvValue(rawValue);
     result[key] = parsed.value;
     if (parsed.expand) literalKeys.delete(key);
     else literalKeys.add(key);
@@ -450,6 +458,25 @@ export function parseComposeEnvFile(content: string): Record<string, string> {
   }
 
   return result;
+}
+
+function joinQuotedContinuation(
+  rawValue: string,
+  lines: string[],
+  start: number,
+): { value: string; endLine: number } | undefined {
+  const value = rawValue.trimStart();
+  const quote = value[0];
+  if (quote !== '"' && quote !== "'") return undefined;
+  if (findClosingQuote(value, quote) >= 0) return undefined;
+
+  let joined = value;
+  for (let i = start + 1; i < lines.length; i++) {
+    joined += `\n${lines[i]}`;
+    if (findClosingQuote(joined, quote) >= 0) return { value: joined, endLine: i };
+  }
+
+  return undefined;
 }
 
 function parseEnvValue(rawValue: string): { value: string; expand: boolean } {

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -275,6 +275,42 @@ BAZ=qux
     expect(parseComposeEnvFile("\n\n   \n")).toEqual({});
   });
 
+  it("parses a quoted value that spans multiple lines", () => {
+    expect(
+      parseComposeEnvFile(
+        'JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkq\n-----END PRIVATE KEY-----"\nNODE_ENV=production',
+      ),
+    ).toEqual({
+      JWT_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkq\n-----END PRIVATE KEY-----",
+      NODE_ENV: "production",
+    });
+  });
+
+  it("does not treat a KEY=value line inside a quoted block as its own entry", () => {
+    expect(
+      parseComposeEnvFile(
+        'CERT="-----BEGIN CERTIFICATE-----\nKEY=notreallyakey\n-----END CERTIFICATE-----"',
+      ),
+    ).toEqual({
+      CERT: "-----BEGIN CERTIFICATE-----\nKEY=notreallyakey\n-----END CERTIFICATE-----",
+    });
+  });
+
+  it("interpolates inside a multi-line double-quoted value but not a single-quoted one", () => {
+    expect(parseComposeEnvFile("BASE=foo\nD=\"a\n${BASE}\nb\"\nS='a\n${BASE}\nb'")).toEqual({
+      BASE: "foo",
+      D: "a\nfoo\nb",
+      S: "a\n${BASE}\nb",
+    });
+  });
+
+  it("falls back to single-line parsing when a quote is never closed", () => {
+    expect(parseComposeEnvFile('BLOCK="never closed\nAFTER=ok')).toEqual({
+      BLOCK: "never closed",
+      AFTER: "ok",
+    });
+  });
+
   it("realistic project .env - database, secrets, runtime config", () => {
     const result = parseComposeEnvFile(`
 # Database


### PR DESCRIPTION
## Summary

`parseComposeEnvFile` splits a `.env` file into lines before any quote parsing, so a quoted value can never span more than one line. A multi-line PEM key or JSON credential blob in a project's `.env` is silently truncated to its first line, and lines inside the quoted block that look like assignments become real environment variables. This makes the parser join continuation lines until the opening quote closes.

## Motivation

`apps/api/src/lib/compose-parser.ts:430`:

```ts
for (const rawLine of content.replace(/^\uFEFF/, "").split(/\r?\n/)) {
```

Everything downstream sees one line at a time. `findClosingQuote` returns `-1`, `parseEnvValue` falls back to `value.slice(1)`, and each continuation line is re-fed through the loop as its own `KEY=value`.

The realistic input is a signing key. With a real 2048-bit RSA key written into `.env` the normal way:

```
JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQ...
...
-----END PRIVATE KEY-----"
DATABASE_URL=postgres://app:s3cret@db:5432/app
```

| | `docker compose config` | `parseComposeEnvFile` (before) |
|---|---|---|
| `JWT_PRIVATE_KEY` length | 1704 | **27** — just `-----BEGIN PRIVATE KEY-----` |
| other keys produced | `DATABASE_URL` | `DATABASE_URL`, **plus `aSb3Zade0ayAYmi08c7Pr28=""`** |

That extra variable is a 23-character fragment of the private key. The last base64 line of the key is `aSb3Zade0ayAYmi08c7Pr28=` — `=` is base64 padding — so the loop reads it as an assignment, the part before `=` happens to satisfy `^[A-Za-z_][A-Za-z0-9_]*$`, and it is seeded into the project's env. There is no warning on either half; the deployed app just gets a key that fails to parse.

The same shape lets a `.env` line inside a quoted block become a live variable:

```
JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
KEY=notreallyakey
-----END PRIVATE KEY-----"
```

`docker compose config` leaves `KEY` unset; before this change openship sets `KEY=notreallyakey`.

`parseComposeEnvFile` feeds `toProjectInfo` at `prepare.service.ts:775` (the wizard's `rootEnv` seed) and `:780` (compose `${VAR}` interpolation). That runs behind `resolveFromReader`, so all four project sources reach it — GitHub, local folder, runtime and server-over-SSH. The SSH path reads a live app's `.env`, which is exactly where PEM keys and JSON service-account blobs live.

### Differential against the real binary

31 `.env` inputs — 18 single-line shapes mirroring what this file's tests already cover, plus 13 multi-line ones — each written to disk and run through `docker compose config --format json` (Docker 29.6.1, Compose 5.2.0) with `environment: [KEY, ...]` passthrough, so an unset key is distinguishable from an empty one:

| | count |
|---|---|
| inputs `docker compose` accepts | 30 |
| of those, `main` agrees with compose | **18 / 30** |
| of those, this branch agrees with compose | **29 / 30** |
| inputs where `main` agreed and this branch does not | **0** |

`main` gets all 18 single-line inputs right and all 12 accepted multi-line inputs wrong: PEM under either quote style, a `KEY=value` line inside the block, multi-line JSON credentials, a blank line inside the block, a `#` line inside the block, `export`-prefixed, `${VAR}` inside the block under either quote style, a trailing comment after the closing quote, two multi-line values in one file, and CRLF. This branch gets 11 of those 12 and changes none of the 18.

Three cases are deliberately **not** changed:

- **Unterminated quote** (`BLOCK="never closed`) — the one input compose rejects outright: `line 3: unterminated quoted value "never closed`. Both `main` and this branch accept it silently and keep the single-line reading. Making that an error would turn a widening into a new rejection on a live path, so it is left alone.
- **CRLF + multi-line** is the one remaining disagreement among the 30 accepted inputs. Compose keeps the CR inside the value (`"first\r\nsecond"`); this branch yields `"first\nsecond"`. `main` yields `"first"`, so it is still strictly better — but it is a real divergence and matching it would mean not normalising CRLF, which this parser does everywhere.
- **Trailing whitespace on the opening line of a joined block.** `parseComposeEnvFile` calls `.trim()` on the opening line but appends continuation lines untrimmed, so `B="first   ` + newline + `second"` gives `"first\nsecond"` where compose gives `"first   \nsecond"`. `main` gives `"first"`. This comes from a pre-existing `.trim()` that this PR does not touch, and removing it would change single-line parsing too, so it is out of scope here — but it is the most common of the residual divergences in random `.env` inputs, so it is worth naming rather than leaving to be discovered.

## Related issue

None.

## Changes

**apps/api**

- `src/lib/compose-parser.ts` — `parseComposeEnvFile` walks lines by index; new `joinQuotedContinuation` helper appends following lines while the opening quote is still open, and returns `undefined` (keeping today's single-line behaviour) if it never closes. `parseEnvValue`, `findClosingQuote` and the interpolation pass are untouched.
- `test/lib/compose-parser.test.ts` — four cases added to the existing `parseComposeEnvFile` block.

## Verification

All 71 pre-existing tests in `compose-parser.test.ts` pass unchanged with the fix applied.

Three of the four new tests fail on `main` with the source change stashed and the tests kept:

```bash
$ git stash push -- apps/api/src/lib/compose-parser.ts
$ npx vitest run test/lib/compose-parser.test.ts

 FAIL  ... > parses a quoted value that spans multiple lines
AssertionError: expected { …(2) } to deeply equal { …(2) }
  {
-   "JWT_PRIVATE_KEY": "-----BEGIN PRIVATE KEY-----
- MIIBVgIBADANBgkq
- -----END PRIVATE KEY-----",
+   "JWT_PRIVATE_KEY": "-----BEGIN PRIVATE KEY-----",
    "NODE_ENV": "production",
  }

 FAIL  ... > does not treat a KEY=value line inside a quoted block as its own entry
AssertionError: expected { …(2) } to deeply equal { Object (CERT) }
  {
-   "CERT": "-----BEGIN CERTIFICATE-----
- KEY=notreallyakey
- -----END CERTIFICATE-----",
+   "CERT": "-----BEGIN CERTIFICATE-----",
+   "KEY": "notreallyakey",
  }

 FAIL  ... > interpolates inside a multi-line double-quoted value but not a single-quoted one
AssertionError: expected { BASE: 'foo', D: 'a', S: 'a' } to deeply equal { BASE: 'foo', D: 'a\nfoo\nb', …(1) }

 Test Files  1 failed (1)
      Tests  3 failed | 72 passed (75)
```

With the change restored:

```bash
$ git stash pop
$ npx vitest run test/lib/compose-parser.test.ts

 ✓ test/lib/compose-parser.test.ts (75 tests) 13ms

 Test Files  1 passed (1)
      Tests  75 passed (75)
```

The fourth test (`falls back to single-line parsing when a quote is never closed`) passes on `main` by design — it pins the behaviour deliberately left alone above. It is not filler: replacing `joinQuotedContinuation`'s `return undefined` with "consume to end of file" makes it fail with `{ BLOCK: 'never closed\nAFTER=ok' }`, which is the mistake the fallback exists to avoid.

Full suite and typecheck, `main` @ `dba7950b` vs this branch:

```bash
$ bun run test -- --continue
# main:        3372 passed | 15 skipped | 0 failed   (7/7 tasks)
# this branch: 3376 passed | 15 skipped | 0 failed   (7/7 tasks)
#   @repo/api 1834 -> 1838, i.e. exactly the four new tests

$ bun run --cwd apps/api lint     # tsc --noEmit, exit 0
```

Both touched files already have pre-existing Prettier drift on `main` (68 and 23 diff lines), so per CONTRIBUTING's "scope the diff" I hand-formatted my own lines rather than running `--write` over them. The drift counts are unchanged at 68 and 23, and `prettier` wants to touch none of the added lines.

### Alternative, if you'd rather

The unterminated-quote case could be made an error to match compose exactly (`unterminated quoted value`). I left it out deliberately: it changes a currently-accepted input into a failure on a path four readers reach, which is a different kind of change from this one. Happy to add it here or in a follow-up if you'd prefer the parser to fail closed there.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test` and `bun run --cwd apps/api lint` pass locally. I did **not** run `bun format` — `bunx prettier -l "**/*.{ts,tsx,js,jsx,json,md}"` reports 1579 pre-existing files on this tree and `--write` would rewrite all of them; I checked with `prettier --check` instead and my added lines are clean (see Verification)
- [x] I understand every line of this diff and can explain it in review
