### PR TITLE
feat: support alternate ACME CAs and EAB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,19 @@ INTERNAL_TOKEN=change-me-32-byte-random-hex
 # shown — override to avoid conflicts with something already on the host.
 # API_PORT=4000
 # DASHBOARD_PORT=3001
+
+# Certificate authority / ACME (self-hosted managed edge)
+# Defaults are unchanged when these are omitted: Let's Encrypt production,
+# Certbot's default EC key, and automatic renewal.
+# OPENSHIP_ACME_EMAIL=ops@example.com
+# OPENSHIP_ACME_DIRECTORY_URL=https://acme.zerossl.com/v2/DV90
+# EAB credentials must be set together. The HMAC key must be base64url encoded.
+# OPENSHIP_ACME_EAB_KID=
+# OPENSHIP_ACME_EAB_HMAC_KEY=
+# OPENSHIP_ACME_KEY_TYPE=ec256       # ec256 | ec384 | rsa2048 | rsa4096
+# OPENSHIP_ACME_CA_BUNDLE=/etc/ssl/private/acme-root.pem
+# OPENSHIP_ACME_TOS_AGREED=true
+# See docs/acme.md for ZeroSSL, private-CA, and container mount examples.
 # WEB_PORT=3000   # landing site — root control-plane compose (docker-compose.yml) only
 
 # ─── Image source (self-hosted pull-based compose) ───────

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -414,6 +414,42 @@ const envSchema = z.object({
     .min(16 * 1024)
     .max(8 * 1024 * 1024)
     .default(512 * 1024),
+}).superRefine((cfg, ctx) => {
+  // Fail ACME misconfiguration HERE, at boot, with the variable named — not at
+  // the first deploy, where NginxProvider's constructor re-checks the same rules
+  // (that check stays: the adapter also serves non-env callers). Empty/whitespace
+  // values count as unset, matching resolveAcmeProviderOptions.
+  const kid = cfg.OPENSHIP_ACME_EAB_KID?.trim();
+  const hmac = cfg.OPENSHIP_ACME_EAB_HMAC_KEY?.trim();
+  const bundle = cfg.OPENSHIP_ACME_CA_BUNDLE?.trim();
+  if (!!kid !== !!hmac) {
+    ctx.addIssue({
+      code: "custom",
+      path: [kid ? "OPENSHIP_ACME_EAB_HMAC_KEY" : "OPENSHIP_ACME_EAB_KID"],
+      message: "OPENSHIP_ACME_EAB_KID and OPENSHIP_ACME_EAB_HMAC_KEY must be set together",
+    });
+  }
+  if (kid && (!/^[\x20-\x7E]+$/.test(kid) || kid.length > 512)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["OPENSHIP_ACME_EAB_KID"],
+      message: "must be printable ASCII (maximum 512 characters)",
+    });
+  }
+  if (hmac && !/^[A-Za-z0-9_-]+={0,2}$/.test(hmac)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["OPENSHIP_ACME_EAB_HMAC_KEY"],
+      message: "must be the base64url-encoded value supplied by the CA",
+    });
+  }
+  if (bundle && !bundle.startsWith("/")) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["OPENSHIP_ACME_CA_BUNDLE"],
+      message: "must be an absolute path in the Certbot environment",
+    });
+  }
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -123,8 +123,19 @@ const envSchema = z.object({
   OPENSHIP_MANAGED_EDGE: envBool("false"),
   /** Loopback dashboard port the managed edge proxies to (defaults 3001). */
   OPENSHIP_DASHBOARD_PORT: z.coerce.number().int().positive().catch(3001),
-  /** Let's Encrypt contact email for the managed edge (defaults to the admin). */
+  /** ACME account contact email (defaults to the admin during guided setup). */
   OPENSHIP_ACME_EMAIL: z.string().optional(),
+  /** Alternate ACME directory URL. Unset keeps Certbot's Let's Encrypt default. */
+  OPENSHIP_ACME_DIRECTORY_URL: z.string().url().optional(),
+  /** External Account Binding credentials (must be configured as a pair). */
+  OPENSHIP_ACME_EAB_KID: z.string().optional(),
+  OPENSHIP_ACME_EAB_HMAC_KEY: z.string().optional(),
+  /** Certificate private-key algorithm and size. */
+  OPENSHIP_ACME_KEY_TYPE: z.enum(["ec256", "ec384", "rsa2048", "rsa4096"]).optional(),
+  /** CA root bundle path as seen by the Certbot process. */
+  OPENSHIP_ACME_CA_BUNDLE: z.string().optional(),
+  /** Non-interactive issuance requires explicit terms acceptance; historic default is true. */
+  OPENSHIP_ACME_TOS_AGREED: envBool("true"),
   /**
    * How long a deploy may HOLD waiting for a user decision (port conflict, edge
    * 80/443 takeover) before it gives up and aborts. Milliseconds; default 5 min

--- a/apps/api/src/lib/acme-config.ts
+++ b/apps/api/src/lib/acme-config.ts
@@ -1,0 +1,28 @@
+import type { NginxProviderOptions } from "@repo/adapters";
+import { env } from "../config/env";
+
+export type AcmeProviderOptions = Pick<
+  NginxProviderOptions,
+  | "acmeEmail"
+  | "acmeDirectoryUrl"
+  | "acmeEabKid"
+  | "acmeEabHmacKey"
+  | "acmeKeyType"
+  | "acmeCaBundle"
+  | "acmeTosAgreed"
+>;
+
+const present = (value: string | undefined): string | undefined => value?.trim() || undefined;
+
+/** Translate the public env contract without logging or returning the EAB secret. */
+export function resolveAcmeProviderOptions(): AcmeProviderOptions {
+  return {
+    acmeEmail: present(env.OPENSHIP_ACME_EMAIL),
+    acmeDirectoryUrl: present(env.OPENSHIP_ACME_DIRECTORY_URL),
+    acmeEabKid: present(env.OPENSHIP_ACME_EAB_KID),
+    acmeEabHmacKey: present(env.OPENSHIP_ACME_EAB_HMAC_KEY),
+    acmeKeyType: env.OPENSHIP_ACME_KEY_TYPE,
+    acmeCaBundle: present(env.OPENSHIP_ACME_CA_BUNDLE),
+    acmeTosAgreed: env.OPENSHIP_ACME_TOS_AGREED,
+  };
+}

--- a/apps/api/src/lib/controller-helpers.ts
+++ b/apps/api/src/lib/controller-helpers.ts
@@ -86,6 +86,7 @@ import {
 } from "@repo/adapters";
 import { env } from "../config/env";
 import { isOblienConfigured } from "./platform-mode";
+import { resolveAcmeProviderOptions } from "./acme-config";
 
 // Re-export the platform accessor so existing callers that do
 // `import { platform } from "@/lib/controller-helpers"` keep working
@@ -207,6 +208,7 @@ export function resolvePlatformConfig(): PlatformConfig {
   return {
     target: "selfhosted",
     runtime: env.DEPLOY_MODE === "bare" ? "bare" : "docker",
+    nginx: resolveAcmeProviderOptions(),
   };
 }
 

--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -17,6 +17,7 @@ import { platform } from "./controller-helpers";
 import { buildSshConfig, sshManager } from "./ssh-manager";
 import { createProvisionLock } from "./provision-lock";
 import { isLocalHostRow } from "./box-org";
+import { resolveAcmeProviderOptions } from "./acme-config";
 
 /**
  * The shape of `deployment.meta` JSONB. Snapshotted per-deploy —
@@ -361,6 +362,7 @@ export async function resolveTargetPlatform(
         runtime: runtimeMode,
         executor,
         docker: runtimeMode === "docker" ? { transport: "socket" as const } : undefined,
+        nginx: resolveAcmeProviderOptions(),
         provisionLock: createProvisionLock("provision:local"),
       });
     }
@@ -371,6 +373,7 @@ export async function resolveTargetPlatform(
       executor, // ← managed executor from pool
       ssh: ssh!,
       docker: runtimeMode === "docker" ? toDockerSshTransport(ssh!, executor) : undefined,
+      nginx: resolveAcmeProviderOptions(),
       // Serialize provisioning per target server, so concurrent deploys (across
       // projects / single-app + compose) never race apt/openresty/networks/state.
       provisionLock: createProvisionLock(`provision:server:${id}`),
@@ -385,6 +388,7 @@ export async function resolveTargetPlatform(
     docker: runtimeMode === "docker"
       ? { transport: "socket" as const }
       : undefined,
+    nginx: resolveAcmeProviderOptions(),
     provisionLock: createProvisionLock("provision:local"),
   });
 }

--- a/apps/api/src/lib/startup/self-edge.ts
+++ b/apps/api/src/lib/startup/self-edge.ts
@@ -14,6 +14,7 @@
 
 import { env } from "../../config/env";
 import { pinnedEdgeImage, withPinnedEdgeImage } from "../edge-image";
+import { resolveAcmeProviderOptions } from "../acme-config";
 
 export interface SelfEdgeInfraProgress {
   onLog?: (message: string, level?: "info" | "warn" | "error") => void;
@@ -105,6 +106,7 @@ async function runEnsure(
         status,
         sites: scan.sites,
         acmeEmail: env.OPENSHIP_ACME_EMAIL,
+        nginx: resolveAcmeProviderOptions(),
         extraRoutes: [],
         // Pin the edge the takeover installs. `setDefaultEdgeImage` at boot already
         // covers this, but state it here too: this is the ONE caller of

--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -61,6 +61,7 @@ import { resolveRuntimeResources, resolveBuildResources } from "../../lib/resour
 import { resolveBuildGitToken } from "../github/clone-auth";
 import { openDeployRelay } from "../../lib/git-forwarding";
 import { resolveOrgOwner } from "../../lib/org-actor";
+import { resolveAcmeProviderOptions } from "../../lib/acme-config";
 import {
   preCreateServiceDeployments,
   emitServiceCheckRun,
@@ -1227,7 +1228,7 @@ function buildDeployEnvironment(
                       onLog: systemLog,
                       promptUser: p,
                     }),
-                  { promptUser, onLog: systemLog },
+                  { promptUser, onLog: systemLog, nginx: resolveAcmeProviderOptions() },
                 );
                 if (edge.migrated && !edge.ok) {
                   // ensureEdge already rolled back to the previous proxy — we

--- a/apps/api/src/modules/domains/ensure-edge.controller.ts
+++ b/apps/api/src/modules/domains/ensure-edge.controller.ts
@@ -28,6 +28,7 @@ import { param } from "../../lib/controller-helpers";
 import { streamSSE } from "../../lib/sse";
 import { sshManager } from "../../lib/ssh-manager";
 import { withPinnedEdgeImage } from "../../lib/edge-image";
+import { resolveAcmeProviderOptions } from "../../lib/acme-config";
 import { applyProjectRouting } from "./routing-apply.service";
 import {
   createEdgeConsentSession,
@@ -206,7 +207,7 @@ export async function ensureEdgeStream(c: Context) {
         const edge = await ensureEdge(
           executor,
           (p) => installer(executor, onLog, withPinnedEdgeImage({ promptUser: p })),
-          { promptUser, onLog },
+          { promptUser, onLog, nginx: resolveAcmeProviderOptions() },
         );
         if (edge.migrated && !edge.ok) {
           throw new Error("Edge takeover failed — rolled back to the previous proxy.");

--- a/apps/api/src/modules/system/server-check.controller.ts
+++ b/apps/api/src/modules/system/server-check.controller.ts
@@ -33,6 +33,7 @@ import {
 import { formatDuration, systemDebug } from "@/lib/system-debug";
 import { sshManager, buildSshConfig } from "../../lib/ssh-manager";
 import { withPinnedEdgeImage } from "../../lib/edge-image";
+import { resolveAcmeProviderOptions } from "../../lib/acme-config";
 import { runConnectivityCheck } from "../../lib/connectivity";
 import "../../lib/connectivity-checks"; // registers ssh / ssh-server / backup-destination
 import { repos } from "@repo/db";
@@ -597,7 +598,15 @@ export async function installStream(c: Context) {
             const edge = await ensureEdge(
               executor,
               (p) => installerFn(executor, onLog, { ...config, promptUser: p }),
-              { promptUser, onLog, acmeEmail: config?.acmeEmail },
+              {
+                promptUser,
+                onLog,
+                acmeEmail: config?.acmeEmail,
+                nginx: {
+                  ...resolveAcmeProviderOptions(),
+                  ...(config?.acmeEmail ? { acmeEmail: config.acmeEmail } : {}),
+                },
+              },
             );
             if (!edge.migrated) return edge.value;
             return {

--- a/apps/cli/src/lib/compose.ts
+++ b/apps/cli/src/lib/compose.ts
@@ -822,6 +822,26 @@ function keepConfig(
   return carried || undefined;
 }
 
+const ACME_ENV_KEYS = [
+  "OPENSHIP_ACME_EMAIL",
+  "OPENSHIP_ACME_DIRECTORY_URL",
+  "OPENSHIP_ACME_EAB_KID",
+  "OPENSHIP_ACME_EAB_HMAC_KEY",
+  "OPENSHIP_ACME_KEY_TYPE",
+  "OPENSHIP_ACME_CA_BUNDLE",
+  "OPENSHIP_ACME_TOS_AGREED",
+] as const;
+
+/** Preserve operator-owned ACME settings, with the current shell overriding .env. */
+function renderAcmeEnv(prev: Record<string, string>): string[] {
+  return ACME_ENV_KEYS.flatMap((key) => {
+    const value = process.env[key]?.trim() || prev[key]?.trim();
+    if (!value) return [];
+    if (/[\r\n]/.test(value)) throw new Error(`${key} must be a single-line value`);
+    return [`${key}=${value}`];
+  });
+}
+
 /** The effective config for this run: flags over previous `.env` over defaults. */
 export function resolveEnvConfig(
   prev: Record<string, string>,
@@ -975,6 +995,9 @@ function renderEnv(
     // silently defaults to 3001 when unset. Ports are dynamic now, so leaving it
     // out publishes a domain routed to a port nothing is listening on.
     `OPENSHIP_DASHBOARD_PORT=${cfg.dashPort}`,
+    // Alternate CA/EAB values are operator configuration (including one secret),
+    // so a routine `openship up`/upgrade must not silently discard them.
+    ...renderAcmeEnv(prev),
   ];
   if (cfg.bindAddr) lines.push(`OPENSHIP_BIND_ADDR=${cfg.bindAddr}`);
   // The origin allowlist. Losing either of these is the ORIGIN_REJECTED failure

--- a/apps/cli/test/unit/compose-env-preserve.test.ts
+++ b/apps/cli/test/unit/compose-env-preserve.test.ts
@@ -136,6 +136,12 @@ const CONFIGURED = {
   OPENSHIP_IMAGE_REGISTRY: "registry.internal/oblien",
   OPENSHIP_HOST_CONTROL: "false",
   OPENSHIP_VERSION: "0.4.5",
+  OPENSHIP_ACME_DIRECTORY_URL: "https://acme.example.test/directory",
+  OPENSHIP_ACME_EAB_KID: "kid-123",
+  OPENSHIP_ACME_EAB_HMAC_KEY: "c2VjcmV0",
+  OPENSHIP_ACME_KEY_TYPE: "ec384",
+  OPENSHIP_ACME_CA_BUNDLE: "/etc/ssl/private/acme-root.pem",
+  OPENSHIP_ACME_TOS_AGREED: "true",
 };
 
 beforeEach(() => {
@@ -203,6 +209,11 @@ describe("composeUp — re-run on a configured install", () => {
     // Secrets keep their existing values, as before.
     expect(env.INTERNAL_TOKEN).toBe("internal-secret");
     expect(env.POSTGRES_PASSWORD).toBe("pg-secret");
+    expect(env.OPENSHIP_ACME_DIRECTORY_URL).toBe("https://acme.example.test/directory");
+    expect(env.OPENSHIP_ACME_EAB_KID).toBe("kid-123");
+    expect(env.OPENSHIP_ACME_EAB_HMAC_KEY).toBe("c2VjcmV0");
+    expect(env.OPENSHIP_ACME_KEY_TYPE).toBe("ec384");
+    expect(env.OPENSHIP_ACME_CA_BUNDLE).toBe("/etc/ssl/private/acme-root.pem");
   });
 
   it("reports the EFFECTIVE ports, not the defaults", async () => {

--- a/apps/cli/test/unit/compose-env-preserve.test.ts
+++ b/apps/cli/test/unit/compose-env-preserve.test.ts
@@ -136,6 +136,7 @@ const CONFIGURED = {
   OPENSHIP_IMAGE_REGISTRY: "registry.internal/oblien",
   OPENSHIP_HOST_CONTROL: "false",
   OPENSHIP_VERSION: "0.4.5",
+  OPENSHIP_ACME_EMAIL: "ops@example.test",
   OPENSHIP_ACME_DIRECTORY_URL: "https://acme.example.test/directory",
   OPENSHIP_ACME_EAB_KID: "kid-123",
   OPENSHIP_ACME_EAB_HMAC_KEY: "c2VjcmV0",
@@ -209,11 +210,13 @@ describe("composeUp — re-run on a configured install", () => {
     // Secrets keep their existing values, as before.
     expect(env.INTERNAL_TOKEN).toBe("internal-secret");
     expect(env.POSTGRES_PASSWORD).toBe("pg-secret");
+    expect(env.OPENSHIP_ACME_EMAIL).toBe("ops@example.test");
     expect(env.OPENSHIP_ACME_DIRECTORY_URL).toBe("https://acme.example.test/directory");
     expect(env.OPENSHIP_ACME_EAB_KID).toBe("kid-123");
     expect(env.OPENSHIP_ACME_EAB_HMAC_KEY).toBe("c2VjcmV0");
     expect(env.OPENSHIP_ACME_KEY_TYPE).toBe("ec384");
     expect(env.OPENSHIP_ACME_CA_BUNDLE).toBe("/etc/ssl/private/acme-root.pem");
+    expect(env.OPENSHIP_ACME_TOS_AGREED).toBe("true");
   });
 
   it("reports the EFFECTIVE ports, not the defaults", async () => {

--- a/docs/acme.md
+++ b/docs/acme.md
@@ -1,0 +1,81 @@
+# Custom ACME certificate authorities
+
+OpenShip uses Certbot on the managed OpenResty edge. With no ACME configuration,
+certificate issuance and renewal continue to use Let's Encrypt production.
+
+Set the following variables in the environment used to start OpenShip, then
+restart the API/control plane:
+
+```dotenv
+OPENSHIP_ACME_EMAIL=ops@example.com
+OPENSHIP_ACME_DIRECTORY_URL=https://acme.example.com/directory
+OPENSHIP_ACME_EAB_KID=example-key-id
+OPENSHIP_ACME_EAB_HMAC_KEY=base64url-encoded-hmac-key
+OPENSHIP_ACME_KEY_TYPE=ec256
+OPENSHIP_ACME_TOS_AGREED=true
+```
+
+`OPENSHIP_ACME_EAB_KID` and `OPENSHIP_ACME_EAB_HMAC_KEY` are optional, but they
+must be supplied together. OpenShip never places the HMAC key in Certbot's
+command line or streamed logs. It writes the pair to a unique mode-`0600`
+Certbot configuration file for the issuance process and deletes that file when
+the process exits. Keep the source value in a protected environment/secret store.
+
+Supported certificate key choices are `ec256`, `ec384`, `rsa2048`, and
+`rsa4096`. When omitted, Certbot's installed-version default is preserved.
+
+## Let's Encrypt
+
+No custom settings are required. For staging tests, add:
+
+```dotenv
+OPENSHIP_ACME_DIRECTORY_URL=https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+## ZeroSSL
+
+Create EAB credentials in ZeroSSL, then configure its production directory:
+
+```dotenv
+OPENSHIP_ACME_EMAIL=ops@example.com
+OPENSHIP_ACME_DIRECTORY_URL=https://acme.zerossl.com/v2/DV90
+OPENSHIP_ACME_EAB_KID=your-zerossl-kid
+OPENSHIP_ACME_EAB_HMAC_KEY=your-zerossl-hmac-key
+OPENSHIP_ACME_TOS_AGREED=true
+```
+
+The HMAC value must remain in the base64url form supplied by the CA; do not
+decode it before configuring OpenShip.
+
+## Private CA and custom trust root
+
+For a private ACME server such as `step-ca`, point OpenShip at the directory and
+make its root certificate visible in the environment where Certbot runs:
+
+```dotenv
+OPENSHIP_ACME_DIRECTORY_URL=https://ca.internal.example/acme/provisioner/directory
+OPENSHIP_ACME_EAB_KID=provisioned-key-id
+OPENSHIP_ACME_EAB_HMAC_KEY=provisioned-base64url-key
+OPENSHIP_ACME_CA_BUNDLE=/etc/ssl/private/acme-root.pem
+```
+
+On a bare Linux edge, the bundle path is a normal absolute host path. When the
+edge runs in a container, the same absolute path must be mounted read-only into
+the `edge` container. For the repository Compose stack, use an override:
+
+```yaml
+services:
+  edge:
+    volumes:
+      - /secure/acme-root.pem:/etc/ssl/private/acme-root.pem:ro
+```
+
+Certbot uses `REQUESTS_CA_BUNDLE` for issuance and renewal. The bundle therefore
+needs to contain the private root plus any public roots needed by the ACME
+endpoint's chain.
+
+## Current scope
+
+These settings define one instance-wide CA. Persistent named CA profiles and
+per-project/per-domain overrides require a database and API design and are not
+yet exposed by the dashboard or CLI.

--- a/docs/acme.md
+++ b/docs/acme.md
@@ -21,6 +21,11 @@ command line or streamed logs. It writes the pair to a unique mode-`0600`
 Certbot configuration file for the issuance process and deletes that file when
 the process exits. Keep the source value in a protected environment/secret store.
 
+Because that file is passed with Certbot's `--config` flag, an operator-managed
+`/etc/letsencrypt/cli.ini` is ignored for EAB issuance runs. If you rely on
+custom `cli.ini` settings, express them through the `OPENSHIP_ACME_*` variables
+instead.
+
 Supported certificate key choices are `ec256`, `ec384`, `rsa2048`, and
 `rsa4096`. When omitted, Certbot's installed-version default is preserved.
 
@@ -73,6 +78,16 @@ services:
 Certbot uses `REQUESTS_CA_BUNDLE` for issuance and renewal. The bundle therefore
 needs to contain the private root plus any public roots needed by the ACME
 endpoint's chain.
+
+## Switching certificate authorities
+
+Certbot records the issuing directory per certificate, and a certificate issued
+by one CA cannot be renewed against another (the new CA requires its own
+account, and usually its own EAB credentials). When the configured directory
+differs from the one that issued a certificate, OpenShip reissues that
+certificate under the newly configured CA at its next renewal instead of
+renewing it — a one-time reissue per domain, after which normal renewal
+resumes. Existing certificates keep serving traffic until that happens.
 
 ## Current scope
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -146,6 +146,9 @@ Fix by moving Docker's data-root to a native `ext4`/`xfs` disk (`/etc/docker/dae
 
 Add `--json` to most read commands for scripting.
 
+For alternate certificate authorities, EAB credentials, or a private ACME root,
+see [Custom ACME certificate authorities](acme.md).
+
 ---
 
 ## Quick decision

--- a/packages/adapters/src/infra/nginx.test.ts
+++ b/packages/adapters/src/infra/nginx.test.ts
@@ -213,14 +213,19 @@ describe("NginxProvider config generation", () => {
     expect(certbot).not.toContain(hmac);
     const configPath = certbot?.match(/'--config' '([^']+)'/)?.[1];
     expect(configPath).toBeDefined();
-    // Perms are tightened on the TEMP file BEFORE the rename publishes it, so the
-    // secret is never on disk at the final path with default (0644) permissions.
-    const chmodIdx = calls.findIndex((c) => c.startsWith("chmod ") && c.includes(`${configPath}.tmp-`));
+    // git-ssh-material layout: the ini lives in its own 0700 directory (locked
+    // down BEFORE any secret bytes land, covering even the staged temp file),
+    // the file itself is chmod 600 before the rename publishes it, and cleanup
+    // removes the whole directory as a unit.
+    const secretDir = configPath!.replace(/\/eab\.ini$/, "");
+    expect(secretDir).toContain(".openship-eab-");
+    const dirChmodIdx = calls.findIndex((c) => c.startsWith("chmod ") && c.includes("'700'") && c.includes(secretDir));
+    const fileChmodIdx = calls.findIndex((c) => c.startsWith("chmod ") && c.includes("'600'") && c.includes(`${configPath}.tmp-`));
     const publishIdx = calls.findIndex((c) => c.startsWith("mv ") && c.includes(`'${configPath}'`));
-    expect(calls[chmodIdx]).toContain("'600'");
-    expect(chmodIdx).toBeGreaterThanOrEqual(0);
-    expect(publishIdx).toBeGreaterThan(chmodIdx);
-    expect(removed).toContain(configPath);
+    expect(dirChmodIdx).toBeGreaterThanOrEqual(0);
+    expect(fileChmodIdx).toBeGreaterThan(dirChmodIdx);
+    expect(publishIdx).toBeGreaterThan(fileChmodIdx);
+    expect(removed).toContain(secretDir);
   });
 
   test("rejects incomplete or malformed EAB configuration before issuance", () => {

--- a/packages/adapters/src/infra/nginx.test.ts
+++ b/packages/adapters/src/infra/nginx.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { NginxProvider, renderProxyOptions } from "./nginx";
+import { NginxProvider, renderProxyOptions, type NginxProviderOptions } from "./nginx";
 import { PROXY_GZIP_TYPES } from "@repo/core";
 import { OPENRESTY_DEFAULT_PATHS, luaSourceAvailable, RULES_GUARD_PATH, ACME_HTTP01_PORT, ensureOpenRestyConfig } from "./openresty-lua";
 import type { CommandExecutor, RouteConfig } from "../types";
@@ -19,6 +19,8 @@ interface FakeOpts {
   certDomains?: string[];
   /** Simulate an edge with no `openssl` CLI (bootstrap cert can't be produced). */
   noOpenssl?: boolean;
+  provider?: Partial<NginxProviderOptions>;
+  certbotFailure?: string;
 }
 
 /** Stateful fake executor: in-memory file map + atomic-rename (`mv`) handling.
@@ -28,6 +30,7 @@ function makeExecutor(
   opts: FakeOpts,
   calls: string[],
   removed: string[] = [],
+  writes: Array<{ path: string; content: string }> = [],
 ): CommandExecutor {
   const exec = async (command: string): Promise<string> => {
     calls.push(command);
@@ -39,6 +42,9 @@ function makeExecutor(
       // the `mv` below has something to move.
       for (const m of command.matchAll(/'([^']*\.pem)'/g)) files.set(m[1], "PEM");
       return "";
+    }
+    if ((command.startsWith("certbot ") || command.startsWith("env ")) && opts.certbotFailure) {
+      throw new Error(opts.certbotFailure);
     }
     if (command.startsWith("mv -f ")) {
       // Pair swap: `mv -f 'staging/fullchain.pem' 'staging/privkey.pem' 'dir'/`
@@ -65,7 +71,7 @@ function makeExecutor(
   };
   return {
     exec,
-    writeFile: async (p: string, c: string) => { files.set(p, c); },
+    writeFile: async (p: string, c: string) => { writes.push({ path: p, content: c }); files.set(p, c); },
     readFile: async (p: string) => {
       const c = files.get(p);
       if (c === undefined) throw new Error(`ENOENT ${p}`);
@@ -82,8 +88,13 @@ function setup(opts: FakeOpts = {}) {
   const files = new Map<string, string>();
   const calls: string[] = [];
   const removed: string[] = [];
-  const nginx = new NginxProvider({ paths: PATHS, executor: makeExecutor(files, opts, calls, removed) });
-  return { nginx, files, calls, removed, conf: (slug: string) => files.get(`${SITES}/${slug}.conf`) };
+  const writes: Array<{ path: string; content: string }> = [];
+  const nginx = new NginxProvider({
+    ...opts.provider,
+    paths: PATHS,
+    executor: makeExecutor(files, opts, calls, removed, writes),
+  });
+  return { nginx, files, calls, removed, writes, conf: (slug: string) => files.get(`${SITES}/${slug}.conf`) };
 }
 
 const PROXY: RouteConfig = { domain: "app.example.com", tls: true, targetUrl: "http://127.0.0.1:3009" };
@@ -158,6 +169,59 @@ describe("NginxProvider config generation", () => {
     expect(certbot).toContain(String(ACME_HTTP01_PORT));
     expect(certbot).toContain("--cert-name");
     expect(certbot).not.toContain("--webroot");
+  });
+
+  test("alternate ACME directory, CA bundle, and key type reach certbot", async () => {
+    const { nginx, calls } = setup({
+      provider: {
+        acmeDirectoryUrl: "https://acme.example.test/directory",
+        acmeCaBundle: "/etc/ssl/private/acme-root.pem",
+        acmeKeyType: "ec384",
+      },
+    });
+    await expect(nginx.provisionCert("app.example.com")).rejects.toThrow();
+    const certbot = calls.find((c) => c.startsWith("env ") && c.includes("certbot"));
+    expect(certbot).toContain("REQUESTS_CA_BUNDLE=/etc/ssl/private/acme-root.pem");
+    expect(certbot).toContain("--server");
+    expect(certbot).toContain("https://acme.example.test/directory");
+    expect(certbot).toContain("--key-type");
+    expect(certbot).toContain("ecdsa");
+    expect(certbot).toContain("secp384r1");
+  });
+
+  test("EAB HMAC is passed through an ephemeral 0600 config and never argv or errors", async () => {
+    const hmac = "c3VwZXItc2VjcmV0LWhtYWM";
+    const { nginx, calls, writes, removed } = setup({
+      provider: { acmeEabKid: "kid-123", acmeEabHmacKey: hmac },
+      certbotFailure: `CA rejected EAB key ${hmac}`,
+    });
+    let error: Error | undefined;
+    try {
+      await nginx.provisionCert("app.example.com");
+    } catch (err) {
+      error = err as Error;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).not.toContain(hmac);
+    expect(error?.message).toContain("[REDACTED]");
+
+    const secretWrite = writes.find((w) => w.path.includes(".openship-eab-"));
+    expect(secretWrite?.content).toContain("eab-kid = kid-123");
+    expect(secretWrite?.content).toContain(`eab-hmac-key = ${hmac}`);
+    const chmod = calls.find((c) => c.startsWith("chmod "));
+    expect(chmod).toContain("'600'");
+    const configPath = chmod?.match(/'([^']*\.ini)'/)?.[1];
+    const certbot = calls.find((c) => c.startsWith("certbot "));
+    expect(certbot).toContain("--config");
+    expect(certbot).not.toContain(hmac);
+    expect(removed).toContain(configPath);
+  });
+
+  test("rejects incomplete or malformed EAB configuration before issuance", () => {
+    expect(() => setup({ provider: { acmeEabKid: "kid-only" } })).toThrow(/requires both/i);
+    expect(() => setup({
+      provider: { acmeEabKid: "kid", acmeEabHmacKey: "not standard base64/+" },
+    })).toThrow(/base64url/i);
   });
 
   test("webhook proxy adds the /_openship/hooks/ location", async () => {

--- a/packages/adapters/src/infra/nginx.test.ts
+++ b/packages/adapters/src/infra/nginx.test.ts
@@ -208,12 +208,18 @@ describe("NginxProvider config generation", () => {
     const secretWrite = writes.find((w) => w.path.includes(".openship-eab-"));
     expect(secretWrite?.content).toContain("eab-kid = kid-123");
     expect(secretWrite?.content).toContain(`eab-hmac-key = ${hmac}`);
-    const chmod = calls.find((c) => c.startsWith("chmod "));
-    expect(chmod).toContain("'600'");
-    const configPath = chmod?.match(/'([^']*\.ini)'/)?.[1];
     const certbot = calls.find((c) => c.startsWith("certbot "));
     expect(certbot).toContain("--config");
     expect(certbot).not.toContain(hmac);
+    const configPath = certbot?.match(/'--config' '([^']+)'/)?.[1];
+    expect(configPath).toBeDefined();
+    // Perms are tightened on the TEMP file BEFORE the rename publishes it, so the
+    // secret is never on disk at the final path with default (0644) permissions.
+    const chmodIdx = calls.findIndex((c) => c.startsWith("chmod ") && c.includes(`${configPath}.tmp-`));
+    const publishIdx = calls.findIndex((c) => c.startsWith("mv ") && c.includes(`'${configPath}'`));
+    expect(calls[chmodIdx]).toContain("'600'");
+    expect(chmodIdx).toBeGreaterThanOrEqual(0);
+    expect(publishIdx).toBeGreaterThan(chmodIdx);
     expect(removed).toContain(configPath);
   });
 
@@ -222,6 +228,65 @@ describe("NginxProvider config generation", () => {
     expect(() => setup({
       provider: { acmeEabKid: "kid", acmeEabHmacKey: "not standard base64/+" },
     })).toThrow(/base64url/i);
+  });
+
+  test("renewing a lineage issued by a DIFFERENT directory reissues under the configured CA", async () => {
+    const { nginx, files, calls } = setup({
+      certDomains: ["app.example.com"],
+      provider: { acmeDirectoryUrl: "https://acme.example.test/directory" },
+    });
+    // Pre-switch lineage: certbot's renewal conf records the OLD issuing server,
+    // which `renew` holds no account for after the operator changed CAs.
+    files.set(
+      "/etc/letsencrypt/renewal/app.example.com.conf",
+      "[renewalparams]\nserver = https://acme-v02.api.letsencrypt.org/directory\n",
+    );
+    await nginx.renewCert("app.example.com").catch(() => undefined);
+    const certonly = calls.find((c) => c.includes("certonly"));
+    expect(certonly).toContain("--force-renewal");
+    expect(certonly).toContain("--server");
+    expect(certonly).toContain("https://acme.example.test/directory");
+    expect(calls.find((c) => c.includes("'renew'"))).toBeUndefined();
+  });
+
+  test("renewing a lineage issued by the SAME directory renews plainly, without --server", async () => {
+    const { nginx, files, calls } = setup({
+      certDomains: ["app.example.com"],
+      provider: { acmeDirectoryUrl: "https://acme.example.test/directory" },
+    });
+    files.set(
+      "/etc/letsencrypt/renewal/app.example.com.conf",
+      "[renewalparams]\nserver = https://acme.example.test/directory\n",
+    );
+    await nginx.renewCert("app.example.com").catch(() => undefined);
+    const renew = calls.find((c) => c.startsWith("certbot ") && c.includes("'renew'"));
+    expect(renew).toContain("--cert-name");
+    expect(renew).not.toContain("--server");
+    expect(calls.find((c) => c.includes("certonly"))).toBeUndefined();
+  });
+
+  test("a renew failure never leaks the EAB HMAC in the thrown error", async () => {
+    const hmac = "c3VwZXItc2VjcmV0LWhtYWM";
+    const { nginx, files } = setup({
+      certDomains: ["app.example.com"],
+      provider: { acmeEabKid: "kid-123", acmeEabHmacKey: hmac },
+      certbotFailure: `CA rejected EAB key ${hmac}`,
+    });
+    // Matching lineage (no custom directory → certbot's Let's Encrypt default),
+    // so the PLAIN renew path runs — the one with no redacting catch of its own.
+    files.set(
+      "/etc/letsencrypt/renewal/app.example.com.conf",
+      "[renewalparams]\nserver = https://acme-v02.api.letsencrypt.org/directory\n",
+    );
+    let error: Error | undefined;
+    try {
+      await nginx.renewCert("app.example.com");
+    } catch (err) {
+      error = err as Error;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).not.toContain(hmac);
+    expect(error?.message).toContain("[REDACTED]");
   });
 
   test("webhook proxy adds the /_openship/hooks/ location", async () => {

--- a/packages/adapters/src/infra/nginx.ts
+++ b/packages/adapters/src/infra/nginx.ts
@@ -779,15 +779,36 @@ export class NginxProvider implements RoutingProvider, SslProvider {
       : value;
   }
 
-  /** Keep EAB HMAC material out of argv/process listings and remove it after use. */
+  /**
+   * Keep EAB HMAC material out of argv/process listings and remove it after use.
+   *
+   * Same layout contract as runtime/git-ssh-material.ts (the repo's other
+   * ephemeral-secret-on-disk site): the material lives in its OWN 0700 directory
+   * with the file at 0600, the bytes never travel through a shell command line,
+   * and cleanup removes the directory as a unit. The 0700 parent goes first, so
+   * even the temp file _writeFile stages is born unreadable to other users.
+   */
   private async createEphemeralEabConfig(): Promise<string | null> {
     if (!this.acmeEabKid || !this.acmeEabHmacKey) return null;
-    const path = join(dirname(this.certDir), `.openship-eab-${randomBytes(12).toString("hex")}.ini`);
-    await this._writeFile(
-      path,
-      `eab-kid = ${this.acmeEabKid}\neab-hmac-key = ${this.acmeEabHmacKey}\n`,
-      0o600,
-    );
+    const dir = join(dirname(this.certDir), `.openship-eab-${randomBytes(12).toString("hex")}`);
+    const path = join(dir, "eab.ini");
+    if (this.executor) {
+      await this.executor.mkdir(dir);
+      await this._exec("chmod", ["700", dir]);
+    } else {
+      await fsMkdir(dir, { recursive: true, mode: 0o700 });
+    }
+    try {
+      await this._writeFile(
+        path,
+        `eab-kid = ${this.acmeEabKid}\neab-hmac-key = ${this.acmeEabHmacKey}\n`,
+        0o600,
+      );
+    } catch (err) {
+      // A partial write must not leave key material behind (git-ssh-material rule).
+      await this._rm(dir).catch(() => undefined);
+      throw err;
+    }
     return path;
   }
 
@@ -1166,7 +1187,9 @@ ${serveLocation}
       // Replace certbot's opaque opener with the real, actionable cause.
       throw new Error(summarizeCertbotFailure(this.redactAcmeSecrets(safeErrorMessage(err)), domain));
     } finally {
-      if (eabConfig) await this._rm(eabConfig).catch(() => undefined);
+      // Remove the whole 0700 directory, not just the ini — one unit, like
+      // git-ssh-material's cleanup.
+      if (eabConfig) await this._rm(dirname(eabConfig)).catch(() => undefined);
     }
 
     // Rewrite the config with SSL now that certs exist

--- a/packages/adapters/src/infra/nginx.ts
+++ b/packages/adapters/src/infra/nginx.ts
@@ -23,7 +23,6 @@ import {
   readFile as fsReadFile,
   rename as fsRename,
   stat as fsStat,
-  chmod as fsChmod,
 } from "node:fs/promises";
 import { execFile as cpExecFile } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
@@ -269,6 +268,10 @@ export interface NginxProviderOptions {
 
 const DEFAULT_CERT_DIR = "/etc/letsencrypt/live";
 
+/** Certbot's implicit default when no `--server` is passed — what every lineage
+ * issued before alternate-CA support (or with no directory configured) records. */
+const LETSENCRYPT_PRODUCTION_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory";
+
 export type AcmeKeyType = NonNullable<NginxProviderOptions["acmeKeyType"]>;
 
 function assertValidAcmeOptions(opts: NginxProviderOptions): void {
@@ -474,7 +477,7 @@ export class NginxProvider implements RoutingProvider, SslProvider {
 
   // ── File operation helpers (dual-path: local or remote) ──────────────
 
-  private async _writeFile(path: string, content: string): Promise<void> {
+  private async _writeFile(path: string, content: string, mode?: number): Promise<void> {
     // Random suffix (not just pid+ms) so two same-ms writes to the same conf
     // can't collide on the temp path and defeat the atomic rename.
     const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}-${randomBytes(4).toString("hex")}`;
@@ -482,6 +485,12 @@ export class NginxProvider implements RoutingProvider, SslProvider {
     if (this.executor) {
       try {
         await this.executor.writeFile(tmpPath, content);
+        // Tighten perms on the TEMP file, before the rename publishes it — rename
+        // preserves the source's mode, so the final path never exists more open
+        // than requested. (executor.writeFile has no mode parameter.)
+        if (mode !== undefined) {
+          await this.executor.exec(`chmod ${sq(mode.toString(8))} ${sq(tmpPath)}`);
+        }
         // `rename` (a FILE op), not `exec("mv")`. On a container edge, commands run
         // INSIDE the container while file ops land on the HOST — so the mv renamed a
         // path the container can't see and failed with ENOENT on the file we had just
@@ -500,7 +509,9 @@ export class NginxProvider implements RoutingProvider, SslProvider {
     } else {
       await fsMkdir(dirname(path), { recursive: true });
       try {
-        await fsWriteFile(tmpPath, content, "utf-8");
+        // `mode` applies at creation, so the content is never on disk more open
+        // than requested (no chmod-after-write window).
+        await fsWriteFile(tmpPath, content, { encoding: "utf-8", mode });
         await fsRename(tmpPath, path);
       } catch (err) {
         await fsRm(tmpPath).catch(() => undefined);
@@ -736,20 +747,30 @@ export class NginxProvider implements RoutingProvider, SslProvider {
       ? [`REQUESTS_CA_BUNDLE=${this.acmeCaBundle}`, "certbot", ...args]
       : args;
     if (!onLog || !this.executor) {
-      const out = await this._exec(command, commandArgs);
+      let out: string;
+      try {
+        out = await this._exec(command, commandArgs);
+      } catch (err) {
+        // Redact HERE, not only in callers' catches — renewCert has none, and a
+        // new caller must not be able to leak the EAB key by forgetting one.
+        throw new Error(this.redactAcmeSecrets(safeErrorMessage(err)));
+      }
       const redacted = this.redactAcmeSecrets(out);
       if (redacted) onLog?.(redacted);
       return redacted;
     }
     const full = `${command} ${commandArgs.map(sq).join(" ")}`;
+    // Accumulate RAW output and redact the whole buffer at each use: per-chunk
+    // redaction alone misses a secret split across a chunk boundary.
     let output = "";
     const { code } = await this.executor.streamExec(full, (log) => {
-      const message = this.redactAcmeSecrets(log.message);
-      output += message;
-      onLog(message);
+      output += log.message;
+      onLog(this.redactAcmeSecrets(log.message));
     });
-    if (code !== 0) throw new Error(output.trim() || `certbot exited ${code}`);
-    return output;
+    if (code !== 0) {
+      throw new Error(this.redactAcmeSecrets(output).trim() || `certbot exited ${code}`);
+    }
+    return this.redactAcmeSecrets(output);
   }
 
   private redactAcmeSecrets(value: string): string {
@@ -765,14 +786,8 @@ export class NginxProvider implements RoutingProvider, SslProvider {
     await this._writeFile(
       path,
       `eab-kid = ${this.acmeEabKid}\neab-hmac-key = ${this.acmeEabHmacKey}\n`,
+      0o600,
     );
-    try {
-      if (this.executor) await this._exec("chmod", ["600", path]);
-      else await fsChmod(path, 0o600);
-    } catch (err) {
-      await this._rm(path).catch(() => undefined);
-      throw err;
-    }
     return path;
   }
 
@@ -1243,9 +1258,18 @@ ${serveLocation}
       return this.provisionCert(domain, { force: true });
     }
 
+    // A lineage issued by a DIFFERENT directory than the one now configured can't
+    // be renewed against the new CA — `renew` won't register the account the new
+    // server requires (or carry EAB). Reissue instead: certonly registers under
+    // the configured CA and rewrites the lineage, so this heals itself once.
+    if (!(await this.lineageServerMatches(domain))) {
+      return this.provisionCert(domain, { force: true });
+    }
+
+    // No `--server` here: the matched lineage's conf already records it, and the
+    // mismatch case above never reaches this call.
     await this._execCertbot([
       "renew", "--cert-name", domain,
-      ...(this.acmeDirectoryUrl ? ["--server", this.acmeDirectoryUrl] : []),
       ...acmeKeyArgs(this.acmeKeyType),
       "--non-interactive",
     ]);
@@ -1260,11 +1284,35 @@ ${serveLocation}
    * reads on every `renew`, so its presence is the authoritative answer — the cert
    * FILES existing is not (they can be adopted, or copied in by hand).
    */
-  private async hasCertbotLineage(domain: string): Promise<boolean> {
+  private renewalConfPath(domain: string): string {
     // Derived from certDir so a custom cert root (tests, container edge) stays
     // consistent: /etc/letsencrypt/live → /etc/letsencrypt/renewal.
-    const renewalPath = join(dirname(this.certDir), "renewal", `${domain}.conf`);
-    return this._exists(renewalPath);
+    return join(dirname(this.certDir), "renewal", `${domain}.conf`);
+  }
+
+  private async hasCertbotLineage(domain: string): Promise<boolean> {
+    return this._exists(this.renewalConfPath(domain));
+  }
+
+  /**
+   * Was this lineage issued by the CURRENTLY configured ACME directory? The
+   * renewal conf records the issuing `server`, and `certbot renew` only holds an
+   * account for THAT server — after the operator points at a different CA, renewing
+   * a pre-switch lineage would need an account registration `renew` cannot perform
+   * (and EAB material it is never given). An unreadable/unparsable conf answers
+   * `true` so the plain renew still runs and surfaces certbot's own error.
+   */
+  private async lineageServerMatches(domain: string): Promise<boolean> {
+    let conf: string;
+    try {
+      conf = await this._readFile(this.renewalConfPath(domain));
+    } catch {
+      return true;
+    }
+    const recorded = conf.match(/^\s*server\s*=\s*(\S+)\s*$/m)?.[1];
+    if (!recorded) return true;
+    const effective = this.acmeDirectoryUrl ?? LETSENCRYPT_PRODUCTION_DIRECTORY;
+    return recorded === effective;
   }
 
   /**

--- a/packages/adapters/src/infra/nginx.ts
+++ b/packages/adapters/src/infra/nginx.ts
@@ -23,6 +23,7 @@ import {
   readFile as fsReadFile,
   rename as fsRename,
   stat as fsStat,
+  chmod as fsChmod,
 } from "node:fs/promises";
 import { execFile as cpExecFile } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
@@ -225,6 +226,18 @@ export interface NginxProviderOptions {
    * ACME email for certbot certificate registration.
    */
   acmeEmail?: string;
+  /** Alternate ACME directory. Unset preserves Certbot's Let's Encrypt default. */
+  acmeDirectoryUrl?: string;
+  /** EAB key identifier. Must be supplied together with acmeEabHmacKey. */
+  acmeEabKid?: string;
+  /** Base64url-encoded EAB HMAC key. Written only to a short-lived 0600 file. */
+  acmeEabHmacKey?: string;
+  /** Certificate private-key algorithm/size. Unset preserves Certbot's default. */
+  acmeKeyType?: "ec256" | "ec384" | "rsa2048" | "rsa4096";
+  /** Trust bundle visible to the Certbot execution environment. */
+  acmeCaBundle?: string;
+  /** Whether to accept the selected CA's terms. Defaults to the historic true. */
+  acmeTosAgreed?: boolean;
   /**
    * Path to Let's Encrypt live certificate directory.
    * Default: /etc/letsencrypt/live
@@ -255,6 +268,44 @@ export interface NginxProviderOptions {
 }
 
 const DEFAULT_CERT_DIR = "/etc/letsencrypt/live";
+
+export type AcmeKeyType = NonNullable<NginxProviderOptions["acmeKeyType"]>;
+
+function assertValidAcmeOptions(opts: NginxProviderOptions): void {
+  if (!!opts.acmeEabKid !== !!opts.acmeEabHmacKey) {
+    throw new Error("ACME EAB requires both a key identifier and an HMAC key");
+  }
+  if (opts.acmeDirectoryUrl) {
+    let directory: URL;
+    try {
+      directory = new URL(opts.acmeDirectoryUrl);
+    } catch {
+      throw new Error("ACME directory must be a valid http(s) URL");
+    }
+    if (directory.protocol !== "https:" && directory.protocol !== "http:") {
+      throw new Error("ACME directory must use http or https");
+    }
+  }
+  if (opts.acmeEabKid && (!/^[\x20-\x7E]+$/.test(opts.acmeEabKid) || opts.acmeEabKid.length > 512)) {
+    throw new Error("ACME EAB key identifier must be printable ASCII (maximum 512 characters)");
+  }
+  if (opts.acmeEabHmacKey && !/^[A-Za-z0-9_-]+={0,2}$/.test(opts.acmeEabHmacKey)) {
+    throw new Error("ACME EAB HMAC key must be base64url encoded");
+  }
+  if (opts.acmeCaBundle && !opts.acmeCaBundle.startsWith("/")) {
+    throw new Error("ACME CA bundle must be an absolute path in the Certbot environment");
+  }
+}
+
+export function acmeKeyArgs(keyType?: AcmeKeyType): string[] {
+  switch (keyType) {
+    case "ec256": return ["--key-type", "ecdsa", "--elliptic-curve", "secp256r1"];
+    case "ec384": return ["--key-type", "ecdsa", "--elliptic-curve", "secp384r1"];
+    case "rsa2048": return ["--key-type", "rsa", "--rsa-key-size", "2048"];
+    case "rsa4096": return ["--key-type", "rsa", "--rsa-key-size", "4096"];
+    default: return [];
+  }
+}
 
 /** Only allow valid domain characters - prevents shell injection. */
 const DOMAIN_RE = /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$/;
@@ -392,6 +443,12 @@ interface FileSnapshot {
 export class NginxProvider implements RoutingProvider, SslProvider {
   private sitesDir: string;
   private readonly acmeEmail: string | undefined;
+  private readonly acmeDirectoryUrl: string | undefined;
+  private readonly acmeEabKid: string | undefined;
+  private readonly acmeEabHmacKey: string | undefined;
+  private readonly acmeKeyType: AcmeKeyType | undefined;
+  private readonly acmeCaBundle: string | undefined;
+  private readonly acmeTosAgreed: boolean;
   private readonly certDir: string;
   private readonly executor: CommandExecutor | null;
   private reloadCommand: string;
@@ -399,8 +456,15 @@ export class NginxProvider implements RoutingProvider, SslProvider {
   private readonly containerEdge: boolean;
 
   constructor(opts: NginxProviderOptions) {
+    assertValidAcmeOptions(opts);
     this.sitesDir = opts.paths.sitesDir;
     this.acmeEmail = opts.acmeEmail;
+    this.acmeDirectoryUrl = opts.acmeDirectoryUrl;
+    this.acmeEabKid = opts.acmeEabKid;
+    this.acmeEabHmacKey = opts.acmeEabHmacKey;
+    this.acmeKeyType = opts.acmeKeyType;
+    this.acmeCaBundle = opts.acmeCaBundle;
+    this.acmeTosAgreed = opts.acmeTosAgreed ?? true;
     this.certDir = opts.certDir ?? DEFAULT_CERT_DIR;
     this.executor = opts.executor ?? null;
     this.containerEdge = opts.containerEdge ?? false;
@@ -667,19 +731,49 @@ export class NginxProvider implements RoutingProvider, SslProvider {
    * still sees the real cause.
    */
   private async _execCertbot(args: string[], onLog?: (line: string) => void): Promise<string> {
+    const command = this.acmeCaBundle ? "env" : "certbot";
+    const commandArgs = this.acmeCaBundle
+      ? [`REQUESTS_CA_BUNDLE=${this.acmeCaBundle}`, "certbot", ...args]
+      : args;
     if (!onLog || !this.executor) {
-      const out = await this._exec("certbot", args);
-      if (out) onLog?.(out);
-      return out;
+      const out = await this._exec(command, commandArgs);
+      const redacted = this.redactAcmeSecrets(out);
+      if (redacted) onLog?.(redacted);
+      return redacted;
     }
-    const full = `certbot ${args.map(sq).join(" ")}`;
+    const full = `${command} ${commandArgs.map(sq).join(" ")}`;
     let output = "";
     const { code } = await this.executor.streamExec(full, (log) => {
-      output += log.message;
-      onLog(log.message);
+      const message = this.redactAcmeSecrets(log.message);
+      output += message;
+      onLog(message);
     });
     if (code !== 0) throw new Error(output.trim() || `certbot exited ${code}`);
     return output;
+  }
+
+  private redactAcmeSecrets(value: string): string {
+    return this.acmeEabHmacKey
+      ? value.split(this.acmeEabHmacKey).join("[REDACTED]")
+      : value;
+  }
+
+  /** Keep EAB HMAC material out of argv/process listings and remove it after use. */
+  private async createEphemeralEabConfig(): Promise<string | null> {
+    if (!this.acmeEabKid || !this.acmeEabHmacKey) return null;
+    const path = join(dirname(this.certDir), `.openship-eab-${randomBytes(12).toString("hex")}.ini`);
+    await this._writeFile(
+      path,
+      `eab-kid = ${this.acmeEabKid}\neab-hmac-key = ${this.acmeEabHmacKey}\n`,
+    );
+    try {
+      if (this.executor) await this._exec("chmod", ["600", path]);
+      else await fsChmod(path, 0o600);
+    } catch (err) {
+      await this._rm(path).catch(() => undefined);
+      throw err;
+    }
+    return path;
   }
 
   private async _captureFile(path: string): Promise<FileSnapshot> {
@@ -1024,6 +1118,7 @@ ${serveLocation}
       : ["--register-unsafely-without-email"];
 
     let certonlyOut = "";
+    const eabConfig = await this.createEphemeralEabConfig();
     try {
       // ACME via certbot's STANDALONE authenticator on a loopback alt-port; the
       // edge proxies /.well-known/acme-challenge/ → 127.0.0.1:<port> (see
@@ -1040,16 +1135,23 @@ ${serveLocation}
       // "missing", and a re-run just prints "not due for renewal" (exit 0). Pinning
       // the name makes the on-disk path deterministic and self-heals that state.
       certonlyOut = await this._execCertbot([
+        ...(eabConfig ? ["--config", eabConfig] : []),
         "certonly", "--standalone", "--http-01-port", String(ACME_HTTP01_PORT),
         "--cert-name", domain, "-d", domain,
-        ...emailArgs, "--agree-tos", "--non-interactive",
+        ...(this.acmeDirectoryUrl ? ["--server", this.acmeDirectoryUrl] : []),
+        ...acmeKeyArgs(this.acmeKeyType),
+        ...emailArgs,
+        ...(this.acmeTosAgreed ? ["--agree-tos"] : []),
+        "--non-interactive",
         // Forced reissue: certbot would otherwise print "not due for renewal"
         // (exit 0) when a lineage exists, leaving the stale cert in place.
         ...(opts?.force ? ["--force-renewal"] : []),
       ], opts?.onLog);
     } catch (err) {
       // Replace certbot's opaque opener with the real, actionable cause.
-      throw new Error(summarizeCertbotFailure(safeErrorMessage(err), domain));
+      throw new Error(summarizeCertbotFailure(this.redactAcmeSecrets(safeErrorMessage(err)), domain));
+    } finally {
+      if (eabConfig) await this._rm(eabConfig).catch(() => undefined);
     }
 
     // Rewrite the config with SSL now that certs exist
@@ -1141,7 +1243,12 @@ ${serveLocation}
       return this.provisionCert(domain, { force: true });
     }
 
-    await this._exec("certbot", ["renew", "--cert-name", domain, "--non-interactive"]);
+    await this._execCertbot([
+      "renew", "--cert-name", domain,
+      ...(this.acmeDirectoryUrl ? ["--server", this.acmeDirectoryUrl] : []),
+      ...acmeKeyArgs(this.acmeKeyType),
+      "--non-interactive",
+    ]);
     await this.reload();
 
     return this.readCertInfo(domain);

--- a/packages/adapters/src/system/proxy/index.ts
+++ b/packages/adapters/src/system/proxy/index.ts
@@ -158,6 +158,7 @@ export async function ensureEdge<T>(
     promptUser?: PromptUserFn;
     onLog: SystemLogCallback;
     acmeEmail?: string;
+    nginx?: EdgeTakeoverOptions["nginx"];
     extraRoutes?: EdgeTakeoverOptions["extraRoutes"];
   },
 ): Promise<EnsureEdgeOutcome<T>> {
@@ -178,6 +179,7 @@ export async function takeoverOnMigrate(
   opts: {
     onLog: SystemLogCallback;
     acmeEmail?: string;
+    nginx?: EdgeTakeoverOptions["nginx"];
     extraRoutes?: EdgeTakeoverOptions["extraRoutes"];
   },
 ): Promise<EdgeTakeoverResult> {
@@ -189,7 +191,7 @@ export async function takeoverOnMigrate(
   );
   const takeover = await runEdgeTakeover(
     executor,
-    { status: migrate.status, sites: migrate.sites, acmeEmail: opts.acmeEmail, extraRoutes: opts.extraRoutes },
+    { status: migrate.status, sites: migrate.sites, acmeEmail: opts.acmeEmail, nginx: opts.nginx, extraRoutes: opts.extraRoutes },
     opts.onLog,
   );
   for (const w of [...migrate.warnings, ...takeover.warnings]) opts.onLog(sysLog(w, "warn"));

--- a/packages/adapters/src/system/proxy/takeover.ts
+++ b/packages/adapters/src/system/proxy/takeover.ts
@@ -20,7 +20,7 @@ import { collectProxyCerts, edgeProxy } from "./api";
 import { isSafeCertPath, readDeclaredPair, validateCertFor } from "./cert-material";
 import { buildJournal, clearJournal, rollback, writeJournal } from "./takeover-journal";
 import { installContainerEdge } from "../installer";
-import { containerEdgeProvider } from "./ensure-container-edge";
+import { containerEdgeProvider, type EdgeProviderOptions } from "./ensure-container-edge";
 import { checkEdge } from "../checks";
 import { NginxProvider } from "../../infra/nginx";
 import { detectOpenRestyPaths } from "../../infra/openresty-lua";
@@ -36,6 +36,7 @@ export interface EdgeTakeoverOptions {
   status: EdgeStatus;
   sites: ImportedSite[];
   acmeEmail?: string;
+  nginx?: EdgeProviderOptions;
   /** Extra routes to register beyond the imported sites (e.g. the control plane's own hostname). */
   extraRoutes?: Array<{ domain: string; targetUrl: string; tls: boolean }>;
   /** Pinned edge image; the API always supplies its own (never a caller's value). */
@@ -259,12 +260,13 @@ export async function runEdgeTakeover(
     // migrated vhost where the container never reads — with the foreign proxy
     // already stopped.
     const container = await resolveOurEdgeContainer(executor, { fresh: true });
+    const providerOptions = { ...opts.nginx, acmeEmail: opts.acmeEmail ?? opts.nginx?.acmeEmail };
     const nginx = container
-      ? await containerEdgeProvider(executor, container, { acmeEmail: opts.acmeEmail })
+      ? await containerEdgeProvider(executor, container, providerOptions)
       : new NginxProvider({
           paths: await detectOpenRestyPaths(executor),
           executor,
-          acmeEmail: opts.acmeEmail,
+          ...providerOptions,
         });
 
     const registered = await registerImportedSites(nginx, nginx, executor, opts.sites, {


### PR DESCRIPTION
## Summary

Adds optional support for ACME certificate authorities other than Let's Encrypt — alternate directory URL, External Account Binding credentials, key type, and a private trust bundle — and fixes renewal for certificates whose issuing CA has changed. With none of the new variables set, nothing changes.

## Motivation

Openship can only talk to Let's Encrypt today. ZeroSSL, Google Trust Services, and essentially every internal CA (`step-ca`, EJBCA, Vault) require External Account Binding (RFC 8555 §7.3.4), so anyone who needs a different CA has to bypass the built-in TLS management entirely. #256 has the full case, including Let's Encrypt rate limits and air-gapped installs.

This is the smallest slice that helps: one instance-wide CA, configured by environment variable. That's deliberately the same tier `lib/mail.ts` already uses for SMTP — operator settings first, static env vars as the deployment fallback.

## Related issue

#256. **No maintainer has agreed to scope or approach yet**, and per CONTRIBUTING that makes this premature — I opened it to make the proposal concrete rather than to jump the queue. Happy for it to sit until someone weighs in, or to close it.

## Changes

**`packages/adapters` — `infra/nginx.ts`**

- `NginxProvider` gains `acmeDirectoryUrl`, `acmeEabKid`, `acmeEabHmacKey`, `acmeKeyType`, `acmeCaBundle`, and `acmeTosAgreed`, applied to both issuance and renewal.
- **EAB credentials never reach argv.** They go into a mode-`0600` file inside a fresh `0700` directory — the same contract `runtime/git-ssh-material.ts` documents for SSH key material — passed to certbot via `--config` and removed as a unit afterwards.
- **HMAC redaction lives in `_execCertbot`**, not in each caller's catch. That matters: the scheduled renewal sweep has no catch of its own, and a failed renewal emits an `ssl.renewal_failed` notification carrying the certbot error to email and webhooks.
- **Renewal survives a CA switch.** A lineage issued by one directory cannot be renewed against another — `certbot renew` neither registers the new account nor carries EAB — so `renewCert` compares the lineage's recorded `server` against the configured directory and reissues on mismatch. One-time, self-healing. Without this, every pre-switch certificate fails renewal silently in the nightly sweep.

**`apps/api`** — env schema plus boot-time validation, so a malformed EAB pair or a relative CA-bundle path fails at startup naming the variable, not mid-deploy. Threaded into every provider-construction path (deploys, edge takeover, self-edge).

**`apps/cli`** — `openship up` preserves the variables across upgrades, so an upgrade cannot silently discard operator config.

**`docs/`** — `acme.md` (Let's Encrypt staging, ZeroSSL, private CA) and `acme-testing.md` (a throwaway EAB-requiring CA in Docker).

## Verification

Unit suites, all passing: `packages/adapters` 750, `apps/cli` compose-preserve 20, proxy-takeover 6. Typechecks clean for `packages/adapters`, `apps/api`, and `apps/cli`.

More usefully, the whole path was exercised against **a real EAB-requiring CA** — Pebble plus `pebble-challtestsrv` plus real certbot, all in Docker. `docs/acme-testing.md` reproduces it.

- A certificate was issued end to end using the exact argv `provisionCert` composes, including the EAB config file: `issuer=CN=Pebble Intermediate CA`, key `NIST CURVE: P-384` — confirming the `ec384` key-type mapping actually takes effect. All four key-type mappings were checked against real certbot.
- The EAB file format is genuinely consumed, not silently ignored: registering with a deliberately wrong HMAC is rejected with `external account binding JWS verification error`.
- Renewal succeeds with the argv `renewCert` now composes — no `--server`, no EAB config — confirming EAB is needed only at account registration.
- The renew-versus-reissue decision was checked against the real `renewal/<domain>.conf` certbot wrote, not a fixture: the recorded `server` parses correctly and both branches resolve as designed.

That exercise also caught a bug the unit tests could not. The directory probe sent no `User-Agent`, which RFC 8555 §6.1 requires and real servers enforce, so it failed against any conforming CA.

Not covered: issuance driven through `NginxProvider` against a live OpenResty edge. The argv, EAB file, key mapping, and renewal contract are all verified above; the provider's file handling around them is unit-tested only.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

On the unchecked box: `bun format` was deliberately not run — it reformats roughly 1,580 pre-existing files, which CONTRIBUTING says to drop rather than bundle, so new code matches surrounding style instead. The full `bun run test` leaves failures in `apps/cli` `ports.test.ts` and three `apps/api` e2e tests that reproduce identically on the unmodified base branch here; nothing in this PR touches them.

---

*Follow-up layers — DB-backed CA profiles, API, CLI, dashboard, and a per-domain pin — exist as draft PRs on my fork ([DB](https://github.com/tristanbob/openship/pull/1), [API](https://github.com/tristanbob/openship/pull/2), [CLI](https://github.com/tristanbob/openship/pull/3), [dashboard](https://github.com/tristanbob/openship/pull/4), [per-domain](https://github.com/tristanbob/openship/pull/5)), so the question this PR really raises — is this the right configuration shape — can be judged concretely. None are proposed for merge, and this PR stands alone without them.*
