### PR TITLE
Add OpenTelemetry Collector to the apps catalog

### DIFF
--- a/apps/dashboard/src/components/AppLogo.tsx
+++ b/apps/dashboard/src/components/AppLogo.tsx
@@ -33,6 +33,7 @@ export const APP_LOGO: Record<
   nocodb: { slug: "nocodb" },
   // Grafana's mark stays colored; Gitea's tea-cup mark is fine as-is.
   grafana: { slug: "grafana" },
+  "otel-collector": { slug: "opentelemetry" },
   gitea: { slug: "gitea" },
   minio: { slug: "minio" },
   freshrss: { slug: "freshrss" },

--- a/apps/dashboard/src/components/services/ServiceIcon.tsx
+++ b/apps/dashboard/src/components/services/ServiceIcon.tsx
@@ -68,6 +68,8 @@ const IMAGE_BRAND: Record<string, string> = {
   grafana: "grafana",
   prometheus: "prometheus",
   loki: "grafana",
+  "opentelemetry-collector-contrib": "opentelemetry",
+  "otel-collector": "opentelemetry",
   n8n: "n8n",
   supabase: "supabase",
   keycloak: "keycloak",

--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -1789,6 +1789,36 @@
           }
         ]
       }
+    },
+    {
+      "available": true,
+      "verified": true,
+      "id": "otel-collector",
+      "name": "OpenTelemetry Collector",
+      "description": "Vendor-neutral telemetry pipeline — receive traces, metrics, and logs over OTLP from your other apps. Ships with the upstream default config; point it at your own backend by editing the collector config after install.",
+      "kind": "template",
+      "logo": "otel-collector",
+      "category": "analytics",
+      "tags": [
+        "observability",
+        "opentelemetry",
+        "otel",
+        "tracing",
+        "metrics",
+        "logs"
+      ],
+      "framework": "docker-compose",
+      "services": [
+        {
+          "name": "otel-collector",
+          "image": "otel/opentelemetry-collector-contrib:latest",
+          "ports": [
+            "4317:4317",
+            "4318:4318"
+          ],
+          "restart": "unless-stopped"
+        }
+      ]
     }
   ]
 }

--- a/packages/core/src/apps/catalog/otel-collector.json
+++ b/packages/core/src/apps/catalog/otel-collector.json
@@ -1,0 +1,30 @@
+{
+  "available": true,
+  "verified": true,
+  "id": "otel-collector",
+  "name": "OpenTelemetry Collector",
+  "description": "Vendor-neutral telemetry pipeline — receive traces, metrics, and logs over OTLP from your other apps. Ships with the upstream default config; point it at your own backend by editing the collector config after install.",
+  "kind": "template",
+  "logo": "otel-collector",
+  "category": "analytics",
+  "tags": [
+    "observability",
+    "opentelemetry",
+    "otel",
+    "tracing",
+    "metrics",
+    "logs"
+  ],
+  "framework": "docker-compose",
+  "services": [
+    {
+      "name": "otel-collector",
+      "image": "otel/opentelemetry-collector-contrib:latest",
+      "ports": [
+        "4317:4317",
+        "4318:4318"
+      ],
+      "restart": "unless-stopped"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #415

## Summary
- Adds `otel-collector` (OpenTelemetry Collector) as a one-click app template, category `analytics`, alongside Grafana and the other observability/backend apps.
- Uses `otel/opentelemetry-collector-contrib:latest` unmodified — verified locally that its baked-in default config already starts an OTLP gRPC receiver on 4317 and an OTLP HTTP receiver on 4318 with a working default pipeline, so no custom `command`/config override was needed (kept the entry as simple as `grafana.json`).
- Regenerated `catalog.json` from `apps/catalog/*.json` via `bun scripts/gen-catalog.ts`.
- Wired up brand-mark resolution so the app doesn't fall back to the generic icon:
  - `AppLogo.tsx`: catalog logo `"otel-collector"` → simpleicons `"opentelemetry"`
  - `ServiceIcon.tsx`: image-name based resolution, covering both `opentelemetry-collector-contrib` (the actual image name) and `otel-collector` (a shorter name some registries/rebuilds use), for services created from a raw compose file rather than the catalog.

## Test plan
- [x] Verified `otel/opentelemetry-collector-contrib:latest`'s `ENTRYPOINT`/`CMD` and confirmed the image's baked-in default config (`/etc/otelcol-contrib/config.yaml`) starts cleanly with OTLP gRPC (4317) + HTTP (4318) receivers and no fatal errors (`docker run --rm`).
- [x] `bun scripts/gen-catalog.ts` — regenerated `catalog.json`, zero diff against my hand-authored version.
- [x] `bunx vitest run` in `packages/core` — **29 test files, 325 tests, all passing**, including `apps/catalog.test.ts`'s drift check and full-schema validation of every bundled app.
- [x] `bunx tsc --noEmit` in `apps/dashboard` — clean, no type errors from the `AppLogo.tsx` / `ServiceIcon.tsx` edits.