### PR TITLE
fix(api): normalize loopback MCP redirect URIs

### DIFF
--- a/apps/api/src/lib/oauth-redirect.ts
+++ b/apps/api/src/lib/oauth-redirect.ts
@@ -1,0 +1,129 @@
+/**
+ * Return the registered redirect URI when the requested URI is an equivalent
+ * loopback address. OAuth normally compares redirect URIs exactly, but native
+ * MCP clients commonly alternate between localhost and 127.0.0.1 for the same
+ * callback listener.
+ *
+ * This deliberately only aliases loopback hostnames and requires every other
+ * URL component to match. Public redirect URIs remain exact-match only.
+ */
+export function findEquivalentLoopbackRedirectUri(
+  requestedUri: string,
+  registeredUris: readonly string[],
+): string | undefined {
+  const exact = registeredUris.find((uri) => uri === requestedUri);
+  if (exact) return exact;
+
+  const requested = parseRedirectUri(requestedUri);
+  if (!requested || !isLoopbackHostname(requested.hostname)) return undefined;
+
+  return registeredUris.find((registeredUri) => {
+    const registered = parseRedirectUri(registeredUri);
+    if (!registered || !isLoopbackHostname(registered.hostname)) return false;
+
+    return (
+      registered.protocol === requested.protocol &&
+      registered.port === requested.port &&
+      registered.username === requested.username &&
+      registered.password === requested.password &&
+      registered.pathname === requested.pathname &&
+      registered.search === requested.search &&
+      registered.hash === requested.hash
+    );
+  });
+}
+
+export type RegisteredRedirectUriResolver = (
+  clientId: string,
+) => Promise<readonly string[] | undefined>;
+
+/**
+ * Rewrite an MCP authorize/token request to the registered loopback URI before
+ * it reaches an OAuth implementation that requires exact redirect_uri equality.
+ */
+export async function normalizeMcpRedirectUri(
+  request: Request,
+  resolveRegisteredUris: RegisteredRedirectUriResolver,
+): Promise<Request> {
+  const url = new URL(request.url);
+  const isAuthorize = request.method === "GET" && url.pathname.endsWith("/mcp/authorize");
+  const isToken = request.method === "POST" && url.pathname.endsWith("/mcp/token");
+
+  if (!isAuthorize && !isToken) return request;
+
+  let clientId: string | undefined;
+  let redirectUri: string | undefined;
+
+  if (isAuthorize) {
+    clientId = url.searchParams.get("client_id") ?? undefined;
+    redirectUri = url.searchParams.get("redirect_uri") ?? undefined;
+  } else {
+    const contentType = request.headers.get("content-type") ?? "";
+    try {
+      if (contentType.includes("application/x-www-form-urlencoded")) {
+        const body = await request.clone().formData();
+        clientId = stringFormValue(body.get("client_id"));
+        redirectUri = stringFormValue(body.get("redirect_uri"));
+      } else if (contentType.includes("application/json")) {
+        const body = (await request.clone().json()) as Record<string, unknown> | null;
+        if (body && typeof body === "object") {
+          clientId = stringFormValue(body.client_id);
+          redirectUri = stringFormValue(body.redirect_uri);
+        }
+      }
+    } catch {
+      // Preserve Better Auth's existing validation response for malformed token
+      // requests instead of failing inside this compatibility shim.
+      return request;
+    }
+  }
+
+  if (!clientId || !redirectUri) return request;
+
+  const registeredUris = await resolveRegisteredUris(clientId);
+  if (!registeredUris) return request;
+
+  const canonicalUri = findEquivalentLoopbackRedirectUri(redirectUri, registeredUris);
+  if (!canonicalUri || canonicalUri === redirectUri) return request;
+
+  if (isAuthorize) {
+    url.searchParams.set("redirect_uri", canonicalUri);
+    return new Request(url, request);
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete("content-length");
+  const contentType = headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    const body = await request.clone().formData();
+    body.set("redirect_uri", canonicalUri);
+    const encoded = new URLSearchParams();
+    body.forEach((value, key) => {
+      if (typeof value === "string") encoded.append(key, value);
+    });
+    return new Request(request, { body: encoded, headers });
+  }
+
+  const body = (await request.clone().json()) as Record<string, unknown>;
+  return new Request(request, {
+    body: JSON.stringify({ ...body, redirect_uri: canonicalUri }),
+    headers,
+  });
+}
+
+function parseRedirectUri(uri: string): URL | undefined {
+  try {
+    return new URL(uri);
+  } catch {
+    return undefined;
+  }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
+function stringFormValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -12,9 +12,10 @@
  */
 
 import { Hono } from "hono";
-import { db, schema } from "@repo/db";
+import { db, eq, schema } from "@repo/db";
 import { env } from "../../config/env";
 import { auth, isSaasDeployment } from "../../lib/auth";
+import { normalizeMcpRedirectUri } from "../../lib/oauth-redirect";
 import { internalAuth } from "../../middleware/internal-auth";
 import { isLoopbackRequest } from "../../middleware/loopback-peer";
 import * as ctrl from "./auth.controller";
@@ -50,4 +51,14 @@ authRoutes.on("POST", "/sign-up/*", async (c, next) => {
 });
 
 // Better Auth catch-all — must be last so the desktop overrides + signup guard win.
-authRoutes.on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw));
+authRoutes.on(["GET", "POST"], "/*", async (c) => {
+  const request = await normalizeMcpRedirectUri(c.req.raw, async (clientId) => {
+    const [client] = await db
+      .select({ redirectUrls: schema.oauthApplication.redirectUrls })
+      .from(schema.oauthApplication)
+      .where(eq(schema.oauthApplication.clientId, clientId))
+      .limit(1);
+    return client?.redirectUrls.split(",");
+  });
+  return auth.handler(request);
+});

--- a/apps/api/test/lib/oauth-redirect.test.ts
+++ b/apps/api/test/lib/oauth-redirect.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  findEquivalentLoopbackRedirectUri,
+  normalizeMcpRedirectUri,
+} from "../../src/lib/oauth-redirect";
+
+describe("findEquivalentLoopbackRedirectUri", () => {
+  it("returns an exact match", () => {
+    const registered = "http://localhost:19876/mcp/oauth/callback";
+
+    expect(findEquivalentLoopbackRedirectUri(registered, [registered])).toBe(registered);
+  });
+
+  it("aliases localhost and 127.0.0.1 for the same callback", () => {
+    const registered = "http://localhost:19876/mcp/oauth/callback";
+
+    expect(
+      findEquivalentLoopbackRedirectUri("http://127.0.0.1:19876/mcp/oauth/callback", [registered]),
+    ).toBe(registered);
+  });
+
+  it("rejects different loopback addresses and lookalike domains", () => {
+    const registered = "http://localhost:19876/mcp/oauth/callback";
+
+    expect(
+      findEquivalentLoopbackRedirectUri("http://127.0.0.2:19876/mcp/oauth/callback", [registered]),
+    ).toBeUndefined();
+    expect(
+      findEquivalentLoopbackRedirectUri("http://127.evil.example:19876/mcp/oauth/callback", [
+        registered,
+      ]),
+    ).toBeUndefined();
+    expect(
+      findEquivalentLoopbackRedirectUri("http://127.0.0.1.nip.io:19876/mcp/oauth/callback", [
+        registered,
+      ]),
+    ).toBeUndefined();
+    expect(
+      findEquivalentLoopbackRedirectUri("http://[::1]:19876/mcp/oauth/callback", [registered]),
+    ).toBeUndefined();
+  });
+
+  it("does not alias a different port or callback path", () => {
+    const registered = "http://localhost:19876/mcp/oauth/callback";
+
+    expect(
+      findEquivalentLoopbackRedirectUri("http://127.0.0.1:19877/mcp/oauth/callback", [registered]),
+    ).toBeUndefined();
+    expect(
+      findEquivalentLoopbackRedirectUri("http://127.0.0.1:19876/other/callback", [registered]),
+    ).toBeUndefined();
+  });
+
+  it("does not relax matching for public hosts", () => {
+    expect(
+      findEquivalentLoopbackRedirectUri("https://example.com/callback", [
+        "https://example.net/callback",
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("rewrites the token request to the registered loopback URI", async () => {
+    const request = new Request("https://openship.test/api/auth/mcp/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: "client",
+        redirect_uri: "http://127.0.0.1:19876/mcp/oauth/callback",
+        code: "code",
+      }),
+    });
+
+    const normalized = await normalizeMcpRedirectUri(request, async () => [
+      "http://localhost:19876/mcp/oauth/callback",
+    ]);
+    const body = await normalized.formData();
+
+    expect(body.get("redirect_uri")).toBe("http://localhost:19876/mcp/oauth/callback");
+    expect(body.get("code")).toBe("code");
+  });
+
+  it("rewrites the authorize request before the redirect URI is persisted", async () => {
+    const request = new Request(
+      "https://openship.test/api/auth/mcp/authorize?client_id=client&redirect_uri=" +
+        encodeURIComponent("http://127.0.0.1:19876/mcp/oauth/callback"),
+    );
+
+    const normalized = await normalizeMcpRedirectUri(request, async () => [
+      "http://localhost:19876/mcp/oauth/callback",
+    ]);
+
+    expect(new URL(normalized.url).searchParams.get("redirect_uri")).toBe(
+      "http://localhost:19876/mcp/oauth/callback",
+    );
+  });
+
+  it("leaves malformed token requests for Better Auth to reject", async () => {
+    const request = new Request("https://openship.test/api/auth/mcp/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    expect(await normalizeMcpRedirectUri(request, async () => [])).toBe(request);
+  });
+});


### PR DESCRIPTION
## Summary

Fix MCP OAuth connections that complete browser consent but fail during token exchange when the client alternates between `localhost` and `127.0.0.1`.

Before Better Auth handles MCP authorize and token requests, Openship now maps an equivalent loopback callback back to the URI registered for that client. Every URL component except the hostname must remain identical.

## Motivation

I noticed this while connecting OpenCode to a self-hosted Openship MCP server. Browser authorization and consent completed successfully, but OpenCode remained disconnected.

Tracing the OAuth flow showed that the dynamically registered callback and the callback submitted during token exchange used different names for the same loopback listener:

| Stage | Redirect URI |
| --- | --- |
| Dynamic client registration | `http://localhost:<port>/mcp/oauth/callback` |
| Token exchange | `http://127.0.0.1:<port>/mcp/oauth/callback` |

Better Auth compares redirect URIs exactly, so the hostname difference caused it to reject the token exchange.

After applying the normalization, `/api/auth/mcp/token` returned `200`, `opencode mcp list` reported Openship as connected, and all 149 MCP tools were available.

## Related issue

None.

## Changes

**apps/api**

- Add an MCP redirect URI normalizer for authorize and token requests.
- Resolve the registered redirect URIs for the requesting OAuth client.
- Treat only `localhost` and `127.0.0.1` as interchangeable.
- Require protocol, port, credentials, path, query, and fragment to remain equal.
- Leave malformed requests for Better Auth to validate normally.
- Add regression tests for authorize and token normalization.
- Add negative cases for public hosts, alternate ports and paths, IPv6, other loopback addresses, and lookalike domains.

## Verification

With the loopback alias fallback disabled, the regression suite fails in the three affected behaviors:

```bash
$ bunx bun@1.3.10 run --cwd apps/api test -- test/lib/oauth-redirect.test.ts

 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
```

```text
× aliases localhost and 127.0.0.1 for the same callback
× rewrites the token request to the registered loopback URI
× rewrites the authorize request before the redirect URI is persisted
```

With the change enabled:

```bash
$ bunx bun@1.3.10 run --cwd apps/api test -- test/lib/oauth-redirect.test.ts

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Full monorepo suite, with Docker-dependent tests skipped because no local daemon was available:

```bash
$ DOCKER_HOST=unix:///tmp/openship-no-docker.sock \
    bunx bun@1.3.10 run test -- --concurrency=1

 Tasks:    7 successful, 7 total
```

The API workspace result within that run:

```text
 Test Files  171 passed | 4 skipped (175)
      Tests  1849 passed | 15 skipped (1864)
```

Typecheck and formatting:

```bash
$ bunx bun@1.3.10 run --cwd apps/api lint
$ tsc --noEmit

$ bunx bun@1.3.10 x prettier --check \
    apps/api/src/lib/oauth-redirect.ts \
    apps/api/src/modules/auth/auth.routes.ts \
    apps/api/test/lib/oauth-redirect.test.ts
All matched files use Prettier code style!
```

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review
