### PR TITLE
fix(adapters): probe Docker daemon with docker version --format '{{.Server.Version}}'

### DIFF
--- a/packages/adapters/docs/SYSTEM.md
+++ b/packages/adapters/docs/SYSTEM.md
@@ -32,7 +32,7 @@ Dashboard Setup Wizard
 SystemManager.setup(onLog, config)
     │
     │  Phase 1: CHECK - run health checks
-    │     checkDocker(executor)  → "docker --version" + "docker info"
+    │     checkDocker(executor)  → "docker --version" + "docker version --format '{{.Server.Version}}'"
     │     checkGit(executor)     → "git --version"
     │     checkNode(executor)    → "node -v"
     │     checkTraefik(executor) → "traefik version" + systemctl status

--- a/packages/adapters/src/system/catalog.ts
+++ b/packages/adapters/src/system/catalog.ts
@@ -89,12 +89,11 @@ export const systemCatalog = {
   checks: {
     docker: {
       versionCommand: "docker --version",
-      // A POSITIVE signal, not a bare exit code: only a daemon that answered can
-      // name its version. `docker info >/dev/null && echo ok` prints ok on ANY
-      // exit-0, so a daemon answering nothing would read as healthy — trading #408's
-      // false negative for a false positive. Leave stderr alone too; `checkDocker`
-      // puts the failure text in the component message.
-      daemonCommand: "docker info --format '{{.ServerVersion}}'",
+      // Docker 29 removed the `.ServerVersion` template field from `docker info`,
+      // so `docker info --format '{{.ServerVersion}}'` fails with "no such field"
+      // on healthy Docker 29+ daemons. `docker version --format '{{.Server.Version}}'`
+      // is the documented, stable server-version probe across Docker 24-29+.
+      daemonCommand: "docker version --format '{{.Server.Version}}'",
       parseVersion: (output: string) =>
         output.match(/Docker version ([^\s,]+)/)?.[1] ?? output,
       missingMessage: "Docker is not installed",

--- a/packages/adapters/src/system/docker-check.test.ts
+++ b/packages/adapters/src/system/docker-check.test.ts
@@ -6,7 +6,7 @@ import type { CommandExecutor } from "../types";
 
 /**
  * #408: an SSH-added server reported "Docker is installed but the daemon is not
- * running" while `docker info` worked from the Terminal tab on the same
+ * running" while `docker version` worked from the Terminal tab on the same
  * connection. The check had already READ the daemon's refusal off stderr and then
  * dropped it, so the report could only be a guess — hence a fix attempt (PR #422)
  * aimed at SSH quoting, which is not how ssh2's exec channel works.
@@ -32,7 +32,7 @@ const VERSION = ["docker --version", "Docker version 29.7.1, build abc1234"] as 
 
 describe("checkDocker", () => {
   it("reports healthy when the daemon names its version", async () => {
-    const status = await checkDocker(box([[...VERSION], ["docker info", "29.7.1"]]));
+    const status = await checkDocker(box([[...VERSION], ["docker version", "29.7.1"]]));
 
     expect(status.healthy).toBe(true);
     expect(status.running).toBe(true);
@@ -46,7 +46,7 @@ describe("checkDocker", () => {
       box([
         [...VERSION],
         [
-          "docker info",
+          "docker version",
           new Error(
             "permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock",
           ),
@@ -64,15 +64,15 @@ describe("checkDocker", () => {
   });
 
   // The other live #408 candidate: `docker --version` is client-only and instant,
-  // `docker info` contacts the daemon and can outrun the 10s probe timeout. Same
+  // `docker version` contacts the daemon and can outrun the 10s probe timeout. Same
   // symptom, completely different fix — so the message has to distinguish them.
   it("surfaces a probe timeout rather than blaming the daemon", async () => {
     const status = await checkDocker(
       box([
         [...VERSION],
         [
-          "docker info",
-          new Error("Command timed out after 10000ms: docker info --format '{{.ServerVersion}}'"),
+          "docker version",
+          new Error("Command timed out after 10000ms: docker version --format '{{.Server.Version}}'"),
         ],
       ]),
     );
@@ -82,9 +82,9 @@ describe("checkDocker", () => {
   });
 
   // Exit 0 with no server version is NOT healthy. This is what an exit-status-only
-  // probe (`docker info >/dev/null && echo ok`) would misreport as running.
+  // probe (`docker version >/dev/null && echo ok`) would misreport as running.
   it("treats an exit-0 probe with no server version as not running", async () => {
-    const status = await checkDocker(box([[...VERSION], ["docker info", "   "]]));
+    const status = await checkDocker(box([[...VERSION], ["docker version", "   "]]));
 
     expect(status.healthy).toBe(false);
     expect(status.running).toBe(false);
@@ -107,7 +107,7 @@ describe("checkDocker", () => {
       box([
         [...VERSION],
         [
-          "docker info",
+          "docker version",
           new Error("Cannot connect to the Docker daemon\nIs the docker daemon running?"),
         ],
       ]),
@@ -121,6 +121,6 @@ describe("checkDocker", () => {
   it("probes for a server version, not just an exit code", () => {
     // Guards the false-positive direction: an exit-code-only probe reports healthy
     // for a daemon that answered nothing. See the comment on daemonCommand.
-    expect(systemCatalog.checks.docker.daemonCommand).toContain("ServerVersion");
+    expect(systemCatalog.checks.docker.daemonCommand).toMatch(/Server\.Version/);
   });
 });


### PR DESCRIPTION
## Summary

Fix Docker health check false negatives on SSH-added external servers running Docker 29 by replacing the `docker info --format '{{.ServerVersion}}'` probe with `docker version --format '{{.Server.Version}}'`.

## Motivation

Closes #408.

On SSH-added servers running Docker 29, the Components tab reported Docker as unhealthy ("daemon not running") even though `docker info` and `docker ps` worked from the interactive Terminal tab. The root cause is that Docker 29 no longer exposes the `.ServerVersion` template field in `docker info`, so the daemon probe exited with a template error (`template: no such field: .ServerVersion`).

## Related issue

Closes #408

## Changes

- **packages/adapters/src/system/catalog.ts** — change `daemonCommand` from `docker info --format '{{.ServerVersion}}'` to `docker version --format '{{.Server.Version}}'`, which is the documented, stable server-version field across Docker 24-29+.
- **packages/adapters/src/system/docker-check.test.ts** — update test needles and the daemon-command assertion to match the new probe and still verify that the probe targets a real server version.
- **packages/adapters/docs/SYSTEM.md** — update the setup-flow diagram to show the new `docker version` probe.

## Problem

Concrete repro from #408: add an external server over password-auth SSH where Docker 29.7.1 is installed and running. The Components tab health check calls `checkDocker()` -> `tryExec(executor, recipe.daemonCommand!)` with `docker info --format '{{.ServerVersion}}'`. On Docker 29 this produces `template: no such field: .ServerVersion`, so `tryExec()` returns an empty output and `checkDocker()` reports the daemon as not running.

## Triage / Root cause

Docker 29 removed the `.ServerVersion` field from the `docker info` Go-template context. `docker version --format '{{.Server.Version}}'` is the documented cross-version way to read the server version.

## Fix

Use `docker version --format '{{.Server.Version}}'`. It contacts the daemon and returns a positive server-version signal, so `checkDocker()` treats any non-empty output as "daemon running" and surfaces the underlying error on failure.

## Verification

```bash
cd packages/adapters && bun test src/system/docker-check.test.ts
# 7 pass, 0 fail
```

Also verified locally on Docker 29.1.3:

```bash
$ docker --version
Docker version 29.1.3, build 29.1.3-0ubuntu3~24.04.2
$ docker info --format '{{.ServerVersion}}'
docker: template: no such field: .ServerVersion
$ docker version --format '{{.Server.Version}}'
29.1.3
```

## Notes / Risks

- Scope is limited to the daemon probe string and its tests; no changes to `SshExecutor` or `checkDocker()` control flow.
- The old command still works on Docker <29, but `docker version --format '{{.Server.Version}}'` is available across Docker 24-29+.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review