### PR TITLE
fix(adapters): honour quoted and one-argument ProxyPass in the Apache importer

### DIFF
--- a/packages/adapters/src/system/proxy/import/apache-edge-cases.test.ts
+++ b/packages/adapters/src/system/proxy/import/apache-edge-cases.test.ts
@@ -249,6 +249,121 @@ describe("apache: names and TLS detection", () => {
   });
 });
 
+describe("apache: quoted arguments and the one-argument ProxyPass", () => {
+  test("quoted ProxyPass arguments yield a bare path and upstream", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName q.example.com
+    SSLEngine on
+    ProxyPass "/api" "http://127.0.0.1:9000/"
+    ProxyPass "/" "http://127.0.0.1:8080/"
+    ProxyPassReverse "/" "http://127.0.0.1:8080/"
+</VirtualHost>
+`),
+    );
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:8080/");
+    expect(res.sites[0].routes).toEqual([
+      { path: "/api", url: "http://127.0.0.1:9000/" },
+      { path: "/", url: "http://127.0.0.1:8080/" },
+    ]);
+  });
+
+  test("quoted ServerName and ServerAlias are hostnames, not quoted strings", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName "q.example.com"
+    ServerAlias "www.q.example.com" 'alt.q.example.com'
+    SSLEngine on
+    ProxyPass / http://127.0.0.1:8080/
+</VirtualHost>
+`),
+    );
+    expect(res.sites[0].serverNames).toEqual([
+      "q.example.com",
+      "www.q.example.com",
+      "alt.q.example.com",
+    ]);
+  });
+
+  test("quoted cert paths stay usable for the carry", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName q.example.com
+    SSLEngine on
+    SSLCertificateFile "/etc/letsencrypt/live/q.example.com/fullchain.pem"
+    SSLCertificateKeyFile "/etc/letsencrypt/live/q.example.com/privkey.pem"
+    ProxyPass / http://127.0.0.1:8080/
+</VirtualHost>
+`),
+    );
+    expect(res.sites[0].tls).toEqual({
+      certPath: "/etc/letsencrypt/live/q.example.com/fullchain.pem",
+      keyPath: "/etc/letsencrypt/live/q.example.com/privkey.pem",
+    });
+  });
+
+  test("a one-argument ProxyPass takes the path of its <Location>", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName loc.example.com
+    SSLEngine on
+    <Location "/api">
+        ProxyPass "http://127.0.0.1:9000/"
+        ProxyPassReverse "http://127.0.0.1:9000/"
+    </Location>
+    <Location "/">
+        ProxyPass "http://127.0.0.1:8080/"
+        ProxyPassReverse "http://127.0.0.1:8080/"
+    </Location>
+</VirtualHost>
+`),
+    );
+    expect(res.sites[0].routes).toEqual([
+      { path: "/api", url: "http://127.0.0.1:9000/" },
+      { path: "/", url: "http://127.0.0.1:8080/" },
+    ]);
+    expect(urlOf(res.sites[0])).toBe("http://127.0.0.1:8080/");
+  });
+
+  test("a one-argument ProxyPass under <LocationMatch> is reported as regex proxying", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName rx.example.com
+    SSLEngine on
+    <LocationMatch "^/v[0-9]+/">
+        ProxyPass "http://127.0.0.1:9000/"
+    </LocationMatch>
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings).toContain(
+      "apache: rx.example.com proxies from inside a <LocationMatch> (regex proxying) — re-add it manually",
+    );
+  });
+
+  test("a one-argument ProxyPass with no enclosing <Location> is not given a `/` route", async () => {
+    const res = await scanApache(
+      exec(`
+<VirtualHost *:443>
+    ServerName bare.example.com
+    SSLEngine on
+    ProxyPass "http://127.0.0.1:9000/"
+</VirtualHost>
+`),
+    );
+    expect(res.sites).toEqual([]);
+    expect(res.warnings).toContain(
+      "apache: bare.example.com has neither ProxyPass nor DocumentRoot — skipped",
+    );
+  });
+});
+
 describe("apache: apachectl -S vhost discovery", () => {
   test("finds vhost files in a non-standard path from the real dump format", async () => {
     // Verbatim `apachectl -S` shape from httpd:2.4 — the paths come from its

--- a/packages/adapters/src/system/proxy/import/apache.ts
+++ b/packages/adapters/src/system/proxy/import/apache.ts
@@ -44,9 +44,16 @@ async function loadApacheConfig(executor: CommandExecutor): Promise<string> {
   return cat ?? "";
 }
 
+/** Drop the `"`/`'` httpd reads as argument delimiters (`DocumentRoot "/srv/x"`). */
+function unquote(value: string): string {
+  return value.replace(/^["']|["']$/g, "");
+}
+
+/** The single argument of a one-argument directive, unquoted. */
 function directive(body: string, name: string): string | undefined {
   const m = body.match(new RegExp(`(?:^|\\n)\\s*${name}\\s+([^\\n]+)`, "i"));
-  return m?.[1]?.trim();
+  const value = m?.[1]?.trim();
+  return value === undefined ? undefined : unquote(value);
 }
 
 /** All values of a directive that may appear on multiple lines (e.g. ServerAlias). */
@@ -80,7 +87,53 @@ function isHttpsRedirectOnly(body: string): boolean {
  *  hostname, and carrying it through produced `server_name example.com:443`,
  *  which matches nothing. */
 function hostOnly(name: string): string {
-  return name.trim().replace(/^https?:\/\//i, "").replace(/:\d+$/, "");
+  return unquote(name.trim())
+    .replace(/^https?:\/\//i, "")
+    .replace(/:\d+$/, "");
+}
+
+/**
+ * Every `ProxyPass` mapping in a vhost, as `<path> → <upstream>`.
+ *
+ * Read line by line so a mapping can't run past its own line, and both documented
+ * argument forms are accepted: `ProxyPass <path> <url>` at vhost level, and the
+ * one-argument `ProxyPass <url>` whose path is the enclosing `<Location>`. A
+ * `<LocationMatch>` path is a regex no single prefix can express, so its mappings
+ * are dropped and reported through `regexScoped` instead.
+ */
+function proxyRoutes(body: string): {
+  routes: Array<{ path: string; url: string }>;
+  regexScoped: boolean;
+} {
+  const routes: Array<{ path: string; url: string }> = [];
+  const scopes: Array<{ path: string | null; regex: boolean }> = [];
+  let regexScoped = false;
+  for (const line of body.split("\n")) {
+    const open = line.match(/^\s*<Location(Match)?\s+([^>]*)>/i);
+    if (open) {
+      const regex = Boolean(open[1]);
+      const arg = unquote(open[2].trim());
+      scopes.push({ path: !regex && arg.startsWith("/") ? arg : null, regex });
+      continue;
+    }
+    if (/^\s*<\/Location(?:Match)?\s*>/i.test(line)) {
+      scopes.pop();
+      continue;
+    }
+    const m = line.match(/^\s*ProxyPass\s+(\S+)(?:\s+(\S+))?/i);
+    if (!m) continue;
+    const first = unquote(m[1]);
+    if (first.startsWith("/")) {
+      routes.push({ path: first, url: m[2] ? unquote(m[2]) : "" });
+      continue;
+    }
+    // The one-argument form is only legal inside a <Location>, which is the only
+    // place a path for it exists.
+    const scope = scopes[scopes.length - 1];
+    if (scope?.path) routes.push({ path: scope.path, url: first });
+    else if (scope?.regex) regexScoped = true;
+  }
+  return { routes, regexScoped };
 }
 
 function parseVhost(body: string, portHint: string): ImportedSite | { warning: string } | null {
@@ -101,10 +154,9 @@ function parseVhost(body: string, portHint: string): ImportedSite | { warning: s
 
   // ProxyPass <path> http://upstream — keep ALL non-"!" mappings (path fan-out);
   // primary = the "/" mapping if present, else the first.
-  const routes = [...body.matchAll(/(?:^|\n)\s*ProxyPass\s+(\S+)\s+(\S+)/gi)]
-    .map((m) => ({ path: m[1], url: m[2] }))
-    .filter((p) => p.url && p.url !== "!");
-  const docRoot = directive(body, "DocumentRoot")?.replace(/^["']|["']$/g, "");
+  const proxy = proxyRoutes(body);
+  const routes = proxy.routes.filter((p) => p.url && p.url !== "!");
+  const docRoot = directive(body, "DocumentRoot");
   // `ProxyPassMatch … fcgi://` / `…php-fpm.sock` — a PHP application, whatever its
   // DocumentRoot says.
   const fcgiMatch = /(?:^|\n)\s*ProxyPassMatch\s+[^\n]*(fcgi:|php-fpm|php\d*-fpm|\.sock)/i.test(body);
@@ -138,6 +190,10 @@ function parseVhost(body: string, portHint: string): ImportedSite | { warning: s
     // Regex-keyed proxying with no docroot has no single upstream either.
     return {
       warning: `apache: ${names[0]} uses ProxyPassMatch (regex proxying) — re-add it manually`,
+    };
+  } else if (proxy.regexScoped) {
+    return {
+      warning: `apache: ${names[0]} proxies from inside a <LocationMatch> (regex proxying) — re-add it manually`,
     };
   } else {
     return { warning: `apache: ${names[0]} has neither ProxyPass nor DocumentRoot — skipped` };


### PR DESCRIPTION
## Summary

The Apache importer treats the `"`/`'` httpd uses as **argument delimiters** as part of the value, and lets a `ProxyPass` mapping run past its own line. A vhost written the way Apache's own `mod_proxy` documentation writes it migrates as nothing.

## Motivation

`ProxyPass "/" "http://foo.example.com/"` is the form in Apache's own docs, and httpd strips those quotes. Confirmed on the `httpd:2.4` image, `Apache/2.4.68 (Unix)`:

```
--- httpd -t ---
Syntax OK
--- httpd -S ---
VirtualHost configuration:
*:443                  q.example.com (/usr/local/apache2/conf/httpd.conf:558)
*:80                   is a NameVirtualHost
         default server loc.example.com (/usr/local/apache2/conf/httpd.conf:569)
         port 80 namevhost loc.example.com (/usr/local/apache2/conf/httpd.conf:569)
         port 80 namevhost rx.example.com (/usr/local/apache2/conf/httpd.conf:581)
```

(those are the vhost bodies the new tests use — quoted `ServerName`/`ServerAlias`/`SSLCertificate*`/`ProxyPass`, a two-`<Location>` one-argument form, and a `<LocationMatch>` one. The sixth test's body, a one-argument `ProxyPass` with no `<Location>`, is deliberately the one httpd refuses: `AH00526: Syntax error ... ProxyPass|ProxyPassMatch needs a path when not defined in a location`.)

In `import/apache.ts` on `main`, exactly one directive strips quotes — `DocumentRoot` (`apache.ts:107`). `ServerName` (`:87`), `ServerAlias` (`:88`), the `ProxyPass` regex (`:104`) and `SSLCertificateFile`/`SSLCertificateKeyFile` (`:111-112`) all keep them.

Measured end to end on `main` @ `2d7fa591` — `scanApache` → `registerImportedSites`, with a real `NginxProvider` over a fake executor for routing and a stub SSL provider:

| vhost body | `registered` | warning | vhost conf written |
|---|---|---|---|
| `ProxyPass "/" "http://127.0.0.1:8080/"` | `[]` | `Invalid proxy target (must be http/https URL): "http://127.0.0.1:8080/"` | none |
| `ProxyPass / http://127.0.0.1:8080/` (control) | `["app.example.com"]` | none | `app-example-com.conf` |
| `ServerName "app.example.com"` + `ServerAlias "www.app.example.com"` | `[]` | `skipped unsupported domain ""app.example.com"" (wildcards/regex names aren't migratable)` (and the same for the alias) | none |
| `SSLCertificateFile "/etc/letsencrypt/live/app.example.com/fullchain.pem"` | `["app.example.com"]` | `app.example.com: existing cert path looks unsafe — issuing a fresh certificate instead` | conf written, **cert dropped** |
| `<Location "/">` + `ProxyPass "http://127.0.0.1:8080/"` | `[]` | `Invalid proxy target (must be http/https URL): ProxyPassReverse` | none |

The cert row measured directly: `isSafeCertPath("\"/etc/letsencrypt/live/app.example.com/fullchain.pem\"")` → `false`; the same path unquoted → `true`. So the carry is refused and a fresh ACME issuance is forced for a domain whose certificate was sitting right there.

The last row is the second half of the same bug: the `ProxyPass` regex separator was `\s+`, which crosses newlines, so

```apache
<Location "/">
    ProxyPass "http://127.0.0.1:8080/"
    ProxyPassReverse "http://127.0.0.1:8080/"
</Location>
```

parsed as `{ path: "\"http://127.0.0.1:8080/\"", url: "ProxyPassReverse" }` — it swallowed the next line. That fails closed at `assertValidUpstream` (`infra/nginx.ts:283`), so the site is simply not migrated.

Why it is worth fixing rather than documenting: this is the takeover path. By the time `registerImportedSites` runs, the operator's Apache is stopped and Openship holds :80/:443 (`takeover.ts:250-274`). An Apache box configured the way the docs show migrates **zero** sites at exactly that moment.

## Related issue

None.

## Changes

`packages/adapters`

- `src/system/proxy/import/apache.ts`
  - new `unquote()`, applied at the read points — `directive()`, `hostOnly()`, and the `ProxyPass` captures. It is `DocumentRoot`'s existing `.replace(/^["']|["']$/g, "")` moved into a shared helper, unanchored form and all. That is deliberate: httpd accepts an unterminated `DocumentRoot "/srv/x` and resolves it to `/srv/x` (measured: `AH00112: Warning: DocumentRoot [/srv/x] does not exist` then `Syntax OK`, vhost live in `httpd -S`), so a matched-pair-only helper would have regressed it from `root=/srv/x`, registered, no warning, to `root="/srv/x`, registered `[]`, `Invalid static root (must be an absolute path, no traversal): "/srv/x`. Behaviour on that input is unchanged by this PR.
  - new `proxyRoutes()` replaces the single `ProxyPass` regex. It reads line by line, so a mapping can no longer run past its own line, and it accepts the documented one-argument form, taking its path from the enclosing `<Location>`.
    - No enclosing `<Location>` means no path to give it, so the mapping is dropped and the vhost is skipped, exactly as on `main`. httpd rejects that config anyway — `AH00526: Syntax error ... ProxyPass|ProxyPassMatch needs a path when not defined in a location` — so it cannot come off a running Apache, which is why defaulting it to `/` would be all risk and no benefit.
    - A `<LocationMatch>` path is a regex no single prefix can express, so its mappings are dropped. When that mapping is the vhost's *only* proxy source, the vhost is reported: `apache: rx.example.com proxies from inside a <LocationMatch> (regex proxying) — re-add it manually`, next to the existing `ProxyPassMatch` warning it mirrors. On `main` that vhost instead reached nginx with an upstream literally named `</LocationMatch>` and failed with `Invalid proxy target (must be http/https URL): </LocationMatch>`.
    - When the vhost *also* carries a root `ProxyPass` or a `DocumentRoot`, the site migrates and the regex mapping is dropped **without** a warning — `parseVhost`'s `else if` chain only reaches the regex branch after `routes`, `ProxyPassMatch` and `DocumentRoot` have all missed, which is the same property the existing `ProxyPassMatch` and FastCGI branches have on `main` today. Measured on `httpd:2.4` (`Syntax OK` both shapes): a vhost with `ProxyPass / http://127.0.0.1:8080/` plus a `<LocationMatch "^/v[0-9]+/">` one-argument mapping migrates `/ → :8080` and silently drops `^/v[0-9]+/ → :9000`; with a `DocumentRoot` instead, the static site migrates and the mapping is likewise dropped. Strictly better than `main`, which migrated neither vhost as anything — but the operator is not told, so traffic Apache sent to `:9000` now falls through. Warning alongside a *returned* site would mean widening `parseVhost`'s `ImportedSite | { warning } | null` return type, which is restructuring rather than a fix — happy to send it as a follow-up if you want it.
- `src/system/proxy/import/apache-edge-cases.test.ts` — six tests in a new `describe`.

Deliberately **not** done: full httpd argument lexing. `ProxyPass` tokens stay `\S+`, so a quoted argument containing whitespace is still not handled (it was not before either). This strips delimiters, nothing more. `isHttpsRedirectOnly()` is left alone — its own `ProxyPass` probe is unaffected by quoting.

One rough edge I did not widen scope to fix: a one-argument `ProxyPass` with no `<Location>` is reported as `has neither ProxyPass nor DocumentRoot — skipped`, which is not literally true of that config. That is `main`'s wording on `main`'s code path, and the config is one httpd refuses to start on, so I left it rather than adding a fifth branch to `parseVhost`. Happy to add it if you want the message tightened.

## Verification

Regression tests fail without the source change and pass with it. Only `apache.ts` was reverted (`git checkout origin/main -- apache.ts`); the new tests were kept in place.

Fix removed:

```
 FAIL  src/system/proxy/import/apache-edge-cases.test.ts > apache: quoted arguments and the one-argument ProxyPass > quoted ProxyPass arguments yield a bare path and upstream
 FAIL  src/system/proxy/import/apache-edge-cases.test.ts > apache: quoted arguments and the one-argument ProxyPass > quoted ServerName and ServerAlias are hostnames, not quoted strings
 FAIL  src/system/proxy/import/apache-edge-cases.test.ts > apache: quoted arguments and the one-argument ProxyPass > quoted cert paths stay usable for the carry
 FAIL  src/system/proxy/import/apache-edge-cases.test.ts > apache: quoted arguments and the one-argument ProxyPass > a one-argument ProxyPass takes the path of its <Location>
 FAIL  src/system/proxy/import/apache-edge-cases.test.ts > apache: quoted arguments and the one-argument ProxyPass > a one-argument ProxyPass under <LocationMatch> is reported as regex proxying

 Test Files  1 failed (1)
      Tests  5 failed | 17 passed (22)
```

Five of the six new tests fail there. The sixth — "a one-argument ProxyPass with no enclosing `<Location>` is not given a `/` route" — passes on `main` too, on purpose: it pins a fail-closed boundary that this change could plausibly have opened, and it would have caught it if I had defaulted that case to `/`.

One of the failure diffs, for the `<Location>` case:

```
-     "path": "/",
-     "url": "http://127.0.0.1:8080/",
+     "path": "\"http://127.0.0.1:8080/\"",
+     "url": "ProxyPassReverse",
```

Fix restored:

```
 ✓ src/system/proxy/import/apache-edge-cases.test.ts (22 tests) 4ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
```

Full suite, `bun run test -- --continue --force`:

```
@repo/desktop:test:       Tests  3 passed (3)
@repo/core:test:          Tests  325 passed (325)
@repo/dashboard:test:     Tests  236 passed (236)
@repo/adapters:test:      Tests  750 passed (750)
openship:test:            Tests  181 passed (181)
@repo/db:test:            Tests  55 passed (55)
@repo/api:test:           Tests  1849 passed | 15 skipped (1864)
 Tasks:    7 successful, 7 total
```

Baseline on `main` @ `2d7fa591`, same command, was identical except `@repo/adapters` at `744 passed (744)` — the +6 is exactly the new tests. No other count moved.

Typecheck:

```
$ bun run --cwd packages/adapters lint   # tsc --noEmit -> exit 0
$ bun run --cwd apps/api lint            # tsc --noEmit -> exit 0
```

Formatting: I ran `bun format`, and since it is a repo-wide `prettier --write` it rewrote 1579 files of pre-existing drift, so I reviewed the diff and dropped everything unrelated as CONTRIBUTING asks. The one line it wanted from me was `hostOnly`'s method chain, which I am changing anyway — that reflow is in the diff. Nothing else it flags in these two files is a line this PR touches: `isHttpsRedirectOnly`'s `matchAll`, the `fcgiMatch` test call and `redirectVhostNames`' chain in `apache.ts`, and the `site` helper in the test file, all already drifted on `origin/main`. Every line this PR adds is prettier-clean.

## Alternative I considered

For the one-argument form, the smaller change is to scope the separator to `[^\S\n]+` and stop there — with no second argument there is no route, so the vhost fails closed with `has neither ProxyPass nor DocumentRoot — skipped` instead of producing garbage. Two characters, and still an improvement, but the documented form stays unmigrated.

I went with reading the `<Location>` path so the one-argument form lands on exactly the semantics the two-argument form already has. Measured on the mod_proxy docs' own example, `<Location "/mirror/foo/">` with a one-argument `ProxyPass`: this branch produces the same `ImportedSite` and the same generated conf as `ProxyPass /mirror/foo/ http://backend.example.com/` produces on `main` today — `routes: [{ path: "/mirror/foo/", ... }]`, and a conf carrying `location /mirror/foo/` and `location /`. Defaulting to `/` instead would drop the real prefix out of `site.routes`, and with it the `/mirror/foo/` location block, in exchange for nothing.

To be explicit about what this does **not** fix, since it is visible in that conf: `parseVhost` picks `routes.find(r => r.path === "/") ?? routes[0]` as the site target, so a vhost whose only mapping is `/mirror/foo/` also gets a `location /` to the same upstream. That is pre-existing behaviour of the two-argument path — `main` emits the identical conf for the identical vhost — and this PR neither introduces nor changes it. Worth a separate look, but not something I wanted to bundle in here.

Happy to switch to the two-character version if you would rather the importer not know about `<Location>` at all.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review
