### PR TITLE
fix(dashboard): skip the sidebar org fetch when signed out

### DIFF
--- a/apps/dashboard/src/components/sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar.tsx
@@ -191,6 +191,11 @@ export function Sidebar() {
   // waiting for the user to click. Cheap (one /list call) and mirrors
   // the AccountSwitcher pattern.
   useEffect(() => {
+    // Signed out, so both endpoints below would 401. This effect is keyed on the
+    // user id, which sign-out transitions to undefined — without the guard every
+    // logout fires two unauthenticated org calls whose failures are swallowed by
+    // the catch, leaving only console noise.
+    if (!user?.id) return;
     let cancelled = false;
     (async () => {
       try {


### PR DESCRIPTION
## Summary

Guards the sidebar's org-list fetch effect so it doesn't fire when the user is signed out.

## Motivation

The effect is keyed on the user id, which sign-out transitions to `undefined`. Without a guard, every logout fires two unauthenticated org calls that 401 and get swallowed by the catch, leaving only console noise.

## Related issue

None

## Changes

- apps/dashboard: bail out of the sidebar org-fetch effect when `user?.id` is missing

## Verification

Manual: signed out and confirmed no 401s fire from the sidebar org fetch on logout.

## Checklist

- [x] One change per PR
- [x] The diff is scoped
- [ ] A test fails without this change and passes with it (manual repro only, no existing test harness for this effect)
- [ ] bun run test / lint / format (not run in this environment)
- [x] I understand every line of this diff and can explain it in review