### PR TITLE
Fix: normalize packageManager "unknown" to "npm" before it hits PackageManagerEnum

### DIFF
--- a/apps/api/src/lib/project-root-detector.ts
+++ b/apps/api/src/lib/project-root-detector.ts
@@ -882,7 +882,11 @@ function toMonorepoApp(snapshot: ProjectRootSnapshot, overrides?: { id?: string;
     rootDirectory,
     stack: stack.stack,
     category: stack.category,
-    packageManager: stack.packageManager,
+    // Same "unknown" → "npm" normalization as prepare.service.ts's ProjectInfo
+    // builder (issue #415) — this MonorepoApp round-trips through the dashboard
+    // into project creation just like the single-root path does, and
+    // PackageManagerEnum rejects the raw sentinel the same way there.
+    packageManager: stack.packageManager === "unknown" ? "npm" : stack.packageManager,
     buildCommand: dockerOwnsBuild ? "" : stack.buildCommand,
     installCommand: dockerOwnsBuild ? "" : stack.installCommand,
     startCommand: dockerOwnsBuild ? "" : stack.startCommand,

--- a/apps/api/src/modules/deployments/prepare.service.ts
+++ b/apps/api/src/modules/deployments/prepare.service.ts
@@ -838,7 +838,14 @@ function toProjectInfo(
     stack: stack.stack,
     projectType,
     category: stack.category,
-    packageManager: stack.packageManager,
+    // detectPackageManager()'s "unknown" fallback (no manifest anywhere in this
+    // root) is an internal sentinel, not a real package manager — PackageManagerEnum
+    // (project.schema.ts) never included it, so echoing it back verbatim here let
+    // the client round-trip it straight into project creation and 400 with
+    // "Expected union value" (issue #415). "npm" mirrors the client's own
+    // `|| "npm"` fallback default (DEFAULT_DEPLOYMENT_CONFIG) — same reasonable
+    // default, now applied where the value is actually produced.
+    packageManager: stack.packageManager === "unknown" ? "npm" : stack.packageManager,
     buildCommand: stack.buildCommand,
     installCommand: stack.installCommand,
     startCommand: stack.startCommand,

--- a/apps/api/test/modules/deployments/prepare.service.test.ts
+++ b/apps/api/test/modules/deployments/prepare.service.test.ts
@@ -63,6 +63,30 @@ describe("resolveProjectInfo", () => {
     });
   });
 
+  it("normalizes an undetected package manager to \"npm\" instead of the internal \"unknown\" sentinel (#415)", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
+    tempDirs.push(tempDir);
+
+    // A compose-only subfolder with no manifest anywhere (package.json, go.mod,
+    // requirements.txt, ...) — detectPackageManager() legitimately falls back to
+    // "unknown" here, but that's an internal sentinel PackageManagerEnum never
+    // accepted. Echoing it back verbatim let the dashboard round-trip it
+    // straight into project creation and 400 with "Expected union value".
+    await mkdir(join(tempDir, "infra", "9router"), { recursive: true });
+    await writeFile(
+      join(tempDir, "infra", "9router", "docker-compose.yml"),
+      ["services:", "  9router:", "    image: decolua/9router:latest"].join("\n"),
+    );
+
+    const info = await resolveProjectInfo({
+      source: "local",
+      path: tempDir,
+      composePath: "infra/9router",
+    });
+
+    expect(info.packageManager).toBe("npm");
+  });
+
   it("reports invalid Compose YAML instead of returning no services", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "openship-prepare-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
Closes #418

## Summary

`detectPackageManager()` returns the internal sentinel `"unknown"` when no manifest is found anywhere in the scanned root — legitimate (`applyWorkspaceContext` already special-cases it), but not a real package manager, and `PackageManagerEnum` (derived from the `STACKS` registry) never accepted it as a literal.

Two builders echoed the raw value straight into API responses the dashboard persists verbatim into the next project-creation request, which validates against that strict enum and 400s with "Expected union value":
- `resolveProjectInfo` in `apps/api/src/modules/deployments/prepare.service.ts` (single-root / declared-compose-path case)
- `toMonorepoApp` in `apps/api/src/lib/project-root-detector.ts` (monorepo sub-app case)

Fixed both at the point the value is produced — `"unknown"` → `"npm"` — rather than patching every read site (the dashboard has a dozen-plus `response.packageManager || "npm"` fallbacks that all silently miss this because `"unknown"` is truthy).

## Test plan
- [x] Added a regression test (`prepare.service.test.ts`) reproducing the exact repro: a `docker-compose.yml` in a subfolder with zero manifest files, scanned via a declared `composePath`. Verified it **fails without the fix** (`expected 'unknown' to be 'npm'`) and **passes with it**.
- [x] `bunx vitest run` across the whole `apps/api` package — **171 test files, 1859 tests passing** (15 pre-existing skips, unrelated), no regressions.
- [x] `bunx tsc --noEmit` in `apps/api` — clean.