### PR TITLE
fix(adapters): match Docker's .dockerignore semantics in the build context

### DIFF
--- a/packages/adapters/src/runtime/docker-build-context.test.ts
+++ b/packages/adapters/src/runtime/docker-build-context.test.ts
@@ -1,0 +1,154 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { promisify } from "node:util";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import type { BuildConfig } from "../types";
+
+import { createDockerBuildContext, prepareSourceTree } from "./docker-build-context";
+
+const exec = promisify(execFile);
+
+const cleanups: Array<() => Promise<void>> = [];
+
+/** A git repo with `build/` and `node_modules/` at the root AND nested, a
+ *  `Dockerfile`, and the given `.dockerignore`. Everything is tracked. */
+async function makeRepo(dockerignore: string): Promise<string> {
+  const repo = await mkdtemp(join(tmpdir(), "dbc-repo-"));
+  cleanups.push(() => rm(repo, { recursive: true, force: true }));
+
+  await exec("git", ["-C", repo, "init", "-q"]);
+  await exec("git", ["-C", repo, "config", "user.email", "t@example.com"]);
+  await exec("git", ["-C", repo, "config", "user.name", "Test"]);
+  await exec("git", ["-C", repo, "config", "commit.gpgsign", "false"]);
+
+  await writeFile(join(repo, ".dockerignore"), dockerignore);
+  await writeFile(join(repo, "Dockerfile"), "FROM node:22\nCOPY . /app\n");
+  await writeFile(join(repo, "package.json"), '{"name":"ctx","version":"0.1.0"}');
+
+  await mkdir(join(repo, "app", "build"), { recursive: true });
+  await writeFile(join(repo, "app", "build", "page.tsx"), "export default () => null;\n");
+
+  await mkdir(join(repo, "build"), { recursive: true });
+  await writeFile(join(repo, "build", "artifact.txt"), "generated\n");
+
+  await mkdir(join(repo, "node_modules", "left-pad"), { recursive: true });
+  await writeFile(join(repo, "node_modules", "left-pad", "index.js"), "module.exports = 0;\n");
+
+  await mkdir(join(repo, "packages", "ui", "node_modules", "left-pad"), { recursive: true });
+  await writeFile(
+    join(repo, "packages", "ui", "node_modules", "left-pad", "index.js"),
+    "module.exports = 0;\n",
+  );
+
+  await exec("git", ["-C", repo, "add", "-A", "-f"]);
+  await exec("git", ["-C", repo, "commit", "-q", "-m", "init"]);
+
+  return repo;
+}
+
+function config(localPath: string): BuildConfig {
+  return {
+    sessionId: "s1",
+    projectId: "p1",
+    repoUrl: "",
+    branch: "main",
+    localPath,
+    stack: "node",
+    buildImage: "node:22",
+    runtimeImage: "node:22",
+    packageManager: "npm",
+    installCommand: "npm ci",
+    buildCommand: "",
+    outputDirectory: "",
+    startCommand: "node index.js",
+    port: 3000,
+    envVars: {},
+  } as unknown as BuildConfig;
+}
+
+/** Every file in `dir`, as posix paths relative to it. */
+async function listContext(dir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  const walk = async (current: string): Promise<void> => {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const absolutePath = join(current, entry.name);
+      if (entry.isDirectory()) await walk(absolutePath);
+      else files.push(relative(dir, absolutePath).split(sep).join("/"));
+    }
+  };
+
+  await walk(dir);
+  return files.sort();
+}
+
+async function contextFor(dockerignore: string): Promise<string[]> {
+  const tree = await prepareSourceTree(config(await makeRepo(dockerignore)));
+  cleanups.push(tree.cleanup);
+  return listContext(tree.contextDir);
+}
+
+afterAll(async () => {
+  await Promise.all(cleanups.map((fn) => fn().catch(() => {})));
+});
+
+describe("prepareSourceTree — .dockerignore pruning", () => {
+  it("keeps the Dockerfile and .dockerignore when .dockerignore excludes them", async () => {
+    const files = await contextFor("Dockerfile\n.dockerignore\n");
+
+    expect(files).toContain("Dockerfile");
+    expect(files).toContain(".dockerignore");
+  });
+
+  it("matches patterns from the context root instead of at every depth", async () => {
+    const files = await contextFor("node_modules\nbuild\n");
+
+    expect(files).toContain("app/build/page.tsx");
+    expect(files).toContain("packages/ui/node_modules/left-pad/index.js");
+    expect(files).not.toContain("build/artifact.txt");
+    expect(files).not.toContain("node_modules/left-pad/index.js");
+  });
+
+  it("prunes at every depth for a globstar pattern", async () => {
+    const files = await contextFor("**/node_modules\n");
+
+    expect(files).not.toContain("node_modules/left-pad/index.js");
+    expect(files).not.toContain("packages/ui/node_modules/left-pad/index.js");
+    expect(files).toContain("app/build/page.tsx");
+  });
+
+  it("keeps a root-level negation in an allowlist .dockerignore", async () => {
+    const files = await contextFor("*\n!package.json\n");
+
+    expect(files).toEqual([".dockerignore", "Dockerfile", "package.json"]);
+  });
+});
+
+describe("createDockerBuildContext", () => {
+  it("resolves the repository Dockerfile when .dockerignore excludes it", async () => {
+    const repo = await makeRepo("Dockerfile\n");
+    const context = await createDockerBuildContext(config(repo), {
+      requireRepositoryDockerfile: true,
+    });
+    cleanups.push(context.cleanup);
+
+    expect(context.dockerfileName).toBe("Dockerfile");
+    expect(context.usesRepositoryDockerfile).toBe(true);
+    expect(context.contextEntries).not.toContain("Dockerfile.openship");
+  });
+
+  it("does not fall back to a generated Dockerfile when .dockerignore excludes the repository one", async () => {
+    const repo = await makeRepo("Dockerfile\n");
+    const context = await createDockerBuildContext(config(repo), {
+      requireRepositoryDockerfile: false,
+    });
+    cleanups.push(context.cleanup);
+
+    expect(context.dockerfileName).toBe("Dockerfile");
+    expect(context.usesRepositoryDockerfile).toBe(true);
+  });
+});

--- a/packages/adapters/src/runtime/docker-build-context.ts
+++ b/packages/adapters/src/runtime/docker-build-context.ts
@@ -117,6 +117,26 @@ function toPosixPath(value: string): string {
 }
 
 /**
+ * Anchor one `.dockerignore` line to the context root. Docker matches patterns
+ * against the whole context-relative path — a slash-less `node_modules` is the
+ * root one only, and a leading globstar is what reaches any depth — while the
+ * `ignore` package applies gitignore rules, where the slash-less form matches
+ * at every depth. Patterns that already carry a slash, leading globstars,
+ * comments and `!` negations are passed through unchanged.
+ */
+function anchorDockerignorePattern(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return line;
+
+  const negated = trimmed.startsWith("!");
+  const pattern = negated ? trimmed.slice(1) : trimmed;
+  if (!pattern || pattern.startsWith("/") || pattern.startsWith("**/")) return line;
+  if (pattern.replace(/\/+$/, "").includes("/")) return line;
+
+  return `${negated ? "!" : ""}/${pattern}`;
+}
+
+/**
  * `.dockerignore` matcher for the build context. `.gitignore` is deliberately
  * NOT read here — the base tree is already git-truth (local: `git ls-files`;
  * clone: a clean checkout), so gitignored output was never included. We only
@@ -125,25 +145,46 @@ function toPosixPath(value: string): string {
  */
 async function loadDockerignoreMatcher(rootPath: string): Promise<IgnoreMatcher | undefined> {
   try {
-    return ignore().add(await readFile(join(rootPath, ".dockerignore"), "utf-8"));
+    const contents = await readFile(join(rootPath, ".dockerignore"), "utf-8");
+    return ignore().add(contents.split(/\r?\n/).map(anchorDockerignorePattern));
   } catch {
     return undefined; // no .dockerignore
   }
 }
 
+/** The build files (`.dockerignore` plus every Dockerfile candidate this config
+ *  can resolve to) and the directories leading to them, in posix form. */
+function buildFilePaths(config: BuildConfig): Set<string> {
+  const paths = new Set<string>([".dockerignore"]);
+
+  const candidates = resolveDockerfileCandidates(config.rootDirectory, config.dockerfilePath);
+
+  for (const candidate of candidates) {
+    const segments = candidate.split("/");
+    for (let depth = 1; depth <= segments.length; depth += 1) {
+      paths.add(segments.slice(0, depth).join("/"));
+    }
+  }
+
+  return paths;
+}
+
 /** Remove everything matching `.dockerignore` from an already-materialized
- *  context tree. No-op when the repo has no `.dockerignore`. */
-async function applyDockerignore(contextDir: string): Promise<void> {
+ *  context tree, except the build files themselves — Docker sends those to the
+ *  builder regardless. No-op when the repo has no `.dockerignore`. */
+async function applyDockerignore(contextDir: string, config: BuildConfig): Promise<void> {
   const matcher = await loadDockerignoreMatcher(contextDir);
   if (!matcher) return;
+
+  const buildFiles = buildFilePaths(config);
 
   const prune = async (currentPath: string): Promise<void> => {
     const entries = await readdir(currentPath, { withFileTypes: true });
     await Promise.all(
       entries.map(async (entry) => {
         const absolutePath = join(currentPath, entry.name);
-        const relativePath = relative(contextDir, absolutePath);
-        if (matcher.ignores(toPosixPath(relativePath))) {
+        const relativePath = toPosixPath(relative(contextDir, absolutePath));
+        if (!buildFiles.has(relativePath) && matcher.ignores(relativePath)) {
           await rm(absolutePath, { recursive: true, force: true });
           return;
         }
@@ -329,7 +370,7 @@ export async function prepareSourceTree(
 
     // Docker-only refinement: dockerode tars the context as-is, so honor
     // .dockerignore here. No-op when the repo has none.
-    await applyDockerignore(contextDir);
+    await applyDockerignore(contextDir, config);
 
     return {
       contextDir,


### PR DESCRIPTION
## Summary

`prepareSourceTree` prunes the materialized build context with `.dockerignore` *before* the Dockerfile is resolved, and matches patterns with gitignore any-depth rules. Both diverge from what `docker build` actually sends: a `.dockerignore` that names `Dockerfile` either breaks the build or silently redirects it to a generated one, and a slash-less pattern like `node_modules` deletes nested matches that real Docker keeps.

## Motivation

Fixture repo, everything tracked and committed:

```
.dockerignore   Dockerfile   package.json
app/build/page.tsx
build/artifact.txt
node_modules/left-pad/index.js
packages/ui/node_modules/left-pad/index.js
```

The differential harness further down adds `src/index.ts` and `docs/readme.md` to the same tree.

**1. `.dockerignore` contains `Dockerfile`.** Docker documents this — the build files still reach the builder because the build needs them, they just cannot be `COPY`'d into the image. `docker build .` on this tree succeeds. openship does not, because `applyDockerignore` deletes the Dockerfile and `resolveServiceDockerfile` then searches the already-pruned tree:

| `createDockerBuildContext` | `main` (`c40eb2d2`) | this branch |
|---|---|---|
| `requireRepositoryDockerfile: true` — `stack=docker` (docker.ts:1219), always on cloud (cloud.ts:865) | throws `No Dockerfile found for this build context. Expected Dockerfile.` | `dockerfileName=Dockerfile`, `usesRepositoryDockerfile=true` |
| `requireRepositoryDockerfile: false` — auto-detected stack | `dockerfileName=Dockerfile.openship`, `usesRepositoryDockerfile=false` | `dockerfileName=Dockerfile`, `usesRepositoryDockerfile=true` |

The second row is the damaging one: no error, no log, the user's Dockerfile replaced by a generated one, a different image deployed.

**2. Patterns match at every depth.** `.dockerignore` uses Go `filepath.Match` anchored at the context root, so `build` means the root `build/` only and `**/build` is the form that reaches any depth. The `ignore` package applies gitignore rules, where a slash-less pattern matches everywhere. With `.dockerignore` of `node_modules` + `build`:

| path | `docker build <dir>` (client 29.6.1 / server 29.5.2) | openship `main` | this branch |
|---|---|---|---|
| `build/artifact.txt` | dropped | dropped | dropped |
| `node_modules/left-pad/index.js` | dropped | dropped | dropped |
| `app/build/page.tsx` | **kept** | dropped | **kept** |
| `packages/ui/node_modules/left-pad/index.js` | **kept** | dropped | **kept** |

`app/build/page.tsx` is a plain Next.js App Router route, and `packages/ui/node_modules` is any workspace with a nested install — both are ordinary tracked files that the build silently loses today.

Both defects go back to the original docker flow (`c08b8cff`), which already pruned before resolving and already fed `.dockerignore` to `ignore()` unanchored.

## Related issue

None.

## Changes

`packages/adapters` is the only workspace touched.

- `src/runtime/docker-build-context.ts`
  - `applyDockerignore` now takes the `BuildConfig` and skips a build-file set: `.dockerignore`, every `resolveDockerfileCandidates` result, and the directories leading to them. This mirrors docker/cli's `TrimBuildFilesFromExcludes` (`cli/command/image/build/dockerignore.go`), which appends `!.dockerignore` / `!<dockerfile>` to the excludes for exactly this reason.
  - New `anchorDockerignorePattern` prefixes `/` onto unanchored lines before `ignore().add(...)`. Lines that already contain a slash, `**/` prefixes, `!` negations, comments and blanks are passed through unchanged.
- `src/runtime/docker-build-context.test.ts` — new file, 6 cases.

**This changes the built image, not only the context/wire size, and that is the fix rather than a side effect.** Docker applies no general `.dockerignore` pattern on our behalf: the CLI does that client-side while tarring a directory, and moby's `remotecontext.removeDockerfile` removes only the Dockerfile and `.dockerignore` themselves — which matches the note already in this file's JSDoc ("dockerode tars the context as-is and does not honour it itself"). Measured on Docker client 29.6.1 / server 29.5.2 with `.dockerignore` of `node_modules`:

| path in the image | `docker build <dir>` | `tar . \| docker build -` |
|---|---|---|
| `node_modules/left-pad/index.js` | dropped | **present** |
| `packages/ui/node_modules/left-pad/index.js` | **present** | **present** |

So on `buildViaDockerode` (docker.ts:1038) whatever survives this prune is what lands in the image, and on `buildImageOnRemote` (docker.ts:794) the remote CLI re-applies the same root-anchored rules to the transferred tree. Either way, a monorepo whose `.dockerignore` says `node_modules` will now ship its nested `node_modules` — which is precisely what `docker build .` on that tree already produces, but the cost lands in **image size**, not just wire size. If you would rather keep the current any-depth pruning as a deliberate size optimisation, say so and I will drop change 2 and keep only the build-file fix.

### Known limits, deliberately not addressed here

**A. A multi-service build computes the build-file set from the first spec only.** `docker.ts:1634` takes `const source = specs[0]!.config` and passes it to `prepareSourceTree` at :1649, while the loop at :1655 resolves each `spec.config` separately. So in a compose/monorepo build, a second service whose `dockerfilePath` points elsewhere is not in the protected set, and a `.dockerignore` naming it still prunes it. Fixing it means changing `prepareSourceTree`'s exported signature to accept the full spec list, which pulls `docker.ts` into this diff — happy to do it as a follow-up, or here if you prefer it in one go.

**B. A negation cannot re-include anything inside an excluded directory.** `applyDockerignore` `rm -rf`s a matched directory before descending into it:

| `.dockerignore` | real docker keeps | `main` | this branch |
|---|---|---|---|
| `docs` + `!docs/readme.md` | `docs/readme.md` | dropped | dropped |
| `*` + `!src/index.ts` | `src/index.ts` | dropped | dropped |

Pre-existing, unchanged by this PR, and the only remaining divergence in the 20-case differential set I ran against the real binary. The new test is named "keeps a **root-level** negation in an allowlist `.dockerignore`" deliberately: `*` + `!package.json` works only because that negation is at the context root, and I did not want the test name to advertise general negation support that the code does not have.

## Verification

Base commit `c40eb2d2`. `origin/main` has since moved to `d4834808`, which touches only `apps/dashboard` and no `packages/adapters` file, so no rebase is needed.

**The regression tests fail without the fix.** The fix is one commit, so the proof restores just the source file to the base commit and leaves the tests in place:

```bash
$ git checkout c40eb2d2 -- packages/adapters/src/runtime/docker-build-context.ts
$ cd packages/adapters && npx vitest run src/runtime/docker-build-context.test.ts

     × keeps the Dockerfile and .dockerignore when .dockerignore excludes them 82ms
     × matches patterns from the context root instead of at every depth 73ms
     ✓ prunes at every depth for a globstar pattern 72ms
     × keeps a root-level negation in an allowlist .dockerignore 73ms
     × resolves the repository Dockerfile when .dockerignore excludes it 77ms
     × does not fall back to a generated Dockerfile when .dockerignore excludes the repository one 72ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected [ 'app/build/page.tsx', …(4) ] to include 'Dockerfile'
AssertionError: expected [ '.dockerignore', 'Dockerfile', …(1) ] to include 'app/build/page.tsx'
AssertionError: expected [ 'package.json' ] to deeply equal [ '.dockerignore', 'Dockerfile', …(1) ]
Error: No Dockerfile found for this build context. Expected Dockerfile.
AssertionError: expected 'Dockerfile.openship' to be 'Dockerfile' // Object.is equality
Expected: "Dockerfile"
Received: "Dockerfile.openship"

 Test Files  1 failed (1)
      Tests  5 failed | 1 passed (6)

$ git checkout HEAD -- packages/adapters/src/runtime/docker-build-context.ts
$ cd packages/adapters && npx vitest run src/runtime/docker-build-context.test.ts

 ✓ src/runtime/docker-build-context.test.ts (6 tests) 464ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

The last of those five is the silent-fallback case — `Dockerfile.openship` instead of the repository `Dockerfile`, with no error raised. The sixth test (`prunes at every depth for a globstar pattern`) passes on `main` as well; it is there to pin the other direction, that anchoring must not stop a `**/` pattern reaching every depth. I could not make it fail by inverting the `**/` guard, because the `ignore` package treats `/**/x` and `**/x` identically — so it is a boundary assertion rather than a regression test, and I am flagging that rather than counting it. Concretely: the `**/` early return in `anchorDockerignorePattern` is defensive against a matcher change rather than load-bearing today, and this test is what would catch a future blanket-prefix or matcher swap breaking `**/` patterns.

**Differential against the real binary** (Docker server 29.5.2, client 29.6.1, legacy builder — no buildx installed). `A` is `docker build <dir>`, `B` is a full tar of the same directory piped to `docker build -`; both images are then listed with `find /ctx -type f`:

```bash
$ ./case.sh nmbuild 'node_modules
build
'
=== nmbuild :: .dockerignore = node_modules build
--- A: docker build <dir>
.dockerignore
Dockerfile
app/build/page.tsx
docs/readme.md
package.json
packages/ui/node_modules/left-pad/index.js
src/index.ts
--- B: tar . | docker build -
.dockerignore
Dockerfile
app/build/page.tsx
build/artifact.txt
docs/readme.md
node_modules/left-pad/index.js
package.json
packages/ui/node_modules/left-pad/index.js
src/index.ts

$ ./case.sh both 'Dockerfile
.dockerignore
'
=== both :: .dockerignore = Dockerfile .dockerignore
--- A: docker build <dir>
app/build/page.tsx
build/artifact.txt
docs/readme.md
node_modules/left-pad/index.js
package.json
packages/ui/node_modules/left-pad/index.js
src/index.ts
--- B: tar . | docker build -
app/build/page.tsx
build/artifact.txt
docs/readme.md
node_modules/left-pad/index.js
package.json
packages/ui/node_modules/left-pad/index.js
src/index.ts
```

Case `nmbuild` is what establishes that the daemon applies no general patterns (B keeps both `node_modules` trees). Case `both` shows the build succeeding with both build files in the context and the daemon stripping them from the image — which is why keeping them in the context dir is safe.

**Full suite**, `bun run test -- --continue`, per the note in CONTRIBUTING about turbo aborting siblings:

```bash
# baseline, c40eb2d2
@repo/desktop     3 passed (3)
@repo/dashboard   236 passed (236)
@repo/db          55 passed (55)
openship          181 passed (181)
@repo/core        325 passed (325)
@repo/adapters    738 passed (738)
@repo/api         1841 passed | 15 skipped (1856)
 Tasks:    7 successful, 7 total        →  3379 passed / 15 skipped / 0 failed

# this branch
@repo/desktop     3 passed (3)
@repo/core        325 passed (325)
@repo/db          55 passed (55)
openship          181 passed (181)
@repo/dashboard   236 passed (236)
@repo/api         1841 passed | 15 skipped (1856)
@repo/adapters    744 passed (744)
 Tasks:    7 successful, 7 total        →  3385 passed / 15 skipped / 0 failed
```

`main` is green; the only delta is the 6 new adapters tests.

**Typecheck**, both CI jobs:

```bash
$ bun run --cwd packages/adapters lint
$ tsc --noEmit
exit=0

$ bun run --cwd apps/api lint
$ tsc --noEmit
exit=0
```

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — with one caveat I would rather state than hide: `bun format` is a repo-wide `prettier --write` and rewrites 1579 files on `main`, so running it would bury this diff. I ran `prettier --check` per file instead. The new test file is clean; `docker-build-context.ts` carries exactly the two drifts it already has on `main` (the `reject(new Error(...))` at :106 and the `assembleGitClone` destructure, :241 on `main` / :282 here) and no new ones.
- [x] I understand every line of this diff and can explain it in review
