### PR TITLE
fix(dashboard): rewrite proxied OAuth redirects to public origin

### DIFF
--- a/apps/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/apps/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -26,6 +26,7 @@
  */
 
 import type { NextRequest } from "next/server";
+import { rewriteUpstreamLocation } from "@/lib/proxy-response";
 
 // Hop-by-hop headers — MUST NOT be forwarded by a proxy.
 // Per RFC 7230 §6.1 (HTTP/1.1) — Next.js's fetch automatically handles
@@ -159,14 +160,21 @@ async function proxy(req: NextRequest, pathSegments: string[]): Promise<Response
   // Mirror response headers, minus the hop-by-hop ones that the runtime
   // will recompute on the OUTGOING response anyway.
   const responseHeaders = new Headers();
+  const publicOrigin = process.env.OPENSHIP_PUBLIC_URL?.trim() || req.url;
   for (const [name, value] of upstreamRes.headers) {
-    if (RESPONSE_HOP_BY_HOP.has(name.toLowerCase())) continue;
+    const normalizedName = name.toLowerCase();
+    if (RESPONSE_HOP_BY_HOP.has(normalizedName)) continue;
     // set-cookie is handled separately below: `.set()` overwrites, so a
     // multi-cookie auth response (Better Auth sends session_token +
     // session_data) would lose all but the last one and the browser would
     // never receive a session.
-    if (name.toLowerCase() === "set-cookie") continue;
-    responseHeaders.set(name, value);
+    if (normalizedName === "set-cookie") continue;
+    responseHeaders.set(
+      name,
+      normalizedName === "location"
+        ? rewriteUpstreamLocation(value, upstream, publicOrigin)
+        : value,
+    );
   }
 
   // Preserve EVERY Set-Cookie header individually. getSetCookie() is the

--- a/apps/dashboard/src/lib/proxy-response.test.ts
+++ b/apps/dashboard/src/lib/proxy-response.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { rewriteUpstreamLocation } from "./proxy-response";
+
+describe("rewriteUpstreamLocation", () => {
+  const upstream = new URL("http://127.0.0.1:4000/api/auth/mcp/authorize");
+  const publicOrigin = "https://ops.example.com";
+
+  it("keeps OAuth self-redirects on the public dashboard origin", () => {
+    const location = "http://127.0.0.1:4000/api/auth/mcp/authorize?client_id=codex&prompt=consent";
+
+    expect(rewriteUpstreamLocation(location, upstream, publicOrigin)).toBe(
+      "https://ops.example.com/api/auth/mcp/authorize?client_id=codex&prompt=consent",
+    );
+  });
+
+  it("does not rewrite the OAuth client's loopback callback", () => {
+    const location = "http://127.0.0.1:60580/callback/codex?code=abc&state=xyz";
+
+    expect(rewriteUpstreamLocation(location, upstream, publicOrigin)).toBe(location);
+  });
+});

--- a/apps/dashboard/src/lib/proxy-response.ts
+++ b/apps/dashboard/src/lib/proxy-response.ts
@@ -1,0 +1,23 @@
+/**
+ * Rewrite redirects that point back at the proxy's private upstream so the
+ * client stays on the dashboard's reachable origin. Redirects to any other
+ * origin (notably an OAuth client's loopback callback) pass through unchanged.
+ */
+export function rewriteUpstreamLocation(
+  location: string,
+  upstream: URL,
+  publicOrigin: string,
+): string {
+  try {
+    const redirect = new URL(location, upstream);
+    if (redirect.origin !== upstream.origin) return location;
+
+    const publicUrl = new URL(publicOrigin);
+    redirect.protocol = publicUrl.protocol;
+    redirect.hostname = publicUrl.hostname;
+    redirect.port = publicUrl.port;
+    return redirect.toString();
+  } catch {
+    return location;
+  }
+}


### PR DESCRIPTION
## Summary

- rewrite same-origin `Location` responses from the private dashboard API upstream to the configured public OpenShip origin
- leave redirects to external origins unchanged, including native MCP clients' loopback OAuth callbacks
- add focused regression coverage for the OpenShip self-redirect and the client callback boundary

## Root cause

The same-host dashboard proxy streamed upstream response headers verbatim. During MCP OAuth, Better Auth adds `prompt=consent` by redirecting back to the authorize endpoint using the API request's internal origin (`http://127.0.0.1:4000`). A remote browser therefore followed the private VM address and failed before the consent page could load.

## Impact

External MCP clients such as Codex can complete OAuth against a self-hosted OpenShip instance served through the dashboard proxy. The API and dashboard may remain bound to loopback; this change does not require opening another port or weakening authentication.

## Validation

- reproduced the released v0.5.0 behavior: the public authorize request returned `Location: http://127.0.0.1:4000/...`
- deployed the same rewrite to a loopback-only self-hosted instance and verified the redirect now stays on its HTTPS public origin with no internal port
- completed `codex mcp login openship`; `codex mcp list` reports the server as `OAuth`
- `bun run --cwd apps/dashboard test` — 123 tests passed
- `bunx tsc --noEmit -p apps/dashboard/tsconfig.json` — passed
- `bunx prettier --check ...` for all changed files — passed
- `NEXT_PUBLIC_API_PROXY=true INTERNAL_API_URL=http://127.0.0.1:4000 OPENSHIP_PUBLIC_URL=https://ops.example.com bun run --cwd apps/dashboard build` — passed

The repository's current `bun run --cwd apps/dashboard lint` command was also attempted, but Next 16 interprets `next lint` as a project-directory argument and exits with `Invalid project directory .../apps/dashboard/lint`. The TypeScript check and production build both pass.

## Exclusions

- no OAuth scopes, consent behavior, cookies, or session handling changed
- no new endpoint, dependency, database change, or public network exposure
- no unrelated formatting changes

## Risk

The rewrite applies only when the upstream `Location` resolves to the same origin as the configured private API upstream. Redirects to a Codex/Claude loopback callback or any other external origin are preserved byte-for-byte.

Related to #346 and #119.
