### PR TITLE
fix(adapters): use POSIX path module for remote nginx/certbot paths

### DIFF
--- a/packages/adapters/src/infra/nginx-posix-paths.test.ts
+++ b/packages/adapters/src/infra/nginx-posix-paths.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, vi } from "vitest";
+import { NginxProvider, type NginxProviderOptions } from "./nginx";
+import { OPENRESTY_DEFAULT_PATHS } from "./openresty-lua";
+import type { CommandExecutor, RouteConfig } from "../types";
+
+// Windows control planes must still produce remote (target Linux) paths with
+// forward slashes. The source already switched to `node:path/posix`; this test
+// makes sure a `node:path` default of `win32` cannot reintroduce backslashes.
+const win32Path = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("node:path/win32") as typeof import("node:path");
+  return { ...path, default: path };
+});
+
+vi.mock("node:path", () => win32Path);
+
+const SITES = "/var/lib/openship/edge/sites-enabled";
+const CERT = "/etc/letsencrypt/live";
+
+interface FakeExecutor extends CommandExecutor {
+  writes: Array<{ path: string; content: string }>;
+}
+
+function makeExecutor(): FakeExecutor {
+  const files = new Map<string, string>();
+  const writes: Array<{ path: string; content: string }> = [];
+
+  function recordWrite(p: string, c: string) {
+    writes.push({ path: p, content: c });
+    files.set(p, c);
+  }
+
+  const executor = {
+    writes,
+    exec: async (command: string) => {
+      const singleMv = command.match(/^mv '([^']+)' '([^']+)'$/);
+      if (singleMv) {
+        const [, src, dest] = singleMv;
+        const c = files.get(src);
+        if (c !== undefined) {
+          files.set(dest, c);
+          recordWrite(dest, c);
+          files.delete(src);
+        }
+        return "";
+      }
+      if (command.startsWith("mv -f ")) {
+        const paths = [...command.matchAll(/'([^']+)'/g)].map((m) => m[1]!);
+        const dir = paths.pop()!;
+        for (const src of paths) {
+          const c = files.get(src);
+          if (c !== undefined) {
+            const dest = `${dir.replace(/\/$/, "")}/${src.split(/[\\/]/).pop()!}`;
+            files.set(dest, c);
+            recordWrite(dest, c);
+            files.delete(src);
+          }
+        }
+        return "";
+      }
+      if (command.startsWith("chmod ")) return "";
+      if (/\s-V\b|command -v|which\s/.test(command)) throw new Error("no openresty in test");
+      return "";
+    },
+    writeFile: async (p: string, c: string) => {
+      files.set(p, c);
+    },
+    readFile: async (p: string) => {
+      const c = files.get(p);
+      if (c === undefined) throw new Error(`ENOENT ${p}`);
+      return c;
+    },
+    exists: async (p: string) => files.has(p) || p.startsWith(`${CERT}/`),
+    mkdir: async () => {},
+    rm: async (p: string) => {
+      files.delete(p);
+    },
+  };
+  return executor as unknown as FakeExecutor;
+}
+
+function setup() {
+  const executor = makeExecutor();
+  const nginx = new NginxProvider({
+    paths: {
+      ...OPENRESTY_DEFAULT_PATHS,
+      sitesDir: SITES,
+    },
+    executor,
+    certDir: CERT,
+  } as unknown as NginxProviderOptions);
+  return { nginx, executor };
+}
+
+describe("NginxProvider remote path construction", () => {
+  test("vhost path uses forward slashes even when the host `node:path` is win32", async () => {
+    const { nginx, executor } = setup();
+    await nginx.registerRoute({
+      domain: "app.example.com",
+      tls: true,
+      targetUrl: "http://127.0.0.1:3009",
+    } as unknown as RouteConfig);
+
+    const vhostWrite = executor.writes.find((w) => w.path.endsWith(".conf"));
+    expect(vhostWrite).toBeDefined();
+    expect(vhostWrite!.path).toBe(`${SITES}/app-example-com.conf`);
+    expect(vhostWrite!.path).not.toContain("\\");
+  });
+});

--- a/packages/adapters/src/infra/nginx.ts
+++ b/packages/adapters/src/infra/nginx.ts
@@ -27,7 +27,7 @@ import {
 import { execFile as cpExecFile } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { promisify } from "node:util";
-import { dirname, join } from "node:path";
+import { dirname, join } from "node:path/posix";
 
 import type { CommandExecutor, ManualCert, RouteConfig, SslResult } from "../types";
 import type { RoutingProvider, SslProvider } from "./types";


### PR DESCRIPTION
## Summary

Windows control planes were building remote Linux paths with the OS-dependent `node:path` module, producing backslash-separated paths. This caused certbot-issued certs to be reported missing (`sslExpiresAt: null`, breaking renewal scheduling) and nginx vhosts to be written to a literal backslash-named file in the CWD.

## Motivation

On a Windows control plane, `join('/etc/letsencrypt/live', 'app.example.com')` becomes `\\etc\\letsencrypt\\live\\app.example.com`. The remote SSH/SFTP executor then looks for a file at that backslash path, which fails, even though certbot correctly wrote the cert to the POSIX path. The same thing happens for vhost paths under `sitesDir`.

## Related issue

Fixes #381

## Changes

- `packages/adapters/src/infra/nginx.ts`: import `dirname` and `join` from `node:path/posix` so every path constructed for the remote target uses forward slashes, regardless of the control plane OS.
- `packages/adapters/src/infra/nginx-posix-paths.test.ts`: add a regression test that mocks `node:path` to `win32` and asserts the generated vhost path stays POSIX.

## Verification

- `bun run --cwd packages/adapters lint` — clean (`tsc --noEmit`)
- `bun run --cwd packages/adapters test` — 757 passed, including the new regression test
- Manually confirmed the new test fails when `nginx.ts` is reverted to `node:path` (path becomes `\\var\\lib\\openship\\edge\\sites-enabled\\app-example-com.conf`) and passes with `node:path/posix`.

```bash
cd packages/adapters
bun run lint
bun run test
```

## Checklist

- [x] One change per PR — one bug, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test`, `bun run --cwd <workspace> lint` pass locally
- [x] I understand every line of this diff and can explain it in review