### PR TITLE
fix(deployments): probe the published host port, not container-internal ports

### DIFF
--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -1418,6 +1418,32 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
         ensurePorts: async (cfg, promptUser) => {
           const executor = phase.targetExecutor;
           if (!executor) return;
+          // A published container binds exactly ONE host port — the loopback pin.
+          // Its own port lives in the container's network namespace and can never
+          // collide on the host, so probing it there compares an unrelated number
+          // against the host's listeners: an app on 80 behind the edge reported a
+          // conflict with the edge itself, and the only "continue" action offered
+          // would have freed the edge — taking every routed site down to publish
+          // one. Probe what the workload actually binds, which is also the
+          // backstop `allocateHostPort` documents.
+          if (cfg.hostPort !== undefined) {
+            // The outgoing deployment still holds the pin at preflight time: the
+            // loopback-port strategy can't overlap, so the pipeline stops it in
+            // the very next step. Prompting the operator about our own container
+            // would stall every redeploy on a conflict that resolves itself.
+            const previousHostPort = prevDep?.containerId
+              ? await previousRuntime
+                  .getContainerInfo(prevDep.containerId)
+                  .then((info) => info?.hostPort)
+                  .catch(() => undefined)
+              : undefined;
+            if (previousHostPort !== cfg.hostPort) {
+              await ensurePortAvailable(executor, cfg.hostPort, logger, promptUser);
+            }
+            return;
+          }
+          // Bare: the app owns 127.0.0.1:<port> on the host, so its declared
+          // ports are the ones to check.
           const ports = Array.from(
             new Set(
               (routeState.publicEndpoints.length > 0


### PR DESCRIPTION
## The bug

The port preflight for a containerized deployment probes the project's **container-internal** ports against the **host**'s listeners.

In `executeServerDeploy`, the serve strategy's `ensurePorts` hook builds its list from `routeState.publicEndpoints` (falling back to `cfg.port`) and calls `ensurePortAvailable(executor, port, ...)` for each. Under the `loopback-port` route strategy those numbers live in the container's network namespace — they can't collide on the host at all. A published container binds exactly **one** host port: the loopback pin in `DeployConfig.hostPort`, published as `127.0.0.1:<hostPort>:<port>`.

So the check compares an unrelated number against the host's listener table.

## Reproduction

Deploy a Dockerized static site behind the Openship edge, with the container declaring port 80 (plain `nginx -g 'daemon off;'`, the default for a lot of `FROM nginx:alpine` images):

```
Port 80 is occupied by unknown listener. Waiting for user decision...
```

The occupant is the Openship **edge** itself. The prompt offers exactly two actions, and the one labeled to continue the deploy is `free_port`. Taking it stops the edge — every routed site on the box goes down in order to publish one. The operator's only safe move is to cancel and go re-declare the app's internal port, which was never actually in conflict.

## The fix

Probe `cfg.hostPort` when it's set. That's what the workload actually binds on the host, and it's the contract `host-port.ts` already documents:

> The deploy-time `ensurePortAvailable` prompt is the final backstop if the pick is taken.

Today that backstop doesn't exist for containers — the pin is never probed, while an unrelated number is.

**Redeploy guard.** The naive one-liner would prompt on *every* redeploy, because the project's own outgoing deployment still holds the pin at preflight time:

- `preflight` (→ `ensurePorts`) runs before `stopPreviousRetaining()` in `runDeployPipeline`
- `canOverlap` is `runtime.name !== "bare" && routeStrategy !== "loopback-port"` → **false** under loopback-port, so the pipeline is stop-first

and `resolveSystemdUnit` in `port-conflict.ts` only recognizes `openship-<depId>.service`, so a `docker-proxy` holding the pin wouldn't even be identified as ours. So the probe is skipped when the previous container's `hostPort` matches the incoming one — the pipeline releases it in the very next step.

**Bare runtime is unchanged.** There the app really does own `127.0.0.1:<port>` on the host, so the existing `publicEndpoints` enumeration is correct and still runs (`hostPort` is `undefined` for bare — see the `pinnedHostPort` guard).

The `readiness` gate a few lines below already does this same host-port remap, with a comment describing the mirror-image symptom:

> Reporting `cfg.port` here sent operators to look at the app's own port (3000) when the probe had really been talking to the published host port

This makes preflight consistent with it.

## Validation

Run on `1f73d58`:

- `bun install --frozen-lockfile` — clean
- `apps/api` `tsc --noEmit` — clean
- `apps/api` `vitest run` — 173 passed / 1 skipped; 1 failure in `test/modules/github/gh-identity-health.test.ts` ("reports no credential ... when nothing is stored"), which **fails identically on unpatched `main`** on a machine that has a real `gh` credential stored. Pre-existing and unrelated.
- `packages/adapters` `vitest run` — **85/85 passed**, including `non-overlap: stops the FAILED new deployment before restarting the old one`.

Found while running a self-hosted instance: an Astro site on `nginx:alpine` behind the edge, which reported the edge as its own port conflict.
