### PR TITLE
fix(api/dashboard): omit the package manager when the source has none

### DIFF
--- a/apps/api/src/modules/deployments/prepare.service.ts
+++ b/apps/api/src/modules/deployments/prepare.service.ts
@@ -184,7 +184,16 @@ export interface ProjectInfo {
   stack: StackResult["stack"];
   projectType: ProjectType;
   category: string;
-  packageManager: string;
+  /**
+   * Absent when the source carries no package manager at all — a stock Compose
+   * project has neither a manifest nor a lockfile, and `detectPackageManager`
+   * reports the `"unknown"` sentinel for it. That sentinel is not one of
+   * `ALL_PACKAGE_MANAGERS`, so echoing it back into `POST /projects/ensure`
+   * (which is exactly what the wizard does with a scan) fails validation and
+   * the deploy 400s (#389). Omitted instead, which the field being optional on
+   * every write body already allows.
+   */
+  packageManager?: string;
   buildCommand: string;
   installCommand: string;
   startCommand: string;
@@ -838,7 +847,7 @@ function toProjectInfo(
     stack: stack.stack,
     projectType,
     category: stack.category,
-    packageManager: stack.packageManager,
+    ...(stack.packageManager !== "unknown" && { packageManager: stack.packageManager }),
     buildCommand: stack.buildCommand,
     installCommand: stack.installCommand,
     startCommand: stack.startCommand,

--- a/apps/api/src/modules/deployments/prepare.service.ts
+++ b/apps/api/src/modules/deployments/prepare.service.ts
@@ -24,6 +24,7 @@ import {
   type RepoTreeEntry,
 } from "../../lib/project-root-detector";
 import {
+  ALL_PACKAGE_MANAGERS,
   parseDeploymentMetadata,
   parseOpenshipConfigJson,
   METADATA_FILES,
@@ -187,10 +188,12 @@ export interface ProjectInfo {
   /**
    * Absent when the source carries no package manager at all — a stock Compose
    * project has neither a manifest nor a lockfile, and `detectPackageManager`
-   * reports the `"unknown"` sentinel for it. That sentinel is not one of
-   * `ALL_PACKAGE_MANAGERS`, so echoing it back into `POST /projects/ensure`
-   * (which is exactly what the wizard does with a scan) fails validation and
-   * the deploy 400s (#389). Omitted instead, which the field being optional on
+   * reports the `"unknown"` sentinel for it. Only values in
+   * `ALL_PACKAGE_MANAGERS` are surfaced, which is the same list every write
+   * body's `packageManager` is generated from: a scan echoed back into
+   * `POST /projects/ensure` (exactly what the wizard does) is then valid by
+   * construction rather than because the one sentinel we know about was
+   * filtered out (#389). Omitted is the shape the field being optional on
    * every write body already allows.
    */
   packageManager?: string;
@@ -847,7 +850,9 @@ function toProjectInfo(
     stack: stack.stack,
     projectType,
     category: stack.category,
-    ...(stack.packageManager !== "unknown" && { packageManager: stack.packageManager }),
+    ...(ALL_PACKAGE_MANAGERS.includes(stack.packageManager) && {
+      packageManager: stack.packageManager,
+    }),
     buildCommand: stack.buildCommand,
     installCommand: stack.installCommand,
     startCommand: stack.startCommand,

--- a/apps/api/test/modules/deployments/prepare.service.test.ts
+++ b/apps/api/test/modules/deployments/prepare.service.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Value } from "@sinclair/typebox/value";
 
 import { resolveProjectInfo } from "../../../src/modules/deployments/prepare.service";
+import { EnsureProjectBody } from "../../../src/modules/projects/project.schema";
 
 describe("resolveProjectInfo", () => {
   const tempDirs: string[] = [];
@@ -107,6 +109,29 @@ describe("resolveProjectInfo", () => {
     expect(result.stack).toBe("docker-compose");
     expect(result.services?.map((service) => service.name)).toEqual(["web"]);
     expect(result.rootEnv).toEqual({ PORT: "9090" });
+  });
+
+  it("omits the package manager when the source has none, so the scan stays a valid project body", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
+    tempDirs.push(tempDir);
+
+    // #389: a stock Compose project has no package.json and no lockfile, so
+    // detection reports the "unknown" sentinel. The wizard echoes the scan
+    // straight back into POST /projects/ensure, whose packageManager is drawn
+    // from the real package-manager list, and the deploy 400s.
+    await writeFile(
+      join(tempDir, "docker-compose.yml"),
+      ["services:", "  immich-server:", "    image: ghcr.io/immich-app/immich-server:release"].join(
+        "\n",
+      ),
+    );
+
+    const result = await resolveProjectInfo({ source: "local", path: tempDir });
+
+    expect(result.packageManager).toBeUndefined();
+    expect(
+      Value.Check(EnsureProjectBody, { name: "immich", packageManager: result.packageManager }),
+    ).toBe(true);
   });
 
   // ── Declared compose path (issue #330) ────────────────────────────────────

--- a/apps/api/test/modules/deployments/prepare.service.test.ts
+++ b/apps/api/test/modules/deployments/prepare.service.test.ts
@@ -118,7 +118,8 @@ describe("resolveProjectInfo", () => {
     // #389: a stock Compose project has no package.json and no lockfile, so
     // detection reports the "unknown" sentinel. The wizard echoes the scan
     // straight back into POST /projects/ensure, whose packageManager is drawn
-    // from the real package-manager list, and the deploy 400s.
+    // from ALL_PACKAGE_MANAGERS, and the deploy 400s. The scan must only ever
+    // surface a value from that same list, whatever detection reports.
     await writeFile(
       join(tempDir, "docker-compose.yml"),
       ["services:", "  immich-server:", "    image: ghcr.io/immich-app/immich-server:release"].join(

--- a/apps/dashboard/src/context/deployment/mode-config.test.ts
+++ b/apps/dashboard/src/context/deployment/mode-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { buildSingleModeSnapshot } from "./mode-config";
+import type { DeploymentConfig } from "./types";
+
+/**
+ * #389: the scan omits `packageManager` when the source has none — a stock
+ * Compose project carries neither a manifest nor a lockfile. The snapshot is
+ * persisted through `POST /projects/ensure`, whose `packageManager` is drawn
+ * from the real package-manager list, so an absent value has to resolve to a
+ * real one here rather than travel as undefined.
+ */
+describe("buildSingleModeSnapshot — compose primary without a package manager", () => {
+  const config = {
+    projectType: "services",
+    projectName: "immich",
+    repo: "immich",
+    services: [],
+    publicEndpoints: [],
+    buildStrategy: "auto",
+    options: {
+      productionPort: "",
+      rootDirectory: "./",
+      installCommand: "",
+      buildCommand: "",
+      startCommand: "",
+      outputDirectory: "",
+      productionPaths: "",
+      hasServer: false,
+      hasBuild: false,
+    },
+    singleAppCandidate: {
+      stack: "docker-compose",
+      projectType: "services",
+      category: "docker",
+      // No packageManager: this is exactly what the scan now returns.
+      buildCommand: "",
+      installCommand: "",
+      startCommand: "",
+      buildImage: "node:22",
+      outputDirectory: "dist",
+      rootDirectory: "./",
+      productionPaths: [],
+      port: 2283,
+      hasServer: false,
+      hasBuild: false,
+    },
+  } as unknown as DeploymentConfig;
+
+  it("falls back to npm instead of carrying an absent package manager", () => {
+    const snapshot = buildSingleModeSnapshot(config);
+
+    expect(snapshot?.packageManager).toBe("npm");
+  });
+});

--- a/apps/dashboard/src/context/deployment/mode-config.ts
+++ b/apps/dashboard/src/context/deployment/mode-config.ts
@@ -305,7 +305,7 @@ function pickComposePrimary(
     const primary: SingleAppPrimary = {
       framework: candidate.stack as FrameworkId,
       detectedFramework: candidate.stack as FrameworkId,
-      packageManager: candidate.packageManager,
+      packageManager: candidate.packageManager || "npm",
       buildImage: candidate.buildImage,
       rootDirectory: candidate.rootDirectory,
       installCommand: candidate.installCommand,

--- a/apps/dashboard/src/lib/api/deploy.ts
+++ b/apps/dashboard/src/lib/api/deploy.ts
@@ -74,7 +74,9 @@ export interface PrepareAppConfig {
   stack: StackId;
   projectType: "app" | "docker" | "services" | "monorepo";
   category: string;
-  packageManager: string;
+  /** Absent when the source has none — a stock Compose project carries neither
+   *  a manifest nor a lockfile. Every read falls back to npm. */
+  packageManager?: string;
   buildCommand: string;
   installCommand: string;
   startCommand: string;


### PR DESCRIPTION
## Summary

A stock Compose project fails to deploy with a 400 on `/packageManager`. Detection reports the `"unknown"` sentinel for a source with no manifest and no lockfile, the wizard echoes the scan back into `POST /projects/ensure`, and `"unknown"` is not a member of the list that route validates against. Omit the field instead of emitting a value our own write schema rejects.

## Motivation

`detectPackageManager` ends with a sentinel rather than a package manager (`stack-detector.ts:144`):

```ts
if (fileSet.has("package.json")) return "npm";

return "unknown";
```

That string is **truthy**, which is what makes it slip through. The wizard carries seven `|| "npm"` fallbacks between a scan and the ensure body — every one of them was written to catch a missing package manager, and every one of them passes `"unknown"` straight through. It reaches `POST /projects/ensure`, whose `packageManager` is drawn from `ALL_PACKAGE_MANAGERS` (`project.schema.ts:287`), and the deploy dies there.

Reproduced against `b22c3701` with the reporter's case — the official immich Compose file, no `package.json`, no lockfile:

| stage | `main` | this branch |
|---|---|---|
| scan `packageManager` | `"unknown"` | omitted |
| ensure body accepted | `false` | `true` |
| errors | `[{"path":"/packageManager","message":"Expected union value","value":"unknown"}]` | `[]` |

The error object on the left is the payload from the issue, field for field.

This is not Compose-specific. Any source without a lockfile or manifest lands on the same sentinel — a plain static site fails identically. No project ever persisted `"unknown"`, since the schema always rejected it, so there is no stored value to migrate.

## Related issue

Closes #389

## Changes

**apps/api**

- `modules/deployments/prepare.service.ts` — `toProjectInfo` surfaces `packageManager` only when it is a member of `ALL_PACKAGE_MANAGERS`, the same list `PackageManagerEnum` is generated from, and omits it otherwise; `ProjectInfo.packageManager` becomes optional. Gating on the list rather than on the `"unknown"` string keeps the scan valid by construction instead of correct only while that is the sole sentinel. `applyMetadataOverrides` never touches the field, so detection is the only source and the two are equivalent today. One choke point covers all four scan surfaces: `/deployments/prepare`, `scanLocal`, `detectStack` and the folder-upload scan all resolve through `resolveProjectInfo`, and the two scan routes already share `projectInfoToScanResponse`.
- `test/modules/deployments/prepare.service.test.ts` — regression test on the existing tmpdir harness, asserting the scan result validates against `EnsureProjectBody`.

**apps/dashboard**

- `context/deployment/mode-config.ts` — `pickComposePrimary` gets the `|| "npm"` fallback its seven siblings already had. This is the single unguarded read in the wizard, and it sits on the compose path, which is exactly where the field now goes missing.
- `context/deployment/mode-config.test.ts` — covers that fallback through `buildSingleModeSnapshot`.
- `lib/api/deploy.ts` — `PrepareAppConfig.packageManager` optional, so the type describes what actually arrives.

Deliberately **not** changed: `detectPackageManager` itself. Coercing at detection looks tempting, but `getInstallCommand("unknown")` returns `""` on purpose (`stack-detector.ts:668`) — mapping the sentinel to `"npm"` there would hand `npm i --force` to every lockfile-less repo. The sentinel stays internal, where `project-root-detector.ts:593` reads it.

Omitting rather than substituting is what the write bodies were built for: `packageManager` is `Type.Optional` on all of them, and absence makes the wizard's existing `|| "npm"` guards fire as designed instead of being dead code.

## Verification

RED first, on the branch with only the source fix reverted:

```
FAIL test/modules/deployments/prepare.service.test.ts > resolveProjectInfo > omits the package manager when the source has none, so the scan stays a valid project body
AssertionError: expected 'unknown' to be undefined

- Expected: undefined
+ Received: "unknown"
```

Same for the dashboard half, with only the `mode-config.ts` fallback reverted:

```
FAIL src/context/deployment/mode-config.test.ts > buildSingleModeSnapshot — compose primary without a package manager
AssertionError: expected undefined to be 'npm'
```

Both fail without the change and pass with it.

End-to-end against committed `HEAD` — real resolver, real temp filesystem, real write schema. Immich's compose file, plus a pnpm repo to confirm a genuine value is still passed through untouched:

```
compose   -> undefined | ensure accepted: true
pnpm repo -> "pnpm"    | ensure accepted: true
```

Against `main` the compose row prints `"unknown"` and `false`, with the reporter's error object.

Full suites, two separate clean runs each:

```bash
$ bun run --cwd apps/api test
 Test Files  174 passed | 1 skipped (175)
      Tests  1870 passed | 4 skipped (1874)
   Duration  42.51s

$ bun run --cwd apps/api test
 Test Files  174 passed | 1 skipped (175)
      Tests  1870 passed | 4 skipped (1874)
   Duration  46.94s

$ bun run --cwd apps/dashboard test
 Test Files  20 passed (20)
      Tests  237 passed (237)

$ npx tsc --noEmit -p apps/api/tsconfig.json        # clean
$ npx tsc --noEmit -p apps/dashboard/tsconfig.json  # clean
```

Four commits, each green on its own: the API fix with its test, the dashboard fallback with its test, the type change (which only typechecks once the fallback exists — that ordering is deliberate), then the switch from the sentinel check to list membership.

One note rather than a silent tick on the checklist: `bun format` was not run across the repo. Three of the files this PR touches already fail `prettier --check` on clean `main`, so formatting them would reformat lines this PR has no business touching. Both files I authored are prettier-clean, and I fixed the one formatting issue that was genuinely mine.

## Questions for a maintainer

@Hydralerne — one thing worth your call, not a blocker for this PR:

**The same field is validated two different ways.** `CreateProjectBody`/`EnsureProjectBody` draw `packageManager` from `PackageManagerEnum` (`project.schema.ts:287`), but `SetOptionsBody` on `POST /projects/:id/options` takes a bare `Type.Optional(Type.String())` (`:543`) — so the Runtime tab's save path accepts any string the create path would reject. Nothing in this report goes through that route, and tightening it is a behavior change rather than a bug fix, so I left it alone. Worth a follow-up if you want the two to agree.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it — two of them, one per workspace, both shown failing above
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — tests and typecheck pass; see the note under Verification for why `bun format` was deliberately not run
- [x] I understand every line of this diff and can explain it in review
