### PR TITLE
Add TanStack Start stack detection

### DIFF
--- a/apps/api/src/lib/stack-detector.ts
+++ b/apps/api/src/lib/stack-detector.ts
@@ -7,7 +7,8 @@
  *
  * Supports:
  *   JS/TS:   Next.js, Nuxt, SvelteKit, Astro, Vite, Angular, Gatsby, Remix,
- *            CRA, Vue, Express, Fastify, Hono, NestJS, Koa, AdonisJS, Elysia
+ *            TanStack Start, CRA, Vue, Express, Fastify, Hono, NestJS, Koa,
+ *            AdonisJS, Elysia
  *   Go:      Standard, Gin, Fiber, Echo
  *   Rust:    Standard, Actix, Axum, Rocket
  *   Python:  Standard, Django, Flask, FastAPI
@@ -238,6 +239,10 @@ const FRAMEWORK_RULES: FrameworkRule[] = [
   { stack: "sveltekit" },
   { stack: "astro" },
   { stack: "remix" },
+  // TanStack Start is Vite-based and often ships vite.config.* — must win over
+  // the generic vite SPA rule so imports get fullstack defaults (.output server)
+  // instead of static Vite (empty start). #400
+  { stack: "tanstack-start" },
   { stack: "angular" },
   { stack: "gatsby" },
   // Vite matches on its own root markers, but a backend framework (Laravel/

--- a/apps/api/test/lib/stack-detector.test.ts
+++ b/apps/api/test/lib/stack-detector.test.ts
@@ -110,6 +110,55 @@ const POSITIVE_STACK_CASES: StackCase[] = [
     packageJson: { dependencies: { "@remix-run/react": "^2.0.0" } },
     expectedStack: "remix",
   },
+  // ── #400: TanStack Start is Vite-based; must detect as fullstack tanstack-start
+  //    (not bare vite SPA) so defaults use .output server start, not empty start.
+  {
+    name: "TanStack Start - vite.config.ts + @tanstack/react-start → tanstack-start, not vite (#400)",
+    files: files("package.json", "vite.config.ts", "src/", "app/"),
+    packageJson: {
+      dependencies: {
+        "@tanstack/react-start": "^1.0.0",
+        react: "^19.0.0",
+        vite: "^6.0.0",
+      },
+      // build script present → pm-prefixed build; no start script → registry default
+      scripts: { build: "vite build" },
+    },
+    expectedStack: "tanstack-start",
+    expectedCategory: "fullstack",
+    expectedProjectType: "app",
+    expectedStartCommand: "node .output/server/index.mjs",
+  },
+  {
+    name: "TanStack Start - app.config.ts + @tanstack/start dep (#400)",
+    files: files("package.json", "app.config.ts"),
+    packageJson: {
+      dependencies: { "@tanstack/start": "^1.0.0" },
+    },
+    expectedStack: "tanstack-start",
+    expectedCategory: "fullstack",
+    expectedStartCommand: "node .output/server/index.mjs",
+  },
+  {
+    name: "TanStack Start - rsbuild.config.ts + @tanstack/react-start dep (#400)",
+    files: files("package.json", "rsbuild.config.ts", "src/"),
+    packageJson: {
+      dependencies: { "@tanstack/react-start": "^1.0.0", "@rsbuild/core": "^1.0.0" },
+    },
+    expectedStack: "tanstack-start",
+    expectedCategory: "fullstack",
+    expectedStartCommand: "node .output/server/index.mjs",
+  },
+  {
+    name: "TanStack Start - pnpm lockfile uses pnpm build default (#400)",
+    files: files("package.json", "vite.config.ts", "pnpm-lock.yaml"),
+    packageJson: {
+      dependencies: { "@tanstack/react-start": "^1.0.0", vite: "^6.0.0" },
+      scripts: { build: "vite build" },
+    },
+    expectedStack: "tanstack-start",
+    expectedStartCommand: "node .output/server/index.mjs",
+  },
   {
     name: "Angular - angular.json + @angular/core",
     files: files("package.json", "angular.json"),
@@ -489,6 +538,29 @@ describe("detectStack - rule ordering & gate disambiguation", () => {
       dependencies: { vite: "^5.0.0", react: "^19.0.0" },
     });
     expect(result.stack).toBe("vite");
+  });
+
+  it("TanStack Start wins over Vite when @tanstack/react-start is present (#400)", () => {
+    const result = detectStack(files("package.json", "vite.config.ts", "pnpm-lock.yaml", "src/"), {
+      dependencies: { "@tanstack/react-start": "^1.0.0", vite: "^6.0.0", react: "^19.0.0" },
+      scripts: { build: "vite build" },
+    });
+    expect(result.stack).toBe("tanstack-start");
+    expect(result.category).toBe("fullstack");
+    expect(result.outputDirectory).toBe(".output");
+    expect(result.buildCommand).toBe("pnpm build");
+    expect(result.startCommand).toBe("node .output/server/index.mjs");
+    expect(result.port).toBe(3000);
+    expect(result.productionPaths).toEqual([".output"]);
+    expect(result.packageManager).toBe("pnpm");
+  });
+
+  it("plain Vite without TanStack deps still detects as vite (#400 guard)", () => {
+    const result = detectStack(files("package.json", "vite.config.ts", "index.html", "src/"), {
+      dependencies: { vite: "^6.0.0", react: "^19.0.0" },
+    });
+    expect(result.stack).toBe("vite");
+    expect(result.stack).not.toBe("tanstack-start");
   });
 
   it("CRA does NOT match a Vite app without react-scripts", () => {

--- a/packages/core/src/stacks.ts
+++ b/packages/core/src/stacks.ts
@@ -286,6 +286,34 @@ export const STACKS = {
       deps: ["@remix-run/react", "@remix-run/node", "remix"],
     },
   },
+  "tanstack-start": {
+    name: "TanStack Start",
+    language: "typescript",
+    category: "fullstack",
+    outputDirectory: ".output",
+    defaultPort: 3000,
+    defaultBuildCommand: "vite build",
+    defaultStartCommand: "node .output/server/index.mjs",
+    // Nitro/Vinxi server bundle is self-contained under .output — same shape as Nuxt.
+    productionPaths: [".output"],
+    detection: {
+      // TanStack Start is Vite/Rsbuild-based; app.config.* is the older
+      // framework-specific marker, while current apps commonly ship vite.config.*
+      // or rsbuild.config.* plus the start package dep.
+      rootMarkers: [
+        "app.config.ts",
+        "app.config.js",
+        "app.config.mjs",
+        "vite.config.ts",
+        "vite.config.js",
+        "vite.config.mjs",
+        "rsbuild.config.ts",
+        "rsbuild.config.js",
+        "rsbuild.config.mjs",
+      ],
+      deps: ["@tanstack/react-start", "@tanstack/start"],
+    },
+  },
   astro: {
     name: "Astro",
     language: "typescript",
@@ -1145,6 +1173,7 @@ export const STACK_ICONS: Partial<Record<StackId, string>> = {
   nuxt:        `${DI}/nuxtjs/nuxtjs-original.svg`,
   sveltekit:   `${DI}/svelte/svelte-original.svg`,
   remix:       `${DI}/react/react-original.svg`,
+  "tanstack-start": `${DI}/react/react-original.svg`,
   astro:       `${DI}/astro/astro-original.svg`,
   vite:        `${DI}/vitejs/vitejs-original.svg`,
   angular:     `${DI}/angular/angular-original.svg`,


### PR DESCRIPTION
## Summary

Adds first-class TanStack Start support to Openship's stack registry and GitHub import detection.

This keeps TanStack Start projects from being detected as plain Vite apps, so they get fullstack defaults instead of static Vite defaults.

## Changes

- Add a `tanstack-start` stack with `.output` server output, port `3000`, and `node .output/server/index.mjs` as the default start command
- Detect TanStack Start before generic Vite detection
- Support common Vite, Rsbuild, and older `app.config.*` project markers when paired with TanStack Start dependencies
- Add regression tests for TanStack Start vs plain Vite detection

Closes #400.

## Verification

- `bun --filter @repo/api test -- test/lib/stack-detector.test.ts`
- `bun --filter @repo/core test`
- `bun --filter @repo/api lint`
- `bun --filter @repo/core lint`
- `git diff --check`
