### PR TITLE
fix(api/dashboard): import Coolify's runtime env during server migration

### DIFF
--- a/apps/api/src/modules/migration/docker-reconcile.ts
+++ b/apps/api/src/modules/migration/docker-reconcile.ts
@@ -337,6 +337,17 @@ export function toDiscoveredService(
     }
   }
 
+  // Coolify injects every runtime variable explicitly and its Nixpacks builds
+  // bake the same values into the image, so subtracting image defaults dropped
+  // real configuration — often all of it. `coolify.managed` is stamped on every
+  // container it manages (bootstrap/helpers/docker.php).
+  const coolifyManaged = "coolify.managed" in detail.labels;
+  if (coolifyManaged) {
+    warnings.push(
+      "Coolify build-time variables (and any BuildKit secrets) are absent from a running container, so they cannot be imported — re-enter them before rebuilding. Runtime variables, including shared, linked-resource and secret values, were imported.",
+    );
+  }
+
   // Drop the container's command when it merely restates the image's default
   // CMD (and compose didn't declare one). Re-specifying it means the deploy
   // re-runs it wrapped as `sh -c "<cmd>"`, which defeats entrypoints that drop
@@ -416,7 +427,7 @@ export function toDiscoveredService(
     build: declared?.build,
     dockerfile: declared?.dockerfile,
     ports,
-    env: envArrayToRecord(detail.env, imageDefaults),
+    env: envArrayToRecord(detail.env, coolifyManaged ? undefined : imageDefaults),
     volumes: mounts,
     networks: detail.networks,
     dependsOn: declared?.dependsOn ?? [],
@@ -443,7 +454,8 @@ export function reconcileStack(opts: {
   networks: DockerNetworkInfo[];
   declared: Map<string, ComposeService>;
   alreadyManaged: number;
-  /** image ref → its baked-in "KEY=VALUE" env, subtracted from container env. */
+  /** image ref → its baked-in "KEY=VALUE" env, subtracted from container env
+   *  (skipped for Coolify-managed containers — see toDiscoveredService). */
   imageDefaults?: Map<string, Set<string>>;
   /** image ref → its baked-in default CMD tokens, dropped when the container
    *  only restates it (see toDiscoveredService). */

--- a/apps/api/test/modules/migration/docker-inspect.test.ts
+++ b/apps/api/test/modules/migration/docker-inspect.test.ts
@@ -72,6 +72,28 @@ const REDIS: DockerContainerDetail = {
   composeService: undefined,
 };
 
+/** A Coolify-managed app. Coolify injects EVERY variable explicitly at run time
+ *  and its Nixpacks builds bake the same values into the image, so the runtime
+ *  env and the image defaults overlap almost completely (#394). */
+const COOLIFY_APP: DockerContainerDetail = {
+  id: "c4",
+  name: "app-kso4gc8",
+  image: "app-kso4gc8:latest",
+  imageId: "sha256:coolify",
+  state: "running",
+  env: ["PATH=/usr/bin", "NODE_ENV=production", "DATABASE_URL=postgres://db:5432/app"],
+  labels: {
+    "coolify.managed": "true",
+    "coolify.type": "application",
+    "coolify.applicationId": "7",
+  },
+  networks: ["coolify"],
+  mounts: [],
+  ports: [{ privatePort: 3000, publicPort: 8081, type: "tcp" }],
+  composeProject: undefined,
+  composeService: undefined,
+};
+
 const VOLUMES: DockerVolumeInfo[] = [
   { name: "myapp_pgdata", driver: "local", labels: {} },
   { name: "unused_vol", driver: "local", labels: {} },
@@ -160,5 +182,29 @@ describe("reconcileStack", () => {
     const db = withDefaults.services.find((s) => s.name === "db")!;
     // LANG is an image default (dropped), PATH is denylisted, POSTGRES_PASSWORD survives.
     expect(db.env).toEqual({ POSTGRES_PASSWORD: "secret" });
+  });
+
+  const coolify = reconcileStack({
+    serverId: "srv-1",
+    details: [COOLIFY_APP],
+    volumes: VOLUMES,
+    networks: NETWORKS,
+    declared: new Map(),
+    alreadyManaged: 0,
+    imageDefaults: new Map([["app-kso4gc8:latest", new Set(COOLIFY_APP.env)]]),
+  });
+
+  it("keeps a Coolify container's env even when it matches the image default", () => {
+    const app = coolify.services.find((s) => s.name === "app-kso4gc8")!;
+    // NODE_ENV and DATABASE_URL match the image default but are real config; PATH is denylisted.
+    expect(app.env).toEqual({
+      NODE_ENV: "production",
+      DATABASE_URL: "postgres://db:5432/app",
+    });
+  });
+
+  it("reports the Coolify variables Docker cannot expose", () => {
+    const app = coolify.services.find((s) => s.name === "app-kso4gc8")!;
+    expect(app.warnings.some((w) => w.includes("build-time"))).toBe(true);
   });
 });

--- a/apps/dashboard/src/components/migration/ServerMigrationWizard.tsx
+++ b/apps/dashboard/src/components/migration/ServerMigrationWizard.tsx
@@ -3144,6 +3144,14 @@ function ServiceConfigCard({
         </span>
       </div>
 
+      {/* What discovery could not carry over: build-time vars, bind mounts, dropped ports */}
+      {service.warnings.map((warning) => (
+        <p key={warning} className="flex items-start gap-1.5 text-xs text-warning">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          {warning}
+        </p>
+      ))}
+
       {/* Route: Free / Custom / None (+ Keep when a route was already detected) */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Migrating a Coolify server imported almost none of its environment variables — usually only the one or two an operator had set to something the image didn't already contain. Scope the image-default subtraction to containers Coolify doesn't manage, and surface the variables Docker genuinely cannot expose instead of leaving the gap silent.

## Motivation

`toDiscoveredService` subtracts any container env entry whose exact `KEY=VALUE` matches the image's `Config.Env`, so a base image's dozen defaults don't masquerade as operator config. That reasoning holds for a hand-run `docker run`. It does not hold for Coolify.

Coolify resolves and re-injects **every** runtime variable explicitly — service-level, shared `{{team.*}}`, linked-resource and secret alike — and its Nixpacks builds bake those same resolved values into the image it then runs. The two sets overlap almost completely, so the subtraction discarded real production configuration.

Docker reports image defaults and explicitly-set values in one flat list, with no marker distinguishing them. Against a real daemon (29.6.2), an image that bakes in `NODE_ENV` / `DATABASE_URL` / `REDIS_URL`, run the way Coolify runs one:

```
container Config.Env : DATABASE_URL, REDIS_URL, APP_SECRET, NODE_ENV, PATH
image     Config.Env : PATH, NODE_ENV, DATABASE_URL, REDIS_URL
```

Four of the five entries are indistinguishable after the fact, so four of the five were dropped. Only `APP_SECRET` — the one value that happened not to be baked in — survived.

The label is the way out: Coolify stamps `coolify.managed=true` on every container it manages, for applications, services and databases alike (`bootstrap/helpers/docker.php`). Keying off it scopes the change to the platform that needs it — plain Docker and Compose migrations keep the base-image denoising and the test that covers it.

The issue also asks that unmigratable variables be reported. Coolify's build-time variables are passed as build args, and BuildKit secrets are never persisted, so neither survives in a running container's config. Discovery now says so per service. That warning had nowhere to render: `DiscoveredService.warnings` was computed and sent to the client, but no wizard step displayed it — so bind-mount and dropped-host-port warnings were invisible too.

## Related issue

Closes #394

## Changes

**apps/api**
- `modules/migration/docker-reconcile.ts` — skip the image-default subtraction for containers carrying the `coolify.managed` label, reusing `envArrayToRecord`'s existing "no image data, drop nothing" path; emit a warning naming build-time variables and BuildKit secrets as unrecoverable.
- `test/modules/migration/docker-inspect.test.ts` — a Coolify-labelled fixture whose image defaults are exactly its runtime env, plus two tests: env survives when it matches the image default, and the unrecoverable-variable warning is reported. The existing "subtracts image-default env" test is untouched and still passes.

**apps/dashboard**
- `components/migration/ServerMigrationWizard.tsx` — render `service.warnings` on the service config card, beside the env editor an operator would use to fill the gaps, reusing the card's existing warning treatment.

## Verification

Unit, at the seam the bug lives in:

```bash
# RED — on upstream/main, the new tests reproduce the report exactly:
$ bun run --cwd apps/api test -- test/modules/migration/docker-inspect.test.ts
 × keeps a Coolify container's env even when it matches the image default
   AssertionError: expected {} to deeply equal { NODE_ENV: 'production', …(1) }
 × reports the Coolify variables Docker cannot expose
   AssertionError: expected false to be true
 Tests  2 failed | 8 passed (10)

# GREEN — same tests, with the fix:
 Tests  10 passed (10)
```

End to end from committed `HEAD` against a real Docker daemon, driving the actual HTTP route rather than the function directly — a Coolify-labelled container on the host, adopted through the migration wizard:

```bash
$ curl -X POST localhost:4000/api/migration/scan -d '{"serverId":"…"}'
# before: env keys ["APP_SECRET"]                                          warnings 0
# after:  env keys ["DATABASE_URL","REDIS_URL","APP_SECRET","NODE_ENV"]    warnings 1
```

Stripping the `coolify.managed` label from the same container yields the old, denoised result, so the scoping holds in both directions.

Completing the migration through the wizard persists all four with their values intact — the service row afterwards:

```json
{"NODE_ENV": "production", "REDIS_URL": "redis://cache:6379",
 "APP_SECRET": "coolify-secret-sentinel", "DATABASE_URL": "postgres://db:5432/app"}
```

Full suites, two separate clean runs, both green:

```bash
$ bun run --cwd apps/api test
 Test Files  174 passed | 1 skipped (175)
      Tests  1862 passed | 4 skipped (1866)

$ bun run --cwd apps/dashboard test
 Test Files  19 passed (19)
      Tests  236 passed (236)

$ bun run --cwd apps/api lint                            # tsc --noEmit, clean
$ bun x tsc --noEmit -p apps/dashboard/tsconfig.json     # clean
```

`bun format` was **not** run: all three touched files already fail `prettier --check` on `upstream/main`, so `--write` would reformat several hundred unrelated lines. The additions follow the surrounding style.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test` and `bun run --cwd <workspace> lint` pass locally (`bun format` — see Verification)
- [x] I understand every line of this diff and can explain it in review
