### PR TITLE
fix(apps): add collection: true to POST /api/apps/custom

### DIFF
--- a/apps/api/src/modules/apps/app.routes.ts
+++ b/apps/api/src/modules/apps/app.routes.ts
@@ -34,6 +34,7 @@ r.post(
   "/custom",
   {
     tag: "project:write",
+    collection: true,
     body: AddCustomAppBody,
     mcp: { description: "Add a custom app from an uploaded JSON definition (stored per-org, unverified)." },
   },

--- a/apps/api/test/modules/apps/app.routes.test.ts
+++ b/apps/api/test/modules/apps/app.routes.test.ts
@@ -1,0 +1,23 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { getRouteRegistry, isPublicSpec } from "../../../src/lib/route-permission";
+
+describe("apps routes are permission-scoped correctly", () => {
+  beforeAll(async () => {
+    // Importing the route module populates the global secure-router registry.
+    await import("../../../src/modules/apps/app.routes");
+  });
+
+  it("POST /api/apps/custom is a collection-scoped write route", () => {
+    const route = getRouteRegistry().find(
+      (r) => r.method === "POST" && r.path === "/api/apps/custom",
+    );
+
+    expect(route, "POST /api/apps/custom must be registered").toBeDefined();
+
+    const spec = route!.spec;
+    expect(isPublicSpec(spec)).toBe(false);
+    if (isPublicSpec(spec)) throw new Error("POST /api/apps/custom must be a permission route");
+
+    expect(spec.collection).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/apps/custom` creates a new per-org custom app and does not take an `:id` in the URL, so the permission middleware must treat it as a collection-scoped write route. The sibling `POST /` install route already declares `collection: true`; this patch applies the same flag to the custom-app route.

Fixes #440

## Motivation

Without `collection: true`, the route-permission middleware tries to resolve a leaf `:id` from the URL for `project:write`. Since `/custom` has no such parameter, the self-hosted "+ Add Custom" app flow is blocked by a permission check that can never succeed.

## Verification

- Preflight against current `oblien/openship:main` confirms the bug marker is still present and the fix marker is absent.
- `bun run --cwd apps/api lint` passes.
- Added `apps/api/test/modules/apps/app.routes.test.ts`, which fails before the change (`spec.collection` is `undefined`) and passes after (`spec.collection` is `true`).
- Ran the new test alongside the existing secure-router and custom-app tests:
  - `bun run --cwd apps/api test -- test/modules/apps/app.routes.test.ts test/lib/secure-router-body-validation.test.ts test/lib/collection-project-routes.test.ts test/modules/apps/custom-app.service.test.ts`