### PR TITLE
fix(backups): fail fast and allow cancel when backup restore-apply hangs with no managed container

### DIFF
--- a/apps/api/src/modules/backups/restore.orchestrator.test.ts
+++ b/apps/api/src/modules/backups/restore.orchestrator.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const h = vi.hoisted(() => {
+  const transitions: Array<[string, string, Record<string, unknown> | undefined]> = [];
+  const fakeExecutor: {
+    runtimeName: "docker" | "bare" | "cloud";
+    stopService: ReturnType<typeof vi.fn>;
+    startService: ReturnType<typeof vi.fn>;
+    isRunning: ReturnType<typeof vi.fn>;
+  } = {
+    runtimeName: "docker",
+    stopService: vi.fn(async () => {}),
+    startService: vi.fn(async () => {}),
+    isRunning: vi.fn(async () => false),
+  };
+  const fakeDestination = { get: vi.fn(), head: vi.fn() };
+
+  return {
+    transitions,
+    fakeExecutor,
+    fakeDestination,
+    buildApplyTargetResult: null as {
+      executor: unknown;
+      serviceHandle: Record<string, unknown>;
+    } | null,
+    currentRestore: null as Record<string, unknown> | null,
+    currentRun: null as Record<string, unknown> | null,
+    currentDestination: null as Record<string, unknown> | null,
+    repos: {
+      backupRestore: {
+        findById: vi.fn(async (_id: string) => h.currentRestore),
+        transition: vi.fn(async (id: string, status: string, patch?: Record<string, unknown>) => {
+          transitions.push([id, status, patch]);
+          if (h.currentRestore && h.currentRestore.id === id) {
+            h.currentRestore.status = status;
+            if (patch?.errorMessage !== undefined) {
+              h.currentRestore.errorMessage = patch.errorMessage;
+            }
+            if (patch?.bytesRestored !== undefined) {
+              h.currentRestore.bytesRestored = patch.bytesRestored;
+            }
+          }
+        }),
+      },
+      backupRun: { findById: vi.fn(async () => h.currentRun) },
+      backupDestination: { findById: vi.fn(async () => h.currentDestination) },
+      service: { findById: vi.fn(async () => null) },
+      project: { findById: vi.fn(async () => null) },
+      deployment: { findById: vi.fn(async () => null) },
+      mailServer: { get: vi.fn(async () => null) },
+    },
+  };
+});
+
+vi.mock("@repo/db", () => ({ repos: h.repos }));
+
+vi.mock("@repo/adapters", () => ({
+  resolveDestination: vi.fn(() => h.fakeDestination),
+  resolveProducer: vi.fn(() => ({ restore: vi.fn() })),
+  resolveExecutor: vi.fn(() => h.fakeExecutor),
+}));
+
+vi.mock("../backup-destinations/hydrate-server", () => ({
+  toAdapterRow: vi.fn((row: unknown) => row),
+}));
+
+vi.mock("./restore.sse", () => ({
+  restoreRunBus: { publish: vi.fn() },
+}));
+
+vi.mock("../../lib/notification-dispatcher", () => ({
+  notification: { emit: vi.fn() },
+}));
+
+vi.mock("../../lib/encryption", () => ({
+  decryptEnvMap: vi.fn((m: Record<string, string>) => m),
+}));
+
+vi.mock("../services/service-container", () => ({
+  liveContainerIdForService: vi.fn(async () => null),
+}));
+
+vi.mock("../../lib/deployment-runtime", () => ({
+  resolveDeploymentPlatform: vi.fn(),
+  resolveTargetPlatform: vi.fn(),
+}));
+
+const { restoreOrchestrator } = await import("./restore.orchestrator");
+
+const fakeCtx = {
+  organizationId: "org1",
+  userId: "usr1",
+  user: { id: "usr1", email: "x", name: null },
+  role: "owner" as const,
+  membershipId: "mem1",
+  sessionId: "sess1",
+  sessionKind: "cookie" as const,
+  clientIp: null,
+  userAgent: null,
+  traceId: "trace1",
+  hono: null,
+} as any;
+
+const makeRestore = (status: string) => ({
+  id: "rst_1",
+  runId: "run1",
+  destinationId: "dst1",
+  organizationId: "org1",
+  status,
+  mode: "in_place",
+  forkMailServerId: null,
+});
+
+const makeRun = (sourceKind: string, over: Record<string, unknown> = {}) => ({
+  id: "run1",
+  sourceKind,
+  serviceId: sourceKind === "service" ? "svc1" : null,
+  mailServerId: sourceKind === "mail_server" ? "ms1" : null,
+  artifacts: [],
+  ...over,
+});
+
+const makeDestination = () => ({
+  id: "dst1",
+  organizationId: "org1",
+});
+
+const makeServiceHandle = (containerId: string | null) => ({
+  id: "svc1",
+  projectId: "proj1",
+  name: "hello",
+  image: null,
+  env: {},
+  volumes: ["trialdata:/data"],
+  containerId,
+  projectSlug: "demo",
+  namespaceVolumes: true,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.transitions.length = 0;
+  h.currentRestore = null;
+  h.currentRun = null;
+  h.currentDestination = null;
+  h.buildApplyTargetResult = null;
+  h.fakeExecutor.runtimeName = "docker";
+
+  (restoreOrchestrator as any).buildApplyTarget = vi.fn(async () => h.buildApplyTargetResult);
+});
+
+describe("RestoreOrchestrator", () => {
+  describe("runApply", () => {
+    it("fails fast when a docker service has no live managed container", async () => {
+      h.currentRestore = makeRestore("prepared");
+      h.currentRun = makeRun("service");
+      h.currentDestination = makeDestination();
+      h.buildApplyTargetResult = {
+        executor: h.fakeExecutor,
+        serviceHandle: makeServiceHandle(null),
+      };
+
+      await (restoreOrchestrator as any).runApply("rst_1");
+
+      const failed = h.transitions.find((t) => t[1] === "failed");
+      expect(failed).toBeTruthy();
+      expect((failed![2] as any).errorMessage).toMatch(/no live managed container/);
+      expect(h.fakeExecutor.stopService).not.toHaveBeenCalled();
+    });
+
+    it("proceeds when the container exists on a docker service", async () => {
+      h.currentRestore = makeRestore("prepared");
+      h.currentRun = makeRun("service");
+      h.currentDestination = makeDestination();
+      h.buildApplyTargetResult = {
+        executor: h.fakeExecutor,
+        serviceHandle: makeServiceHandle("container123"),
+      };
+
+      await (restoreOrchestrator as any).runApply("rst_1");
+
+      expect(h.transitions.map((t) => t[1])).toEqual(["applying", "succeeded"]);
+      expect(h.fakeExecutor.stopService).toHaveBeenCalledTimes(1);
+      expect(h.fakeExecutor.startService).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows bare runtimes with no container", async () => {
+      h.currentRestore = makeRestore("prepared");
+      h.currentRun = makeRun("service");
+      h.currentDestination = makeDestination();
+      h.fakeExecutor.runtimeName = "bare";
+      h.buildApplyTargetResult = {
+        executor: h.fakeExecutor,
+        serviceHandle: makeServiceHandle(null),
+      };
+
+      await (restoreOrchestrator as any).runApply("rst_1");
+
+      expect(h.transitions.map((t) => t[1])).toEqual(["applying", "succeeded"]);
+    });
+
+    it("allows mail-server restores with no container", async () => {
+      h.currentRestore = makeRestore("prepared");
+      h.currentRun = makeRun("mail_server");
+      h.currentDestination = makeDestination();
+      h.fakeExecutor.runtimeName = "bare";
+      h.buildApplyTargetResult = {
+        executor: h.fakeExecutor,
+        serviceHandle: makeServiceHandle(null),
+      };
+
+      await (restoreOrchestrator as any).runApply("rst_1");
+
+      expect(h.transitions.map((t) => t[1])).toEqual(["applying", "succeeded"]);
+    });
+  });
+
+  describe("cancel", () => {
+    it("cancels an applying restore and best-effort starts the service", async () => {
+      h.currentRestore = makeRestore("applying");
+      h.currentRun = makeRun("service");
+      h.currentDestination = makeDestination();
+      h.buildApplyTargetResult = {
+        executor: h.fakeExecutor,
+        serviceHandle: makeServiceHandle("container123"),
+      };
+
+      await restoreOrchestrator.cancel(fakeCtx, "rst_1");
+
+      expect(h.transitions.map((t) => t[1])).toContain("cancelled");
+
+      // bestEffortStart is scheduled on setImmediate.
+      await new Promise((resolve) => setImmediate(resolve));
+      await vi.waitFor(() => expect(h.fakeExecutor.startService).toHaveBeenCalled());
+    });
+
+    it("still cancels a prepared restore", async () => {
+      h.currentRestore = makeRestore("prepared");
+
+      await restoreOrchestrator.cancel(fakeCtx, "rst_1");
+
+      expect(h.transitions).toEqual([["rst_1", "cancelled", undefined]]);
+    });
+
+    it("refuses to cancel a terminal restore", async () => {
+      h.currentRestore = makeRestore("succeeded");
+
+      await expect(restoreOrchestrator.cancel(fakeCtx, "rst_1")).rejects.toThrow(
+        "Cannot cancel a succeeded restore",
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/backups/restore.orchestrator.ts
+++ b/apps/api/src/modules/backups/restore.orchestrator.ts
@@ -23,7 +23,7 @@
  */
 
 import crypto from "node:crypto";
-import { repos, type BackupRun, type BackupRestoreStatus } from "@repo/db";
+import { repos, type BackupRun, type BackupRestore, type BackupRestoreStatus } from "@repo/db";
 import { liveContainerIdForService } from "../services/service-container";
 import {
   resolveDestination,
@@ -36,7 +36,7 @@ import {
 } from "@repo/adapters";
 import { decryptEnvMap } from "../../lib/encryption";
 import { resolveDeploymentPlatform, resolveTargetPlatform } from "../../lib/deployment-runtime";
-import { safeErrorMessage } from "@repo/core";
+import { safeErrorMessage, withTimeout } from "@repo/core";
 import { assertResourceInOrg } from "../../lib/controller-helpers";
 import type { RequestContext } from "../../lib/request-context";
 import { toAdapterRow } from "../backup-destinations/hydrate-server";
@@ -44,6 +44,7 @@ import { restoreRunBus } from "./restore.sse";
 import { notification } from "../../lib/notification-dispatcher";
 
 const TRUNCATE_ERROR = 4096;
+const STOP_START_TIMEOUT_MS = 60_000;
 
 export interface PrepareRestoreInput {
   /** Source backup run to restore from. */
@@ -124,11 +125,7 @@ export class RestoreOrchestrator {
    * stops, target volume is wiped + replaced, service restarts.
    * Verifies the confirmation token from beginPrepare.
    */
-  async apply(
-    ctx: RequestContext,
-    restoreId: string,
-    confirmationToken: string,
-  ): Promise<void> {
+  async apply(ctx: RequestContext, restoreId: string, confirmationToken: string): Promise<void> {
     const restore = await repos.backupRestore.findById(restoreId);
     try {
       assertResourceInOrg(restore, "Restore", ctx.organizationId, restoreId);
@@ -153,9 +150,7 @@ export class RestoreOrchestrator {
       throw new Error("Confirmation token mismatch");
     }
     if (restore.status !== "prepared") {
-      throw new Error(
-        `Restore is in status=${restore.status}, must be 'prepared' to apply`,
-      );
+      throw new Error(`Restore is in status=${restore.status}, must be 'prepared' to apply`);
     }
 
     setImmediate(() => {
@@ -167,7 +162,7 @@ export class RestoreOrchestrator {
     });
   }
 
-  /** Cancel a prepared (or queued) restore. Cleans up staging. */
+  /** Cancel a queued, preparing, prepared or applying restore. */
   async cancel(ctx: RequestContext, restoreId: string): Promise<void> {
     const restore = await repos.backupRestore.findById(restoreId);
     try {
@@ -176,10 +171,21 @@ export class RestoreOrchestrator {
       throw new Error("Restore not found");
     }
     void ctx.userId;
-    if (!["queued", "preparing", "prepared"].includes(restore.status)) {
+    const allowed: BackupRestoreStatus[] = ["queued", "preparing", "prepared", "applying"];
+    if (!allowed.includes(restore.status as BackupRestoreStatus)) {
       throw new Error(`Cannot cancel a ${restore.status} restore`);
     }
+    const wasApplying = restore.status === "applying";
     await this.transition(restoreId, "cancelled");
+    if (wasApplying) {
+      setImmediate(() => {
+        void this.bestEffortStart(restore).catch((err) =>
+          console.error(
+            `[restore-orchestrator] best-effort start after cancel ${restoreId} failed: ${safeErrorMessage(err)}`,
+          ),
+        );
+      });
+    }
   }
 
   // ── Internal phases ──────────────────────────────────────────────
@@ -213,9 +219,7 @@ export class RestoreOrchestrator {
       const sourceRun = await repos.backupRun.findById(restore.runId);
       if (!sourceRun) throw new Error("Source backup run disappeared");
 
-      const destinationRow = await repos.backupDestination.findById(
-        restore.destinationId,
-      );
+      const destinationRow = await repos.backupDestination.findById(restore.destinationId);
       if (!destinationRow) throw new Error("Destination disappeared");
       this.assertDestinationOrg(destinationRow, restore.organizationId);
 
@@ -289,38 +293,35 @@ export class RestoreOrchestrator {
       // Resolve the TARGET — a deployed service, or a bare mail server. A
       // mail restore can go in-place (onto the source) or to_fork (onto a
       // DIFFERENT mail server = migrate A→B).
-      let executor: BackupExecutor;
-      let serviceHandle: ServiceHandle;
-      if (sourceRun.sourceKind === "mail_server") {
-        const targetMailServerId =
-          restore.mode === "to_fork" ? restore.forkMailServerId : sourceRun.mailServerId;
-        if (!targetMailServerId) {
-          throw new Error("Mail restore has no target mail server");
+      const { executor, serviceHandle } = await this.buildApplyTarget(
+        restore,
+        sourceRun,
+        destinationRow.organizationId,
+      );
+
+      if (sourceRun.sourceKind !== "mail_server" && executor.runtimeName !== "bare") {
+        if (!serviceHandle.containerId) {
+          throw new Error(
+            `Service ${serviceHandle.name} has no live managed container to restore into. ` +
+              `Restore-apply can only stop and start service-managed containers ` +
+              `(e.g. containers created by Openship compose deployments). ` +
+              `Deployment-managed app containers are not a valid restore target.`,
+          );
         }
-        const built = await this.buildMailTarget(
-          targetMailServerId,
-          destinationRow.organizationId,
-        );
-        executor = built.executor;
-        serviceHandle = built.handle;
-      } else {
-        if (!sourceRun.serviceId) throw new Error("Source run has no serviceId");
-        const serviceRow = await repos.service.findById(sourceRun.serviceId);
-        if (!serviceRow) throw new Error("Target service disappeared");
-        const project = await repos.project.findById(serviceRow.projectId);
-        if (!project) throw new Error("Project disappeared");
-        const platform = await resolveDeploymentPlatform(
-          (await this.activeDeploymentMeta(project.id)) as Parameters<
-            typeof resolveDeploymentPlatform
-          >[0],
-          { organizationId: destinationRow.organizationId },
-        );
-        executor = resolveExecutor(platform.platform.runtime.name, platform.platform.runtime);
-        serviceHandle = await this.buildServiceHandle(serviceRow);
       }
 
+      if (await this.isCancelled(restoreId)) return;
+
       // Stop the service so volume swap is safe. (No-op for bare/mail.)
-      await executor.stopService(serviceHandle);
+      // Some Docker/SSH calls can hang without a client-side timeout; bound
+      // this so a stuck stop fails the restore instead of freezing in applying.
+      await withTimeout(
+        executor.stopService(serviceHandle),
+        STOP_START_TIMEOUT_MS,
+        `stopService(${serviceHandle.name}) timed out after ${STOP_START_TIMEOUT_MS}ms`,
+      );
+
+      if (await this.isCancelled(restoreId)) return;
 
       try {
         const artifacts = Array.isArray(sourceRun.artifacts)
@@ -352,21 +353,32 @@ export class RestoreOrchestrator {
           bytesRestored += recorded.sizeBytes;
         }
 
+        if (await this.isCancelled(restoreId)) return;
+
         // Start service back up.
-        await executor.startService(serviceHandle);
+        await withTimeout(
+          executor.startService(serviceHandle),
+          STOP_START_TIMEOUT_MS,
+          `startService(${serviceHandle.name}) timed out after ${STOP_START_TIMEOUT_MS}ms`,
+        );
 
         await this.transition(restoreId, "succeeded", { bytesRestored });
       } catch (innerErr) {
         // Try to bring the service back up so the user isn't stuck
         // with a stopped container after a failed restore.
         try {
-          await executor.startService(serviceHandle);
+          await withTimeout(
+            executor.startService(serviceHandle),
+            STOP_START_TIMEOUT_MS,
+            `startService(${serviceHandle.name}) timed out after ${STOP_START_TIMEOUT_MS}ms`,
+          );
         } catch {
           // best-effort
         }
         throw innerErr;
       }
     } catch (err) {
+      if (await this.isCancelled(restoreId)) return;
       const message = safeErrorMessage(err);
       console.error(`[restore-orchestrator] apply ${restoreId} failed: ${message}`);
       await this.transition(restoreId, "failed", {
@@ -387,15 +399,9 @@ export class RestoreOrchestrator {
       restoreRunBus.publish(restoreId, {
         type: "transition",
         status,
-        bytesRestored:
-          typeof patch?.bytesRestored === "number" ? patch.bytesRestored : undefined,
+        bytesRestored: typeof patch?.bytesRestored === "number" ? patch.bytesRestored : undefined,
       });
-      const TERMINAL: BackupRestoreStatus[] = [
-        "succeeded",
-        "failed",
-        "cancelled",
-        "server_error",
-      ];
+      const TERMINAL: BackupRestoreStatus[] = ["succeeded", "failed", "cancelled", "server_error"];
       if (TERMINAL.includes(status)) {
         restoreRunBus.publish(restoreId, {
           type: "complete",
@@ -417,7 +423,8 @@ export class RestoreOrchestrator {
           const project = await repos.project.findById(row.projectId).catch(() => null);
           notification.emit({
             organizationId: row.organizationId,
-            eventType: status === "succeeded" ? "backup_restore.completed" : "backup_restore.failed",
+            eventType:
+              status === "succeeded" ? "backup_restore.completed" : "backup_restore.failed",
             resourceType: "backup_restore",
             resourceId: restoreId,
             payload: {
@@ -429,9 +436,81 @@ export class RestoreOrchestrator {
           });
         }
       } catch (err) {
-        console.error(`[restore-orchestrator] notify failed for ${restoreId}: ${safeErrorMessage(err)}`);
+        console.error(
+          `[restore-orchestrator] notify failed for ${restoreId}: ${safeErrorMessage(err)}`,
+        );
       }
     }
+  }
+
+  private async isCancelled(restoreId: string): Promise<boolean> {
+    const row = await repos.backupRestore.findById(restoreId);
+    return row?.status === "cancelled";
+  }
+
+  /**
+   * Build the executor + ServiceHandle for an apply. Shared by runApply
+   * and the best-effort restart path after a mid-apply cancel.
+   */
+  private async buildApplyTarget(
+    restore: BackupRestore,
+    sourceRun: BackupRun,
+    organizationId: string,
+  ): Promise<{ executor: BackupExecutor; serviceHandle: ServiceHandle }> {
+    if (sourceRun.sourceKind === "mail_server") {
+      const targetMailServerId =
+        restore.mode === "to_fork" ? restore.forkMailServerId : sourceRun.mailServerId;
+      if (!targetMailServerId) {
+        throw new Error("Mail restore has no target mail server");
+      }
+      const built = await this.buildMailTarget(targetMailServerId, organizationId);
+      return { executor: built.executor, serviceHandle: built.handle };
+    }
+
+    if (!sourceRun.serviceId) throw new Error("Source run has no serviceId");
+    const serviceRow = await repos.service.findById(sourceRun.serviceId);
+    if (!serviceRow) throw new Error("Target service disappeared");
+    const project = await repos.project.findById(serviceRow.projectId);
+    if (!project) throw new Error("Project disappeared");
+    const platform = await resolveDeploymentPlatform(
+      (await this.activeDeploymentMeta(project.id)) as Parameters<
+        typeof resolveDeploymentPlatform
+      >[0],
+      { organizationId },
+    );
+    const executor = resolveExecutor(platform.platform.runtime.name, platform.platform.runtime);
+    const serviceHandle = await this.buildServiceHandle(serviceRow);
+    return { executor, serviceHandle };
+  }
+
+  /**
+   * After cancelling a restore that was already in applying, make a
+   * best-effort attempt to start the service back up. Never awaits in the
+   * caller: if it hangs, the cancel is still accepted and the in-flight
+   * runApply will see the cancelled status when it wakes up.
+   */
+  private async bestEffortStart(restore: BackupRestore): Promise<void> {
+    const sourceRun = await repos.backupRun.findById(restore.runId);
+    if (!sourceRun) return;
+
+    const destinationRow = await repos.backupDestination.findById(restore.destinationId);
+    if (!destinationRow) return;
+    this.assertDestinationOrg(destinationRow, restore.organizationId);
+
+    const { executor, serviceHandle } = await this.buildApplyTarget(
+      restore,
+      sourceRun,
+      destinationRow.organizationId,
+    );
+
+    if (sourceRun.sourceKind === "mail_server" || executor.runtimeName === "bare") return;
+    if (!serviceHandle.containerId) return;
+
+    await withTimeout(
+      executor.startService(serviceHandle),
+      STOP_START_TIMEOUT_MS,
+      `startService(${serviceHandle.name}) timed out after ${STOP_START_TIMEOUT_MS}ms`,
+    );
   }
 
   /**
@@ -456,10 +535,7 @@ export class RestoreOrchestrator {
       mailServerId,
       organizationId,
     );
-    const executor = resolveExecutor(
-      targetPlatform.runtime.name,
-      targetPlatform.runtime,
-    );
+    const executor = resolveExecutor(targetPlatform.runtime.name, targetPlatform.runtime);
 
     const handle: ServiceHandle = {
       id: mailServerId,
@@ -488,8 +564,7 @@ export class RestoreOrchestrator {
     const project = await repos.project.findById(serviceRow.projectId);
     if (!project) throw new Error(`Project ${serviceRow.projectId} not found`);
 
-    const envFromService =
-      (serviceRow.environment as Record<string, string> | null) ?? {};
+    const envFromService = (serviceRow.environment as Record<string, string> | null) ?? {};
     const envFromProjectEncrypted = await repos.project
       .listEnvVars(serviceRow.projectId)
       .then((vars) => {


### PR DESCRIPTION
Fixes #434.

## Summary

- Fail fast in `runApply()` before calling `stopService()` when the target docker/cloud service has no live managed `containerId`. This prevents restore-apply from hanging in `applying` for hybrid deployments where a service row exists for backup policy fan-out but the app container is deployment-managed (`openship-<slug>-dep_*`) and not a service-managed restore target.
- Wrap `stopService()` and `startService()` with a 60-second client-side timeout so a stuck Docker/SSH call fails the restore instead of leaving it frozen in `applying`.
- Extend `cancel()` to accept `applying` restores, and schedule a best-effort `startService()` afterwards so a cancelled mid-apply restore attempts to bring the service back up.
- Add a regression test covering the no-managed-container fail-fast path, normal apply, bare runtimes, mail-server restores, and mid-apply cancellation.

## Test plan

- `bunx vitest run src/modules/backups/restore.orchestrator.test.ts` — 7/7 passing.
- `bun run lint` (`tsc --noEmit`) in `apps/api` passes.
- `npx prettier --check apps/api/src/modules/backups/restore.orchestrator.ts apps/api/src/modules/backups/restore.orchestrator.test.ts` passes.
