### PR TITLE
fix(adapters): refuse a unix-socket upstream in the nginx importer

### DIFF
--- a/packages/adapters/src/system/proxy/import/nginx.ts
+++ b/packages/adapters/src/system/proxy/import/nginx.ts
@@ -45,8 +45,9 @@ function parseUpstreams(config: string): Map<string, string> {
 /**
  * Turn a raw proxy_pass value into a concrete Openship route target, or reject
  * it (so the caller warns and skips) when it can't be resolved to a real
- * host:port — an unknown/undeclared upstream, an nginx variable, or a unix
- * socket would otherwise produce a vhost that fails `openresty -t`.
+ * host:port — an unknown/undeclared upstream or an nginx variable would
+ * otherwise produce a vhost that fails `openresty -t`, and a unix socket one
+ * that passes it but points at a path the edge can't reach.
  */
 function resolveProxyTarget(
   proxyPass: string,
@@ -60,7 +61,13 @@ function resolveProxyTarget(
   const scheme = m[1];
   const authority = m[2];
   const host = authority.replace(/:\d+$/, "");
-  if (upstreams.has(host)) return { url: `${scheme}${upstreams.get(host)}` };
+  const upstream = upstreams.get(host);
+  if (upstream) {
+    if (/^unix:/i.test(upstream)) {
+      return { reason: `proxy_pass "${raw}" resolves to upstream "${host}", a unix socket` };
+    }
+    return { url: `${scheme}${upstream}` };
+  }
   const isIp = /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
   // `localhost` is NOT safe to carry over verbatim: nginx resolves it to ::1
   // first, and most app servers bind IPv4 only — so an adopted

--- a/packages/adapters/src/system/proxy/import/proxy-import.test.ts
+++ b/packages/adapters/src/system/proxy/import/proxy-import.test.ts
@@ -68,6 +68,20 @@ describe("scanNginx", () => {
     expect(res.warnings.some((w) => w.includes("variable"))).toBe(true);
   });
 
+  test("refuses a unix-socket upstream reached through an `upstream` block", async () => {
+    const conf = `
+      upstream app { server unix:/run/app.sock; }
+      upstream tcp { server 127.0.0.1:9000; }
+      server { server_name sock.example.com; location / { proxy_pass http://app; } }
+      server { server_name tcp.example.com;  location / { proxy_pass http://tcp; } }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+    expect(res.sites.some((s) => s.serverNames.includes("sock.example.com"))).toBe(false);
+    expect(res.warnings.some((w) => w.includes("unix socket"))).toBe(true);
+    const tcp = res.sites.find((s) => s.serverNames.includes("tcp.example.com"));
+    expect(tcp?.target).toEqual({ kind: "proxy", url: "http://127.0.0.1:9000" });
+  });
+
   test("path-routing: keeps EVERY location upstream in `routes`, primary stays `/`", async () => {
     // `location /` is declared AFTER `/api` — the primary must still be `/`, and
     // the extra upstream is RETAINED (not dropped to a warning) so the edge can


### PR DESCRIPTION
## Summary

The nginx importer refuses `proxy_pass http://unix:/run/app.sock:/` outright, but migrates the same socket when it is reached through an `upstream` block — as the route target `http://unix:/run/app.sock`.

## Motivation

```nginx
upstream app { server unix:/run/app.sock; }
server { server_name sock.example.com; location / { proxy_pass http://app; } }
```

`resolveProxyTarget` substitutes the block's `server` value into the scheme without looking at it. To nginx the two spellings are one config — measured on `nginx:1.27-alpine`, `proxy_pass http://unix:/run/app.sock` and `…:/` log the identical `upstream: "http://unix:/run/app.sock:/foo"` — so only which one the operator typed decided whether the site migrated.

Nothing downstream catches it: `assertValidUpstream` accepts `http://unix:/…` as an http URL, and `openresty -t` on the edge's own base image accepts `proxy_pass http://unix:/run/app.sock;`. But that socket is unreachable from the edge now serving it — `EDGE_CONTAINER_MOUNTS` mounts nothing under `/run` — so the host answers 502. On the takeover path the operator's nginx is already stopped, and the domain is reported as migrated.

Warn and skip is what the direct form already does, and what the caddy importer does for both of its unix-socket shapes.

## Related issue

None.

## Changes

- `packages/adapters` — the upstream branch of `resolveProxyTarget` applies the existing unix-socket test to the value it resolved.
- Regression test in `proxy-import.test.ts`.

## Verification

```
# scanNginx -> registerImportedSites, real NginxProvider over a fake executor
main: registered ["sock.example.com"], warnings [], logs
      `Migrated sock.example.com → http://unix:/run/app.sock`,
      vhost gets `proxy_pass http://unix:/run/app.sock;`
PR:   registered [], warning
      `nginx: sock.example.com / — proxy_pass "http://app" resolves to upstream "app", a unix socket (skipped)`

$ npx vitest run ... -t "refuses a unix-socket upstream"
  fix reverted: FAIL (expected true to be false - the site still migrated)
  restored:     19 passed
$ bun run test -- --continue --force
  7/7 tasks, 3415 passed / 15 skipped / 0 failed (main: 3414, +1 is this test)
```

A 21-config corpus through `scanNginx` differs on exactly the two unix-socket-via-upstream cases.

Happy to migrate these instead of skipping them, if you'd rather — that needs the edge to see the socket path.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test` and `bun run --cwd packages/adapters lint` pass; both files carry pre-existing prettier drift on `main`, so I hand-formatted my own lines instead of running `--write` over them
- [x] I understand every line of this diff and can explain it in review
