### PR TITLE
fix(api/dashboard): interpolate Compose vars from the configured deploy env

### DIFF
--- a/apps/api/src/modules/deployments/deployment.controller.ts
+++ b/apps/api/src/modules/deployments/deployment.controller.ts
@@ -353,11 +353,15 @@ export async function prepare(c: Context) {
     branch?: string;
     path?: string;
     composePath?: string;
+    env?: Record<string, string>;
   }>();
 
   // Determine source - callers may send { owner, repo } without an explicit source
   const source = body.source ?? (body.owner && body.repo ? "github" : undefined);
   const composePath = body.composePath?.trim() || undefined;
+  // Interpolation-only: never persisted here, and the response masks every
+  // service env below, so supplying a value cannot echo it back unmasked.
+  const composeEnv = body.env && Object.keys(body.env).length > 0 ? body.env : undefined;
 
   try {
     let input: prepareService.Source;
@@ -373,6 +377,7 @@ export async function prepare(c: Context) {
         branch: body.branch,
         ctx,
         composePath,
+        env: composeEnv,
       };
     } else if (source === "local") {
       if (env.CLOUD_MODE) {
@@ -381,7 +386,7 @@ export async function prepare(c: Context) {
       if (!body.path) {
         return c.json({ error: "path is required" }, 400);
       }
-      input = { source: "local", path: body.path, composePath };
+      input = { source: "local", path: body.path, composePath, env: composeEnv };
     } else {
       return c.json({ error: "source must be 'github' or 'local'" }, 400);
     }

--- a/apps/api/src/modules/deployments/deployment.schema.ts
+++ b/apps/api/src/modules/deployments/deployment.schema.ts
@@ -173,6 +173,12 @@ export const PrepareDeployBody = Type.Object({
         "Where the compose file lives when it is not at the auto-detected root — the file itself (\"deploy/stack.yml\", which also covers non-standard filenames) or the directory holding it (\"deploy/docker-compose\"). Detects the project as a compose/services deploy; errors when no compose file is there.",
     }),
   ),
+  env: Type.Optional(
+    Type.Record(Type.String(), Type.String(), {
+      description:
+        "Env already configured for this deploy. Compose interpolation resolves against these on top of the repo .env, so a file declaring ${VAR:?...} scans once the user has supplied VAR.",
+    }),
+  ),
 });
 
 // POST /:id/build/respond — answer a build gate/prompt.

--- a/apps/api/src/modules/deployments/prepare.service.ts
+++ b/apps/api/src/modules/deployments/prepare.service.ts
@@ -68,8 +68,16 @@ export type Source =
       ctx?: RequestContext;
       /** See {@link ResolveOptions.composePath}. */
       composePath?: string;
+      /** See {@link ResolveOptions.env}. */
+      env?: Record<string, string>;
     }
-  | { source: "local"; path: string; composePath?: string };
+  | {
+      source: "local";
+      path: string;
+      composePath?: string;
+      /** See {@link ResolveOptions.env}. */
+      env?: Record<string, string>;
+    };
 
 export interface ResolveOptions {
   /**
@@ -84,6 +92,14 @@ export interface ResolveOptions {
    * buildpack build (the confusing behaviour this option exists to replace).
    */
   composePath?: string;
+  /**
+   * Env the caller already holds for this deploy (the values configured on the
+   * project / entered in the wizard). Compose interpolation resolves against
+   * these on top of the repo `.env`, so a file declaring `${VAR:?...}` scans
+   * cleanly once the user has supplied VAR — without it the scan reports the
+   * file as unparseable even though the deploy would have succeeded (#383).
+   */
+  env?: Record<string, string>;
 }
 
 /** Thrown when a declared `composePath` has no compose file behind it. */
@@ -602,6 +618,7 @@ export async function resolveProjectInfo(input: Source): Promise<ProjectInfo> {
     }
     return resolveFromGitHub(input.ctx, input.owner, input.repo, input.branch, {
       composePath: input.composePath,
+      env: input.env,
     });
   }
 
@@ -611,7 +628,7 @@ export async function resolveProjectInfo(input: Source): Promise<ProjectInfo> {
 
   // Dynamic import keeps local-source (node:fs) out of the cloud module graph.
   const { resolveFromLocal } = await import("./local-source");
-  return resolveFromLocal(input.path, { composePath: input.composePath });
+  return resolveFromLocal(input.path, { composePath: input.composePath, env: input.env });
 }
 
 type RepoMeta = Parameters<typeof toProjectInfo>[0];
@@ -704,7 +721,7 @@ export async function resolveFromReader(
     composeEnvContent,
     root.monorepo,
     routing,
-    { declaredCompose: !!root.declaredComposePath },
+    { declaredCompose: !!root.declaredComposePath, env: opts.env },
   );
   const overlaid = applyOpenshipOverlay(info, openshipConfig);
 
@@ -769,6 +786,8 @@ function toProjectInfo(
      *  services project even when stack detection wouldn't say so on its own
      *  (a non-standard filename like `stack.yml` matches no root marker). */
     declaredCompose?: boolean;
+    /** See {@link ResolveOptions.env}. */
+    env?: Record<string, string>;
   },
 ): ProjectInfo {
   const stack = projectRoot.stack;
@@ -777,7 +796,10 @@ function toProjectInfo(
   let services: ComposeService[] | undefined;
   if (composeContent && (opts?.declaredCompose || stack.projectType === "services")) {
     try {
-      const parsed = parseComposeFile(composeContent, { envFileContent: composeEnvContent });
+      const parsed = parseComposeFile(composeContent, {
+        envFileContent: composeEnvContent,
+        env: opts?.env,
+      });
       services = parsed.services;
     } catch (err) {
       // Surface the broken file. Swallowing it returns a services project with

--- a/apps/api/test/modules/deployments/prepare.service.test.ts
+++ b/apps/api/test/modules/deployments/prepare.service.test.ts
@@ -32,6 +32,37 @@ describe("resolveProjectInfo", () => {
     );
   });
 
+  it("interpolates required Compose variables from the configured deploy env", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
+    tempDirs.push(tempDir);
+
+    // #383: compose lives outside the repo root (#330) and declares a required
+    // variable. The user supplied it in the Openship deploy configuration, so
+    // the scan must interpolate it instead of reporting the file as unparseable.
+    await mkdir(join(tempDir, "deploy", "docker-compose"), { recursive: true });
+    await writeFile(
+      join(tempDir, "deploy", "docker-compose", "docker-compose.yaml"),
+      [
+        "services:",
+        "  db:",
+        "    image: postgres:16-alpine",
+        "    environment:",
+        "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}",
+      ].join("\n"),
+    );
+
+    const info = await resolveProjectInfo({
+      source: "local",
+      path: tempDir,
+      composePath: "deploy/docker-compose",
+      env: { POSTGRES_PASSWORD: "s3cret" },
+    });
+
+    expect(info.services?.find((s) => s.name === "db")?.environment).toMatchObject({
+      POSTGRES_PASSWORD: "s3cret",
+    });
+  });
+
   it("reports invalid Compose YAML instead of returning no services", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
     tempDirs.push(tempDir);

--- a/apps/dashboard/src/context/deployment/useDeploymentConfig.ts
+++ b/apps/dashboard/src/context/deployment/useDeploymentConfig.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
-import type { FrameworkId } from "@/components/import-project/types";
+import type { EnvironmentVariable, FrameworkId } from "@/components/import-project/types";
 import { deployApi, projectsApi, servicesApi, serviceKind } from "@/lib/api";
 import { folderApi } from "@/lib/api/folder";
 import type { PrepareProjectResponse, PrepareComposeService, PrepareMonorepoApp } from "@/lib/api/deploy";
@@ -138,6 +138,24 @@ function scanComposePath(
     (typeof project?.composePath === "string" ? project.composePath : undefined);
   const trimmed = declared?.trim();
   return trimmed ? { composePath: trimmed } : {};
+}
+
+/**
+ * The env the scan should interpolate the compose file against (#383). A compose
+ * file declaring `${VAR:?...}` is unparseable until VAR has a value, so a re-scan
+ * has to carry what the user already entered — otherwise the wizard reports the
+ * file as broken even though the deploy itself would resolve the same variable.
+ *
+ * Returns an `{ env }` fragment to spread into the prepare body, empty when
+ * nothing is set so a blank map never reaches the API.
+ */
+function scanEnv(envVars: EnvironmentVariable[]): { env?: Record<string, string> } {
+  const env: Record<string, string> = {};
+  for (const { key, value } of envVars) {
+    const name = key.trim();
+    if (name) env[name] = value;
+  }
+  return Object.keys(env).length > 0 ? { env } : {};
 }
 
 function hasSavedProjectPort(project: PersistedProject) {
@@ -757,7 +775,12 @@ export function useDeploymentConfig() {
       owner: string,
       repo: string,
       force?: string,
-      context?: { branch?: string; projectId?: string; composePath?: string },
+      context?: {
+        branch?: string;
+        projectId?: string;
+        composePath?: string;
+        env?: Record<string, string>;
+      },
     ): Promise<{ success: boolean; error?: string; errorType?: string; buildInProgress?: boolean }> => {
       try {
         let project: PersistedProject = null;
@@ -786,6 +809,7 @@ export function useDeploymentConfig() {
           branch: requestedBranch,
           force,
           ...scanComposePath(context?.composePath, project),
+          ...(context?.env ? { env: context.env } : {}),
         });
 
         if (response?.error) {
@@ -835,7 +859,7 @@ export function useDeploymentConfig() {
   const initializeFromLocal = useCallback(
     async (
       path: string,
-      context?: { projectId?: string; composePath?: string },
+      context?: { projectId?: string; composePath?: string; env?: Record<string, string> },
     ): Promise<{ success: boolean; error?: string; errorType?: string }> => {
       try {
         let project: PersistedProject = null;
@@ -849,6 +873,7 @@ export function useDeploymentConfig() {
           source: "local",
           path,
           ...scanComposePath(context?.composePath, project),
+          ...(context?.env ? { env: context.env } : {}),
         });
 
         if (response?.error) {
@@ -891,11 +916,15 @@ export function useDeploymentConfig() {
       // "" clears the pin: the initialize* paths drop a blank value, so the scan
       // falls back to ordinary root detection.
       const trimmed = composePath.trim();
+      // Carry the env the user has already entered so a compose file with
+      // required variables re-scans instead of erroring as unparseable (#383).
+      const env = scanEnv(config.envVars);
 
       if (config.localPath) {
         return initializeFromLocal(config.localPath, {
           projectId: config.projectId,
           composePath: trimmed,
+          ...env,
         });
       }
       if (!config.owner || !config.repo) {
@@ -909,6 +938,7 @@ export function useDeploymentConfig() {
         branch: config.branch,
         projectId: config.projectId,
         composePath: trimmed,
+        ...env,
       });
       return { success: result.success, error: result.error, errorType: result.errorType };
     },
@@ -918,6 +948,7 @@ export function useDeploymentConfig() {
       config.repo,
       config.branch,
       config.projectId,
+      config.envVars,
       initializeFromLocal,
       initializeFromRepo,
     ],

--- a/apps/dashboard/src/lib/api/deploy.ts
+++ b/apps/dashboard/src/lib/api/deploy.ts
@@ -26,8 +26,16 @@ export type PrepareProjectSource =
       force?: string | boolean;
       /** Pin the compose file location (file or directory) instead of detecting the root. */
       composePath?: string;
+      /** Env already configured for this deploy, for compose interpolation. */
+      env?: Record<string, string>;
     }
-  | { source: "local"; path: string; composePath?: string };
+  | {
+      source: "local";
+      path: string;
+      composePath?: string;
+      /** Env already configured for this deploy, for compose interpolation. */
+      env?: Record<string, string>;
+    };
 
 export interface PrepareComposeService {
   name: string;


### PR DESCRIPTION
## Summary

A Compose file that declares a required variable (`${VAR:?message}`) fails the wizard scan even when the operator has already entered that variable in the Openship deploy configuration. The scan interpolates against the repo `.env` alone, so the configured env never reaches the parser. Thread that env through to `parseComposeFile`, which already accepts it.

## Motivation

`toProjectInfo` is the single place the wizard parses Compose (`prepare.service.ts:780` on `main`):

```ts
const parsed = parseComposeFile(composeContent, { envFileContent: composeEnvContent });
```

`composeEnvContent` is a `.env` read from beside the Compose file. It is the **only** interpolation source. `Source` and `ResolveOptions` carry no env at all, so there is no way for a caller to supply one — the values the operator typed into the wizard are simply not in scope at the point the file is parsed.

Compose treats `${VAR:?message}` as fatal when `VAR` is unset, so the parse throws and the wizard reports the file as broken. Reproduced against `0f59f94f` with the reporter's layout — Compose pinned outside the repo root (the `composePath` feature from #330), one required variable, supplied through the deploy configuration:

| supplied env | `main` | this branch |
|---|---|---|
| `POSTGRES_PASSWORD=s3cret` | `Error: Could not parse the Docker Compose file at "deploy/docker-compose": Set POSTGRES_PASSWORD in .env` | `services[db].environment.POSTGRES_PASSWORD === "s3cret"` |
| nothing supplied | same error | same error (unchanged) |

The second row is the behaviour worth keeping: a genuinely unset required variable must still be reported. #339 established that swallowing a parse failure returns a services project with zero services and no reason why, and the existing `reports missing required Compose variables` test pins that. This change only suppresses the error when the operator actually provided the value.

The parser side already supports this. `ComposeParseOptions.env` is documented as "Explicit interpolation values. Overrides values loaded from `envFileContent`" (`compose-parser.ts:69`) and `buildInterpolationEnv` layers it over the `.env` map (`:424`). Nothing new was needed there — only the plumbing to reach it.

## Related issue

Closes #383

## Changes

**apps/api**

- `modules/deployments/prepare.service.ts` — `ResolveOptions` gains `env`, mirrored onto both `Source` variants; forwarded through `resolveFromReader` into `toProjectInfo` and on to `parseComposeFile`. `ResolveOptions` already reaches both `resolveFromGitHub` and `resolveFromLocal`, so neither resolver needed touching.
- `modules/deployments/deployment.schema.ts` — `PrepareDeployBody.env`, a `Type.Record(Type.String(), Type.String())`, matching how `project.schema.ts` and `service.schema.ts` already declare env maps. The route is validated, so the shape is checked at the trust boundary rather than in the handler.
- `modules/deployments/deployment.controller.ts` — pass the body's `env` into both the github and local `Source`. Interpolation-only: not persisted here, and the response already masks every service env through `maskScanService` (#336), so a supplied value cannot be echoed back unmasked.
- `test/modules/deployments/prepare.service.test.ts` — one regression test on the existing tmpdir harness, reproducing the reporter's nested `deploy/docker-compose` layout.

**apps/dashboard**

- `context/deployment/useDeploymentConfig.ts` — new `scanEnv` helper folds `config.envVars` into a record; `rescanWithComposePath` carries it through both initialize paths. Empty maps are dropped so a blank value never reaches the API, matching how the neighbouring `scanComposePath` handles an unset pin.
- `lib/api/deploy.ts` — `env` on `PrepareProjectSource`.

`rescanWithComposePath` is the path that matters here: it re-reads the source precisely because projectType, the service list and each service's env can only come from the Compose file, so it is the one flow where the operator has already entered env and then triggers a fresh parse.

## Verification

RED first, on the branch with the fix reverted — the new test reproduces the report verbatim:

```
 × interpolates required Compose variables from the configured deploy env
   Error: Could not parse the Docker Compose file at "deploy/docker-compose": Set POSTGRES_PASSWORD in .env
    789|       throw new Error(`Could not parse the Docker Compose file${where}…
```

GREEN, and the pre-existing missing-variable test still passes beside it:

```
 ✓ reports missing required Compose variables instead of returning no services
 ✓ interpolates required Compose variables from the configured deploy env
 Tests  16 passed (16)
```

Full API suite, two separate clean runs:

```
$ bun run --cwd apps/api test
 Test Files  174 passed | 1 skipped (175)
      Tests  1861 passed | 4 skipped (1865)
   Duration  41.39s

$ bun run --cwd apps/api test
 Test Files  174 passed | 1 skipped (175)
      Tests  1861 passed | 4 skipped (1865)
   Duration  45.86s
```

Dashboard suite and typecheck:

```
$ bun run --cwd apps/dashboard test
 Test Files  19 passed (19)
      Tests  236 passed (236)

$ turbo run lint --filter=@repo/api     # tsc --noEmit
 Tasks:    4 successful, 4 total

$ npx tsc --noEmit -p apps/dashboard/tsconfig.json
 (clean)
```

Re-run against committed `HEAD` after the three commits: 16/16 on the focused file, old failure gone.

Two notes on the checklist rather than a silent tick:

- `bun format` is **not** run. All five touched files already fail `prettier --check` on `main` — verified by checking out `main` and running it there — so formatting them would reformat lines this PR has no business touching.
- `turbo run lint --filter=@repo/dashboard` fails on `main` as well as here, with `Invalid project directory provided, no such directory: apps/dashboard/lint`. The `next lint` script is incompatible with the installed Next; unrelated to this change. Used `tsc --noEmit` on the dashboard instead, which is clean.

## Questions for a maintainer

@Hydralerne — a few calls I would rather you make than assume:

1. **Scope of the endpoint change.** The template asks for prior agreement on new endpoints and schema changes. This adds an optional field to an existing route's body rather than a new endpoint, and I read it as within "bug fix" — but it is a request-shape change, so say the word if you would rather it went through an issue first.

2. **Three sibling callers left unwired, deliberately.** `resolveProjectInfo` has three other callers with the identical gap, and I did not touch them because each needs a decision about where project env is read from:
   - `reconcileComposeDrift` (`build.service.ts:470`) — the interesting one. Its parse failure is caught into a `console.warn`, so on a Compose file with required variables, drift reconciliation silently stops tracking upstream changes and nothing surfaces. It has the project record in hand, so wiring it is a question of which env you consider authoritative there.
   - `detectStack` (`github.controller.ts:834`) — a GET, so env would have to arrive as a query parameter or the route would need to change shape.
   - `scanLocal` (`project.controller.ts:923`).

   Happy to do any or all in this PR or a follow-up — tell me which, and where env should come from for the drift path.

3. **No dashboard test.** `apps/dashboard` has no jsdom or Testing Library; its render tests use `renderToStaticMarkup`, which runs no effects, so a hook like `rescanWithComposePath` cannot be exercised. I did not add a test framework to cover it. If you would rather that half were covered, that is a jsdom addition and a bigger conversation than this fix.

The API half is genuinely covered — real resolver, real parser, real temp filesystem.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — see the two notes under Verification: `bun format` deliberately not run, and dashboard `lint` is broken on `main` independently of this change
- [x] I understand every line of this diff and can explain it in review
