### PR TITLE
fix(api): close terminal audit rows after parked sessions time out

### DIFF
--- a/apps/api/src/modules/service-terminal/service-terminal.controller.ts
+++ b/apps/api/src/modules/service-terminal/service-terminal.controller.ts
@@ -362,13 +362,16 @@ interface HandshakeCtx {
   resumeToken: string;
 }
 
-interface ConnState {
+export interface ConnState {
   ctx: HandshakeCtx;
   sessionId: string | null;
   shell: ShellSession | null;
   ws: WSLike | null;
   heartbeatTimer: ReturnType<typeof setInterval> | null;
+  /** True when this WebSocket connection has detached; stops its data pump and incoming messages. */
   closed: boolean;
+  /** True when this connection's session has been fully ended (shell killed, audit row closed). */
+  ended: boolean;
   userTerminated: boolean;
 }
 
@@ -386,6 +389,7 @@ function buildHandlers(ctx: HandshakeCtx) {
     ws: null,
     heartbeatTimer: null,
     closed: false,
+    ended: false,
     userTerminated: false,
   };
 
@@ -416,6 +420,17 @@ function buildHandlers(ctx: HandshakeCtx) {
         state.shell = existing.shell;
         state.sessionId = existing.sessionId;
         attachServiceWs(existing.sessionId, dataPump);
+
+        // Re-bind the timeout hook to this fresh WS/connection state so a
+        // later idle or hard-cap timeout closes the session from the live
+        // connection, not the stale parked one. Re-arm the idle timer so a
+        // resume does not inherit an expiry from the original WS.
+        existing.onTimeout = (_sid, reason) => {
+          sendControl(ws, { type: "error", code: reason as ErrorCode, message: reason });
+          safeWsClose(ws, 1011, reason);
+          void teardown(state, reason, null, /* alreadyUnregistered */ true, /* forceClose */ true);
+        };
+        touchServiceSession(existing.sessionId);
 
         existing.shell.onClose((code: number | null, signal?: string) => {
           sendControl(ws, { type: "exit", code, signal });
@@ -576,14 +591,22 @@ function buildHandlers(ctx: HandshakeCtx) {
   };
 }
 
-async function teardown(
+export async function teardown(
   state: ConnState,
   reason: TerminalExitReason,
   exitCode: number | null,
   alreadyUnregistered = false,
   forceClose = true,
 ) {
-  if (state.closed) return;
+  // Full teardown already completed for this connection.
+  if (state.ended) return;
+
+  // The WS side of this connection is already gone and this is not the
+  // timeout/unregister path that intentionally runs after the WS detached.
+  // This deflects stale shell.onClose callbacks from a previous WS after a
+  // resume, while still allowing the idle/cap timeout to finalize the row.
+  if (state.closed && !alreadyUnregistered) return;
+
   state.closed = true;
 
   if (state.heartbeatTimer) {
@@ -595,6 +618,10 @@ async function teardown(
     parkServiceSession(state.sessionId);
     return;
   }
+
+  // Force-close: this session is ending. Mark it now so any re-entrant
+  // shell.onClose / onClose handler for this same connection no-ops.
+  state.ended = true;
 
   if (state.shell) {
     safeShellClose(state.shell);

--- a/apps/api/src/modules/terminal/terminal.controller.ts
+++ b/apps/api/src/modules/terminal/terminal.controller.ts
@@ -287,14 +287,16 @@ interface HandshakeCtx {
   resumeToken: string;
 }
 
-interface ConnState {
+export interface ConnState {
   ctx: HandshakeCtx;
   sessionId: string | null;
   shell: ShellSession | null;
   ws: WSLike | null;
   heartbeatTimer: ReturnType<typeof setInterval> | null;
-  /** Guards the cleanup path so it can't run twice. */
+  /** True when this WebSocket connection has detached; stops its data pump and incoming messages. */
   closed: boolean;
+  /** True when this connection's session has been fully ended (shell killed, audit row closed). */
+  ended: boolean;
   /**
    * True when the client sent a `{type:"close"}` control frame, meaning
    * "I'm permanently closing this shell — do NOT park it". The onClose
@@ -318,6 +320,7 @@ function buildHandlers(ctx: HandshakeCtx) {
     ws: null,
     heartbeatTimer: null,
     closed: false,
+    ended: false,
     userTerminated: false,
   };
 
@@ -366,12 +369,24 @@ function buildHandlers(ctx: HandshakeCtx) {
         state.sessionId = existing.sessionId;
         attachWs(existing.sessionId, dataPump);
 
+        // Re-bind the timeout hook to this fresh WS/connection state so a
+        // later idle or hard-cap timeout closes the session from the live
+        // connection, not the stale parked one. Re-arm the idle timer so a
+        // resume does not inherit an expiry from the original WS.
+        existing.onTimeout = (_sid, reason) => {
+          sendControl(ws, { type: "error", code: reason as ErrorCode, message: reason });
+          safeWsClose(ws, 1011, reason);
+          void teardown(state, reason, null, /* alreadyUnregistered */ true, /* forceClose */ true);
+        };
+        touchSession(existing.sessionId);
+
         // Wire up shell-exit / heartbeat from the resumed channel.
         // (Note: existing.shell.onClose subscribers from the PREVIOUS
         // WS attachment are stale - they reference a dead `ws`. We
         // can't unsubscribe from ssh2's channel events, but those
-        // closures' `state.closed = true` guard makes their writes
-        // no-ops. The new onClose subscriber below is the live one.)
+        // closures are guarded by `state.ended` / `state.closed` and
+        // `alreadyUnregistered`, so they cannot double-close the audit
+        // row. The new onClose subscriber below is the live one.)
         existing.shell.onClose((code: number | null, signal?: string) => {
           sendControl(ws, { type: "exit", code, signal });
           safeWsClose(ws, 1000, "remote_exit");
@@ -574,16 +589,29 @@ function writeStdin(state: ConnState, buf: Buffer): void {
  *                       retain are preserved. The session manager's
  *                       idle + hard-cap timers continue running.
  *
- * Idempotent in both modes via the `state.closed` flag.
+ * `state.closed` tracks whether this WebSocket connection has detached.
+ * `state.ended` tracks whether the audit row has been finalized for this
+ * connection. A parked session is `closed` but not `ended`, so an idle/cap
+ * timeout that fires later (which passes `alreadyUnregistered=true`) can
+ * still close the DB row. Stale handlers from a previous WS (e.g. after a
+ * resume) are rejected by the `state.closed && !alreadyUnregistered` guard.
  */
-async function teardown(
+export async function teardown(
   state: ConnState,
   reason: TerminalExitReason,
   exitCode: number | null,
   alreadyUnregistered = false,
   forceClose = true,
 ) {
-  if (state.closed) return;
+  // Full teardown already completed for this connection.
+  if (state.ended) return;
+
+  // The WS side of this connection is already gone and this is not the
+  // timeout/unregister path that intentionally runs after the WS detached.
+  // This deflects stale shell.onClose callbacks from a previous WS after a
+  // resume, while still allowing the idle/cap timeout to finalize the row.
+  if (state.closed && !alreadyUnregistered) return;
+
   state.closed = true;
 
   if (state.heartbeatTimer) {
@@ -596,6 +624,10 @@ async function teardown(
     parkSession(state.sessionId);
     return;
   }
+
+  // Force-close: this session is ending. Mark it now so any re-entrant
+  // shell.onClose / onClose handler for this same connection no-ops.
+  state.ended = true;
 
   if (state.shell) {
     safeShellClose(state.shell);

--- a/apps/api/test/modules/service-terminal/service-terminal.controller.test.ts
+++ b/apps/api/test/modules/service-terminal/service-terminal.controller.test.ts
@@ -1,0 +1,151 @@
+import "../mail/_setup-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShellSession } from "@repo/adapters";
+
+const serviceTerminalSession = vi.hoisted(() => {
+  const rows = new Map<
+    string,
+    {
+      userId: string;
+      endedAt: Date | null;
+      exitCode: number | null;
+      exitReason: string | null;
+    }
+  >();
+
+  return {
+    open: vi.fn(async (data: { userId: string; serviceId: string }) => {
+      const id = `sts_${Math.random().toString(36).slice(2)}`;
+      rows.set(id, {
+        userId: data.userId,
+        endedAt: null,
+        exitCode: null,
+        exitReason: null,
+      });
+      return { id };
+    }),
+    close: vi.fn(
+      async (
+        id: string,
+        data: { exitCode?: number | null; exitReason: string },
+      ) => {
+        const row = rows.get(id);
+        if (row) {
+          row.endedAt = new Date();
+          row.exitCode = data.exitCode ?? null;
+          row.exitReason = data.exitReason;
+        }
+      },
+    ),
+    countActiveByUser: vi.fn(async (userId: string) => {
+      return [...rows.values()].filter((r) => r.userId === userId && !r.endedAt)
+        .length;
+    }),
+    reset: () => {
+      rows.clear();
+    },
+  };
+});
+
+vi.mock("@repo/db", () => ({ repos: { serviceTerminalSession } }));
+vi.mock("../../../src/lib/ws", () => ({
+  upgradeWebSocket: (fn: unknown) => fn,
+}));
+vi.mock("../../../src/lib/auth", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+import {
+  teardown,
+  type ConnState,
+} from "../../../src/modules/service-terminal/service-terminal.controller";
+
+beforeEach(() => {
+  serviceTerminalSession.reset();
+  vi.clearAllMocks();
+});
+
+function fakeShell(): ShellSession {
+  return {
+    close: vi.fn(),
+    stdin: { write: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    setWindow: vi.fn(),
+    onClose: vi.fn(),
+  } as unknown as ShellSession;
+}
+
+function makeConnState(
+  userId: string,
+  sessionId: string,
+  shell: ShellSession,
+): ConnState {
+  return {
+    ctx: {
+      userId,
+      serviceId: "test-service",
+      containerId: "test-container",
+      runtime: { name: "docker" } as ConnState["ctx"]["runtime"],
+      clientIp: null,
+      userAgent: null,
+      subprotocol: undefined,
+      resumeToken: "",
+    } as ConnState["ctx"],
+    sessionId,
+    shell,
+    ws: { send: vi.fn(), close: vi.fn() },
+    heartbeatTimer: null,
+    closed: false,
+    ended: false,
+    userTerminated: false,
+  };
+}
+
+describe("service-terminal.controller teardown", () => {
+  it("closes the audit row when a parked session is later force-closed by timeout", async () => {
+    const userId = `user_${Math.random().toString(36).slice(2)}`;
+    const { id: sessionId } = await serviceTerminalSession.open({
+      userId,
+      serviceId: "test-service",
+    });
+    const shell = fakeShell();
+    const state = makeConnState(userId, sessionId, shell);
+
+    // Browser disconnect parks the session.
+    await teardown(state, "client_close", null, false, false);
+    expect(state.closed).toBe(true);
+    expect(state.ended).toBe(false);
+    expect(serviceTerminalSession.close).not.toHaveBeenCalled();
+    expect(await serviceTerminalSession.countActiveByUser(userId)).toBe(1);
+
+    // Idle / hard-cap timeout fires after the session was unregistered.
+    await teardown(state, "idle_timeout", null, true, true);
+
+    expect(state.ended).toBe(true);
+    expect(shell.close).toHaveBeenCalledOnce();
+    expect(serviceTerminalSession.close).toHaveBeenCalledOnce();
+    expect(serviceTerminalSession.close).toHaveBeenLastCalledWith(sessionId, {
+      exitCode: null,
+      exitReason: "idle_timeout",
+    });
+    expect(await serviceTerminalSession.countActiveByUser(userId)).toBe(0);
+  });
+
+  it("rejects stale shell.onClose from a previous WebSocket after a resume", async () => {
+    const userId = `user_${Math.random().toString(36).slice(2)}`;
+    const { id: sessionId } = await serviceTerminalSession.open({
+      userId,
+      serviceId: "test-service",
+    });
+    const shell = fakeShell();
+    const state = makeConnState(userId, sessionId, shell);
+    state.closed = true;
+
+    await teardown(state, "remote_exit", 0, false, true);
+
+    expect(state.ended).toBe(false);
+    expect(shell.close).not.toHaveBeenCalled();
+    expect(serviceTerminalSession.close).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/modules/terminal/terminal.controller.test.ts
+++ b/apps/api/test/modules/terminal/terminal.controller.test.ts
@@ -1,0 +1,173 @@
+import "../mail/_setup-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShellSession } from "@repo/adapters";
+
+const terminalSession = vi.hoisted(() => {
+  const rows = new Map<
+    string,
+    {
+      userId: string;
+      endedAt: Date | null;
+      exitCode: number | null;
+      exitReason: string | null;
+    }
+  >();
+
+  return {
+    open: vi.fn(async (data: { userId: string; serverId: string }) => {
+      const id = `ts_${Math.random().toString(36).slice(2)}`;
+      rows.set(id, {
+        userId: data.userId,
+        endedAt: null,
+        exitCode: null,
+        exitReason: null,
+      });
+      return { id };
+    }),
+    close: vi.fn(
+      async (
+        id: string,
+        data: { exitCode?: number | null; exitReason: string },
+      ) => {
+        const row = rows.get(id);
+        if (row) {
+          row.endedAt = new Date();
+          row.exitCode = data.exitCode ?? null;
+          row.exitReason = data.exitReason;
+        }
+      },
+    ),
+    countActiveByUser: vi.fn(async (userId: string) => {
+      return [...rows.values()].filter((r) => r.userId === userId && !r.endedAt)
+        .length;
+    }),
+    reset: () => {
+      rows.clear();
+    },
+  };
+});
+
+vi.mock("@repo/db", () => ({ repos: { terminalSession } }));
+vi.mock("../../../src/lib/ws", () => ({
+  upgradeWebSocket: (fn: unknown) => fn,
+}));
+vi.mock("../../../src/lib/auth", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+vi.mock("../../../src/lib/ssh-manager", () => ({
+  sshManager: { retain: vi.fn(), release: vi.fn() },
+}));
+
+import { teardown, type ConnState } from "../../../src/modules/terminal/terminal.controller";
+
+function fakeShell(): ShellSession {
+  return {
+    close: vi.fn(),
+    stdin: { write: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    setWindow: vi.fn(),
+    onClose: vi.fn(),
+  } as unknown as ShellSession;
+}
+
+beforeEach(() => {
+  terminalSession.reset();
+  vi.clearAllMocks();
+});
+
+function makeConnState(
+  userId: string,
+  sessionId: string,
+  shell: ShellSession,
+): ConnState {
+  return {
+    ctx: {
+      userId,
+      serverId: "test-server",
+      clientIp: null,
+      userAgent: null,
+      subprotocol: undefined,
+      resumeToken: "",
+    } as ConnState["ctx"],
+    sessionId,
+    shell,
+    ws: { send: vi.fn(), close: vi.fn() },
+    heartbeatTimer: null,
+    closed: false,
+    ended: false,
+    userTerminated: false,
+  };
+}
+
+describe("terminal.controller teardown", () => {
+  it("closes the audit row when a parked session is later force-closed by timeout", async () => {
+    const userId = `user_${Math.random().toString(36).slice(2)}`;
+    const { id: sessionId } = await terminalSession.open({
+      userId,
+      serverId: "test-server",
+    });
+    const shell = fakeShell();
+    const state = makeConnState(userId, sessionId, shell);
+
+    // 1. Browser disconnect parks the session. This sets state.closed but
+    //    deliberately does not close the audit row, so the user can resume.
+    await teardown(state, "client_close", null, false, false);
+    expect(state.closed).toBe(true);
+    expect(state.ended).toBe(false);
+    expect(terminalSession.close).not.toHaveBeenCalled();
+    expect(await terminalSession.countActiveByUser(userId)).toBe(1);
+
+    // 2. Idle / hard-cap timeout fires. fireTimeout has already unregistered
+    //    the session, so it calls teardown with alreadyUnregistered=true. The
+    //    fix ensures this still finalizes the DB row even though state.closed
+    //    is already true from the earlier park.
+    await teardown(state, "idle_timeout", null, true, true);
+
+    expect(state.ended).toBe(true);
+    expect(shell.close).toHaveBeenCalledOnce();
+    expect(terminalSession.close).toHaveBeenCalledOnce();
+    expect(terminalSession.close).toHaveBeenLastCalledWith(sessionId, {
+      exitCode: null,
+      exitReason: "idle_timeout",
+    });
+    expect(await terminalSession.countActiveByUser(userId)).toBe(0);
+  });
+
+  it("rejects stale shell.onClose from a previous WebSocket after a resume", async () => {
+    const userId = `user_${Math.random().toString(36).slice(2)}`;
+    const { id: sessionId } = await terminalSession.open({
+      userId,
+      serverId: "test-server",
+    });
+    const shell = fakeShell();
+    const state = makeConnState(userId, sessionId, shell);
+    state.closed = true; // the old WS was parked
+
+    // A stale shell.onClose callback from the old connection must not close
+    // the audit row for a session that has since resumed on a new WS.
+    await teardown(state, "remote_exit", 0, false, true);
+
+    expect(state.ended).toBe(false);
+    expect(shell.close).not.toHaveBeenCalled();
+    expect(terminalSession.close).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when force-close is triggered twice", async () => {
+    const userId = `user_${Math.random().toString(36).slice(2)}`;
+    const { id: sessionId } = await terminalSession.open({
+      userId,
+      serverId: "test-server",
+    });
+    const shell = fakeShell();
+    const state = makeConnState(userId, sessionId, shell);
+
+    await teardown(state, "remote_exit", 0, false, true);
+    expect(state.ended).toBe(true);
+    expect(terminalSession.close).toHaveBeenCalledOnce();
+
+    // A second call (e.g. onClose after shell exit) must not re-close the row.
+    await teardown(state, "client_close", null, false, true);
+    expect(terminalSession.close).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Split connection state (`state.closed`) from session-end state (`state.ended`) in both `terminal.controller.ts` and `service-terminal.controller.ts`.
- `teardown` now short-circuits on `state.ended`, and only skips stale non-timeout handlers (`state.closed && !alreadyUnregistered`), so a parked session that later times out still finalizes the DB row, kills the shell, and releases the session.
- Re-bind the `onTimeout` hook and re-arm the idle timer on resume so a resumed session is not killed by the stale parked connection's timeout.
- Add unit tests covering park → timeout close and stale-handler guard for both terminal and service-terminal.

Fixes oblien/openship #426

## Test plan

- [x] `bun run --cwd apps/api test --run test/modules/terminal/terminal.controller.test.ts test/modules/service-terminal/service-terminal.controller.test.ts`
- [x] `bun run --cwd apps/api lint`