### PR TITLE
fix(dashboard): enable rollback for success-mapped deployment rows

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/deployments/components/DeploymentMenu.tsx
+++ b/apps/dashboard/src/app/(dashboard)/deployments/components/DeploymentMenu.tsx
@@ -14,6 +14,7 @@ import {
 import { generateIcon } from "@/utils/icons";
 import { deployApi, getApiErrorMessage } from "@/lib/api";
 import { useI18n, interpolate } from "@/components/i18n-provider";
+import { isDeploymentRollbackEligible } from "../utils";
 
 interface Deployment {
   id: string;
@@ -77,7 +78,7 @@ export const DeploymentMenu: React.FC<DeploymentMenuProps> = ({
   // "Redeploy this commit" fallback is gone: it was the same operation behind a
   // second label.
   const canRollback =
-    (deployment.status === "ready" || deployment.status === "partial_failure") &&
+    isDeploymentRollbackEligible(deployment.status) &&
     !deployment.isActive &&
     !isInFlight &&
     (!!deployment.artifactRetainedAt || hasCommit);
@@ -261,7 +262,7 @@ export const DeploymentMenu: React.FC<DeploymentMenuProps> = ({
 
           {/* Pin / Unpin — toggles the artifact's exemption from
               retention prune. Available for any ready deployment. */}
-          {!isInFlight && deployment.status === "ready" && (
+          {!isInFlight && isDeploymentRollbackEligible(deployment.status) && (
             <button
               onClick={handleTogglePin}
               disabled={!deployment.pinned && !deployment.artifactRetainedAt}

--- a/apps/dashboard/src/app/(dashboard)/deployments/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/deployments/utils.ts
@@ -1,6 +1,13 @@
 import type { Deployment } from "./types";
 import type { Dictionary } from "@/i18n";
 
+/** Terminal success statuses eligible for rollback/pin in the dashboard.
+ *  The API persists `ready`, but `mapRowToDeployment` normalizes that to
+ *  `success` for list rendering — menu gating must accept both shapes. */
+export function isDeploymentRollbackEligible(status: string): boolean {
+  return status === "ready" || status === "success" || status === "partial_failure";
+}
+
 export const mapRowToDeployment = (row: any): Deployment => {
   const statusMap: Record<string, Deployment["status"]> = {
     ready: "success",

--- a/apps/dashboard/src/utils/project-status.test.ts
+++ b/apps/dashboard/src/utils/project-status.test.ts
@@ -5,6 +5,8 @@ import {
   calculateDeploymentStats,
   filterDeployments,
   getStatusConfig,
+  isDeploymentRollbackEligible,
+  mapRowToDeployment,
 } from "@/app/(dashboard)/deployments/utils";
 import type { Deployment } from "@/app/(dashboard)/deployments/types";
 
@@ -97,5 +99,28 @@ describe("deployments list — a blocked deploy is visible and counted", () => {
     ]);
     expect(stats.failed).toBe(2);
     expect(stats.success).toBe(1);
+  });
+});
+
+describe("deployment rollback eligibility — list status normalization", () => {
+  it("accepts success, the display status mapRowToDeployment emits for ready rows", () => {
+    const mapped = mapRowToDeployment({
+      id: "d1",
+      status: "ready",
+      commitSha: "abc1234567890",
+      artifactRetainedAt: "2026-08-03T00:00:00Z",
+      isActive: false,
+    });
+    expect(mapped.status).toBe("success");
+    expect(isDeploymentRollbackEligible(mapped.status)).toBe(true);
+  });
+
+  it("still accepts the raw ready status when a caller skips mapRowToDeployment", () => {
+    expect(isDeploymentRollbackEligible("ready")).toBe(true);
+  });
+
+  it("rejects in-flight and failed statuses", () => {
+    expect(isDeploymentRollbackEligible("building")).toBe(false);
+    expect(isDeploymentRollbackEligible("failed")).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #410

## Problem

On the deployments list, finished deploys show status `success` because `mapRowToDeployment` normalizes the API's terminal `ready` value for display/filtering. `DeploymentMenu` only enabled Rollback and Pin when `deployment.status === "ready"`, so `canRollback` was always false for normally completed deployments — even when the row showed the Snapshotted chip and had a retained artifact or commit SHA.

## Triage / Root cause

- API persists `ready` (`deployment-lifecycle.ts`).
- List mapping converts `ready → success` in `apps/dashboard/src/app/(dashboard)/deployments/utils.ts`.
- Rollback/pin gating in `DeploymentMenu.tsx` still checked only for `ready`.

## Fix

- Add `isDeploymentRollbackEligible()` beside the status map in `utils.ts`, accepting `ready`, `success`, and `partial_failure`.
- Use it for rollback enablement and pin visibility in `DeploymentMenu.tsx`.

## Verification

```bash
bun run --cwd apps/dashboard test src/utils/project-status.test.ts
```

11 tests passed, including new coverage that a `ready` API row mapped to `success` is rollback-eligible.

## Notes / Risks

- Dashboard-only change; server-side `rollbackDeployment()` was already ungated.
- No behavior change for in-flight or failed rows.