### PR TITLE
Add standalone PostgreSQL install app

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/apps/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/apps/page.tsx
@@ -45,6 +45,7 @@ interface FeaturedApp {
 // (single source: AVAILABLE_APP_IDS in @repo/core).
 const FEATURED_APPS: FeaturedApp[] = [
   { id: "supabase", name: "Supabase", desc: "Postgres backend + Studio", icon: Database },
+  { id: "postgres", name: "PostgreSQL", desc: "Standalone Postgres database", icon: Database },
   { id: "convex", name: "Convex", desc: "Reactive backend & database", icon: Database },
   { id: "mongodb", name: "MongoDB", desc: "Document database + Mongo Express", icon: Database },
   { id: "n8n", name: "n8n", desc: "Workflow automation", icon: Workflow },

--- a/apps/dashboard/src/components/AppLogo.tsx
+++ b/apps/dashboard/src/components/AppLogo.tsx
@@ -21,6 +21,8 @@ export const APP_LOGO: Record<
   // Supabase's official mark, rendered in its brand green by the simpleicons CDN.
   supabase: { slug: "supabase" },
   mongodb: { slug: "mongodb" },
+  // Catalog id is "postgres"; simpleicons brand slug is "postgresql".
+  postgres: { slug: "postgresql" },
   n8n: { slug: "n8n" },
   // Ghost's brand mark is near-black — invert it on the dark themes so it
   // stays visible (it's monochrome, so invert = clean white). Colored logos

--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -1789,6 +1789,156 @@
           }
         ]
       }
+    },
+    {
+      "available": true,
+      "verified": true,
+      "id": "postgres",
+      "name": "PostgreSQL",
+      "description": "Standalone PostgreSQL database — persistent volume, generated password, and connection strings for apps in the same project or over a public TCP endpoint.",
+      "kind": "template",
+      "logo": "postgresql",
+      "category": "database",
+      "tags": [
+        "database",
+        "postgres",
+        "postgresql",
+        "sql",
+        "relational"
+      ],
+      "framework": "docker-compose",
+      "services": [
+        {
+          "name": "postgres",
+          "image": "postgres:16-alpine",
+          "ports": [
+            "5432:5432"
+          ],
+          "secretEnv": [
+            "POSTGRES_PASSWORD"
+          ],
+          "volumes": [
+            "postgres_data:/var/lib/postgresql/data"
+          ],
+          "healthcheck": {
+            "test": [
+              "CMD-SHELL",
+              "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
+            ],
+            "interval": "10s",
+            "timeout": "5s",
+            "retries": 5,
+            "startPeriod": "20s"
+          },
+          "restart": "unless-stopped"
+        }
+      ],
+      "configFields": [
+        {
+          "key": "POSTGRES_PASSWORD",
+          "service": "postgres",
+          "label": "Database password",
+          "help": "Auto-generated. The password for the PostgreSQL user.",
+          "generate": "secret",
+          "secret": true
+        },
+        {
+          "key": "POSTGRES_DB",
+          "service": "postgres",
+          "label": "Database name",
+          "help": "Created on first start. Apps connect to this database by default.",
+          "type": "text",
+          "default": "app",
+          "required": true
+        },
+        {
+          "key": "POSTGRES_USER",
+          "service": "postgres",
+          "label": "Database user",
+          "help": "The PostgreSQL role used in connection strings.",
+          "type": "text",
+          "default": "postgres",
+          "required": true
+        }
+      ],
+      "management": {
+        "kind": "schema"
+      },
+      "connection": {
+        "title": "Connect to PostgreSQL",
+        "description": "Point an ORM, driver, or CLI at the connection URL. Prefer Internal for apps on the same project network.",
+        "guide": {
+          "intro": "Your project gets a PostgreSQL connection, ready to use.",
+          "useHint": "Read `process.env.DATABASE_URL` in your code — it's set the next time your project deploys. Nothing else to do.",
+          "defaultMode": "internal"
+        },
+        "outputs": [
+          {
+            "id": "dbUrl",
+            "label": "Database URL",
+            "source": "template:postgresql://{{env:postgres:POSTGRES_USER}}:{{env:postgres:POSTGRES_PASSWORD}}@{{host}}:5432/{{env:postgres:POSTGRES_DB}}",
+            "sourceLabel": "Public",
+            "variants": [
+              {
+                "id": "internal",
+                "label": "Internal",
+                "source": "template:postgresql://{{env:postgres:POSTGRES_USER}}:{{env:postgres:POSTGRES_PASSWORD}}@postgres:5432/{{env:postgres:POSTGRES_DB}}"
+              }
+            ],
+            "service": "postgres",
+            "secret": true,
+            "envKey": "DATABASE_URL",
+            "recommended": true,
+            "help": "Direct Postgres connection. Published on port 5432. Switch to Internal for apps on the same project network."
+          },
+          {
+            "id": "dbUser",
+            "label": "User",
+            "source": "env:postgres:POSTGRES_USER",
+            "envKey": "POSTGRES_USER",
+            "width": "half"
+          },
+          {
+            "id": "dbPassword",
+            "label": "Password",
+            "source": "env:postgres:POSTGRES_PASSWORD",
+            "secret": true,
+            "envKey": "POSTGRES_PASSWORD",
+            "width": "half"
+          },
+          {
+            "id": "dbName",
+            "label": "Database",
+            "source": "env:postgres:POSTGRES_DB",
+            "envKey": "POSTGRES_DB",
+            "width": "half"
+          },
+          {
+            "id": "dbHost",
+            "label": "Host (internal)",
+            "source": "template:postgres",
+            "help": "Docker service name — use from other services in this project.",
+            "width": "half"
+          }
+        ]
+      },
+      "endpoints": [
+        {
+          "service": "postgres",
+          "port": 5432,
+          "label": "Database",
+          "kind": "tcp"
+        }
+      ],
+      "provides": [
+        {
+          "id": "postgres",
+          "outputRefs": [
+            "dbUrl"
+          ],
+          "category": "database"
+        }
+      ]
     }
   ]
 }

--- a/packages/core/src/apps/catalog/postgres.json
+++ b/packages/core/src/apps/catalog/postgres.json
@@ -1,0 +1,150 @@
+{
+  "available": true,
+  "verified": true,
+  "id": "postgres",
+  "name": "PostgreSQL",
+  "description": "Standalone PostgreSQL database \u2014 persistent volume, generated password, and connection strings for apps in the same project or over a public TCP endpoint.",
+  "kind": "template",
+  "logo": "postgresql",
+  "category": "database",
+  "tags": [
+    "database",
+    "postgres",
+    "postgresql",
+    "sql",
+    "relational"
+  ],
+  "framework": "docker-compose",
+  "services": [
+    {
+      "name": "postgres",
+      "image": "postgres:16-alpine",
+      "ports": [
+        "5432:5432"
+      ],
+      "secretEnv": [
+        "POSTGRES_PASSWORD"
+      ],
+      "volumes": [
+        "postgres_data:/var/lib/postgresql/data"
+      ],
+      "healthcheck": {
+        "test": [
+          "CMD-SHELL",
+          "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
+        ],
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "20s"
+      },
+      "restart": "unless-stopped"
+    }
+  ],
+  "configFields": [
+    {
+      "key": "POSTGRES_PASSWORD",
+      "service": "postgres",
+      "label": "Database password",
+      "help": "Auto-generated. The password for the PostgreSQL user.",
+      "generate": "secret",
+      "secret": true
+    },
+    {
+      "key": "POSTGRES_DB",
+      "service": "postgres",
+      "label": "Database name",
+      "help": "Created on first start. Apps connect to this database by default.",
+      "type": "text",
+      "default": "app",
+      "required": true
+    },
+    {
+      "key": "POSTGRES_USER",
+      "service": "postgres",
+      "label": "Database user",
+      "help": "The PostgreSQL role used in connection strings.",
+      "type": "text",
+      "default": "postgres",
+      "required": true
+    }
+  ],
+  "management": {
+    "kind": "schema"
+  },
+  "connection": {
+    "title": "Connect to PostgreSQL",
+    "description": "Point an ORM, driver, or CLI at the connection URL. Prefer Internal for apps on the same project network.",
+    "guide": {
+      "intro": "Your project gets a PostgreSQL connection, ready to use.",
+      "useHint": "Read `process.env.DATABASE_URL` in your code \u2014 it's set the next time your project deploys. Nothing else to do.",
+      "defaultMode": "internal"
+    },
+    "outputs": [
+      {
+        "id": "dbUrl",
+        "label": "Database URL",
+        "source": "template:postgresql://{{env:postgres:POSTGRES_USER}}:{{env:postgres:POSTGRES_PASSWORD}}@{{host}}:5432/{{env:postgres:POSTGRES_DB}}",
+        "sourceLabel": "Public",
+        "variants": [
+          {
+            "id": "internal",
+            "label": "Internal",
+            "source": "template:postgresql://{{env:postgres:POSTGRES_USER}}:{{env:postgres:POSTGRES_PASSWORD}}@postgres:5432/{{env:postgres:POSTGRES_DB}}"
+          }
+        ],
+        "service": "postgres",
+        "secret": true,
+        "envKey": "DATABASE_URL",
+        "recommended": true,
+        "help": "Direct Postgres connection. Published on port 5432. Switch to Internal for apps on the same project network."
+      },
+      {
+        "id": "dbUser",
+        "label": "User",
+        "source": "env:postgres:POSTGRES_USER",
+        "envKey": "POSTGRES_USER",
+        "width": "half"
+      },
+      {
+        "id": "dbPassword",
+        "label": "Password",
+        "source": "env:postgres:POSTGRES_PASSWORD",
+        "secret": true,
+        "envKey": "POSTGRES_PASSWORD",
+        "width": "half"
+      },
+      {
+        "id": "dbName",
+        "label": "Database",
+        "source": "env:postgres:POSTGRES_DB",
+        "envKey": "POSTGRES_DB",
+        "width": "half"
+      },
+      {
+        "id": "dbHost",
+        "label": "Host (internal)",
+        "source": "template:postgres",
+        "help": "Docker service name \u2014 use from other services in this project.",
+        "width": "half"
+      }
+    ]
+  },
+  "endpoints": [
+    {
+      "service": "postgres",
+      "port": 5432,
+      "label": "Database",
+      "kind": "tcp"
+    }
+  ],
+  "provides": [
+    {
+      "id": "postgres",
+      "outputRefs": [
+        "dbUrl"
+      ],
+      "category": "database"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a standalone PostgreSQL app to the Install App catalog.

This gives users a simpler option when they only need Postgres, without installing the full Supabase stack.

## Changes

- Add a `postgres` catalog template using `postgres:16-alpine`
- Generate the database password during install
- Persist data in a named Docker volume
- Expose the PostgreSQL TCP endpoint
- Show connection outputs, including public and internal `DATABASE_URL` variants
- Add PostgreSQL to the featured apps list
- Add a PostgreSQL logo mapping for the catalog card
- Regenerate the merged app catalog

Closes #402.

## Verification

- `bun packages/core/scripts/gen-catalog.ts`
- `bun --filter @repo/core test -- src/apps/catalog.test.ts`
- `bun --filter @repo/core lint`
- `git diff --check`
- `cd apps/dashboard && bun x tsc --noEmit`

Note: the existing dashboard `lint` script currently fails with `next lint` under the repo's Next.js version before checking this diff. I used a dashboard typecheck instead for the touched UI files.
