### PR TITLE
fix(mail): scope outbound-relay TLS to the relay transport

### DIFF
--- a/apps/api/src/modules/mail/admin/outbound-relay.service.test.ts
+++ b/apps/api/src/modules/mail/admin/outbound-relay.service.test.ts
@@ -64,12 +64,14 @@ beforeEach(() => {
 describe("configureOutboundRelay", () => {
   const base = { provider: "ses" as const, region: "us-east-1", port: 587, username: "AKIASMTPUSER", password: "s3cr3tPass" };
 
-  test("writes creds via SFTP writeFile, NEVER through a shell command", async () => {
+  test("writes creds + per-destination TLS policy via SFTP, NEVER through a shell command", async () => {
     const { exec, execCalls, writes } = makeExec();
     await configureOutboundRelay(exec, base);
 
     expect(writes[0].path).toBe("/etc/postfix/sasl_passwd");
     expect(writes[0].content).toContain("[email-smtp.us-east-1.amazonaws.com]:587 AKIASMTPUSER:s3cr3tPass");
+    expect(writes[1].path).toBe("/etc/postfix/tls_policy");
+    expect(writes[1].content).toContain("[email-smtp.us-east-1.amazonaws.com]:587 encrypt");
 
     // SECURITY INVARIANT: no shell command may contain the password or username.
     for (const cmd of execCalls) {
@@ -83,10 +85,16 @@ describe("configureOutboundRelay", () => {
     await configureOutboundRelay(exec, base);
     const joined = execCalls.join("\n");
     expect(joined).toContain("postmap /etc/postfix/sasl_passwd");
+    expect(joined).toContain("postmap /etc/postfix/tls_policy");
     expect(joined).toContain("postconf -e");
     expect(joined).toContain("relayhost=[email-smtp.us-east-1.amazonaws.com]:587");
     expect(joined).toContain("smtp_sasl_auth_enable=yes");
     expect(joined).toContain("smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd");
+    expect(joined).toContain("smtp_tls_security_level=may");
+    expect(joined).toContain("smtp_tls_policy_maps=hash:/etc/postfix/tls_policy");
+    expect(joined).toContain("postconf -P");
+    expect(joined).toContain("smtp-amavis/unix/smtp_tls_security_level=none");
+    expect(joined).not.toContain("smtp_tls_security_level=encrypt");
     expect(joined).toMatch(/reload postfix|postfix reload/);
   });
 
@@ -132,6 +140,14 @@ describe("configureOutboundRelay", () => {
       configureOutboundRelay(makeExec().exec, { provider: "ses", port: 587, username: "u", password: "p" }),
     ).rejects.toThrow();
   });
+
+  test("port 465 uses implicit TLS wrapper for the relay but not for Amavis", async () => {
+    const { exec, execCalls } = makeExec();
+    await configureOutboundRelay(exec, { ...base, port: 465 });
+    const joined = execCalls.join("\n");
+    expect(joined).toContain("smtp_tls_wrappermode=yes");
+    expect(joined).toContain("smtp-amavis/unix/smtp_tls_wrappermode=no");
+  });
 });
 
 describe("disableOutboundRelay", () => {
@@ -149,7 +165,10 @@ describe("disableOutboundRelay", () => {
     await disableOutboundRelay(exec);
     const joined = execCalls.join("\n");
     expect(joined).toContain("postconf -X relayhost");
+    expect(joined).toMatch(/postconf -X .*smtp_tls_policy_maps/);
+    expect(joined).toContain("postconf -e smtp_tls_security_level=may");
     expect(joined).toContain("rm -f /etc/postfix/sasl_passwd");
+    expect(joined).toContain("/etc/postfix/tls_policy");
     expect(joined).toMatch(/reload postfix|postfix reload/);
     expect((fakeState as { outboundRelay?: unknown }).outboundRelay).toBeUndefined();
     const dns = (fakeState as { dnsRecords: { spf: { value: string }; extraRecords?: unknown } }).dnsRecords;

--- a/apps/api/src/modules/mail/admin/outbound-relay.service.ts
+++ b/apps/api/src/modules/mail/admin/outbound-relay.service.ts
@@ -7,10 +7,16 @@
  *
  * Postfix config applied over SSH:
  *   /etc/postfix/sasl_passwd  =  [<host>]:<port> <user>:<pass>
+ *   /etc/postfix/tls_policy   =  [<host>]:<port> encrypt
+ *   postmap sasl_passwd tls_policy
  *   postconf -e relayhost=[<host>]:<port> smtp_sasl_auth_enable=yes
  *              smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd
  *              smtp_sasl_security_options=noanonymous
- *              smtp_tls_security_level=encrypt
+ *              smtp_tls_security_level=may
+ *              smtp_tls_policy_maps=hash:/etc/postfix/tls_policy
+ *              (port 465: smtp_tls_wrappermode=yes)
+ *   postconf -P smtp-amavis/unix/smtp_tls_security_level=none
+ *             smtp-amavis/unix/smtp_tls_wrappermode=no
  *   postmap + systemctl reload postfix
  *
  * SECURITY (see security-invariants): the SASL credentials are operator-
@@ -34,6 +40,7 @@ import {
 import { execute, q } from "./psql-runner";
 
 const SASL_PASSWD_PATH = "/etc/postfix/sasl_passwd";
+const TLS_POLICY_PATH = "/etc/postfix/tls_policy";
 const SES_INCLUDE = "include:amazonses.com";
 
 /** Single-quote-wrap for the one shell-interpolated value (the validated host). */
@@ -252,33 +259,37 @@ export async function configureOutboundRelay(
   const scope: "all" | "selected" = input.scope === "selected" ? "selected" : "all";
   const nexthop = `[${host}]:${input.port}`;
 
-  // 1) Write the SASL map via SFTP (creds never touch a shell string). One
-  //    entry per relay host covers both global and per-sender routing.
+  // 1) Write the SASL + TLS policy maps via SFTP (creds never touch a shell).
+  //    The TLS policy is per-destination, so only the relay host requires
+  //    TLS; local delivery to Amavis keeps using the global "may" default.
   await exec.writeFile(SASL_PASSWD_PATH, `${nexthop} ${input.username}:${input.password}\n`);
+  await exec.writeFile(TLS_POLICY_PATH, `${nexthop} encrypt\n`);
 
-  // 2) Lock down + hash the map (fixed paths, no interpolation).
+  // 2) Lock down + hash the maps (fixed paths, no interpolation).
   await exec.exec(
-    `chmod 600 ${SASL_PASSWD_PATH} && postmap ${SASL_PASSWD_PATH} && chmod 600 ${SASL_PASSWD_PATH}.db`,
+    `chmod 600 ${SASL_PASSWD_PATH} ${TLS_POLICY_PATH} && ` +
+      `postmap ${SASL_PASSWD_PATH} && postmap ${TLS_POLICY_PATH} && ` +
+      `chmod 600 ${SASL_PASSWD_PATH}.db ${TLS_POLICY_PATH}.db`,
   );
 
-  // 3) SASL/TLS client directives always; the GLOBAL relayhost only in "all"
-  //    scope. In "selected" scope we clear the global relayhost so unmatched
-  //    domains deliver direct, and route the chosen domains via `sender_relayhost`.
-  const sasl = [
+  // 3) Client directives: SASL + opportunistic TLS globally; the mandatory
+  //    "encrypt" level is scoped to the relay destination via smtp_tls_policy_maps.
+  const clientDirectives = [
     "smtp_sasl_auth_enable=yes",
     `smtp_sasl_password_maps=hash:${SASL_PASSWD_PATH}`,
     "smtp_sasl_security_options=noanonymous",
-    "smtp_tls_security_level=encrypt",
+    "smtp_tls_security_level=may",
+    `smtp_tls_policy_maps=hash:${TLS_POLICY_PATH}`,
   ];
-  if (input.port === 465) sasl.push("smtp_tls_wrappermode=yes"); // implicit-TLS submission
+  if (input.port === 465) clientDirectives.push("smtp_tls_wrappermode=yes"); // implicit-TLS submission
 
   if (scope === "all") {
-    await exec.exec(`postconf -e ${[`relayhost=${nexthop}`, ...sasl].map(sq).join(" ")}`);
+    await exec.exec(`postconf -e ${[`relayhost=${nexthop}`, ...clientDirectives].map(sq).join(" ")}`);
     // No per-sender rows for this relay host when routing everything globally.
     await execute(exec, `DELETE FROM sender_relayhost WHERE relayhost = ${q(nexthop)}`).catch(() => {});
   } else {
     await exec.exec("postconf -X relayhost 2>/dev/null || true");
-    await exec.exec(`postconf -e ${sasl.map(sq).join(" ")}`);
+    await exec.exec(`postconf -e ${clientDirectives.map(sq).join(" ")}`);
     const selected = (input.domains ?? []).map((d) => `@${d}`);
     for (const account of selected) {
       await execute(
@@ -292,10 +303,17 @@ export async function configureOutboundRelay(
     await execute(exec, `DELETE FROM sender_relayhost WHERE relayhost = ${q(nexthop)}${notIn}`).catch(() => {});
   }
 
-  // 4) Reload Postfix.
+  // 4) Pin the Amavis client transport to "none" so it cannot inherit a global
+  //    "encrypt" or wrapper setting.
+  await exec.exec(
+    'postconf -P "smtp-amavis/unix/smtp_tls_security_level=none" ' +
+      '"smtp-amavis/unix/smtp_tls_wrappermode=no" 2>/dev/null || true',
+  );
+
+  // 5) Reload Postfix.
   await exec.exec("systemctl reload postfix 2>/dev/null || postfix reload");
 
-  // 5) Persist the relay block (encrypted password) + fan DNS across every
+  // 6) Persist the relay block (encrypted password) + fan DNS across every
   //    relayed domain (primary + additional).
   const state = await readState(exec);
   if (!state) throw new Error("Mail server state not found — is mail provisioned on this server?");
@@ -327,12 +345,13 @@ export async function configureOutboundRelay(
 
 /** Disable the outbound relay — revert Postfix to direct-to-MX + clear state. */
 export async function disableOutboundRelay(exec: CommandExecutor): Promise<MailServerState | null> {
-  // Remove the relay-specific directives (leave smtp_tls_security_level — it's
-  // good hygiene for direct delivery too and reverting it could weaken TLS).
+  // Remove the relay-specific directives and the per-destination TLS policy map,
+  // but keep smtp_tls_security_level at "may" so direct-to-MX stays opportunistic.
   await exec.exec(
-    "postconf -X relayhost smtp_sasl_auth_enable smtp_sasl_password_maps smtp_sasl_security_options smtp_tls_wrappermode 2>/dev/null || true",
+    "postconf -X relayhost smtp_sasl_auth_enable smtp_sasl_password_maps smtp_sasl_security_options smtp_tls_policy_maps smtp_tls_wrappermode 2>/dev/null || true",
   );
-  await exec.exec(`rm -f ${SASL_PASSWD_PATH} ${SASL_PASSWD_PATH}.db`);
+  await exec.exec("postconf -e smtp_tls_security_level=may");
+  await exec.exec(`rm -f ${SASL_PASSWD_PATH} ${SASL_PASSWD_PATH}.db ${TLS_POLICY_PATH} ${TLS_POLICY_PATH}.db`);
 
   // Delete the per-sender rows we own for this relay host (no `active` column —
   // presence = active, so disable must DELETE rather than deactivate).

--- a/apps/email/engine/samples/postfix/master.cf
+++ b/apps/email/engine/samples/postfix/master.cf
@@ -30,6 +30,8 @@ smtp-amavis unix -  -   n   -   PH_AMAVISD_MAX_SERVERS  smtp
     -o smtp_data_done_timeout=1200
     -o smtp_send_xforward_command=yes
     -o smtp_dns_support_level=disabled
+    -o smtp_tls_security_level=none
+    -o smtp_tls_wrappermode=no
     -o max_use=20
 
 # smtp port used by Amavisd to re-inject scanned email back to Postfix


### PR DESCRIPTION
## Summary

Stop setting `smtp_tls_security_level=encrypt` globally in `configureOutboundRelay`; that forces TLS on the local `smtp-amavis` delivery to `127.0.0.1:10024`, which does not speak TLS, causing all inbound mail to be silently deferred.

## Motivation

Reported in #392. `apps/api/src/modules/mail/admin/outbound-relay.service.ts` uses `postconf -e smtp_tls_security_level=encrypt` whenever an outbound relay is enabled. `smtp_tls_security_level` is a global Postfix client directive, so it also applies to the `smtp-amavis` transport and any other local SMTP client delivery. Amavis on `127.0.0.1:10024` does not offer STARTTLS, so Postfix logs `status=deferred (TLS is required, but was not offered by host 127.0.0.1...)` and inbound mail never arrives.

## Related issue

Fixes #392

## Changes

- **apps/api**
  - `outbound-relay.service.ts`:
    - Write a per-destination `/etc/postfix/tls_policy` map (`[<host>]:<port> encrypt`) and reference it via `smtp_tls_policy_maps`.
    - Change the global `smtp_tls_security_level` from `encrypt` to `may`.
    - For port 465, still add `smtp_tls_wrappermode=yes` globally, but pin the `smtp-amavis/unix` transport to `smtp_tls_wrappermode=no` via `postconf -P`.
    - Pin `smtp-amavis/unix` to `smtp_tls_security_level=none` via `postconf -P`.
    - On `disableOutboundRelay`, remove `smtp_tls_policy_maps` and `smtp_tls_wrappermode`, reset `smtp_tls_security_level=may`, and delete the `tls_policy` map files.
  - `outbound-relay.service.test.ts`: add/extend assertions for the `tls_policy` map, the `may` security level, the Amavis per-transport overrides, the port-465 wrapper-mode split, and disable cleanup.
- **apps/email/engine/samples/postfix/master.cf**: add `-o smtp_tls_security_level=none` and `-o smtp_tls_wrappermode=no` to the `smtp-amavis` transport so the sample config matches the runtime override.

## Verification

```bash
python3 /home/ubuntu/Projects/open-source/scripts/preflight_ship.py \
  --repo oblien/openship --local openship --branch main --issue 392 \
  --file apps/api/src/modules/mail/admin/outbound-relay.service.ts \
  --must-contain 'smtp_tls_security_level=encrypt' \
  --must-not-contain 'smtp_tls_policy_maps'
# PREFLIGHT CLEAR

bun run --cwd apps/api test outbound-relay.service.test.ts
# ✓ src/modules/mail/admin/outbound-relay.service.test.ts (18 tests)

bun run --cwd apps/api lint
# tsc --noEmit (pass)
```

The targeted test includes new assertions that fail against the original code (which emits `smtp_tls_security_level=encrypt` and no `smtp_tls_policy_maps` / no Amavis override).

## Screenshots

N/A — backend Postfix config change only.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

Note on the unchecked box: `bunx prettier --check` on the two touched `apps/api` files reports pre-existing formatting issues (long lines) unrelated to this change; running `bun format` would reformat many lines I didn't touch, so I scoped the diff to the functional change. `bun run --cwd apps/api lint` and the targeted test pass.