### PR TITLE
fix: keep self-hosted deploy state consistent

### DIFF
--- a/apps/api/src/lib/deployment-runtime-local-edge.test.ts
+++ b/apps/api/src/lib/deployment-runtime-local-edge.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  server: {
+    id: "srv-local",
+    isLocal: true,
+    sshHost: "127.0.0.1",
+    sshPort: 22,
+    sshUser: "whirmill",
+  },
+  executor: { kind: "host-executor" },
+  platformConfigs: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@repo/adapters", () => ({
+  DockerRuntime: { create: vi.fn() },
+  createPlatform: vi.fn(async (config: Record<string, unknown>) => {
+    h.platformConfigs.push(config);
+    return { target: "selfhosted", runtime: {}, routing: {}, ssl: {}, system: {}, executor: null };
+  }),
+  resolveStaticOutputPath: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    server: {
+      getInOrganization: vi.fn(async () => h.server),
+      listByOrganization: vi.fn(async () => [h.server]),
+      update: vi.fn(async () => undefined),
+    },
+  },
+}));
+
+vi.mock("./box-org", () => ({
+  isLocalHostRow: vi.fn(async (server: { isLocal?: boolean }) => Boolean(server.isLocal)),
+}));
+
+vi.mock("./ssh-manager", () => ({
+  sshManager: { acquire: vi.fn(async () => h.executor) },
+  buildSshConfig: vi.fn(async (server: { sshHost: string }) => ({
+    host: server.sshHost,
+    port: 22,
+    username: "root",
+  })),
+}));
+
+vi.mock("./provision-lock", () => ({
+  createProvisionLock: vi.fn(() => ({ run: (fn: () => unknown) => fn() })),
+}));
+vi.mock("./cloud/client", () => ({ cloudClient: {}, getOrgCloudToken: vi.fn() }));
+vi.mock("./cloud/transport", () => ({ resolveOrgCloudUserId: vi.fn() }));
+vi.mock("./controller-helpers", () => ({ platform: () => ({ target: "selfhosted" }) }));
+vi.mock("./acme-config", () => ({ resolveAcmeProviderOptions: () => ({}) }));
+vi.mock("../config", () => ({ env: {} }));
+
+const { resolveTargetPlatform } = await import("./deployment-runtime");
+
+beforeEach(() => {
+  h.server = {
+    id: "srv-local",
+    isLocal: true,
+    sshHost: "127.0.0.1",
+    sshPort: 22,
+    sshUser: "whirmill",
+  };
+  h.platformConfigs = [];
+  vi.stubEnv("OPENSHIP_EDGE_MODE", "docker");
+  vi.stubEnv("OPENSHIP_EDGE_CONTAINER", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveTargetPlatform — local compose edge", () => {
+  it.each(["docker", "bare"] as const)(
+    "keeps the host executor for an isLocal %s workload but selects the mounted local edge",
+    async (runtimeMode) => {
+      await resolveTargetPlatform("server", runtimeMode, "srv-local", "org-1");
+
+      expect(h.platformConfigs).toHaveLength(1);
+      expect(h.platformConfigs[0]).toMatchObject({
+        target: "selfhosted",
+        runtime: runtimeMode,
+        executor: h.executor,
+        localEdgeContainer: "openship-edge",
+      });
+    },
+  );
+
+  it("honours the configured local edge container name", async () => {
+    vi.stubEnv("OPENSHIP_EDGE_CONTAINER", "custom-edge");
+
+    await resolveTargetPlatform("server", "docker", "srv-local", "org-1");
+
+    expect(h.platformConfigs[0]?.localEdgeContainer).toBe("custom-edge");
+  });
+
+  it("does not select the control-plane edge for a remote server", async () => {
+    h.server = {
+      id: "srv-remote",
+      isLocal: false,
+      sshHost: "203.0.113.8",
+      sshPort: 22,
+      sshUser: "root",
+    };
+
+    await resolveTargetPlatform("server", "docker", "srv-remote", "org-1");
+
+    expect(h.platformConfigs[0]?.localEdgeContainer).toBeUndefined();
+    expect(h.platformConfigs[0]).toHaveProperty("ssh");
+  });
+
+  it("keeps the legacy host/bare edge path when docker-edge mode is disabled", async () => {
+    vi.stubEnv("OPENSHIP_EDGE_MODE", "host");
+
+    await resolveTargetPlatform("server", "docker", "srv-local", "org-1");
+
+    expect(h.platformConfigs[0]?.localEdgeContainer).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -19,6 +19,7 @@ import { buildSshConfig, sshManager } from "./ssh-manager";
 import { createProvisionLock } from "./provision-lock";
 import { isLocalHostRow } from "./box-org";
 import { resolveAcmeProviderOptions } from "./acme-config";
+import { targetSourceCloneSupportedForTopology } from "./source-clone-topology";
 
 /**
  * The shape of `deployment.meta` JSONB. Snapshotted per-deploy —
@@ -223,6 +224,28 @@ async function resolveOrgServer(
   }
 
   throw new Error("Deployment target is a server, but this deployment has no server ID. Redeploy and select a server explicitly.");
+}
+
+/**
+ * Resolve whether the concrete server topology supports target-host source
+ * acquisition without constructing a runtime or opening SSH. Preflight uses
+ * this read-only answer; the build pipeline independently verifies the same
+ * invariant through the resolved runtime capability.
+ */
+export async function resolveTargetSourceCloneSupport(input: {
+  effectiveTarget: DeployTarget;
+  runtimeMode: RuntimeMode;
+  serverId?: string;
+  organizationId?: string;
+}): Promise<boolean> {
+  if (input.effectiveTarget !== "server") return false;
+  if (input.runtimeMode === "bare") return true;
+
+  const server = await resolveOrgServer(input.serverId, input.organizationId);
+  return targetSourceCloneSupportedForTopology(
+    input.runtimeMode,
+    await isLocalHostRow(server),
+  );
 }
 
 /**

--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -414,10 +414,23 @@ export async function resolveTargetPlatform(
     // server-host mode): local host executor, host docker socket (DooD),
     // everything on-box.
     if (isLocal) {
+      // This row represents the control plane's own host. In compose edge mode
+      // the API and edge share the vhost/certificate mounts and the Docker
+      // socket, even though workload/system commands may still need the pooled
+      // HOST executor (especially for a bare runtime). Tell the platform about
+      // that edge topology explicitly: inferring it from `!executor` made SSL
+      // run certbot inside the edge but verify/write files as the unprivileged
+      // host SSH user, yielding a false "certificate is missing" and no TLS
+      // vhost after a successful issuance.
+      const localEdgeContainer =
+        process.env.OPENSHIP_EDGE_MODE === "docker"
+          ? process.env.OPENSHIP_EDGE_CONTAINER?.trim() || "openship-edge"
+          : undefined;
       return createPlatform({
         target: "selfhosted",
         runtime: runtimeMode,
         executor,
+        localEdgeContainer,
         docker: runtimeMode === "docker" ? { transport: "socket" as const } : undefined,
         nginx: resolveAcmeProviderOptions(),
         provisionLock: createProvisionLock("provision:local"),

--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -189,9 +189,7 @@ async function resolveOrgServer(
   organizationId: string | undefined,
 ): Promise<OrgServer> {
   if (!organizationId) {
-    throw new Error(
-      "Cannot resolve a server deployment target without an organization ID",
-    );
+    throw new Error("Cannot resolve a server deployment target without an organization ID");
   }
 
   if (serverId) {
@@ -223,7 +221,9 @@ async function resolveOrgServer(
     throw new Error("No server configured. Add your SSH server in Settings.");
   }
 
-  throw new Error("Deployment target is a server, but this deployment has no server ID. Redeploy and select a server explicitly.");
+  throw new Error(
+    "Deployment target is a server, but this deployment has no server ID. Redeploy and select a server explicitly.",
+  );
 }
 
 /**
@@ -242,10 +242,7 @@ export async function resolveTargetSourceCloneSupport(input: {
   if (input.runtimeMode === "bare") return true;
 
   const server = await resolveOrgServer(input.serverId, input.organizationId);
-  return targetSourceCloneSupportedForTopology(
-    input.runtimeMode,
-    await isLocalHostRow(server),
-  );
+  return targetSourceCloneSupportedForTopology(input.runtimeMode, await isLocalHostRow(server));
 }
 
 /**
@@ -255,7 +252,10 @@ export async function resolveTargetSourceCloneSupport(input: {
  * and the build pipeline both route through this so their notion of the target
  * can never drift (a drift caused the self-hosted→cloud-preflight 403).
  */
-export function resolveEffectiveTarget(base: Platform["target"], snapshot: DeploymentMeta): DeployTarget {
+export function resolveEffectiveTarget(
+  base: Platform["target"],
+  snapshot: DeploymentMeta,
+): DeployTarget {
   // AUTO-DETECT, don't hardcode per host platform: a deployment PINNED to a
   // specific server always routes over SSH to that server — whether the host is
   // a self-hosted box OR the DESKTOP app operating a remote server. Only the SaaS
@@ -278,7 +278,10 @@ export function resolveEffectiveTarget(base: Platform["target"], snapshot: Deplo
   return "cloud";
 }
 
-export function usesManagedRouting(base: Platform["target"], effectiveTarget: DeployTarget): boolean {
+export function usesManagedRouting(
+  base: Platform["target"],
+  effectiveTarget: DeployTarget,
+): boolean {
   // Managed (local OpenResty) routing applies only to on-box targets. A cloud
   // target — including the local-orchestrated cloud deploy — routes via cloud
   // pages/edge, not the local proxy.
@@ -332,7 +335,8 @@ export async function resolveDeploymentPlatform(
 ): Promise<ResolvedDeploymentPlatform> {
   const basePlatform = opts?.basePlatform ?? platform();
   const effectiveTarget = resolveEffectiveTarget(basePlatform.target, snapshot);
-  const runtimeMode = snapshot.runtimeMode ?? (basePlatform.runtime.name === "docker" ? "docker" : "bare");
+  const runtimeMode =
+    snapshot.runtimeMode ?? (basePlatform.runtime.name === "docker" ? "docker" : "bare");
 
   if (effectiveTarget === "local" || effectiveTarget === "server") {
     const resolvedServerId = effectiveTarget === "server" ? (snapshot.serverId ?? null) : null;
@@ -405,10 +409,7 @@ export async function resolveTargetPlatform(
     // ONE resolution for the server's executor + transport (isLocal → host
     // executor + socket docker; else → pooled SSH). Shared with
     // createServerDockerRuntime / createServerCommandExecutor — no drift.
-    const { id, executor, isLocal, ssh } = await resolveServerExecutor(
-      serverId,
-      organizationId,
-    );
+    const { id, executor, isLocal, ssh } = await resolveServerExecutor(serverId, organizationId);
 
     // The auto-registered "This Server" row IS the OpenShip host (VPS /
     // server-host mode): local host executor, host docker socket (DooD),
@@ -455,9 +456,7 @@ export async function resolveTargetPlatform(
   return createPlatform({
     target: "selfhosted",
     runtime: runtimeMode,
-    docker: runtimeMode === "docker"
-      ? { transport: "socket" as const }
-      : undefined,
+    docker: runtimeMode === "docker" ? { transport: "socket" as const } : undefined,
     nginx: resolveAcmeProviderOptions(),
     provisionLock: createProvisionLock("provision:local"),
   });
@@ -559,7 +558,11 @@ export async function resolveServerExecutor(
 export async function createServerCommandExecutor(
   serverId: string,
   organizationId: string,
-): Promise<{ executor: CommandExecutor; conn: { host: string; port: number; user: string }; isLocal: boolean }> {
+): Promise<{
+  executor: CommandExecutor;
+  conn: { host: string; port: number; user: string };
+  isLocal: boolean;
+}> {
   const { executor, conn, isLocal } = await resolveServerExecutor(serverId, organizationId);
   return { executor, conn, isLocal };
 }

--- a/apps/api/src/lib/route-apply.service.ts
+++ b/apps/api/src/lib/route-apply.service.ts
@@ -70,6 +70,10 @@ export interface RouteRegister {
   /** Cloud target port (workspace expose / domains.connect). */
   port?: number;
   isCustomDomain: boolean;
+  /** Override whether this vhost listens with TLS (external ingress may not). */
+  tls?: boolean;
+  /** Override where TLS terminates; defaults to local for custom domains. */
+  terminatesTlsLocally?: boolean;
   /**
    * Force (`true`) or suppress (`false`) the `/_openship/hooks/` webhook-proxy
    * location. Omit to auto-detect from the project's `webhookDomain` — callers
@@ -108,6 +112,14 @@ export async function reconcileProjectRoutes(
     routing?: Platform["routing"];
     registers?: RouteRegister[];
     removes?: RouteRemove[];
+    /**
+     * Require the requested edge state to be applied before returning.
+     *
+     * Mutation paths keep the default best-effort behaviour because their DB
+     * write is already committed. Verification/recovery paths opt into strict
+     * mode so they never report a domain as live when no vhost was written.
+     */
+    strict?: boolean;
   },
 ): Promise<void> {
   const registers = opts.registers ?? [];
@@ -152,6 +164,11 @@ export async function reconcileProjectRoutes(
       }
     }
     if (registers.length > 0) {
+      if (opts.strict) {
+        throw new Error(
+          `[route-apply] no deployment routing resolved — ${registers.length} route(s) not applied`,
+        );
+      }
       console.warn(
         `[route-apply] no deployment routing resolved — ${registers.length} route(s) not applied (redeploy to re-sync)`,
       );
@@ -166,32 +183,36 @@ export async function reconcileProjectRoutes(
   const proxy = sanitizeProxySettings(project.routingConfig?.proxy);
 
   for (const r of removes) {
-    await routing
-      .removeRoute(r.hostname)
-      .catch((err) =>
-        console.warn(`[route-apply] removeRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`),
-      );
+    try {
+      await routing.removeRoute(r.hostname);
+    } catch (err) {
+      if (opts.strict) throw err;
+      console.warn(`[route-apply] removeRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`);
+    }
   }
 
   for (const r of registers) {
     // A route serves `/` from ONE of two things: a host directory (static, files
     // on disk) or an upstream. Neither → nothing to serve.
     if (!r.staticRoot && !r.targetUrl) {
+      if (opts.strict) {
+        throw new Error(`[route-apply] no upstream or static root resolved for ${r.hostname}`);
+      }
       console.warn(
         `[route-apply] no upstream or static root resolved for ${r.hostname} — route not applied (redeploy to re-sync)`,
       );
       continue;
     }
     const isWebhook = r.webhook ?? (!!webhookHost && r.hostname.toLowerCase() === webhookHost);
-    await routing
-      .registerRoute({
+    try {
+      await routing.registerRoute({
         domain: r.hostname,
-        tls: true,
+        tls: r.tls ?? true,
         // A custom domain's TLS is ours to terminate, so the edge must keep a :443
         // listener up for it even before its cert exists — otherwise the origin
         // refuses the handshake and a proxied domain shows Cloudflare 525 (#308).
         // A free *.opsh.io host is fronted by Cloud's edge; not ours.
-        terminatesTlsLocally: r.isCustomDomain,
+        terminatesTlsLocally: r.terminatesTlsLocally ?? r.isCustomDomain,
         // staticRoot wins when present: it is the more specific instruction, and a
         // caller that resolved a doc root has already decided this domain serves
         // files. registerRoute keys off which one is set.
@@ -205,9 +226,10 @@ export async function reconcileProjectRoutes(
         ...(r.redirects?.length ? { redirects: r.redirects } : {}),
         ...(r.headerRules?.length ? { headerRules: r.headerRules } : {}),
         ...(r.redirectHost ? { redirectHost: r.redirectHost } : {}),
-      })
-      .catch((err) =>
-        console.warn(`[route-apply] registerRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`),
-      );
+      });
+    } catch (err) {
+      if (opts.strict) throw err;
+      console.warn(`[route-apply] registerRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`);
+    }
   }
 }

--- a/apps/api/src/lib/route-apply.service.ts
+++ b/apps/api/src/lib/route-apply.service.ts
@@ -159,7 +159,9 @@ export async function reconcileProjectRoutes(
         await local
           .removeRoute(r.hostname)
           .catch((err) =>
-            console.warn(`[route-apply] fallback removeRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`),
+            console.warn(
+              `[route-apply] fallback removeRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`,
+            ),
           );
       }
     }
@@ -187,7 +189,9 @@ export async function reconcileProjectRoutes(
       await routing.removeRoute(r.hostname);
     } catch (err) {
       if (opts.strict) throw err;
-      console.warn(`[route-apply] removeRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`);
+      console.warn(
+        `[route-apply] removeRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`,
+      );
     }
   }
 
@@ -229,7 +233,9 @@ export async function reconcileProjectRoutes(
       });
     } catch (err) {
       if (opts.strict) throw err;
-      console.warn(`[route-apply] registerRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`);
+      console.warn(
+        `[route-apply] registerRoute ${r.hostname} failed (non-fatal): ${safeErrorMessage(err)}`,
+      );
     }
   }
 }

--- a/apps/api/src/lib/source-clone-topology.ts
+++ b/apps/api/src/lib/source-clone-topology.ts
@@ -1,0 +1,14 @@
+import type { RuntimeMode } from "@repo/core";
+
+/**
+ * Pure topology rule for target-host source acquisition. Bare builds execute
+ * through the target command executor. Docker can acquire source there only on
+ * a remote SSH server; "This Server" uses the API host's socket transport,
+ * whose source staging runs in the API process.
+ */
+export function targetSourceCloneSupportedForTopology(
+  runtimeMode: RuntimeMode,
+  isLocalServer: boolean,
+): boolean {
+  return runtimeMode === "bare" || (runtimeMode === "docker" && !isLocalServer);
+}

--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -660,15 +660,21 @@ async function executeBuildAndDeploy(project: Project, dep: Deployment, buildSes
     // persisted) is opted into per deploy via snapshot.forwardGitCredentials.
     const clonePlan = resolveClonePlan({
       effectiveTarget: resolved.effectiveTarget,
-      serverId: resolved.serverId,
       runtimeIsBare: runtime.name === "bare",
       cloneStrategy: snapshot.cloneStrategy,
       buildStrategy,
       isDesktop: plat.target === "desktop",
       forwardGitCredentials: snapshot.forwardGitCredentials,
-      repoIsGithub: !!project.gitOwner,
+      targetSourceCloneSupported: runtime.supports("targetSourceClone"),
     });
     const cloneOnServer = clonePlan.runsOnServer;
+    if (clonePlan.targetCloneUnavailable) {
+      logger.log(
+        "Clone-on-server was requested, but the selected Docker transport stages source on the API host. " +
+          "Cloning on the API host and transferring the build context instead.",
+        "warn",
+      );
+    }
     // The relay needs a real SSH reverse tunnel — `reverseForward` exists on every
     // SSH executor and is absent only on a LocalExecutor (relay.ts). This is the
     // TRUE capability gate (not the server's SSH auth method); combined with the

--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -14,11 +14,7 @@
  * pipeline owns the deploy↔rollback cycle (a deliberate dynamic import).
  */
 
-import {
-  hasLegacyFlattenedCommandArgvAmbiguity,
-  repos,
-  type Project,
-} from "@repo/db";
+import { hasLegacyFlattenedCommandArgvAmbiguity, repos, type Project } from "@repo/db";
 import {
   AppError,
   NotFoundError,
@@ -35,10 +31,7 @@ import {
   type StackDefinition,
   type ReleaseSource,
 } from "@repo/core";
-import type {
-  LogEntry,
-  ResourceConfig,
-} from "@repo/adapters";
+import type { LogEntry, ResourceConfig } from "@repo/adapters";
 import { resolveCloudResourceConfig } from "./cloud-resources";
 import type { TBuildAccessBody } from "./deployment.schema";
 import { platform } from "../../lib/controller-helpers";
@@ -74,7 +67,11 @@ import {
   syncProjectRouteState,
 } from "../domains/project-route.service";
 import { kickoffBuild, resolveServicePipelineMode } from "./build-pipeline";
-import { resolveReleaseDist, resolveLatestVersion, readApiVersion } from "../../lib/release-resolver";
+import {
+  resolveReleaseDist,
+  resolveLatestVersion,
+  readApiVersion,
+} from "../../lib/release-resolver";
 import { env } from "../../config";
 
 function throwPreflightFailure(preflight: PreflightResult): never {
@@ -325,10 +322,7 @@ function toRuntimeMode(value: string | null | undefined): "bare" | "docker" | un
 
 /** Build a config snapshot from the project - pure pass-through, no fallbacks.
  *  All values must be set by prepare / ensureProject before this is called. */
-export function buildConfigSnapshot(
-  project: Project,
-  branch?: string,
-): DeploymentConfigSnapshot {
+export function buildConfigSnapshot(project: Project, branch?: string): DeploymentConfigSnapshot {
   const runtimeImage = resolveRuntimeImage(project);
 
   return {
@@ -497,9 +491,12 @@ async function reconcileComposeDrift(
     const pendingCommandReviews = composeRows
       .filter((service) => {
         const pending = service.driftSpec;
-        return !!pending && hasLegacyFlattenedCommandArgvAmbiguity(
-          { command: service.command, commandArgv: service.commandArgv },
-          pending,
+        return (
+          !!pending &&
+          hasLegacyFlattenedCommandArgvAmbiguity(
+            { command: service.command, commandArgv: service.commandArgv },
+            pending,
+          )
         );
       })
       .map((service) => service.name);
@@ -511,7 +508,11 @@ async function reconcileComposeDrift(
     }
 
     if (!project.gitOwner || !project.gitRepo) return NO_COMPOSE_DRIFT; // local/no-git source → nothing to re-parse
-    if (changedPaths && changedPaths.length > 0 && !changedPaths.some((p) => COMPOSE_PATH_RE.test(p))) {
+    if (
+      changedPaths &&
+      changedPaths.length > 0 &&
+      !changedPaths.some((p) => COMPOSE_PATH_RE.test(p))
+    ) {
       return NO_COMPOSE_DRIFT; // this push didn't touch the compose file → no drift possible
     }
     if (!composeRows.some((s) => s.kind === "compose")) return NO_COMPOSE_DRIFT; // not a compose project
@@ -528,8 +529,10 @@ async function reconcileComposeDrift(
     });
     const services = info.services ?? [];
     if (services.length === 0) return NO_COMPOSE_DRIFT;
-    const { driftedNames, commandArgvReviewNames } =
-      await repos.service.reconcileFromCompose(project.id, services);
+    const { driftedNames, commandArgvReviewNames } = await repos.service.reconcileFromCompose(
+      project.id,
+      services,
+    );
     if (driftedNames.length > 0) {
       console.log(
         `[compose-drift] ${project.id}: kept user edits on ${driftedNames.join(", ")} (pending review)`,
@@ -876,10 +879,7 @@ export async function createQueuedDeployment(opts: {
 export { subscribe as subscribeToBuildSession } from "./session-manager";
 
 /** Resolve a pending pipeline prompt (e.g. port conflict). */
-export async function respondToPrompt(
-  deploymentId: string,
-  action: string,
-): Promise<boolean> {
+export async function respondToPrompt(deploymentId: string, action: string): Promise<boolean> {
   await loadDeployment(deploymentId);
   return sessionManager.respondToPrompt(deploymentId, action);
 }
@@ -890,11 +890,12 @@ export async function respondToPrompt(
  * with neither is dropped downstream (see deriveEnvironmentPublicEndpoints), so
  * pick the one the project's shape needs.
  */
-function defaultFreeEndpoint(project: {
-  slug: string;
-  hasServer: boolean;
-  port: number | null;
-}): { domain: string; domainType: "free"; port?: string; targetPath?: string } {
+function defaultFreeEndpoint(project: { slug: string; hasServer: boolean; port: number | null }): {
+  domain: string;
+  domainType: "free";
+  port?: string;
+  targetPath?: string;
+} {
   return project.hasServer && project.port
     ? { domain: project.slug, domainType: "free", port: String(project.port) }
     : { domain: project.slug, domainType: "free", targetPath: "/" };
@@ -941,9 +942,7 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
   // Folder-upload: resolve the session UP FRONT — its scanned compose services
   // feed the service-mode decision below. The snapshot mutations it drives still
   // happen further down, after target resolution (which the upload mode overrides).
-  const uploadSession = input.uploadSessionId
-    ? getFolderSession(input.uploadSessionId)
-    : undefined;
+  const uploadSession = input.uploadSessionId ? getFolderSession(input.uploadSessionId) : undefined;
   if (input.uploadSessionId && (!uploadSession || uploadSession.orgId !== ctx.organizationId)) {
     throw new AppError("Upload session not found or expired — re-upload the folder.", 400);
   }
@@ -977,9 +976,7 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
   // null), bootstraps their baseline while KEEPING the adopted image — so mapped
   // services reuse their running image (no rebuild) and everything else in the
   // compose is taken from the repo. Best-effort; self-guards to compose+git projects.
-  assertNoLegacyCommandArgvReview(
-    await reconcileComposeDrift(ctx, project, resolvedBranch),
-  );
+  assertNoLegacyCommandArgvReview(await reconcileComposeDrift(ctx, project, resolvedBranch));
 
   // #336: the wizard sees compose env MASKED, so a deploy request can echo the
   // "••••••••" sentinel back. Recover the real values before they're persisted
@@ -1119,7 +1116,11 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
   // the single source of truth shared with triggerDeployment — UI override >
   // cloudWorkspaceId > active-deployment meta. Keeps the two deploy entry points
   // from diverging on where a project deploys.
-  const resolvedTarget = await resolveSnapshotTarget(project, { deployTarget, serverId, runtimeMode });
+  const resolvedTarget = await resolveSnapshotTarget(project, {
+    deployTarget,
+    serverId,
+    runtimeMode,
+  });
   snapshot.deployTarget = resolvedTarget.deployTarget;
   snapshot.serverId = resolvedTarget.serverId;
   snapshot.runtimeMode = resolvedTarget.runtimeMode;
@@ -1146,14 +1147,13 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
   // default, and a redeploy then resolves to that default (bare) — silently
   // flipping a docker/sandbox project to direct-on-host. Best-effort: a failed
   // persist must not block the deploy. Only write when it actually changed.
-  if (
-    (runtimeMode === "bare" || runtimeMode === "docker") &&
-    runtimeMode !== project.runtimeMode
-  ) {
+  if ((runtimeMode === "bare" || runtimeMode === "docker") && runtimeMode !== project.runtimeMode) {
     await repos.project
       .update(project.id, { runtimeMode })
       .catch((err) =>
-        console.warn(`[requestBuildAccess] failed to persist runtimeMode: ${safeErrorMessage(err)}`),
+        console.warn(
+          `[requestBuildAccess] failed to persist runtimeMode: ${safeErrorMessage(err)}`,
+        ),
       );
   }
 
@@ -1202,11 +1202,7 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
   const env = environment || "production";
 
   // ── Resolve commit info from the branch HEAD ────
-  const { commitSha, commitMessage } = await resolveLatestCommitInfo(
-    ctx,
-    project,
-    snapshot.branch,
-  );
+  const { commitSha, commitMessage } = await resolveLatestCommitInfo(ctx, project, snapshot.branch);
 
   // ── Resolve rollback context (shared helper — single default) ─────────
   const { rollbackStrategy, commitShaBefore } = await resolveRollbackContext(
@@ -1273,7 +1269,6 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
     project_id: project.id,
   };
 }
-
 
 /**
  * Cancel an in-flight deployment.
@@ -1470,10 +1465,7 @@ export async function redeployBuildSession(
   };
 
   // ── Resolve rollback context (shared helper — single default) ─────────
-  const { rollbackStrategy, commitShaBefore } = await resolveRollbackContext(
-    project,
-    branch,
-  );
+  const { rollbackStrategy, commitShaBefore } = await resolveRollbackContext(project, branch);
 
   // "update" wants a snapshot of the OLD state before the (destructive) tag
   // roll-forward — the safety net for stateful apps (n8n/Ghost/Convex volumes).

--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -14,7 +14,11 @@
  * pipeline owns the deploy↔rollback cycle (a deliberate dynamic import).
  */
 
-import { repos, type Project } from "@repo/db";
+import {
+  hasLegacyFlattenedCommandArgvAmbiguity,
+  repos,
+  type Project,
+} from "@repo/db";
 import {
   AppError,
   NotFoundError,
@@ -470,19 +474,47 @@ async function resolveProjectBranch(ctx: RequestContext, project: Project, branc
  * redeploy) or empty, reconcile runs to be safe.
  */
 const COMPOSE_PATH_RE = /(^|\/)(docker-compose|compose)\.ya?ml$/i;
+type ComposeDriftResult = {
+  driftedNames: string[];
+  commandArgvReviewNames: string[];
+};
+const NO_COMPOSE_DRIFT: ComposeDriftResult = {
+  driftedNames: [],
+  commandArgvReviewNames: [],
+};
+
 async function reconcileComposeDrift(
   ctx: RequestContext,
   project: Project,
   branch: string,
   changedPaths?: string[] | null,
-) {
+): Promise<ComposeDriftResult> {
   try {
-    if (!project.gitOwner || !project.gitRepo) return; // local/no-git source → nothing to re-parse
-    if (changedPaths && changedPaths.length > 0 && !changedPaths.some((p) => COMPOSE_PATH_RE.test(p))) {
-      return; // this push didn't touch the compose file → no drift possible
-    }
+    // A prior reconcile may already have persisted this review marker. Check it
+    // before every optimization/early return so a webhook that changes only
+    // application files cannot bypass an unresolved command-argv decision.
     const composeRows = await listProjectComposeServices(project.id);
-    if (!composeRows.some((s) => s.kind === "compose")) return; // not a compose project
+    const pendingCommandReviews = composeRows
+      .filter((service) => {
+        const pending = service.driftSpec;
+        return !!pending && hasLegacyFlattenedCommandArgvAmbiguity(
+          { command: service.command, commandArgv: service.commandArgv },
+          pending,
+        );
+      })
+      .map((service) => service.name);
+    if (pendingCommandReviews.length > 0) {
+      return {
+        driftedNames: pendingCommandReviews,
+        commandArgvReviewNames: pendingCommandReviews,
+      };
+    }
+
+    if (!project.gitOwner || !project.gitRepo) return NO_COMPOSE_DRIFT; // local/no-git source → nothing to re-parse
+    if (changedPaths && changedPaths.length > 0 && !changedPaths.some((p) => COMPOSE_PATH_RE.test(p))) {
+      return NO_COMPOSE_DRIFT; // this push didn't touch the compose file → no drift possible
+    }
+    if (!composeRows.some((s) => s.kind === "compose")) return NO_COMPOSE_DRIFT; // not a compose project
     const info = await resolveProjectInfo({
       source: "github",
       owner: project.gitOwner,
@@ -495,16 +527,29 @@ async function reconcileComposeDrift(
       composePath: project.composePath ?? undefined,
     });
     const services = info.services ?? [];
-    if (services.length === 0) return;
-    const { driftedNames } = await repos.service.reconcileFromCompose(project.id, services);
+    if (services.length === 0) return NO_COMPOSE_DRIFT;
+    const { driftedNames, commandArgvReviewNames } =
+      await repos.service.reconcileFromCompose(project.id, services);
     if (driftedNames.length > 0) {
       console.log(
         `[compose-drift] ${project.id}: kept user edits on ${driftedNames.join(", ")} (pending review)`,
       );
     }
+    return { driftedNames, commandArgvReviewNames };
   } catch (err) {
     console.warn(`[compose-drift] reconcile skipped for ${project.id}:`, err);
+    return NO_COMPOSE_DRIFT;
   }
+}
+
+function assertNoLegacyCommandArgvReview(result: ComposeDriftResult): void {
+  if (result.commandArgvReviewNames.length === 0) return;
+  throw new AppError(
+    `Compose command arguments need review for: ${result.commandArgvReviewNames.join(", ")}. ` +
+      "Open Apps & Services, accept the incoming Compose changes for those services, then redeploy.",
+    409,
+    "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
+  );
 }
 
 /**
@@ -932,7 +977,9 @@ export async function requestBuildAccess(ctx: RequestContext, input: BuildAccess
   // null), bootstraps their baseline while KEEPING the adopted image — so mapped
   // services reuse their running image (no rebuild) and everything else in the
   // compose is taken from the repo. Best-effort; self-guards to compose+git projects.
-  await reconcileComposeDrift(ctx, project, resolvedBranch);
+  assertNoLegacyCommandArgvReview(
+    await reconcileComposeDrift(ctx, project, resolvedBranch),
+  );
 
   // #336: the wizard sees compose env MASKED, so a deploy request can echo the
   // "••••••••" sentinel back. Recover the real values before they're persisted
@@ -1405,7 +1452,7 @@ export async function redeployBuildSession(
   // Reconcile upstream compose drift BEFORE reading the rows, so this redeploy
   // picks up repo changes on unedited services (and flags edited ones). See
   // reconcileComposeDrift — best-effort, never blocks.
-  await reconcileComposeDrift(ctx, project, branch);
+  assertNoLegacyCommandArgvReview(await reconcileComposeDrift(ctx, project, branch));
 
   const currentComposeRows = await listProjectComposeServices(project.id).catch(() => []);
   const currentComposeServices = projectServicesToDeployableServices(
@@ -1658,7 +1705,9 @@ export async function triggerDeployment(
   // ship the frozen snapshot verbatim. `changedPaths` (webhook) lets it skip the
   // repo scan when the push didn't touch the compose file. Best-effort; never blocks.
   if (!data.reuseSnapshot && data.trigger !== "rollback") {
-    await reconcileComposeDrift(ctx, project, branch, data.changedPaths);
+    assertNoLegacyCommandArgvReview(
+      await reconcileComposeDrift(ctx, project, branch, data.changedPaths),
+    );
   }
 
   // ATOMIC rollback path: reuse the target deployment's frozen snapshot verbatim

--- a/apps/api/src/modules/deployments/clone-plan.test.ts
+++ b/apps/api/src/modules/deployments/clone-plan.test.ts
@@ -3,12 +3,11 @@ import { resolveClonePlan, type ClonePlanInput } from "./clone-plan";
 
 const base: ClonePlanInput = {
   effectiveTarget: "server",
-  serverId: "srv_1",
   runtimeIsBare: false,
   cloneStrategy: "server",
   buildStrategy: "server",
   isDesktop: true,
-  repoIsGithub: true,
+  targetSourceCloneSupported: true,
 };
 
 describe("resolveClonePlan — relayEligible (forward is the default on desktop)", () => {
@@ -29,12 +28,11 @@ describe("resolveClonePlan — relayEligible (forward is the default on desktop)
   });
 
   it("is NOT eligible when the clone doesn't run on the server", () => {
-    // api-host clone of a non-github repo → not on-server → no relay.
+    // api-host clone → not on-server → no relay, regardless of provider.
     expect(
       resolveClonePlan({
         ...base,
         cloneStrategy: "api-host",
-        repoIsGithub: false,
       }).relayEligible,
     ).toBe(false);
   });

--- a/apps/api/src/modules/deployments/clone-plan.ts
+++ b/apps/api/src/modules/deployments/clone-plan.ts
@@ -19,8 +19,6 @@
 export interface ClonePlanInput {
   /** Resolved deploy target for this build. */
   effectiveTarget: "local" | "server" | "cloud";
-  /** Target server id (server deploys only). */
-  serverId?: string | null;
   /** Resolved runtime is bare (host process) vs docker (sandbox). The pipeline
    *  passes `runtime.name === "bare"`; preflight passes `runtimeMode === "bare"`
    *  — each from its own source, kept as an input so neither has to know the
@@ -28,8 +26,8 @@ export interface ClonePlanInput {
   runtimeIsBare: boolean;
   /** Per-deploy clone strategy for docker/server deploys ("api-host" default). */
   cloneStrategy?: "api-host" | "server" | null;
-  /** Where the BUILD runs — used only to decide the clone's credential purpose
-   *  (a local build always clones on this machine). */
+  /** Where the BUILD runs. For cloud deployments, a local build acquires source
+   *  on the API host before upload; a server build acquires it in the cloud. */
   buildStrategy?: "local" | "server";
   /** Whether this instance is the desktop app (relay is desktop-only). */
   isDesktop: boolean;
@@ -40,18 +38,23 @@ export interface ClonePlanInput {
    *  real SSH tunnel + a local `gh` identity, probed at runtime by the pipeline /
    *  resolver — this only expresses the operator's preference. */
   forwardGitCredentials?: boolean | null;
-  /** Repo is hosted on GitHub (`gitProvider === "github"` / has a parsed owner) →
-   *  the server can download the source tarball directly (source-tarball.ts), so
-   *  docker can acquire on the server without the explicit `cloneStrategy ===
-   *  "server"` opt-in, skipping the orchestrator clone + context transfer.
-   *  Whether it ACTUALLY runs on the server still depends on a shippable
-   *  credential (resolved later; degrades to an api-host clone otherwise). The
-   *  adapter re-validates the URL (github + https) before downloading and falls
-   *  back to clone. Local/imported projects → false → unchanged. */
-  repoIsGithub?: boolean;
+  /** Whether the resolved runtime/transport can acquire source on the target
+   *  host. Docker-over-SSH can; Docker through a local socket/TCP transport
+   *  cannot because its clone implementation runs in the API process. Bare
+   *  runtimes have their own target-host source path and do not need this flag. */
+  targetSourceCloneSupported?: boolean;
 }
 
+export type SourceExecutionSite = "api-host" | "target-host" | "cloud";
+
 export interface ClonePlan {
+  /** Where source acquisition physically executes. Credential selection and
+   *  preflight checks MUST follow this value, never the deploy target alone. */
+  sourceSite: SourceExecutionSite;
+  /** True when the operator requested target-host acquisition but the selected
+   *  runtime transport cannot execute it. The caller should surface the
+   *  transparent API-host fallback. */
+  targetCloneUnavailable: boolean;
   /** The clone runs directly on the deploy server — bare always, docker on the
    *  explicit "clone on the server" opt-in. (Pipeline's `cloneOnServer`.) */
   runsOnServer: boolean;
@@ -90,25 +93,29 @@ export function relayConfigEligible(input: {
 export function resolveClonePlan(input: ClonePlanInput): ClonePlan {
   const onServer = input.effectiveTarget === "server";
 
-  // Docker acquires source ON THE SERVER when the deploy opted in
-  // (cloneStrategy="server") OR the repo is a GitHub HTTPS remote — the server
-  // downloads the tarball directly, skipping the orchestrator clone + context
-  // transfer. Bare has its own always-on-server path (below), so it's excluded
-  // here. Whether it truly runs on the server still hinges on a shippable
-  // credential; effectiveCloneOnServer degrades to an api-host clone otherwise
-  // (allowApiHostFallback is driven by dockerClonesOnServer).
-  const dockerServerSide =
-    onServer &&
-    !input.runtimeIsBare &&
-    (input.cloneStrategy === "server" || input.repoIsGithub === true);
-
-  // Pipeline: the clone runs on the server (bare always; docker per above).
+  // Provider and source site are deliberately independent. GitHub repositories
+  // may use the tarball optimization AFTER target-host acquisition is selected,
+  // but being hosted on GitHub must never override an explicit "api-host"
+  // choice. Bare runtimes always acquire on their target. Docker does so only
+  // when requested AND its concrete transport implements that path.
+  const dockerTargetRequested =
+    onServer && !input.runtimeIsBare && input.cloneStrategy === "server";
+  const targetCloneUnavailable =
+    dockerTargetRequested && input.targetSourceCloneSupported !== true;
   const runsOnServer =
-    onServer && !!input.serverId && (input.runtimeIsBare || dockerServerSide);
+    onServer &&
+    (input.runtimeIsBare ||
+      (dockerTargetRequested && input.targetSourceCloneSupported === true));
+
+  const sourceSite: SourceExecutionSite = runsOnServer
+    ? "target-host"
+    : input.effectiveTarget === "cloud" && input.buildStrategy !== "local"
+      ? "cloud"
+      : "api-host";
 
   // Preflight warn-case + api-host-fallback gate: DOCKER (non-bare) acquiring on
   // the server. Bare is handled by the separate hard-fail remote-build checks.
-  const dockerClonesOnServer = dockerServerSide;
+  const dockerClonesOnServer = runsOnServer && !input.runtimeIsBare;
 
   // The clone's credential purpose follows WHERE THE CLONE RUNS, not where the
   // build runs: a local build clones on this machine, and a server deploy that
@@ -136,10 +143,11 @@ export function resolveClonePlan(input: ClonePlanInput): ClonePlan {
   // runsLocally MUST imply !runsOnServer — otherwise a contradictory config
   // (buildStrategy="local" + cloneStrategy="server") would tag an on-server clone
   // as local and ship the operator's local gh/OAuth token off-host to the remote.
-  const runsLocally =
-    !runsOnServer && (input.effectiveTarget !== "cloud" || input.buildStrategy === "local");
+  const runsLocally = sourceSite === "api-host";
 
   return {
+    sourceSite,
+    targetCloneUnavailable,
     runsOnServer,
     dockerClonesOnServer,
     runsLocally,

--- a/apps/api/src/modules/deployments/compose/composite-route.test.ts
+++ b/apps/api/src/modules/deployments/compose/composite-route.test.ts
@@ -49,7 +49,9 @@ describe("buildDomainFanoutRegistrations", () => {
   });
 
   it("is a no-op for null / empty routes", () => {
-    expect(buildDomainFanoutRegistrations({ routes: null, resolveTargetUrl: () => null })).toEqual([]);
+    expect(buildDomainFanoutRegistrations({ routes: null, resolveTargetUrl: () => null })).toEqual(
+      [],
+    );
     expect(buildDomainFanoutRegistrations({ routes: [], resolveTargetUrl: () => "x" })).toEqual([]);
   });
 
@@ -85,8 +87,8 @@ describe("buildCompositeRegistration canonical redirect", () => {
           enabled: true,
         },
       ],
-      resolveTargetUrl: (id) => id === "api" ? "http://10.0.0.2:3000" : null,
-      resolveStaticRoot: (id) => id === "web" ? "/opt/openship/static/web" : null,
+      resolveTargetUrl: (id) => (id === "api" ? "http://10.0.0.2:3000" : null),
+      resolveStaticRoot: (id) => (id === "web" ? "/opt/openship/static/web" : null),
       resolveDomain: () => ({ hostname: "www.example.com", isCustomDomain: true }),
       resolveRedirectHost: () => ({ target: "example.com", statusCode: 301 }),
     });

--- a/apps/api/src/modules/deployments/compose/composite-route.test.ts
+++ b/apps/api/src/modules/deployments/compose/composite-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildDomainFanoutRegistrations } from "./composite-route";
+import { buildCompositeRegistration, buildDomainFanoutRegistrations } from "./composite-route";
 import type { ProjectCompositeRoute } from "@repo/core";
 
 const onvo: ProjectCompositeRoute = {
@@ -51,5 +51,49 @@ describe("buildDomainFanoutRegistrations", () => {
   it("is a no-op for null / empty routes", () => {
     expect(buildDomainFanoutRegistrations({ routes: null, resolveTargetUrl: () => null })).toEqual([]);
     expect(buildDomainFanoutRegistrations({ routes: [], resolveTargetUrl: () => "x" })).toEqual([]);
+  });
+
+  it("carries the canonical redirect into a redeployed fanout vhost", () => {
+    const regs = buildDomainFanoutRegistrations({
+      routes: [onvo],
+      resolveTargetUrl: (id) => upstreams[id],
+      resolveRedirectHost: () => ({ target: "onvo.me", statusCode: 308 }),
+    });
+
+    expect(regs[0].redirectHost).toEqual({ target: "onvo.me", statusCode: 308 });
+  });
+});
+
+describe("buildCompositeRegistration canonical redirect", () => {
+  it("carries the canonical redirect into a redeployed composite vhost", () => {
+    const registration = buildCompositeRegistration({
+      services: [
+        {
+          id: "web",
+          name: "web",
+          kind: "monorepo",
+          framework: "vite",
+          startCommand: "",
+          enabled: true,
+        },
+        {
+          id: "api",
+          name: "api",
+          kind: "monorepo",
+          framework: "express",
+          startCommand: "npm start",
+          enabled: true,
+        },
+      ],
+      resolveTargetUrl: (id) => id === "api" ? "http://10.0.0.2:3000" : null,
+      resolveStaticRoot: (id) => id === "web" ? "/opt/openship/static/web" : null,
+      resolveDomain: () => ({ hostname: "www.example.com", isCustomDomain: true }),
+      resolveRedirectHost: () => ({ target: "example.com", statusCode: 301 }),
+    });
+
+    expect(registration?.register).toMatchObject({
+      hostname: "www.example.com",
+      redirectHost: { target: "example.com", statusCode: 301 },
+    });
   });
 });

--- a/apps/api/src/modules/deployments/compose/composite-route.ts
+++ b/apps/api/src/modules/deployments/compose/composite-route.ts
@@ -122,6 +122,8 @@ export function buildCompositeRegistration(input: {
    * host directory to serve.
    */
   resolveStaticRoot?: (serviceId: string) => string | null | undefined;
+  /** Canonical host redirect attached to this vhost, when configured. */
+  resolveRedirectHost?: (hostname: string) => RouteRegister["redirectHost"] | null | undefined;
 }): CompositeRegistration | null {
   const routing = input.routingConfig ?? undefined;
   const plan = planCompositeRoute(input.services, { rewrites: routing?.rewrites });
@@ -143,6 +145,7 @@ export function buildCompositeRegistration(input: {
     compiled && compiled.proxyLocations.length > 0
       ? compiled.proxyLocations
       : buildCompositeProxyLocations(plan, backendUrl);
+  const redirectHost = input.resolveRedirectHost?.(domain.hostname);
 
   return {
     frontendServiceId: plan.frontendServiceId,
@@ -155,6 +158,7 @@ export function buildCompositeRegistration(input: {
       proxyLocations,
       ...(compiled?.redirects.length ? { redirects: compiled.redirects } : {}),
       ...(compiled?.headerRules.length ? { headerRules: compiled.headerRules } : {}),
+      ...(redirectHost ? { redirectHost } : {}),
     },
   };
 }
@@ -172,6 +176,8 @@ export function buildCompositeRegistration(input: {
 export function buildDomainFanoutRegistrations(input: {
   routes: ProjectCompositeRoute[] | null | undefined;
   resolveTargetUrl: (serviceId: string) => string | null | undefined;
+  /** Canonical host redirect attached to each compiled vhost, when configured. */
+  resolveRedirectHost?: (hostname: string) => RouteRegister["redirectHost"] | null | undefined;
 }): RouteRegister[] {
   const out: RouteRegister[] = [];
   for (const route of input.routes ?? []) {
@@ -182,11 +188,13 @@ export function buildDomainFanoutRegistrations(input: {
       const url = input.resolveTargetUrl(loc.serviceId);
       if (url) proxyLocations.push({ pathPrefix: loc.pathPrefix, targetUrl: url });
     }
+    const redirectHost = input.resolveRedirectHost?.(route.hostname);
     out.push({
       hostname: route.hostname,
       isCustomDomain: route.isCustomDomain,
       targetUrl: rootUrl,
       ...(proxyLocations.length ? { proxyLocations } : {}),
+      ...(redirectHost ? { redirectHost } : {}),
     });
   }
   return out;

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -57,7 +57,10 @@ import {
   toRoutedDomainInputs,
   type PlannedRouteDomain,
 } from "../../../lib/routing-domains";
-import { resolveServiceEndpointUrls, resolveServicePublicEndpoints } from "../../../lib/public-endpoints";
+import {
+  resolveServiceEndpointUrls,
+  resolveServicePublicEndpoints,
+} from "../../../lib/public-endpoints";
 import { ensureManagedEdgeProxy } from "../../../lib/managed-edge-proxy";
 import { ensureRoutingReady } from "../../../lib/edge-reconcile";
 import * as sessionManager from "../session-manager";
@@ -1109,7 +1112,9 @@ export async function deployComposeServices(
         svc.name,
         `no public URL is known for ${unresolvedEnvUrls
           .map((u) => `${u.key}=${u.tokens.join("")}`)
-          .join(", ")} — ${unresolvedEnvUrls.length === 1 ? "that variable is" : "those variables are"} left UNSET rather than blank`,
+          .join(
+            ", ",
+          )} — ${unresolvedEnvUrls.length === 1 ? "that variable is" : "those variables are"} left UNSET rather than blank`,
       );
     }
 
@@ -1742,9 +1747,7 @@ export async function deployComposeServices(
     const probes = Promise.all(
       portAuditTargets.map(async (target) => {
         const [pc] = await auditPorts(runtime, target.containerId, [target.port], logger);
-        return pc
-          ? { ...pc, serviceId: target.serviceId, serviceName: target.serviceName }
-          : null;
+        return pc ? { ...pc, serviceId: target.serviceId, serviceName: target.serviceName } : null;
       }),
     );
     const audited = await Promise.race([
@@ -1813,9 +1816,7 @@ export async function deployComposeServices(
         f.target.serviceId &&
         readinessByServiceId.get(f.target.serviceId)?.onFailure === "fail",
     );
-    for (const finding of findings.filter(
-      (f) => !f.verdict.ok && !vetoing.includes(f),
-    )) {
+    for (const finding of findings.filter((f) => !f.verdict.ok && !vetoing.includes(f))) {
       // "warn": say what didn't hold, but leave the service's deploy result alone
       // so the stack stays up. Opting into the watch to get the signal must not
       // also opt into a veto.

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -76,6 +76,7 @@ import { buildCompositeRegistration, buildDomainFanoutRegistrations } from "./co
 import { newerThanRestoredRelease, serviceKind } from "./project-services";
 import { buildUpstreamUrl, resolveRouteStrategy } from "../../../lib/upstream-url";
 import { withLoopbackPublish } from "../../../lib/loopback-publish";
+import { resolveRouteRedirect } from "../../../lib/domain-redirect";
 
 export interface ComposeDeployResult {
   /** `reconciling` when at least one service's outcome is UNKNOWN because the
@@ -2017,6 +2018,13 @@ export async function deployComposeServices(
           containerPort: port,
         });
       };
+      const validRedirectHosts = [...routeContext.domainByHostname.values()].map(
+        (domain) => domain.hostname,
+      );
+      const resolveRedirectHost = (hostname: string) => {
+        const domain = routeContext.domainByHostname.get(hostname.toLowerCase());
+        return domain ? resolveRouteRedirect(domain, validRedirectHosts) : null;
+      };
       const composite = buildCompositeRegistration({
         services: enabled,
         routingConfig: project.routingConfig,
@@ -2025,6 +2033,7 @@ export async function deployComposeServices(
         // still proxies the backend at the prefix, in the same vhost.
         resolveStaticRoot: (serviceId) =>
           results.find((r) => r.serviceId === serviceId)?.staticRoot ?? null,
+        resolveRedirectHost,
         resolveDomain: (serviceId) => {
           const svc = enabled.find((s) => s.id === serviceId);
           // Composite (vercel-style single-domain) uses the service's PRIMARY route.
@@ -2054,6 +2063,7 @@ export async function deployComposeServices(
           ...(r.proxyLocations?.length ? { proxyLocations: r.proxyLocations } : {}),
           ...(r.redirects?.length ? { redirects: r.redirects } : {}),
           ...(r.headerRules?.length ? { headerRules: r.headerRules } : {}),
+          ...(r.redirectHost ? { redirectHost: r.redirectHost } : {}),
           ...(routeContext.proxy ? { proxy: routeContext.proxy } : {}),
         });
         logger.log(
@@ -2067,6 +2077,7 @@ export async function deployComposeServices(
       for (const reg of buildDomainFanoutRegistrations({
         routes: project.compositeRoutes,
         resolveTargetUrl,
+        resolveRedirectHost,
       })) {
         await routeContext.routing.registerRoute({
           domain: reg.hostname,
@@ -2077,6 +2088,7 @@ export async function deployComposeServices(
           ),
           targetUrl: reg.targetUrl!,
           ...(reg.proxyLocations?.length ? { proxyLocations: reg.proxyLocations } : {}),
+          ...(reg.redirectHost ? { redirectHost: reg.redirectHost } : {}),
           ...(routeContext.proxy ? { proxy: routeContext.proxy } : {}),
         });
         logger.log(

--- a/apps/api/src/modules/deployments/preflight.ts
+++ b/apps/api/src/modules/deployments/preflight.ts
@@ -15,8 +15,10 @@ import type { DeploymentConfigSnapshot } from "./build.service";
 import { platform } from "../../lib/controller-helpers";
 import {
   resolveEffectiveTarget,
+  resolveTargetSourceCloneSupport,
   usesManagedRouting as usesManagedRoutingFor,
 } from "../../lib/deployment-runtime";
+import { resolveBuildRuntimeModes } from "./build-execution-plan";
 import {
   resolveServiceHostnameLabel,
   normalizeCustomHostname,
@@ -30,7 +32,11 @@ import { runCloudPreflight, type CloudPreflightData } from "../../lib/cloud-pref
 import { isStaticService, type DeployableService } from "../../lib/deployable-service";
 import { isFullyPinned, snapshotNeedsGitSource } from "./pinned-artifacts";
 import { serviceKind } from "./compose/project-services";
-import { relayConfigEligible, resolveClonePlan } from "./clone-plan";
+import {
+  relayConfigEligible,
+  resolveClonePlan,
+  type SourceExecutionSite,
+} from "./clone-plan";
 import { hasLocalGitIdentity } from "../github/github.local-auth";
 import { isPublicRepo } from "../github/github.http";
 import { getRoutingBaseDomain } from "../../lib/routing-domains";
@@ -222,8 +228,8 @@ async function checkGitHubAppInstallation(
  *
  *   - The API runs in a non-App mode (oauth / cli / token) - no short-lived
  *     installation token exists to mint.
- *   - The build runs on the deploy target (`buildStrategy === "server"`),
- *     not on the API host - so the token has to travel.
+ *   - Source acquisition runs on the target host, not on the API host - so the
+ *     token has to travel.
  *   - The deploy target is remote (not the same host as the API).
  *
  * In that combination, today we ship the OAuth / gh / static PAT to the
@@ -253,7 +259,7 @@ async function relayWillClone(
 async function checkRemoteBuildTokenLeak(
   ctx: RequestContext | null,
   effectiveTarget: string,
-  buildStrategy: "local" | "server" | undefined,
+  sourceSite: SourceExecutionSite,
   serverId: string | undefined,
   isDesktop: boolean,
   forwardGitCredentials: boolean | undefined,
@@ -269,7 +275,7 @@ async function checkRemoteBuildTokenLeak(
   // App-scoped modes (local-signed or cloud-proxied) already use
   // short-lived installation tokens — safe to ship to a remote build.
   if (mode === "app" || mode === "cloud-app") return { ...baseCheck, status: "pass" };
-  if (buildStrategy === "local") return { ...baseCheck, status: "pass" };
+  if (sourceSite === "api-host") return { ...baseCheck, status: "pass" };
   if (effectiveTarget === "cloud") return { ...baseCheck, status: "pass" };
   // A per-server credential means the clone authenticates as the SERVER, not by
   // shipping the operator's gh-cli token off-host — so the leak concern (and the
@@ -326,7 +332,7 @@ async function checkRemoteBuildTokenLeak(
  *
  * Skipped when:
  *   - no userId / no owner (nothing to resolve)
- *   - buildStrategy === "local" (clone happens on the API host, not remote)
+ *   - sourceSite === "api-host" (clone happens here, not remotely)
  *   - effectiveTarget === "local" (no remote at all)
  *
  * On fail, emits GITHUB_REMOTE_TOKEN_REQUIRED — the dashboard maps that
@@ -340,7 +346,7 @@ async function checkRemoteCloneToken(
   owner: string | null | undefined,
   projectId: string | undefined,
   effectiveTarget: string,
-  buildStrategy: "local" | "server" | undefined,
+  sourceSite: SourceExecutionSite,
   serverId: string | undefined,
   isDesktop: boolean,
   forwardGitCredentials: boolean | undefined,
@@ -350,7 +356,7 @@ async function checkRemoteCloneToken(
     label: "Remote clone credential",
   };
   if (!ctx || !owner) return { ...baseCheck, status: "pass" };
-  if (buildStrategy === "local") return { ...baseCheck, status: "pass" };
+  if (sourceSite === "api-host") return { ...baseCheck, status: "pass" };
   if (effectiveTarget === "local") return { ...baseCheck, status: "pass" };
 
   // A per-server GitHub credential (device token / PAT / SSH key) satisfies the
@@ -1403,6 +1409,39 @@ export async function runPreflightChecks(
   const effectiveBuildStrategy =
     opts?.buildStrategy ?? (snapshot.buildStrategy as "local" | "server" | undefined);
 
+  // Resolve the same BUILD runtime and concrete source-acquisition topology the
+  // pipeline will use. A static/bare service can be built in Docker, and a
+  // "This Server" Docker target uses a socket transport that stages source in
+  // the API process. Credential preflight must follow that physical site.
+  const configuredRuntimeMode = snapshot.runtimeMode ?? "docker";
+  const runtimeModes = resolveBuildRuntimeModes({
+    hasServer: !!snapshot.hasServer,
+    serverId: snapshot.serverId,
+    baseTarget: plat.target,
+    effectiveTarget,
+    willRunServices: !!opts?.multiService,
+  });
+  const buildRuntimeMode = runtimeModes.buildRuntimeMode ?? configuredRuntimeMode;
+  const targetSourceCloneSupported =
+    effectiveTarget === "server" &&
+    (buildRuntimeMode === "bare" || snapshot.cloneStrategy === "server")
+      ? await resolveTargetSourceCloneSupport({
+          effectiveTarget,
+          runtimeMode: buildRuntimeMode,
+          serverId: snapshot.serverId,
+          organizationId: snapshot.organizationId,
+        })
+      : false;
+  const clonePlan = resolveClonePlan({
+    effectiveTarget,
+    runtimeIsBare: buildRuntimeMode === "bare",
+    cloneStrategy: snapshot.cloneStrategy,
+    buildStrategy: effectiveBuildStrategy,
+    isDesktop: plat.target === "desktop",
+    forwardGitCredentials: snapshot.forwardGitCredentials,
+    targetSourceCloneSupported,
+  });
+
   // A PUBLIC github.com repo clones with NO credential, so none of the
   // credential checks below should block it — this is how a public repo
   // deploys on Vercel. Probe tokenlessly (cached, fails CLOSED): private /
@@ -1412,34 +1451,27 @@ export async function runPreflightChecks(
   const ghRepo = parseGithubOwnerRepo(snapshot.repoUrl, opts?.gitOwner, opts?.gitRepo);
   const repoIsPublic = ghRepo ? await isPublicRepo(ghRepo.owner, ghRepo.repo) : false;
 
-  // GitHub App installation check — only relevant when the repo is cloned on a
-  // REMOTE build worker (server build). A LOCAL build ("Build on this machine")
-  // clones on the API host using local credentials (gh CLI / OAuth), so the
-  // cloud App installation is irrelevant — skip it. This mirrors the
-  // remote-clone-token check below, which already passes for local builds.
-  if (!repoIsPublic && getGitHubAuthMode() === "app" && effectiveBuildStrategy !== "local") {
+  // GitHub App installation check — only relevant when source acquisition runs
+  // away from the API host. An API-host clone can use the configured local
+  // credential chain, so no remote-scoped App installation is required.
+  if (!repoIsPublic && getGitHubAuthMode() === "app" && clonePlan.sourceSite !== "api-host") {
     checks.push(
       await checkGitHubAppInstallation(githubCtx, opts?.gitOwner),
     );
   }
 
-  // A remote clone credential is only needed when the repo is actually cloned
-  // ON the remote build worker. Per the build pipeline (build-pipeline.ts:774),
-  // that is ONLY the bare runtime on a server build: Docker builds — including
-  // EVERY services deploy — clone on the orchestrator (the token never leaves
-  // the API host), and cloud builds clone inside the workspace. So the two
-  // credential checks below apply only to bare + server; otherwise the clone is
-  // local and these checks would wrongly demand a remote/App/cloud credential.
-  const runtimeMode = snapshot.runtimeMode ?? "docker";
+  // Bare server deployments cannot transfer a prepared context, so they require
+  // a credential that is valid at the target. Docker target-host acquisition is
+  // handled separately below because it can safely fall back to an API-host
+  // clone + context transfer when no target-safe credential exists.
   const clonesOnRemote =
     !repoIsPublic &&
-    runtimeMode === "bare" &&
+    buildRuntimeMode === "bare" &&
     // Static apps now BUILD in a Docker sandbox (see build-pipeline's static
     // flip) which clones on the orchestrator — never a remote bare clone — so
     // they never need a remote clone credential even if runtimeMode is "bare".
     snapshot.hasServer &&
-    effectiveTarget === "server" &&
-    effectiveBuildStrategy !== "local";
+    clonePlan.sourceSite === "target-host";
 
   if (clonesOnRemote) {
     // Remote-build credential check. For App-scoped modes (app / cloud-app):
@@ -1449,7 +1481,7 @@ export async function runPreflightChecks(
       await checkRemoteBuildTokenLeak(
         githubCtx,
         effectiveTarget,
-        effectiveBuildStrategy,
+        clonePlan.sourceSite,
         snapshot.serverId,
         plat.target === "desktop",
         snapshot.forwardGitCredentials,
@@ -1464,7 +1496,7 @@ export async function runPreflightChecks(
         opts?.gitOwner,
         opts?.projectId,
         effectiveTarget,
-        effectiveBuildStrategy,
+        clonePlan.sourceSite,
         snapshot.serverId,
         plat.target === "desktop",
         snapshot.forwardGitCredentials,
@@ -1479,19 +1511,7 @@ export async function runPreflightChecks(
   // is already covered by the hard-fail clonesOnRemote checks above.
   // Same clone decision the build pipeline uses (resolveClonePlan) — so this
   // credential check verifies exactly the clone the pipeline will perform.
-  const dockerClonesOnServer = resolveClonePlan({
-    effectiveTarget,
-    serverId: snapshot.serverId,
-    runtimeIsBare: runtimeMode === "bare",
-    cloneStrategy: snapshot.cloneStrategy,
-    buildStrategy: effectiveBuildStrategy,
-    isDesktop: plat.target === "desktop",
-    forwardGitCredentials: snapshot.forwardGitCredentials,
-    // GitHub projects carry a parsed gitOwner; docker acquires the source
-    // tarball on the server for them. Same structured signal the pipeline uses
-    // (`!!project.gitOwner`) so the two decisions can't drift.
-    repoIsGithub: !!opts?.gitOwner,
-  }).dockerClonesOnServer;
+  const dockerClonesOnServer = clonePlan.dockerClonesOnServer;
   if (dockerClonesOnServer) {
     checks.push(
       await checkCloneOnServerCredential(

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -6,12 +6,9 @@
  *
  * verifyDomain checks DNS and, on success, kicks off SSL provisioning
  * + promotes the domain to primary if no other custom primary exists.
- * The SSL provisioner (nginx.ts) reads the existing HTTP-only route
- * config off disk and re-registers it with TLS once the cert lands,
- * so no route registration is needed here — the existing infra is
- * reused. SSL provisioning runs in the background; the verify response
- * stays fast and a failed cert (rate-limit, ACME outage) shows up
- * in the SSL status pill on the next read.
+ * A successful self-hosted verification strictly re-applies the live route
+ * before the row becomes verified. Certificate presence alone is not proof
+ * that the edge has a vhost for the hostname.
  */
 
 import { repos, normalizeRoutingFields, type Domain, type Project } from "@repo/db";
@@ -29,6 +26,11 @@ import { getRoutingBaseDomain } from "../../lib/routing-domains";
 import { resolveRecords } from "../../lib/dns-resolver";
 import { resolveProjectServerHost, resolveLocalServerHost, resolveInstancePublicIp, isLoopbackHost } from "../../lib/server-target";
 import { reconcileProjectRoutes } from "../../lib/route-apply.service";
+import {
+  convergeAllProjectRoutes,
+  convergeVerifiedDomainRoute,
+} from "./project-route.service";
+import { syncProjectManagedEdge } from "../projects/project-runtime.service";
 import { generateToken } from "../../lib/domain-token";
 import { untrackedSiteFor } from "../../lib/edge-orphans.service";
 import { publicEndpointHostname, resolveServicePublicEndpoints } from "../../lib/public-endpoints";
@@ -482,6 +484,25 @@ async function markDomainVerifiedActive(
 }
 
 /**
+ * Clear the project-level Action Required flag only when every verified route
+ * can be strictly re-applied. A sibling failure keeps the warning visible but
+ * does not undo this domain's successful certificate + vhost verification.
+ */
+async function clearRoutingWarningAfterFullConvergence(project: Project): Promise<void> {
+  try {
+    await convergeAllProjectRoutes(project);
+    const result = await syncProjectManagedEdge(project, project.organizationId);
+    if (!result.ok) {
+      throw new Error(`managed edge sync failed for ${result.failures.join(", ")}`);
+    }
+  } catch (err) {
+    console.warn(
+      `[DOMAIN] project ${project.id} still has unsynchronised routes: ${safeErrorMessage(err)}`,
+    );
+  }
+}
+
+/**
  * Bare-metal edge, but the SSL executor lands INSIDE a container: every SSL op
  * (certbot, cert read, vhost write) then hits the container's own (empty)
  * `/etc/letsencrypt`, not the host's bare OpenResty — so it silently no-ops.
@@ -582,11 +603,13 @@ export async function reuseServerCertForDomain(ctx: RequestContext, domainId: st
         projectId: domain.projectId ?? undefined,
         allowUnverified: true,
       });
+      await convergeVerifiedDomainRoute(domain, project);
       await markDomainVerifiedActive(domain, domainId, {
         issuer: cert.renewable ? "reused" : cert.issuer,
         ...(cert.renewable ? {} : { manualSsl: true }),
         expiresAt: result.expiresAt || cert.expiresAt,
       });
+      await clearRoutingWarningAfterFullConvergence(project);
       console.log(
         `[DOMAIN] adopted cert for ${domain.hostname} from ${cert.source} ` +
           `(issuer "${cert.issuer}", expires ${cert.expiresAt}, ` +
@@ -600,10 +623,12 @@ export async function reuseServerCertForDomain(ctx: RequestContext, domainId: st
       projectId: domain.projectId ?? undefined,
     }).catch(() => null);
     if (existing?.verified) {
+      await convergeVerifiedDomainRoute(domain, project);
       await markDomainVerifiedActive(domain, domainId, {
         issuer: existing.issuer,
         expiresAt: existing.expiresAt || undefined,
       });
+      await clearRoutingWarningAfterFullConvergence(project);
       return true;
     }
 
@@ -684,10 +709,10 @@ async function certbotLineageDirs(exec: CommandExecutor, hostname: string): Prom
 
 // ─── Verify ──────────────────────────────────────────────────────────────────
 //
-// Checks DNS records and, on success, marks verified + active, promotes
-// to primary (when no other custom primary exists), and fires SSL
-// provisioning in the background. The SSL provider re-registers the
-// route with TLS internally, so no explicit route reconciler is needed.
+// Checks ownership/certificate state and strictly converges the authoritative
+// live route before a self-hosted domain may become verified + active. A retry
+// for an already-verified row repairs routing but preserves its current SSL
+// status; only a real certificate check/issuance may promote TLS to active.
 
 export async function verifyDomain(
   ctx: RequestContext,
@@ -696,18 +721,39 @@ export async function verifyDomain(
 ) {
   const log = (line: string) => opts.onLog?.(line);
   const { domain, project } = await getDomainWithAuth(domainId, ctx.organizationId);
+  const { target } = platform();
 
   if (domain.verified) {
+    if (target !== "cloud" && !domain.externalIngress) {
+      try {
+        log(`Re-applying the live route for ${domain.hostname}…`);
+        await convergeVerifiedDomainRoute(domain, project);
+        await repos.domain.markVerified(domainId);
+        await clearRoutingWarningAfterFullConvergence(project);
+      } catch (err) {
+        const message = `The certificate is valid, but the live route could not be applied: ${safeErrorMessage(err)}`;
+        const attempts = await repos.domain.recordVerifyFailure(domainId, message);
+        return {
+          verified: false,
+          recordVerified: true,
+          cnameVerified: true,
+          txtVerified: true,
+          attempts,
+          message,
+          sslStatus: domain.sslStatus,
+        };
+      }
+    }
     return {
       verified: true,
       cnameVerified: true,
       txtVerified: true,
-      message: "Already verified",
+      message: target !== "cloud" && !domain.externalIngress
+        ? "Already verified — live route re-applied."
+        : "Already verified",
       sslStatus: domain.sslStatus,
     };
   }
-
-  const { target } = platform();
   const external = domain.externalIngress;
 
   const promoteToPrimary = () => promoteCustomDomainToPrimary(domain, domainId);
@@ -785,10 +831,27 @@ export async function verifyDomain(
         log(
           `A valid certificate is already present for ${domain.hostname} (expires ${existing.expiresAt.slice(0, 10)}) — reusing it. No new certificate requested.`,
         );
-        await markDomainVerifiedActive(domain, domainId, {
-          issuer: existing.issuer,
-          expiresAt: existing.expiresAt,
-        });
+        try {
+          await convergeVerifiedDomainRoute(domain, project);
+          await markDomainVerifiedActive(domain, domainId, {
+            issuer: existing.issuer,
+            expiresAt: existing.expiresAt,
+          });
+          await clearRoutingWarningAfterFullConvergence(project);
+        } catch (err) {
+          const message = `A valid certificate exists, but the live route could not be applied: ${safeErrorMessage(err)}`;
+          log(message);
+          const attempts = await repos.domain.recordVerifyFailure(domainId, message);
+          return {
+            verified: false,
+            recordVerified: true,
+            cnameVerified: true,
+            txtVerified: true,
+            attempts,
+            message,
+            sslStatus: existing.verified ? "active" : domain.sslStatus,
+          };
+        }
         return {
           verified: true,
           recordVerified: true,
@@ -808,9 +871,14 @@ export async function verifyDomain(
         force: opts.force,
       });
       if (result.verified) {
-        log("Certificate issued — marking the domain verified and SSL active.");
-        await repos.domain.markVerified(domainId);
-        await promoteToPrimary();
+        log("Certificate issued — applying the live HTTPS route.");
+        await convergeVerifiedDomainRoute(domain, project);
+        log("Live route applied — marking the domain verified and SSL active.");
+        await markDomainVerifiedActive(domain, domainId, {
+          issuer: result.issuer,
+          expiresAt: result.expiresAt || undefined,
+        });
+        await clearRoutingWarningAfterFullConvergence(project);
         return {
           verified: true,
           recordVerified: true,
@@ -1007,11 +1075,27 @@ export async function renewDomainSsl(ctx: RequestContext, domainId: string) {
  * means a transient read failure leaves an "active" domain untouched.
  */
 export async function verifyDomainSsl(ctx: RequestContext, domainId: string) {
-  const { domain } = await getDomainWithAuth(domainId, ctx.organizationId);
+  const { domain, project } = await getDomainWithAuth(domainId, ctx.organizationId);
 
   const result = await manageDomainSsl(domain.hostname, {
     action: "verify",
   });
+
+  // A valid certificate is only half of a working HTTPS route. Rechecking SSL
+  // is the always-available recovery action for an already-verified row, so on
+  // self-hosted TLS also converge the vhost before reporting success. This
+  // makes the dashboard's "Recheck SSL" repair cert-present/vhost-missing drift
+  // without reissuing the certificate or rebuilding the workload.
+  const { target } = platform();
+  if (
+    result.verified &&
+    target !== "cloud" &&
+    !project.cloudWorkspaceId &&
+    !domain.externalIngress
+  ) {
+    await convergeVerifiedDomainRoute(domain, project);
+    await clearRoutingWarningAfterFullConvergence(project);
+  }
 
   // Re-read the persisted row so the response reflects the no-clobber outcome
   // (a transient read failure leaves an existing "active" untouched).

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -12,7 +12,16 @@
  */
 
 import { repos, normalizeRoutingFields, type Domain, type Project } from "@repo/db";
-import { NotFoundError, ConflictError, ValidationError, safeErrorMessage, normalizeCustomHostname, isValidCustomHostname, wwwSiblingHostname, SYSTEM } from "@repo/core";
+import {
+  NotFoundError,
+  ConflictError,
+  ValidationError,
+  safeErrorMessage,
+  normalizeCustomHostname,
+  isValidCustomHostname,
+  wwwSiblingHostname,
+  SYSTEM,
+} from "@repo/core";
 import { platform, assertResourceInOrg } from "../../lib/controller-helpers";
 import { buildBackgroundContext, type RequestContext } from "../../lib/request-context";
 import {
@@ -24,12 +33,14 @@ import {
 } from "../../lib/domain-ssl";
 import { getRoutingBaseDomain } from "../../lib/routing-domains";
 import { resolveRecords } from "../../lib/dns-resolver";
-import { resolveProjectServerHost, resolveLocalServerHost, resolveInstancePublicIp, isLoopbackHost } from "../../lib/server-target";
-import { reconcileProjectRoutes } from "../../lib/route-apply.service";
 import {
-  convergeAllProjectRoutes,
-  convergeVerifiedDomainRoute,
-} from "./project-route.service";
+  resolveProjectServerHost,
+  resolveLocalServerHost,
+  resolveInstancePublicIp,
+  isLoopbackHost,
+} from "../../lib/server-target";
+import { reconcileProjectRoutes } from "../../lib/route-apply.service";
+import { convergeAllProjectRoutes, convergeVerifiedDomainRoute } from "./project-route.service";
 import { syncProjectManagedEdge } from "../projects/project-runtime.service";
 import { generateToken } from "../../lib/domain-token";
 import { untrackedSiteFor } from "../../lib/edge-orphans.service";
@@ -165,10 +176,7 @@ export async function addDomain(
     // still running), retrying must resume from the existing row instead of
     // trapping the user behind a same-project "already in use" conflict.
     const patch: Partial<Domain> = {};
-    if (
-      data.externalIngress !== undefined &&
-      existing.externalIngress !== data.externalIngress
-    ) {
+    if (data.externalIngress !== undefined && existing.externalIngress !== data.externalIngress) {
       patch.externalIngress = data.externalIngress;
     }
     // Only ever SET a redirect here; `redirectTo: undefined` (the common case —
@@ -373,9 +381,7 @@ export async function ensurePendingServiceDomain(opts: {
   // surface it as a conflict (matches addDomain) instead of silently skipping.
   const foreign = await repos.domain.findByHostname(hostname);
   if (foreign) {
-    throw new ConflictError(
-      `The domain "${hostname}" is already connected to another project.`,
-    );
+    throw new ConflictError(`The domain "${hostname}" is already connected to another project.`);
   }
 
   // findOrCreate (not create) so a concurrent insert of the same brand-new
@@ -471,9 +477,10 @@ async function markDomainVerifiedActive(
   domainId: string,
   ssl: { issuer?: string; expiresAt?: string; manualSsl?: boolean },
 ): Promise<void> {
-  const promote = (await shouldPromoteToPrimary(domain, domainId)) && domain.projectId
-    ? { projectId: domain.projectId }
-    : undefined;
+  const promote =
+    (await shouldPromoteToPrimary(domain, domainId)) && domain.projectId
+      ? { projectId: domain.projectId }
+      : undefined;
   await repos.domain.markVerifiedActive(domainId, {
     sslStatus: "active",
     ...(ssl.manualSsl ? { manualSsl: true } : {}),
@@ -522,20 +529,24 @@ async function edgeHostUnreachable(ctx: RequestContext, project: Project): Promi
   // the FIRST, feedback-less blocking call and make verify look hung).
   const serverId = await resolveServerIdForProject(project);
   if (!serverId) return false;
-  const server = await repos.server.getInOrganization(serverId, ctx.organizationId).catch(() => null);
+  const server = await repos.server
+    .getInOrganization(serverId, ctx.organizationId)
+    .catch(() => null);
   if (!server?.isLocal) return false;
-  return sshManager
-    .withHostExecutor(
-      async (exec) =>
-        (await exec.exists("/.dockerenv").catch(() => false)) ||
-        (await exec.exists("/run/.containerenv").catch(() => false)),
-    )
-    // Acquiring the host channel THROWS when the API is containerized with no
-    // channel provisioned — which is precisely this function's "unreachable" case,
-    // so it must answer TRUE. Answering false would let verify march on to a
-    // certbot attempt that fails far from the cause, instead of surfacing
-    // HOST_CHANNEL_HINT below.
-    .catch(() => true);
+  return (
+    sshManager
+      .withHostExecutor(
+        async (exec) =>
+          (await exec.exists("/.dockerenv").catch(() => false)) ||
+          (await exec.exists("/run/.containerenv").catch(() => false)),
+      )
+      // Acquiring the host channel THROWS when the API is containerized with no
+      // channel provisioned — which is precisely this function's "unreachable" case,
+      // so it must answer TRUE. Answering false would let verify march on to a
+      // certbot attempt that fails far from the cause, instead of surfacing
+      // HOST_CHANNEL_HINT below.
+      .catch(() => true)
+  );
 }
 
 const HOST_CHANNEL_HINT =
@@ -575,7 +586,10 @@ function isPathSafeHostname(hostname: string): boolean {
  * Self-hosted only; best-effort + non-fatal (domains never fail a deploy, see
  * [[domains-never-fail-deploy]]). Returns true when it adopted a cert.
  */
-export async function reuseServerCertForDomain(ctx: RequestContext, domainId: string): Promise<boolean> {
+export async function reuseServerCertForDomain(
+  ctx: RequestContext,
+  domainId: string,
+): Promise<boolean> {
   try {
     const { domain, project } = await getDomainWithAuth(domainId, ctx.organizationId);
     if (domain.verified) return true; // already good — nothing to reuse
@@ -748,9 +762,10 @@ export async function verifyDomain(
       verified: true,
       cnameVerified: true,
       txtVerified: true,
-      message: target !== "cloud" && !domain.externalIngress
-        ? "Already verified — live route re-applied."
-        : "Already verified",
+      message:
+        target !== "cloud" && !domain.externalIngress
+          ? "Already verified — live route re-applied."
+          : "Already verified",
       sslStatus: domain.sslStatus,
     };
   }
@@ -781,7 +796,8 @@ export async function verifyDomain(
         recordVerified: true,
         cnameVerified: true,
         txtVerified: true,
-        message: "Domain verified — TLS is handled by your external ingress; no certificate is issued here.",
+        message:
+          "Domain verified — TLS is handled by your external ingress; no certificate is issued here.",
         sslStatus: "external",
       };
     }
@@ -792,7 +808,14 @@ export async function verifyDomain(
     if (await edgeHostUnreachable(ctx, project)) {
       log(HOST_CHANNEL_HINT);
       const attempts = await repos.domain.recordVerifyFailure(domainId, HOST_CHANNEL_HINT);
-      return { verified: false, recordVerified: false, cnameVerified: false, txtVerified: false, attempts, message: HOST_CHANNEL_HINT };
+      return {
+        verified: false,
+        recordVerified: false,
+        cnameVerified: false,
+        txtVerified: false,
+        attempts,
+        message: HOST_CHANNEL_HINT,
+      };
     }
 
     // Fast-fail a dead/slow REMOTE server (~2.5s TCP probe) with a clear message
@@ -800,7 +823,9 @@ export async function verifyDomain(
     // connect timeout while the modal sits on a blank "Connecting…".
     const serverId = await resolveServerIdForProject(project);
     if (serverId) {
-      const server = await repos.server.getInOrganization(serverId, ctx.organizationId).catch(() => null);
+      const server = await repos.server
+        .getInOrganization(serverId, ctx.organizationId)
+        .catch(() => null);
       if (server && !server.isLocal) {
         log(`Connecting to ${server.name || server.sshHost || "the server"}…`);
         const reachable = await sshManager.probeReachable(serverId).catch(() => false);
@@ -808,7 +833,14 @@ export async function verifyDomain(
           const message = `Can't reach ${server.sshHost || "the server"} over SSH — check it's online and reachable, then Verify again.`;
           log(message);
           const attempts = await repos.domain.recordVerifyFailure(domainId, message);
-          return { verified: false, recordVerified: false, cnameVerified: false, txtVerified: false, attempts, message };
+          return {
+            verified: false,
+            recordVerified: false,
+            cnameVerified: false,
+            txtVerified: false,
+            attempts,
+            message,
+          };
         }
       }
     }
@@ -857,7 +889,8 @@ export async function verifyDomain(
           recordVerified: true,
           cnameVerified: true,
           txtVerified: true,
-          message: "Domain verified — a valid certificate is already present; no new certificate was requested.",
+          message:
+            "Domain verified — a valid certificate is already present; no new certificate was requested.",
           sslStatus: "active",
         };
       }
@@ -900,13 +933,27 @@ export async function verifyDomain(
         `Couldn't confirm a certificate (${detail}). Make sure the domain points at this server (a CDN like ` +
         `Cloudflare in front is fine) and ports 80/443 are reachable, then Verify again.`;
       const attempts = await repos.domain.recordVerifyFailure(domainId, message);
-      return { verified: false, recordVerified: false, cnameVerified: false, txtVerified: false, attempts, message };
+      return {
+        verified: false,
+        recordVerified: false,
+        cnameVerified: false,
+        txtVerified: false,
+        attempts,
+        message,
+      };
     } catch (err) {
       // summarizeCertbotFailure (adapters) already mapped this to the real cause
       // — DNS not resolving, :80 firewalled, or a proxy 404. Surface it verbatim.
       const message = safeErrorMessage(err);
       const attempts = await repos.domain.recordVerifyFailure(domainId, message);
-      return { verified: false, recordVerified: false, cnameVerified: false, txtVerified: false, attempts, message };
+      return {
+        verified: false,
+        recordVerified: false,
+        cnameVerified: false,
+        txtVerified: false,
+        attempts,
+        message,
+      };
     }
   }
 
@@ -926,7 +973,8 @@ export async function verifyDomain(
         verified: true,
         cnameVerified: true,
         txtVerified: true,
-        message: "Domain verified — TLS is handled by your external ingress; no certificate is issued here.",
+        message:
+          "Domain verified — TLS is handled by your external ingress; no certificate is issued here.",
         sslStatus: "external",
       };
     }
@@ -1116,11 +1164,7 @@ export async function verifyDomainSsl(ctx: RequestContext, domainId: string) {
  * from the uploaded cert and never runs certbot — the piece that gives an
  * externalIngress domain (Cloudflare Full-strict) a real cert at origin.
  */
-export async function uploadDomainCert(
-  ctx: RequestContext,
-  domainId: string,
-  cert: ManualCert,
-) {
+export async function uploadDomainCert(ctx: RequestContext, domainId: string, cert: ManualCert) {
   const { domain } = await getDomainWithAuth(domainId, ctx.organizationId);
 
   const result = await installDomainCert(domain.hostname, cert, {
@@ -1337,7 +1381,10 @@ export async function verifyPendingDomains(opts?: {
 }
 
 export async function renewOrgCerts(ctx: RequestContext) {
-  const projects = await repos.project.listByOrganization(ctx.organizationId, { page: 1, perPage: 1000 });
+  const projects = await repos.project.listByOrganization(ctx.organizationId, {
+    page: 1,
+    perPage: 1000,
+  });
   const results: Array<{ domain: string; status: string; error?: string }> = [];
 
   for (const p of projects.rows) {
@@ -1485,7 +1532,9 @@ async function buildRecords(
       const cloud = runtime as CloudRuntime;
       const result = await cloud.verifyDomain(hostname);
       cnameTarget = result.requiredRecords.cname.target;
-    } catch { /* Oblien unreachable */ }
+    } catch {
+      /* Oblien unreachable */
+    }
 
     const records: DnsRecord[] = [
       { type: "CNAME", host: routeHost, name: routeName, value: cnameTarget ?? "" },

--- a/apps/api/src/modules/domains/ensure-edge.controller.ts
+++ b/apps/api/src/modules/domains/ensure-edge.controller.ts
@@ -75,13 +75,18 @@ async function isLocalHostServer(serverId: string, organizationId: string): Prom
 export async function resolveProjectServer(
   projectId: string,
   organizationId: string,
-): Promise<{ project: NonNullable<Awaited<ReturnType<typeof repos.project.findById>>>; serverId: string } | { error: string; status: 400 | 404 }> {
+): Promise<
+  | { project: NonNullable<Awaited<ReturnType<typeof repos.project.findById>>>; serverId: string }
+  | { error: string; status: 400 | 404 }
+> {
   const project = await repos.project.findById(projectId);
-  if (!project || project.organizationId !== organizationId) return { error: "Project not found", status: 404 };
+  if (!project || project.organizationId !== organizationId)
+    return { error: "Project not found", status: 404 };
   if (project.cloudWorkspaceId) {
     return { error: "Cloud projects manage routing at the edge automatically", status: 400 };
   }
-  if (!project.activeDeploymentId) return { error: "Deploy the project before setting up its edge", status: 400 };
+  if (!project.activeDeploymentId)
+    return { error: "Deploy the project before setting up its edge", status: 400 };
   // Prefer the durable binding; fall back to the active deployment's snapshot for
   // legacy rows not yet backfilled.
   const dep = await repos.deployment.findById(project.activeDeploymentId);
@@ -253,7 +258,9 @@ export async function ensureEdgeStream(c: Context) {
       })().catch(() => {});
       const retry = await retryProjectRouting(id, ctx.organizationId);
       if (!retry.ok) {
-        throw new Error(retry.warning || "Edge is ready, but one or more routes could not be applied.");
+        throw new Error(
+          retry.warning || "Edge is ready, but one or more routes could not be applied.",
+        );
       }
       appendEdgeLog(session.id, "Done — routes are live.");
       finishEdgeConsentSession(session.id, "completed");

--- a/apps/api/src/modules/domains/ensure-edge.controller.ts
+++ b/apps/api/src/modules/domains/ensure-edge.controller.ts
@@ -4,7 +4,7 @@
  * the exact engine (`ensureEdge` → `ensureEdgeClear` → `runEdgeTakeover`) and the
  * generic prompt transport, so the SAME consent modal appears — but WITHOUT a
  * container redeploy: it installs/owns the edge on the project's server, then
- * re-applies the project's routes reload-free via `applyProjectRouting`.
+ * re-applies the project's routes reload-free via the strict retry reconciler.
  *
  * Used by the Domains tab (first route / "set up edge") instead of forcing a
  * full deploy — which matters for migrated attach-live stacks whose containers
@@ -32,7 +32,7 @@ import { streamSSE } from "../../lib/sse";
 import { sshManager } from "../../lib/ssh-manager";
 import { withPinnedEdgeImage } from "../../lib/edge-image";
 import { resolveAcmeProviderOptions } from "../../lib/acme-config";
-import { applyProjectRouting } from "./routing-apply.service";
+import { retryProjectRouting } from "../projects/project-runtime.service";
 import {
   createEdgeConsentSession,
   getEdgeConsentSession,
@@ -251,9 +251,10 @@ export async function ensureEdgeStream(c: Context) {
           onLog: (m) => appendEdgeLog(session.id, m.trim(), "warn"),
         });
       })().catch(() => {});
-      await applyProjectRouting(id).catch((e) =>
-        appendEdgeLog(session.id, `Route apply warning: ${safeErrorMessage(e)}`, "warn"),
-      );
+      const retry = await retryProjectRouting(id, ctx.organizationId);
+      if (!retry.ok) {
+        throw new Error(retry.warning || "Edge is ready, but one or more routes could not be applied.");
+      }
       appendEdgeLog(session.id, "Done — routes are live.");
       finishEdgeConsentSession(session.id, "completed");
     } catch (err) {

--- a/apps/api/src/modules/domains/project-route.service.ts
+++ b/apps/api/src/modules/domains/project-route.service.ts
@@ -15,7 +15,10 @@ import { buildUpstreamUrl, resolveUpstreamUrl, resolveRouteStrategy } from "../.
 import { deregisterManagedEdgeRoutes, syncManagedEdgeRoutes } from "../../lib/managed-edge-proxy";
 import { syncProjectPublicRoutes } from "../../lib/project-route-store";
 import { resolveRouteRedirect } from "../../lib/domain-redirect";
-import { resolveDeploymentRuntime, resolveDeploymentStaticRoot } from "../../lib/deployment-runtime";
+import {
+  resolveDeploymentRuntime,
+  resolveDeploymentStaticRoot,
+} from "../../lib/deployment-runtime";
 import { buildServiceRouteDomains } from "../../lib/routing-domains";
 import { isStaticService } from "../../lib/deployable-service";
 import { applyProjectRouting } from "./routing-apply.service";
@@ -56,19 +59,23 @@ export function deriveEnvironmentPublicEndpoints(
   if (!primaryEndpoint) return [];
 
   if (primaryEndpoint.targetPath) {
-    return [{
-      targetPath: primaryEndpoint.targetPath,
-      domain: normalizedSlug,
-      domainType: "free",
-    }];
+    return [
+      {
+        targetPath: primaryEndpoint.targetPath,
+        domain: normalizedSlug,
+        domainType: "free",
+      },
+    ];
   }
 
   if (primaryEndpoint.port !== undefined) {
-    return [{
-      port: primaryEndpoint.port,
-      domain: normalizedSlug,
-      domainType: "free",
-    }];
+    return [
+      {
+        port: primaryEndpoint.port,
+        domain: normalizedSlug,
+        domainType: "free",
+      },
+    ];
   }
 
   return [];
@@ -91,7 +98,10 @@ function draftEndpointsWithIds(
   endpoints: StoredPublicEndpoint[],
 ): ProjectRouteEndpoint[] {
   const idByHostname = new Map(
-    normalizeProjectRouteRows(projectDomains).map((domain) => [domain.hostname.toLowerCase(), domain.id]),
+    normalizeProjectRouteRows(projectDomains).map((domain) => [
+      domain.hostname.toLowerCase(),
+      domain.id,
+    ]),
   );
 
   return endpoints.map((endpoint, index) => {
@@ -204,7 +214,7 @@ export async function resolveProjectRouteState(
   project: ProjectRouteProject,
   opts?: { projectDomains?: Domain[] },
 ): Promise<ProjectRouteState> {
-  const projectDomains = opts?.projectDomains ?? await listProjectRouteRows(project.id);
+  const projectDomains = opts?.projectDomains ?? (await listProjectRouteRows(project.id));
   return deriveProjectRouteState(project, { projectDomains });
 }
 
@@ -237,7 +247,7 @@ export async function syncProjectRouteState(
     preserveVerifiedCustom?: boolean;
   },
 ): Promise<ProjectRouteState> {
-  const projectDomains = input.projectDomains ?? await listProjectRouteRows(project.id);
+  const projectDomains = input.projectDomains ?? (await listProjectRouteRows(project.id));
   const nextState = deriveNextProjectRouteState(project, {
     ...input,
     projectDomains,
@@ -342,7 +352,8 @@ export async function reapplyProjectLiveRoutes(
 ): Promise<void> {
   const isCloud = !!project.cloudWorkspaceId;
   if (!isCloud && !project.activeDeploymentId) {
-    if (opts.strict) throw new ValidationError("No active deployment is available for this domain route");
+    if (opts.strict)
+      throw new ValidationError("No active deployment is available for this domain route");
     return;
   }
 
@@ -353,7 +364,8 @@ export async function reapplyProjectLiveRoutes(
   );
   const allCurrent = normalizeProjectRouteRows(state.projectDomains);
   const current = allCurrent.filter(
-    (domain) => !opts.onlyHostname || domain.hostname.toLowerCase() === opts.onlyHostname.toLowerCase(),
+    (domain) =>
+      !opts.onlyHostname || domain.hostname.toLowerCase() === opts.onlyHostname.toLowerCase(),
   );
   if (opts.strict && opts.onlyHostname && current.length === 0) {
     throw new ValidationError(`No project route is configured for ${opts.onlyHostname}`);
@@ -408,7 +420,8 @@ export async function reapplyProjectLiveRoutes(
   // resolver deploy/delete use), then compute each upstream from the container.
   const deployment = await repos.deployment.findById(project.activeDeploymentId!);
   if (!deployment) {
-    if (opts.strict) throw new ValidationError("The active deployment could not be found for this domain route");
+    if (opts.strict)
+      throw new ValidationError("The active deployment could not be found for this domain route");
     console.warn(
       `[project-route] ${project.slug}: no active deployment row — skipping live route re-apply`,
     );
@@ -472,7 +485,9 @@ export async function reapplyProjectLiveRoutes(
     await pushProjectRules(project.id, serverId ?? null, previousHostnames).catch(() => {});
     // Shared-dict state is RAM: the analytics collection switches have to be re-pushed
     // whenever routing is applied, or an nginx restart silently reverts them to off.
-    await pushProjectAnalyticsConfig(project.id, serverId ?? null, previousHostnames).catch(() => {});
+    await pushProjectAnalyticsConfig(project.id, serverId ?? null, previousHostnames).catch(
+      () => {},
+    );
     syncAddedManagedEdge();
     return;
   }
@@ -483,9 +498,16 @@ export async function reapplyProjectLiveRoutes(
     // live). Bare / no-host-port fall back to container IP (or 127.0.0.1 bare).
     let hostPort: number | undefined;
     if (strategy === "loopback-port" && runtime.name !== "bare") {
-      hostPort = (await runtime.getContainerInfo?.(containerId).catch(() => null))?.hostPort ?? undefined;
+      hostPort =
+        (await runtime.getContainerInfo?.(containerId).catch(() => null))?.hostPort ?? undefined;
     }
-    const url = await resolveUpstreamUrl({ strategy, runtime, containerId, containerPort: port, hostPort });
+    const url = await resolveUpstreamUrl({
+      strategy,
+      runtime,
+      containerId,
+      containerPort: port,
+      hostPort,
+    });
     if (!url) {
       console.warn(
         `[project-route] ${project.slug}: could not resolve upstream for ${containerId} (target=${effectiveTarget}, server=${serverId ?? "local"})`,
@@ -542,7 +564,10 @@ export async function reapplyProjectLiveRoutes(
       try {
         // Same call the deploy path's route registration and the output probe
         // make — one rule for "which directory does this path serve".
-        registers.push({ ...common, staticRoot: resolveServedStaticPath(staticRootBase, domain.targetPath) });
+        registers.push({
+          ...common,
+          staticRoot: resolveServedStaticPath(staticRootBase, domain.targetPath),
+        });
       } catch (err) {
         // A `../` in the operator's route path. Refuse this ONE route; the rest of
         // the re-apply (and the project's other domains) must still go through.
@@ -574,9 +599,9 @@ export async function reapplyProjectLiveRoutes(
   // hostnames. Best-effort — the DB is the source of truth; a failure defers to
   // the next reconcile. previousHostnames clears rules for any dropped hostname.
   await pushProjectRules(project.id, serverId ?? null, previousHostnames).catch(() => {});
-    // Shared-dict state is RAM: the analytics collection switches have to be re-pushed
-    // whenever routing is applied, or an nginx restart silently reverts them to off.
-    await pushProjectAnalyticsConfig(project.id, serverId ?? null, previousHostnames).catch(() => {});
+  // Shared-dict state is RAM: the analytics collection switches have to be re-pushed
+  // whenever routing is applied, or an nginx restart silently reverts them to off.
+  await pushProjectAnalyticsConfig(project.id, serverId ?? null, previousHostnames).catch(() => {});
 
   // Register the newly-added managed slug(s) on the cloud edge (the "add" half
   // of the edit; dropped slugs were deregistered above). Per-route — unchanged
@@ -635,9 +660,8 @@ export async function convergeVerifiedDomainRoute(domain: Domain, project: Proje
 
   const liveRows = await repos.service.listByDeployment(project.activeDeploymentId);
   const live = liveRows.find((row) => row.serviceId === service.id);
-  const staticRoot = isStaticService(service) && live?.imageRef?.startsWith("/")
-    ? live.imageRef
-    : null;
+  const staticRoot =
+    isStaticService(service) && live?.imageRef?.startsWith("/") ? live.imageRef : null;
   const targetUrl = staticRoot
     ? null
     : buildUpstreamUrl({
@@ -651,21 +675,26 @@ export async function convergeVerifiedDomainRoute(domain: Domain, project: Proje
   }
 
   const allDomains = await repos.domain.listByProject(project.id);
-  const redirectHost = resolveRouteRedirect(domain, allDomains.map((row) => row.hostname));
+  const redirectHost = resolveRouteRedirect(
+    domain,
+    allDomains.map((row) => row.hostname),
+  );
 
   await reconcileProjectRoutes(project, {
     deployment,
     routing,
     strict: true,
-    registers: [{
-      hostname: planned.hostname,
-      ...(staticRoot ? { staticRoot } : { targetUrl: targetUrl! }),
-      port: planned.targetPort,
-      isCustomDomain: planned.domainType === "custom",
-      tls: planned.tls,
-      terminatesTlsLocally: planned.terminatesTlsLocally,
-      ...(redirectHost ? { redirectHost } : {}),
-    }],
+    registers: [
+      {
+        hostname: planned.hostname,
+        ...(staticRoot ? { staticRoot } : { targetUrl: targetUrl! }),
+        port: planned.targetPort,
+        isCustomDomain: planned.domainType === "custom",
+        tls: planned.tls,
+        terminatesTlsLocally: planned.terminatesTlsLocally,
+        ...(redirectHost ? { redirectHost } : {}),
+      },
+    ],
   });
 }
 

--- a/apps/api/src/modules/domains/project-route.service.ts
+++ b/apps/api/src/modules/domains/project-route.service.ts
@@ -1,5 +1,5 @@
 import { repos, type Domain, type Project } from "@repo/db";
-import { safeErrorMessage } from "@repo/core";
+import { safeErrorMessage, ValidationError } from "@repo/core";
 import { resolveServedStaticPath } from "@repo/adapters";
 import {
   isLoopbackHost,
@@ -11,11 +11,14 @@ import {
   type StoredPublicEndpoint,
 } from "../../lib/public-endpoints";
 import { assertValidCustomDomain, assertValidCustomDomains } from "../../lib/custom-domain-guard";
-import { resolveUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
+import { buildUpstreamUrl, resolveUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
 import { deregisterManagedEdgeRoutes, syncManagedEdgeRoutes } from "../../lib/managed-edge-proxy";
 import { syncProjectPublicRoutes } from "../../lib/project-route-store";
 import { resolveRouteRedirect } from "../../lib/domain-redirect";
 import { resolveDeploymentRuntime, resolveDeploymentStaticRoot } from "../../lib/deployment-runtime";
+import { buildServiceRouteDomains } from "../../lib/routing-domains";
+import { isStaticService } from "../../lib/deployable-service";
+import { applyProjectRouting } from "./routing-apply.service";
 import { pushProjectRules } from "../route-rules/route-rule.service";
 import { pushProjectAnalyticsConfig } from "../analytics/analytics-config.service";
 import {
@@ -260,8 +263,8 @@ export async function syncProjectRouteState(
  * upstream from the active deployment's container (docker) or the host (bare).
  * Cloud re-applies via the runtime's page/workspace primitives.
  *
- * Static-path routes (served straight from the web root) are left to the next
- * deploy — they have no live upstream to point at here.
+ * Static-path routes reuse the deployment's persisted served root, so edits and
+ * verification can restore them without a redeploy.
  */
 export interface ReapplyProjectLiveRoutesOptions {
   /**
@@ -292,6 +295,12 @@ export interface ReapplyProjectLiveRoutesOptions {
    * correct by default.
    */
   managedEdgeSyncedByCaller?: boolean;
+
+  /** Fail unless every requested local route is actually written. */
+  strict?: boolean;
+
+  /** Limit a recovery reconcile to one hostname instead of coupling siblings. */
+  onlyHostname?: string;
 }
 
 /**
@@ -332,10 +341,23 @@ export async function reapplyProjectLiveRoutes(
   opts: ReapplyProjectLiveRoutesOptions = {},
 ): Promise<void> {
   const isCloud = !!project.cloudWorkspaceId;
-  if (!isCloud && !project.activeDeploymentId) return;
+  if (!isCloud && !project.activeDeploymentId) {
+    if (opts.strict) throw new ValidationError("No active deployment is available for this domain route");
+    return;
+  }
 
-  const state = await resolveProjectRouteState({ id: project.id, slug: project.slug });
-  const current = normalizeProjectRouteRows(state.projectDomains);
+  const allDomainRows = await listProjectRouteRows(project.id);
+  const state = await resolveProjectRouteState(
+    { id: project.id, slug: project.slug },
+    { projectDomains: allDomainRows },
+  );
+  const allCurrent = normalizeProjectRouteRows(state.projectDomains);
+  const current = allCurrent.filter(
+    (domain) => !opts.onlyHostname || domain.hostname.toLowerCase() === opts.onlyHostname.toLowerCase(),
+  );
+  if (opts.strict && opts.onlyHostname && current.length === 0) {
+    throw new ValidationError(`No project route is configured for ${opts.onlyHostname}`);
+  }
   const currentHostnames = new Set(current.map((d) => d.hostname.toLowerCase()));
   // domainType isn't retained for a dropped row — infer managed vs custom from
   // the base-domain suffix so cloud teardown targets the right primitive.
@@ -386,6 +408,7 @@ export async function reapplyProjectLiveRoutes(
   // resolver deploy/delete use), then compute each upstream from the container.
   const deployment = await repos.deployment.findById(project.activeDeploymentId!);
   if (!deployment) {
+    if (opts.strict) throw new ValidationError("The active deployment could not be found for this domain route");
     console.warn(
       `[project-route] ${project.slug}: no active deployment row — skipping live route re-apply`,
     );
@@ -442,7 +465,10 @@ export async function reapplyProjectLiveRoutes(
     console.warn(
       `[project-route] ${project.slug}: deployment ${deployment.id} has no containerId (target=${effectiveTarget}) — skipping single-app route registration`,
     );
-    await reconcileProjectRoutes(project, { routing, removes });
+    if (opts.strict && current.length > 0) {
+      throw new ValidationError("The active deployment has no routable application container");
+    }
+    await reconcileProjectRoutes(project, { routing, removes, strict: opts.strict });
     await pushProjectRules(project.id, serverId ?? null, previousHostnames).catch(() => {});
     // Shared-dict state is RAM: the analytics collection switches have to be re-pushed
     // whenever routing is applied, or an nginx restart silently reverts them to off.
@@ -488,13 +514,15 @@ export async function reapplyProjectLiveRoutes(
 
   // A redirect only goes live when its target is one of the hostnames this
   // project currently routes — see resolveRouteRedirect.
-  const liveHostnames = current.map((domain) => domain.hostname);
+  const liveHostnames = allDomainRows.map((domain) => domain.hostname);
   const registers: RouteRegister[] = [];
   for (const domain of current) {
     const redirectHost = resolveRouteRedirect(domain, liveHostnames);
     const common = {
       hostname: domain.hostname,
       isCustomDomain: domain.domainType === "custom",
+      tls: !domain.externalIngress || domain.manualSsl,
+      terminatesTlsLocally: domain.domainType === "custom" && !domain.externalIngress,
       ...(redirectHost ? { redirectHost } : {}),
     };
 
@@ -537,7 +565,10 @@ export async function reapplyProjectLiveRoutes(
 
   // The webhook-proxy location is re-attached automatically for the project's
   // webhookDomain inside reconcileProjectRoutes.
-  await reconcileProjectRoutes(project, { routing, registers, removes });
+  if (opts.strict && registers.length !== current.length) {
+    throw new ValidationError("One or more project domain routes have no live upstream");
+  }
+  await reconcileProjectRoutes(project, { routing, registers, removes, strict: opts.strict });
 
   // Re-sync per-route edge rules (rate-limit / ban / allow-deny) for the current
   // hostnames. Best-effort — the DB is the source of truth; a failure defers to
@@ -551,4 +582,114 @@ export async function reapplyProjectLiveRoutes(
   // of the edit; dropped slugs were deregistered above). Per-route — unchanged
   // hostnames are not re-synced.
   syncAddedManagedEdge();
+}
+
+/**
+ * Converge the exact live route that backs a domain before verification reports
+ * it active. Project domains reuse the full single-app route compiler; service
+ * domains resolve their live compose row and register the service upstream on
+ * the deployment's actual edge (local, remote, bare or Docker).
+ */
+export async function convergeVerifiedDomainRoute(domain: Domain, project: Project): Promise<void> {
+  if (!domain.serviceId) {
+    await reapplyProjectLiveRoutes(project, [], {
+      managedEdgeSyncedByCaller: true,
+      onlyHostname: domain.hostname,
+      strict: true,
+    });
+    return;
+  }
+
+  if (!project.activeDeploymentId) {
+    throw new ValidationError("No active deployment is available for this service domain");
+  }
+
+  const [service, deployment] = await Promise.all([
+    repos.service.findById(domain.serviceId),
+    repos.deployment.findById(project.activeDeploymentId),
+  ]);
+  if (!service || service.projectId !== project.id) {
+    throw new ValidationError("The service for this domain could not be found");
+  }
+  if (!service.enabled || !service.exposed) {
+    throw new ValidationError("The service for this domain is not enabled and exposed");
+  }
+  if (!deployment) {
+    throw new ValidationError("The active deployment could not be found for this service domain");
+  }
+
+  const { routing, runtime } = await resolveDeploymentRuntime(deployment);
+  if (await applyProjectRouting(project.id, { strict: true, onlyHostname: domain.hostname })) {
+    return;
+  }
+  const planned = buildServiceRouteDomains({
+    project,
+    service,
+    runtimeName: runtime.name,
+    usesManagedRouting: true,
+    domainByHostname: new Map([[domain.hostname.toLowerCase(), domain]]),
+  }).find((route) => route.hostname.toLowerCase() === domain.hostname.toLowerCase());
+  if (!planned?.targetPort) {
+    throw new ValidationError("The service domain has no configured target port");
+  }
+
+  const liveRows = await repos.service.listByDeployment(project.activeDeploymentId);
+  const live = liveRows.find((row) => row.serviceId === service.id);
+  const staticRoot = isStaticService(service) && live?.imageRef?.startsWith("/")
+    ? live.imageRef
+    : null;
+  const targetUrl = staticRoot
+    ? null
+    : buildUpstreamUrl({
+        strategy: resolveRouteStrategy(project.routeStrategy),
+        ip: live?.ip,
+        hostPort: live?.hostPort,
+        containerPort: planned.targetPort,
+      });
+  if (!staticRoot && !targetUrl) {
+    throw new ValidationError("The service domain has no live deployment upstream");
+  }
+
+  const allDomains = await repos.domain.listByProject(project.id);
+  const redirectHost = resolveRouteRedirect(domain, allDomains.map((row) => row.hostname));
+
+  await reconcileProjectRoutes(project, {
+    deployment,
+    routing,
+    strict: true,
+    registers: [{
+      hostname: planned.hostname,
+      ...(staticRoot ? { staticRoot } : { targetUrl: targetUrl! }),
+      port: planned.targetPort,
+      isCustomDomain: planned.domainType === "custom",
+      tls: planned.tls,
+      terminatesTlsLocally: planned.terminatesTlsLocally,
+      ...(redirectHost ? { redirectHost } : {}),
+    }],
+  });
+}
+
+/**
+ * Strictly converge every configured hostname for a project. Used only before
+ * clearing the deployment-wide routing warning: repairing one verified
+ * hostname must not hide a pending sibling route that is still unsynchronised.
+ */
+export async function convergeAllProjectRoutes(project: Project): Promise<void> {
+  const domains = await repos.domain.listByProject(project.id);
+  const projectDomains = domains.filter((domain) => !domain.serviceId);
+  if (projectDomains.length > 0) {
+    await reapplyProjectLiveRoutes(project, [], {
+      managedEdgeSyncedByCaller: true,
+      strict: true,
+    });
+  }
+  for (const domain of domains) {
+    if (!domain.serviceId) continue;
+    const service = await repos.service.findById(domain.serviceId);
+    // Domain rows intentionally survive an expose/pause toggle. They are not
+    // expected to have a live vhost until the service is enabled + exposed
+    // again, so they must not permanently pin a project routing warning.
+    if (service && (!service.enabled || !service.exposed)) continue;
+    await convergeVerifiedDomainRoute(domain, project);
+  }
 }

--- a/apps/api/src/modules/domains/routing-apply.service.ts
+++ b/apps/api/src/modules/domains/routing-apply.service.ts
@@ -15,7 +15,7 @@
  */
 
 import { repos } from "@repo/db";
-import { safeErrorMessage } from "@repo/core";
+import { safeErrorMessage, ValidationError } from "@repo/core";
 import {
   CloudRuntime,
   PAGE_CONTAINER_PREFIX,
@@ -25,7 +25,7 @@ import {
 import { platform } from "../../lib/controller-helpers";
 import { resolveDeploymentRuntime, usesManagedRouting } from "../../lib/deployment-runtime";
 import { reconcileProjectRoutes } from "../../lib/route-apply.service";
-import { resolveServicePort } from "../../lib/deployable-service";
+import { isStaticService, resolveServicePort } from "../../lib/deployable-service";
 import { buildServiceRouteDomain } from "../../lib/routing-domains";
 import {
   buildCompositeRegistration,
@@ -33,17 +33,28 @@ import {
   planCompositeRoute,
 } from "../deployments/compose/composite-route";
 import { buildUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
+import { resolveRouteRedirect } from "../../lib/domain-redirect";
 
-export async function applyProjectRouting(projectId: string): Promise<void> {
+export interface ApplyProjectRoutingOptions {
+  /** Verification/recovery must observe edge-write failures. */
+  strict?: boolean;
+  /** Re-apply only the compiled vhost for this hostname. */
+  onlyHostname?: string;
+}
+
+export async function applyProjectRouting(
+  projectId: string,
+  opts: ApplyProjectRoutingOptions = {},
+): Promise<boolean> {
   const project = await repos.project.findById(projectId);
-  if (!project) return;
+  if (!project) return false;
 
   // No active deployment → the persisted routingConfig applies on the next deploy.
-  if (!project.activeDeploymentId) return;
+  if (!project.activeDeploymentId) return false;
 
   try {
     const deployment = await repos.deployment.findById(project.activeDeploymentId);
-    if (!deployment) return;
+    if (!deployment) return false;
 
     const { routing, runtime, effectiveTarget } = await resolveDeploymentRuntime(deployment);
     const managed = usesManagedRouting(platform().target, effectiveTarget);
@@ -53,13 +64,27 @@ export async function applyProjectRouting(projectId: string): Promise<void> {
     // Cloud: apply the vercel routing at the Oblien edge (no OpenResty).
     if (runtime instanceof CloudRuntime) {
       await applyCloudRouting({ project, runtime, defs, liveRows, usesManaged: managed });
-      return;
+      return true;
     }
 
     // Self-hosted: compile to OpenResty locations and reconcile the domain.
-    if (!routing) return;
+    if (!routing) {
+      if (opts.strict) throw new ValidationError("No routing provider is available for this deployment");
+      return false;
+    }
+    const domainByHostname = new Map(
+      (await repos.domain.listByProject(project.id)).map((domain) => [
+        domain.hostname.toLowerCase(),
+        domain,
+      ]),
+    );
     const rowByService = new Map(liveRows.map((row) => [row.serviceId, row]));
     const routeStrategy = resolveRouteStrategy(project.routeStrategy);
+    const validRedirectHosts = [...domainByHostname.values()].map((domain) => domain.hostname);
+    const resolveRedirectHost = (hostname: string) => {
+      const domain = domainByHostname.get(hostname.toLowerCase());
+      return domain ? resolveRouteRedirect(domain, validRedirectHosts) : null;
+    };
 
     // One live-upstream resolver, shared by the vercel composite AND the migration
     // path-fan-out — each service's URL from its service_deployment row.
@@ -71,10 +96,20 @@ export async function applyProjectRouting(projectId: string): Promise<void> {
       return buildUpstreamUrl({ strategy: routeStrategy, ip: row?.ip, hostPort: row?.hostPort, containerPort: port });
     };
 
+    const resolveStaticRoot = (serviceId: string) => {
+      const def = defs.find((service) => service.id === serviceId);
+      const row = rowByService.get(serviceId);
+      return def && isStaticService(def) && row?.imageRef?.startsWith("/")
+        ? row.imageRef
+        : null;
+    };
+
     const composite = buildCompositeRegistration({
       services: defs,
       routingConfig: project.routingConfig,
       resolveTargetUrl,
+      resolveStaticRoot,
+      resolveRedirectHost,
       resolveDomain: (serviceId) => {
         const def = defs.find((s) => s.id === serviceId);
         const domain = def
@@ -93,16 +128,77 @@ export async function applyProjectRouting(projectId: string): Promise<void> {
 
     // Re-emit any migration path-fan-out domains from live upstreams (a domain
     // whose paths route to different services) — persisted so it survives here.
-    const fanout = buildDomainFanoutRegistrations({ routes: project.compositeRoutes, resolveTargetUrl });
-
-    const registers = [...(composite ? [composite.register] : []), ...fanout];
-    if (registers.length > 0) {
-      await reconcileProjectRoutes(project, { deployment, routing, registers });
+    const requested = opts.onlyHostname?.toLowerCase();
+    if (opts.strict) {
+      const fanoutRoutes = (project.compositeRoutes ?? []).filter(
+        (route) => !requested || route.hostname.toLowerCase() === requested,
+      );
+      for (const route of fanoutRoutes) {
+        if (!resolveTargetUrl(route.rootServiceId)) {
+          throw new ValidationError(`The root upstream for ${route.hostname} is not live`);
+        }
+        const missingLocation = route.locations.find(
+          (location) => !resolveTargetUrl(location.serviceId),
+        );
+        if (missingLocation) {
+          throw new ValidationError(
+            `The ${missingLocation.pathPrefix} upstream for ${route.hostname} is not live`,
+          );
+        }
+      }
     }
+    const fanout = buildDomainFanoutRegistrations({
+      routes: project.compositeRoutes,
+      resolveTargetUrl,
+      resolveRedirectHost,
+    });
+
+    const allRegisters = [...(composite ? [composite.register] : []), ...fanout].map((register) => {
+      const domain = domainByHostname.get(register.hostname.toLowerCase());
+      if (!domain) return register;
+      return {
+        ...register,
+        tls: !domain.externalIngress || domain.manualSsl,
+        terminatesTlsLocally: register.isCustomDomain && !domain.externalIngress,
+      };
+    });
+    const registers = requested
+      ? allRegisters.filter((register) => register.hostname.toLowerCase() === requested)
+      : allRegisters;
+
+    if (opts.strict && requested && registers.length === 0) {
+      const compositePlan = planCompositeRoute(defs, { rewrites: project.routingConfig?.rewrites });
+      const compositeDomain = compositePlan
+        ? buildServiceRouteDomain({
+            project,
+            service: defs.find((service) => service.id === compositePlan.frontendServiceId)!,
+            runtimeName: runtime.name,
+            usesManagedRouting: managed,
+          })
+        : null;
+      const fanoutConfigured = (project.compositeRoutes ?? []).some(
+        (route) => route.hostname.toLowerCase() === requested,
+      );
+      if (compositeDomain?.hostname.toLowerCase() === requested || fanoutConfigured) {
+        throw new ValidationError(`The compiled route for ${opts.onlyHostname} has no live upstream`);
+      }
+    }
+    if (registers.length > 0) {
+      await reconcileProjectRoutes(project, {
+        deployment,
+        routing,
+        registers,
+        strict: opts.strict,
+      });
+      return true;
+    }
+    return false;
   } catch (err) {
+    if (opts.strict) throw err;
     console.warn(
       `[routing-apply] ${project.slug}: live routing re-apply failed (non-fatal, applies next deploy): ${safeErrorMessage(err)}`,
     );
+    return false;
   }
 }
 

--- a/apps/api/src/modules/domains/routing-apply.service.ts
+++ b/apps/api/src/modules/domains/routing-apply.service.ts
@@ -69,7 +69,8 @@ export async function applyProjectRouting(
 
     // Self-hosted: compile to OpenResty locations and reconcile the domain.
     if (!routing) {
-      if (opts.strict) throw new ValidationError("No routing provider is available for this deployment");
+      if (opts.strict)
+        throw new ValidationError("No routing provider is available for this deployment");
       return false;
     }
     const domainByHostname = new Map(
@@ -93,15 +94,18 @@ export async function applyProjectRouting(
       const row = rowByService.get(serviceId);
       const port = def ? resolveServicePort(def, project.port) : null;
       if (!port) return null;
-      return buildUpstreamUrl({ strategy: routeStrategy, ip: row?.ip, hostPort: row?.hostPort, containerPort: port });
+      return buildUpstreamUrl({
+        strategy: routeStrategy,
+        ip: row?.ip,
+        hostPort: row?.hostPort,
+        containerPort: port,
+      });
     };
 
     const resolveStaticRoot = (serviceId: string) => {
       const def = defs.find((service) => service.id === serviceId);
       const row = rowByService.get(serviceId);
-      return def && isStaticService(def) && row?.imageRef?.startsWith("/")
-        ? row.imageRef
-        : null;
+      return def && isStaticService(def) && row?.imageRef?.startsWith("/") ? row.imageRef : null;
     };
 
     const composite = buildCompositeRegistration({
@@ -180,7 +184,9 @@ export async function applyProjectRouting(
         (route) => route.hostname.toLowerCase() === requested,
       );
       if (compositeDomain?.hostname.toLowerCase() === requested || fanoutConfigured) {
-        throw new ValidationError(`The compiled route for ${opts.onlyHostname} has no live upstream`);
+        throw new ValidationError(
+          `The compiled route for ${opts.onlyHostname} has no live upstream`,
+        );
       }
     }
     if (registers.length > 0) {

--- a/apps/api/src/modules/github/clone-auth.ts
+++ b/apps/api/src/modules/github/clone-auth.ts
@@ -43,7 +43,7 @@ import { type BuildStrategy } from "@repo/core";
 import type { AmbientGitVia, CommandExecutor } from "@repo/adapters";
 import { tokenFor, requireTokenFor, type TokenContext } from "./github.token";
 import { isPublicRepo } from "./github.http";
-import { getLocalGhToken, hasLocalGitIdentity } from "./github.local-auth";
+import { hasLocalGitIdentity } from "./github.local-auth";
 import { resolveServerGitCredential } from "./server-github.service";
 import type { RequestContext } from "../../lib/request-context";
 
@@ -103,8 +103,10 @@ async function resolveLocalCredential(
   ctx: RequestContext,
   tokenCtx: TokenContext,
 ): Promise<{ token?: string }> {
-  const ghToken = await getLocalGhToken();
-  if (ghToken) return { token: ghToken };
+  // Route every local credential through the unified chain. Calling
+  // getLocalGhToken() directly here bypassed the user's Disconnect suppression
+  // and the operator-consent gate, so a token could remain active for clones
+  // after Settings reported it removed.
   const r = await tokenFor(ctx, "local", tokenCtx);
   return r?.token ? { token: r.token } : {};
 }

--- a/apps/api/src/modules/github/github.auth.ts
+++ b/apps/api/src/modules/github/github.auth.ts
@@ -825,10 +825,9 @@ export async function getGitHubConnectionState(
 
   // ── gh CLI side ────────────────────────────────────────────────────
   // Only meaningful on self-hosted. On the SaaS the binary isn't there.
-  // Single rule: `gh auth token` is valid → connected. `gh auth logout`
-  // is the durable way to disconnect. We do NOT consult any per-user
-  // suppression flag here — the user already said this is the rule:
-  // "if gh cli logged in, use it as source of truth."
+  // A valid host/stored credential is connected only when this user has not
+  // explicitly disconnected it. The suppression flag is the durable boundary
+  // that keeps Settings, discovery, and clone resolution in agreement.
   let cliAvailable = false;
   let cliLogin: string | undefined;
   let cliAvatar: string | undefined;
@@ -840,18 +839,22 @@ export async function getGitHubConnectionState(
   let cliProblem: "rejected" | "unreachable" | undefined;
   let cliCheckedAt: string | undefined;
   if (onSelfHosted) {
-    // Dynamic import: gh probed ONLY when self-hosted; never loaded on the SaaS.
-    const { getLocalGhStatus } = await import("./github.local-auth");
-    const localStatus = await getLocalGhStatus();
-    cliCheckedAt = localStatus.checkedAt;
-    if (localStatus.available) {
-      cliAvailable = true;
-      cliLogin = localStatus.login;
-      cliAvatar = localStatus.avatar_url;
-      cliMethod = localStatus.method;
-    } else {
-      cliMethod = localStatus.method ?? undefined;
-      cliProblem = localStatus.problem;
+    const { isGithubCliDisabled } = await import("../settings/settings.service");
+    const cliDisabled = await isGithubCliDisabled(ctx.userId).catch(() => true);
+    if (!cliDisabled) {
+      // Dynamic import: gh probed ONLY when self-hosted; never loaded on the SaaS.
+      const { getLocalGhStatus } = await import("./github.local-auth");
+      const localStatus = await getLocalGhStatus();
+      cliCheckedAt = localStatus.checkedAt;
+      if (localStatus.available) {
+        cliAvailable = true;
+        cliLogin = localStatus.login;
+        cliAvatar = localStatus.avatar_url;
+        cliMethod = localStatus.method;
+      } else {
+        cliMethod = localStatus.method ?? undefined;
+        cliProblem = localStatus.problem;
+      }
     }
   }
 
@@ -1267,19 +1270,14 @@ export async function disconnectUser(
     await repos.account.unlinkProvider(userId, "github");
   }
   if (source === "cli" || source === "all") {
-    const { setGithubCliDisabled } = await import("../settings/settings.service");
+    const { setGithubCliDisabled, setGhCliOperatorOptedIn } = await import("../settings/settings.service");
     await setGithubCliDisabled(userId, true);
-    // Also drop the stored device-flow token. Without this, "Disconnect" only
-    // flipped the per-user opt-in while the credential itself stayed on the
-    // instance — so the UI said disconnected and clones kept working. Dynamic
-    // import to keep the SaaS bundle free of the gh module (see its CLOUD_MODE
-    // floor); a failure here must not abort the rest of the disconnect.
-    try {
-      const { setStoredDeviceToken } = await import("./github.local-auth");
-      await setStoredDeviceToken(null);
-    } catch (err) {
-      console.warn(`[GitHub] clearing stored device token failed: ${(err as Error).message}`);
-    }
+    await setGhCliOperatorOptedIn(userId, false);
+    // This mutation is the meaning of Disconnect, so fail the request if it
+    // cannot be persisted; returning success while the secret remains active
+    // leaves the dashboard lying and makes replacement impossible.
+    const { setStoredDeviceToken } = await import("./github.local-auth");
+    await setStoredDeviceToken(null);
   }
   await invalidateUserGitHubCache(userId);
   // Cascade MEDIUM — every org this user belongs to shares cache

--- a/apps/api/src/modules/github/github.controller.ts
+++ b/apps/api/src/modules/github/github.controller.ts
@@ -518,6 +518,15 @@ export async function connectRedirect(c: Context) {
  *  Gated by `localOnly` middleware - never reaches this handler in cloud modes.
  */
 export async function getLocalStatus(c: Context) {
+  const ctx = getRequestContext(c);
+  const { isGithubCliDisabled } = await import("../settings/settings.service");
+  if (await isGithubCliDisabled(ctx.userId).catch(() => true)) {
+    return c.json({
+      available: false,
+      method: null,
+      activeMode: githubAuth.getGitHubAuthMode(),
+    });
+  }
   const { getLocalGhStatus } = await import("./github.local-auth");
   const localStatus = await getLocalGhStatus();
   return c.json({

--- a/apps/api/src/modules/github/github.token.ts
+++ b/apps/api/src/modules/github/github.token.ts
@@ -458,6 +458,11 @@ async function mayUseOperatorCliToken(
   purpose: GitHubPurpose,
 ): Promise<boolean> {
   if (purpose === "remote") return false;
+  // Disconnect is a real authorization boundary, not just a dashboard hint.
+  // Check it before every local gh-token use, including zero-auth
+  // desktop/internal contexts.
+  const { isGithubCliDisabled } = await import("../settings/settings.service");
+  if (await isGithubCliDisabled(userId).catch(() => true)) return false;
   if (!organizationId) return true;
   return isCliOperatorAllowed(userId);
 }

--- a/apps/api/src/modules/github/sources/index.ts
+++ b/apps/api/src/modules/github/sources/index.ts
@@ -29,9 +29,12 @@ export async function createGitHubSource(ctx: RequestContext): Promise<GitHubSou
   }
 
   // Local: gh-FIRST. Resolve the gh sub-source from a LOCAL token read — do NOT
-  // probe the cloud here. The merge resolves the App side lazily.
+  // probe the cloud here. A user who disconnected local GitHub auth must not
+  // have the instance-wide credential silently reintroduced for discovery.
+  const { isGithubCliDisabled } = await import("../../settings/settings.service");
+  const cliDisabled = await isGithubCliDisabled(ctx.userId).catch(() => true);
   const { GhCliSource } = await import("./gh-cli-source");
   const gh = new GhCliSource(ctx.userId);
   const { LocalGitHubSource } = await import("./local-source");
-  return new LocalGitHubSource(ctx, (await gh.token()) ? gh : null);
+  return new LocalGitHubSource(ctx, !cliDisabled && (await gh.token()) ? gh : null);
 }

--- a/apps/api/src/modules/projects/project-runtime.service.ts
+++ b/apps/api/src/modules/projects/project-runtime.service.ts
@@ -11,7 +11,7 @@ import { assertResourceInOrg } from "../../lib/controller-helpers";
 import { syncManagedEdgeRoutes, edgeUnsyncedWarning } from "../../lib/managed-edge-proxy";
 import { resolveManagedHostname } from "../../lib/routing-domains";
 import { sshManager } from "../../lib/ssh-manager";
-import { applyProjectRouting } from "../domains/routing-apply.service";
+import { convergeAllProjectRoutes } from "../domains/project-route.service";
 
 // ─── Runtime logs ────────────────────────────────────────────────────────────
 
@@ -154,9 +154,12 @@ export async function retryProjectRouting(
   const serverId = p.serverId ?? (dep?.meta as { serverId?: string } | null)?.serverId ?? undefined;
   await restoreCustomPortsFromEdge(p, serverId).catch(() => {});
 
-  // Live re-apply is best-effort, but its failure must NOT clear the warning.
+  // Retry is an explicit recovery action: strictly converge every currently
+  // routable project + service hostname before any warning may be cleared.
+  // The older routing-config helper is deliberately best-effort and can return
+  // false without throwing, which previously produced a false "Live" state.
   let applyOk = true;
-  await applyProjectRouting(projectId).catch(() => {
+  await convergeAllProjectRoutes(p).catch(() => {
     applyOk = false;
   });
 
@@ -314,5 +317,3 @@ async function markRoutingWarning(
   meta.deployWarning = warning;
   await repos.deployment.updateStatus(dep.id, dep.status, { meta });
 }
-
-

--- a/apps/api/src/modules/projects/project-runtime.service.ts
+++ b/apps/api/src/modules/projects/project-runtime.service.ts
@@ -15,11 +15,7 @@ import { convergeAllProjectRoutes } from "../domains/project-route.service";
 
 // ─── Runtime logs ────────────────────────────────────────────────────────────
 
-export async function getRuntimeLogs(
-  projectId: string,
-  organizationId: string,
-  tail?: number,
-) {
+export async function getRuntimeLogs(projectId: string, organizationId: string, tail?: number) {
   const p = await repos.project.findById(projectId);
   assertResourceInOrg(p, "Project", organizationId, projectId);
 
@@ -145,9 +141,7 @@ export async function retryProjectRouting(
   // Cloud manages its own ingress — there is no server edge to repair here.
   if (p.cloudWorkspaceId) return { ok: true };
 
-  const dep = p.activeDeploymentId
-    ? await repos.deployment.findById(p.activeDeploymentId)
-    : null;
+  const dep = p.activeDeploymentId ? await repos.deployment.findById(p.activeDeploymentId) : null;
 
   await repairDeploymentServerBinding(p, dep).catch(() => {});
 
@@ -170,8 +164,11 @@ export async function retryProjectRouting(
   if (!ok) return { ok: false, warning: edgeUnsyncedWarning(failures, "retry") };
 
   if (!applyOk) {
-    const warning = "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.";
-    const fresh = p.activeDeploymentId ? await repos.deployment.findById(p.activeDeploymentId) : null;
+    const warning =
+      "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.";
+    const fresh = p.activeDeploymentId
+      ? await repos.deployment.findById(p.activeDeploymentId)
+      : null;
     await markRoutingWarning(fresh, warning).catch(() => {});
     return { ok: false, warning };
   }

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -12,7 +12,18 @@ import {
   type Service,
   type ServicePublicEndpoint,
 } from "@repo/db";
-import { aliasConflictsWithSiblings, ForbiddenError, getProjectType, mergeAdvanced, normalizeServiceLabel, normalizeAliasStrict, withTimeout, type ComposeAdvanced, type ServiceContainerState, type StackId } from "@repo/core";
+import {
+  aliasConflictsWithSiblings,
+  ForbiddenError,
+  getProjectType,
+  mergeAdvanced,
+  normalizeServiceLabel,
+  normalizeAliasStrict,
+  withTimeout,
+  type ComposeAdvanced,
+  type ServiceContainerState,
+  type StackId,
+} from "@repo/core";
 import {
   BuildLogger,
   DockerRuntime,
@@ -22,7 +33,13 @@ import {
 } from "@repo/adapters";
 import { scopedVolumeName, type CommandExecutor } from "@repo/adapters";
 import { encrypt, decrypt } from "../../lib/encryption";
-import { ENV_MASK, hasMaskedValue, maskDriftChanges, maskServiceEnv, unmaskEnv } from "../../lib/secret-env";
+import {
+  ENV_MASK,
+  hasMaskedValue,
+  maskDriftChanges,
+  maskServiceEnv,
+  unmaskEnv,
+} from "../../lib/secret-env";
 import { assertResourceInOrg, platform } from "../../lib/controller-helpers";
 import { assertValidCustomDomains, customHostnamesOf } from "../../lib/custom-domain-guard";
 import type { RequestContext } from "../../lib/request-context";
@@ -51,7 +68,11 @@ import {
 } from "../../lib/public-endpoints";
 import { resolveRuntimeResources } from "../../lib/resources";
 import { assertFreeEndpointsAllowed } from "../../lib/free-domain-guard";
-import { ensurePendingServiceDomain, removeServiceDomain, reuseServerCertForDomain } from "../domains/domain.service";
+import {
+  ensurePendingServiceDomain,
+  removeServiceDomain,
+  reuseServerCertForDomain,
+} from "../domains/domain.service";
 import { buildUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
 import {
   reconcileProjectRoutes,
@@ -74,11 +95,7 @@ const ROUTE_EDGE_APPLY_TIMEOUT_MS = 6000;
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Verify a service exists and belongs to a project in the given org */
-async function assertServiceAccess(
-  ctx: RequestContext,
-  projectId: string,
-  serviceId: string,
-) {
+async function assertServiceAccess(ctx: RequestContext, projectId: string, serviceId: string) {
   const project = await repos.project.findById(projectId);
   assertResourceInOrg(project, "Project", ctx.organizationId, projectId);
   const svc = await repos.service.findById(serviceId);
@@ -219,11 +236,7 @@ export async function listServices(ctx: RequestContext, projectId: string) {
   return (await repos.service.listByProject(projectId)).map(withDrift);
 }
 
-export async function getService(
-  ctx: RequestContext,
-  projectId: string,
-  serviceId: string,
-) {
+export async function getService(ctx: RequestContext, projectId: string, serviceId: string) {
   const { svc } = await assertServiceAccess(ctx, projectId, serviceId);
   return withDrift(svc);
 }
@@ -279,11 +292,7 @@ export async function acceptServiceDrift(
  * Keep the user's edits: advance the baseline to the upstream spec (so it stops
  * re-flagging on every deploy) WITHOUT changing the row's current values.
  */
-export async function keepServiceDrift(
-  ctx: RequestContext,
-  projectId: string,
-  serviceId: string,
-) {
+export async function keepServiceDrift(ctx: RequestContext, projectId: string, serviceId: string) {
   const { svc } = await assertServiceAccess(ctx, projectId, serviceId);
   if (!svc.driftSpec) return withDrift(svc);
   await repos.service.update(serviceId, { importedSpec: svc.driftSpec, driftSpec: null });
@@ -414,9 +423,7 @@ export async function createService(
   // sentinel the client sent is dropped (never persist "••••••••"). Warn so a
   // real value accidentally lost this way is traceable.
   if (data.environment && hasMaskedValue(data.environment)) {
-    console.warn(
-      `[services] create "${name}": dropping masked env value(s) with no stored source`,
-    );
+    console.warn(`[services] create "${name}": dropping masked env value(s) with no stored source`);
     data = { ...data, environment: unmaskEnv(data.environment, null) };
   }
 
@@ -563,7 +570,12 @@ export async function updateService(
   // deep merge would make a partially-specified healthcheck inherit stale fields.
   if ("advanced" in patch) {
     patch.advanced = mergeAdvanced(svc.advanced as ComposeAdvanced | null, patch.advanced);
-    await validateServiceAlias(projectId, serviceId, patch.advanced as ComposeAdvanced, project.internalAlias);
+    await validateServiceAlias(
+      projectId,
+      serviceId,
+      patch.advanced as ComposeAdvanced,
+      project.internalAlias,
+    );
   }
 
   if ("name" in patch && typeof patch.name === "string") {
@@ -618,9 +630,7 @@ export async function updateService(
     // mergeServiceRoutingPatch. Before this, an array on the row shadowed the
     // scalars outright: the user's chosen custom domain was dropped and the gate
     // below then judged the stored "free" primary instead.
-    const normalized = normalizeRoutingPatch(
-      mergeServiceRoutingPatch({ patch, stored: svc }),
-    );
+    const normalized = normalizeRoutingPatch(mergeServiceRoutingPatch({ patch, stored: svc }));
 
     // Write the merged routing through VERBATIM, nulls included. `normalized` is
     // the row's whole intended routing state (unexposing only closes the gate — it
@@ -685,21 +695,39 @@ export async function updateService(
       // Diff the SET of routes (a service can publish several ports). A hostname
       // present before but gone now is removed; every current route is
       // (re-)registered (register is additive/idempotent upstream).
-      const oldRoutes = buildServiceRouteDomains({ project, service: svc, runtimeName, usesManagedRouting: true });
+      const oldRoutes = buildServiceRouteDomains({
+        project,
+        service: svc,
+        runtimeName,
+        usesManagedRouting: true,
+      });
       const nextRoutes = isRoutable
-        ? buildServiceRouteDomains({ project, service: updated, runtimeName, usesManagedRouting: true })
+        ? buildServiceRouteDomains({
+            project,
+            service: updated,
+            runtimeName,
+            usesManagedRouting: true,
+          })
         : [];
       const nextByHost = new Map(nextRoutes.map((route) => [route.hostname.toLowerCase(), route]));
 
       const removes: RouteRemove[] = oldRoutes
         .filter((route) => !nextByHost.has(route.hostname.toLowerCase()))
-        .map((route) => ({ hostname: route.hostname, isCustomDomain: route.domainType === "custom" }));
+        .map((route) => ({
+          hostname: route.hostname,
+          isCustomDomain: route.domainType === "custom",
+        }));
 
       // Self-hosted upstream = loopback host port (published) or the active
       // deployment's service-row IP; cloud ignores targetUrl. Resolve once.
       let ip: string | undefined;
       let hostPort: number | undefined;
-      if (isRoutable && nextRoutes.length > 0 && !project.cloudWorkspaceId && project.activeDeploymentId) {
+      if (
+        isRoutable &&
+        nextRoutes.length > 0 &&
+        !project.cloudWorkspaceId &&
+        project.activeDeploymentId
+      ) {
         const rows = await repos.service.listByDeployment(project.activeDeploymentId);
         const row = rows.find((r) => r.serviceId === serviceId);
         ip = row?.ip ?? undefined;
@@ -709,7 +737,8 @@ export async function updateService(
       const registers: RouteRegister[] = nextRoutes.map((route) => ({
         hostname: route.hostname,
         targetUrl: route.targetPort
-          ? (buildUpstreamUrl({ strategy, ip, hostPort, containerPort: route.targetPort }) ?? undefined)
+          ? (buildUpstreamUrl({ strategy, ip, hostPort, containerPort: route.targetPort }) ??
+            undefined)
           : undefined,
         port: route.targetPort,
         isCustomDomain: route.domainType === "custom",
@@ -812,7 +841,9 @@ const SERVICE_TEARDOWN_TIMEOUT_MS = 20_000;
  * Read paths (status/logs/terminal) are deliberately NOT gated — they're the
  * reason the services are linked at all.
  */
-function assertNotControlPlaneService(project: { appTemplateId?: string | null } | undefined): void {
+function assertNotControlPlaneService(
+  project: { appTemplateId?: string | null } | undefined,
+): void {
   if (project?.appTemplateId === "openship") {
     throw new ForbiddenError(
       "These are the Openship control plane's own services — manage them with the CLI " +
@@ -821,11 +852,7 @@ function assertNotControlPlaneService(project: { appTemplateId?: string | null }
   }
 }
 
-export async function deleteService(
-  ctx: RequestContext,
-  projectId: string,
-  serviceId: string,
-) {
+export async function deleteService(ctx: RequestContext, projectId: string, serviceId: string) {
   const { project, svc } = await assertServiceAccess(ctx, projectId, serviceId);
   assertNotControlPlaneService(project);
 
@@ -1161,7 +1188,8 @@ export async function getActiveServiceContainers(
                   matchedBy: null,
                   duplicates: [],
                 };
-                if (!hint?.containerId) return { ...base, status: "stopped" as ServiceContainerState };
+                if (!hint?.containerId)
+                  return { ...base, status: "stopped" as ServiceContainerState };
                 const info = await runtime.getContainerInfo(hint.containerId).catch(() => null);
                 return {
                   ...base,
@@ -1293,7 +1321,8 @@ export async function getServiceVolumeSizes(
     partial: parsed.length > 0,
   });
 
-  if (parsed.length === 0) return { measurable: true, volumes: [], totalBytes: null, partial: false };
+  if (parsed.length === 0)
+    return { measurable: true, volumes: [], totalBytes: null, partial: false };
   if (!project.activeDeploymentId) return unmeasured(false);
 
   const dep = await repos.deployment.findById(project.activeDeploymentId);
@@ -1361,20 +1390,36 @@ export async function getServiceVolumeSizes(
     }
   }
 
-  const volumes = await bounded(parsed, VOL_SIZE_CONCURRENCY, async (p): Promise<ServiceVolumeSize> => {
-    const hostPath = p.target ? mountsByDest.get(p.target) : undefined;
-    let bytes: number | null;
-    if (hostPath) {
-      bytes = await duBytes(executor, hostPath);
-    } else if (p.kind === "bind" && p.source) {
-      bytes = await duBytes(executor, p.source);
-    } else if (p.kind === "named" && p.source) {
-      bytes = await namedVolumeBytesByName(executor, project.slug, p.source, !!svc.namespaceVolumes);
-    } else {
-      bytes = null; // anonymous volume with no running container → unknown
-    }
-    return { raw: p.raw, source: p.source, target: p.target, kind: p.kind, readOnly: p.readOnly, bytes };
-  });
+  const volumes = await bounded(
+    parsed,
+    VOL_SIZE_CONCURRENCY,
+    async (p): Promise<ServiceVolumeSize> => {
+      const hostPath = p.target ? mountsByDest.get(p.target) : undefined;
+      let bytes: number | null;
+      if (hostPath) {
+        bytes = await duBytes(executor, hostPath);
+      } else if (p.kind === "bind" && p.source) {
+        bytes = await duBytes(executor, p.source);
+      } else if (p.kind === "named" && p.source) {
+        bytes = await namedVolumeBytesByName(
+          executor,
+          project.slug,
+          p.source,
+          !!svc.namespaceVolumes,
+        );
+      } else {
+        bytes = null; // anonymous volume with no running container → unknown
+      }
+      return {
+        raw: p.raw,
+        source: p.source,
+        target: p.target,
+        kind: p.kind,
+        readOnly: p.readOnly,
+        bytes,
+      };
+    },
+  );
 
   let totalBytes: number | null = null;
   let partial = false;
@@ -1402,11 +1447,7 @@ export async function getServiceVolumeSizes(
  * (it's the only key an adopted container with a foreign name has) — see
  * live-state.ts for the resolution order.
  */
-async function resolveServiceContainer(
-  ctx: RequestContext,
-  projectId: string,
-  serviceId: string,
-) {
+async function resolveServiceContainer(ctx: RequestContext, projectId: string, serviceId: string) {
   const project = await repos.project.findById(projectId);
   assertResourceInOrg(project, "Project", ctx.organizationId, projectId);
   if (!project.activeDeploymentId) throw new Error("No active deployment");
@@ -1501,7 +1542,9 @@ async function provisionServiceContainer(
   const resolved = await resolveServicePlatform(project, dep);
   const runtime = resolved.platform.runtime;
   if (!isMultiServiceRuntime(runtime)) {
-    throw new Error(`The ${runtime.name} runtime cannot run services — enable Docker on this target.`);
+    throw new Error(
+      `The ${runtime.name} runtime cannot run services — enable Docker on this target.`,
+    );
   }
 
   // Surface the per-service provisioning trace (and any Oblien failure reason)
@@ -1587,11 +1630,7 @@ export async function stopServiceContainer(
   serviceId: string,
 ) {
   assertNotControlPlaneService(await repos.project.findById(projectId));
-  const { runtime, containerId, row } = await resolveServiceContainer(
-    ctx,
-    projectId,
-    serviceId,
-  );
+  const { runtime, containerId, row } = await resolveServiceContainer(ctx, projectId, serviceId);
   try {
     await runtime.stop(containerId);
     // Deploy-history bookkeeping only — the panel reads state from the host.
@@ -1610,11 +1649,7 @@ export async function restartServiceContainer(
   serviceId: string,
 ) {
   assertNotControlPlaneService(await repos.project.findById(projectId));
-  const { runtime, containerId, row } = await resolveServiceContainer(
-    ctx,
-    projectId,
-    serviceId,
-  );
+  const { runtime, containerId, row } = await resolveServiceContainer(ctx, projectId, serviceId);
   try {
     await runtime.restart(containerId);
     if (row) {
@@ -1632,11 +1667,7 @@ export async function getServiceRuntimeLogs(
   serviceId: string,
   tail?: number,
 ) {
-  const { runtime, containerId } = await resolveServiceContainer(
-    ctx,
-    projectId,
-    serviceId,
-  );
+  const { runtime, containerId } = await resolveServiceContainer(ctx, projectId, serviceId);
   try {
     return await runtime.getRuntimeLogs(containerId, tail);
   } finally {

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -2,7 +2,16 @@
  * Service business logic - CRUD and compose sync.
  */
 
-import { normalizeRoutingFields, repos, composeSpecDiff, type Project, type Service, type ServicePublicEndpoint } from "@repo/db";
+import {
+  composeSpecDiff,
+  hasLegacyFlattenedCommandArgvAmbiguity,
+  normalizeRoutingFields,
+  repos,
+  toComposeSpec,
+  type Project,
+  type Service,
+  type ServicePublicEndpoint,
+} from "@repo/db";
 import { aliasConflictsWithSiblings, ForbiddenError, getProjectType, mergeAdvanced, normalizeServiceLabel, normalizeAliasStrict, withTimeout, type ComposeAdvanced, type ServiceContainerState, type StackId } from "@repo/core";
 import {
   BuildLogger,
@@ -186,10 +195,18 @@ export async function validateServiceName(
 export { aliasConflictsWithSiblings };
 
 function withDrift(svc: Service) {
+  const driftBase =
+    svc.driftSpec &&
+    hasLegacyFlattenedCommandArgvAmbiguity(
+      { command: svc.command, commandArgv: svc.commandArgv },
+      svc.driftSpec,
+    )
+      ? toComposeSpec(svc)
+      : (svc.importedSpec ?? {});
   return {
     ...maskServiceEnv(svc),
     drift: svc.driftSpec
-      ? { changes: maskDriftChanges(composeSpecDiff(svc.importedSpec ?? {}, svc.driftSpec)) }
+      ? { changes: maskDriftChanges(composeSpecDiff(driftBase, svc.driftSpec)) }
       : null,
   };
 }
@@ -248,6 +265,7 @@ export async function acceptServiceDrift(
     environment: theirs.environment ?? {},
     volumes: theirs.volumes ?? [],
     command: theirs.command ?? null,
+    commandArgv: theirs.commandArgv ?? null,
     restart: theirs.restart ?? "unless-stopped",
     advanced: theirs.advanced ?? {},
     importedSpec: theirs,
@@ -1650,4 +1668,3 @@ export async function streamServiceRuntimeLogs(
   };
   return { cleanup, serverId };
 }
-

--- a/apps/api/test/lib/deployment-runtime-source-clone.test.ts
+++ b/apps/api/test/lib/deployment-runtime-source-clone.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { targetSourceCloneSupportedForTopology } from "../../src/lib/source-clone-topology";
+
+describe("targetSourceCloneSupportedForTopology", () => {
+  it("supports bare source acquisition through the target executor", () => {
+    expect(targetSourceCloneSupportedForTopology("bare", false)).toBe(true);
+    expect(targetSourceCloneSupportedForTopology("bare", true)).toBe(true);
+  });
+
+  it("supports Docker target acquisition only on a remote SSH server", () => {
+    expect(targetSourceCloneSupportedForTopology("docker", false)).toBe(true);
+    expect(targetSourceCloneSupportedForTopology("docker", true)).toBe(false);
+  });
+});

--- a/apps/api/test/lib/route-apply-proxy.test.ts
+++ b/apps/api/test/lib/route-apply-proxy.test.ts
@@ -24,7 +24,9 @@ const project = (proxy?: unknown) => ({
   routingConfig: proxy ? ({ proxy } as never) : null,
 });
 
-const REGISTER = [{ hostname: "app.example.com", targetUrl: "http://127.0.0.1:3000", isCustomDomain: false }];
+const REGISTER = [
+  { hostname: "app.example.com", targetUrl: "http://127.0.0.1:3000", isCustomDomain: false },
+];
 
 function fakeRouting() {
   const registerRoute = vi.fn(async () => {});
@@ -84,7 +86,13 @@ describe("reconcileProjectRoutes — project request limits", () => {
 
     await reconcileProjectRoutes(project({ clientMaxBodySize: "50m" }), {
       routing,
-      registers: [{ hostname: "site.example.com", staticRoot: "/opt/openship/static/site", isCustomDomain: false }],
+      registers: [
+        {
+          hostname: "site.example.com",
+          staticRoot: "/opt/openship/static/site",
+          isCustomDomain: false,
+        },
+      ],
     });
 
     expect(registerRoute.mock.calls[0][0]).toMatchObject({

--- a/apps/api/test/lib/route-apply-proxy.test.ts
+++ b/apps/api/test/lib/route-apply-proxy.test.ts
@@ -92,4 +92,45 @@ describe("reconcileProjectRoutes — project request limits", () => {
       proxy: { clientMaxBodySize: "50m" },
     });
   });
+
+  it("keeps ordinary mutation reconciles best-effort when the edge write fails", async () => {
+    const registerRoute = vi.fn().mockRejectedValue(new Error("nginx reload failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      reconcileProjectRoutes(project(), {
+        routing: { registerRoute, removeRoute: vi.fn() } as never,
+        registers: REGISTER,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("nginx reload failed"));
+    warn.mockRestore();
+  });
+
+  it("propagates the edge write failure in strict verification mode", async () => {
+    const registerRoute = vi.fn().mockRejectedValue(new Error("nginx reload failed"));
+
+    await expect(
+      reconcileProjectRoutes(project(), {
+        routing: { registerRoute, removeRoute: vi.fn() } as never,
+        registers: REGISTER,
+        strict: true,
+      }),
+    ).rejects.toThrow("nginx reload failed");
+  });
+
+  it("refuses a strict registration with no live target", async () => {
+    const { routing, registerRoute } = fakeRouting();
+
+    await expect(
+      reconcileProjectRoutes(project(), {
+        routing,
+        registers: [{ hostname: "missing.example.com", isCustomDomain: true }],
+        strict: true,
+      }),
+    ).rejects.toThrow("no upstream or static root resolved");
+
+    expect(registerRoute).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/test/modules/deployments/build.service.test.ts
+++ b/apps/api/test/modules/deployments/build.service.test.ts
@@ -227,18 +227,16 @@ describe("resolveSnapshotTarget", () => {
   });
 
   it("lets cloud win over a stray serverId and drops the serverId", async () => {
-    const t = await resolveSnapshotTarget(
-      project({ cloudWorkspaceId: "ws_1", serverId: "srv_1" }),
-    );
+    const t = await resolveSnapshotTarget(project({ cloudWorkspaceId: "ws_1", serverId: "srv_1" }));
     expect(t.deployTarget).toBe("cloud");
     expect(t.serverId).toBeUndefined();
   });
 
   it("lets an explicit override win over the durable binding", async () => {
-    const t = await resolveSnapshotTarget(
-      project({ serverId: "srv_1" }),
-      { deployTarget: "server", serverId: "srv_override" },
-    );
+    const t = await resolveSnapshotTarget(project({ serverId: "srv_1" }), {
+      deployTarget: "server",
+      serverId: "srv_override",
+    });
     expect(t).toMatchObject({ deployTarget: "server", serverId: "srv_override" });
   });
 
@@ -350,25 +348,29 @@ describe("triggerDeployment", () => {
   });
 
   it("blocks a git redeploy until ambiguous legacy command argv is reviewed", async () => {
-    repos.project.findById.mockResolvedValue(baseProject({
-      gitUrl: "https://github.com/acme/app.git",
-      localPath: null,
-      gitProvider: "github",
-      gitOwner: "acme",
-      gitRepo: "app",
-      composePath: "docker-compose.yml",
-    }));
+    repos.project.findById.mockResolvedValue(
+      baseProject({
+        gitUrl: "https://github.com/acme/app.git",
+        localPath: null,
+        gitProvider: "github",
+        gitOwner: "acme",
+        gitRepo: "app",
+        composePath: "docker-compose.yml",
+      }),
+    );
     repos.service.reconcileFromCompose.mockResolvedValue({
       services: composeServices,
       driftedNames: ["web"],
       commandArgvReviewNames: ["web"],
     });
 
-    await expect(triggerDeployment(ctx, {
-      projectId: "project-1",
-      branch: "main",
-      commitSha: "abc123",
-    })).rejects.toMatchObject({
+    await expect(
+      triggerDeployment(ctx, {
+        projectId: "project-1",
+        branch: "main",
+        commitSha: "abc123",
+      }),
+    ).rejects.toMatchObject({
       statusCode: 409,
       code: "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
     });
@@ -387,23 +389,27 @@ describe("triggerDeployment", () => {
         commandArgv: ["/bin/sh", "-ec", "echo grouped script"],
       },
     };
-    repos.project.findById.mockResolvedValue(baseProject({
-      gitUrl: "https://github.com/acme/app.git",
-      localPath: null,
-      gitProvider: "github",
-      gitOwner: "acme",
-      gitRepo: "app",
-    }));
+    repos.project.findById.mockResolvedValue(
+      baseProject({
+        gitUrl: "https://github.com/acme/app.git",
+        localPath: null,
+        gitProvider: "github",
+        gitOwner: "acme",
+        gitRepo: "app",
+      }),
+    );
     repos.service.listByProject.mockResolvedValue([pending]);
     hasLegacyFlattenedCommandArgvAmbiguity.mockReturnValue(true);
 
-    await expect(triggerDeployment(ctx, {
-      projectId: "project-1",
-      branch: "main",
-      commitSha: "def456",
-      trigger: "webhook",
-      changedPaths: ["src/app.ts"],
-    })).rejects.toMatchObject({
+    await expect(
+      triggerDeployment(ctx, {
+        projectId: "project-1",
+        branch: "main",
+        commitSha: "def456",
+        trigger: "webhook",
+        changedPaths: ["src/app.ts"],
+      }),
+    ).rejects.toMatchObject({
       code: "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
     });
 
@@ -414,24 +420,28 @@ describe("triggerDeployment", () => {
   });
 
   it("blocks requestBuildAccess on the same pending command argv review", async () => {
-    repos.project.findById.mockResolvedValue(baseProject({
-      gitUrl: "https://github.com/acme/app.git",
-      localPath: null,
-      gitProvider: "github",
-      gitOwner: "acme",
-      gitRepo: "app",
-      composePath: "docker-compose.yml",
-    }));
+    repos.project.findById.mockResolvedValue(
+      baseProject({
+        gitUrl: "https://github.com/acme/app.git",
+        localPath: null,
+        gitProvider: "github",
+        gitOwner: "acme",
+        gitRepo: "app",
+        composePath: "docker-compose.yml",
+      }),
+    );
     repos.service.reconcileFromCompose.mockResolvedValue({
       services: composeServices,
       driftedNames: ["web"],
       commandArgvReviewNames: ["web"],
     });
 
-    await expect(requestBuildAccess(ctx, {
-      projectId: "project-1",
-      branch: "main",
-    })).rejects.toMatchObject({
+    await expect(
+      requestBuildAccess(ctx, {
+        projectId: "project-1",
+        branch: "main",
+      }),
+    ).rejects.toMatchObject({
       code: "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
     });
 
@@ -561,14 +571,32 @@ describe("requestBuildAccess — folder-upload compose services", () => {
   it("#336: recovers the real env when the caller echoes the mask sentinel", async () => {
     const uploadSessionId = seedSession({
       services: [
-        { name: "api", image: "ghcr.io/acme/api:1", ports: [], dependsOn: [], environment: { API_TOKEN: "real-token" }, volumes: [] },
+        {
+          name: "api",
+          image: "ghcr.io/acme/api:1",
+          ports: [],
+          dependsOn: [],
+          environment: { API_TOKEN: "real-token" },
+          volumes: [],
+        },
       ],
     });
     const requested = [
-      { name: "api", image: "ghcr.io/acme/api:1", ports: [], dependsOn: [], environment: { API_TOKEN: "••••••••" }, volumes: [] },
+      {
+        name: "api",
+        image: "ghcr.io/acme/api:1",
+        ports: [],
+        dependsOn: [],
+        environment: { API_TOKEN: "••••••••" },
+        volumes: [],
+      },
     ];
 
-    await requestBuildAccess(ctx, { projectId: "project-1", uploadSessionId, services: requested as any });
+    await requestBuildAccess(ctx, {
+      projectId: "project-1",
+      uploadSessionId,
+      services: requested as any,
+    });
 
     expect(repos.service.syncFromCompose).toHaveBeenCalledWith(
       "project-1",
@@ -581,10 +609,21 @@ describe("requestBuildAccess — folder-upload compose services", () => {
     const uploadSessionId = seedSession({ services: [] });
     repos.service.listByProject.mockResolvedValue([]);
     const requested = [
-      { name: "api", image: "x", ports: [], dependsOn: [], environment: { GHOST: "••••••••", REAL: "keep" }, volumes: [] },
+      {
+        name: "api",
+        image: "x",
+        ports: [],
+        dependsOn: [],
+        environment: { GHOST: "••••••••", REAL: "keep" },
+        volumes: [],
+      },
     ];
 
-    await requestBuildAccess(ctx, { projectId: "project-1", uploadSessionId, services: requested as any });
+    await requestBuildAccess(ctx, {
+      projectId: "project-1",
+      uploadSessionId,
+      services: requested as any,
+    });
 
     expect(repos.service.syncFromCompose).toHaveBeenCalledWith(
       "project-1",

--- a/apps/api/test/modules/deployments/build.service.test.ts
+++ b/apps/api/test/modules/deployments/build.service.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   assertGitHubRepoAccess,
   getForwardGitToServer,
+  hasLegacyFlattenedCommandArgvAmbiguity,
   kickoffBuild,
   repos,
   resolveProjectRouteState,
+  resolveProjectInfo,
   resolveServicePipelineMode,
   resolveSmartRoute,
   resolveStrategy,
@@ -14,6 +16,7 @@ const {
 } = vi.hoisted(() => ({
   assertGitHubRepoAccess: vi.fn(),
   getForwardGitToServer: vi.fn(),
+  hasLegacyFlattenedCommandArgvAmbiguity: vi.fn(),
   kickoffBuild: vi.fn(),
   repos: {
     project: {
@@ -23,6 +26,7 @@ const {
     },
     deployment: {
       findById: vi.fn(),
+      findInProgressByCommit: vi.fn(),
       listByProject: vi.fn(),
       getLatestSuccessfulForBranch: vi.fn(),
       create: vi.fn(),
@@ -33,9 +37,11 @@ const {
     service: {
       listByProject: vi.fn(),
       syncFromCompose: vi.fn(),
+      reconcileFromCompose: vi.fn(),
     },
   },
   resolveProjectRouteState: vi.fn(),
+  resolveProjectInfo: vi.fn(),
   resolveServicePipelineMode: vi.fn(),
   resolveSmartRoute: vi.fn(),
   resolveStrategy: vi.fn(),
@@ -45,6 +51,7 @@ const {
 
 vi.mock("@repo/db", () => ({
   repos,
+  hasLegacyFlattenedCommandArgvAmbiguity,
 }));
 
 vi.mock("../../../src/modules/deployments/preflight", () => ({
@@ -54,6 +61,10 @@ vi.mock("../../../src/modules/deployments/preflight", () => ({
 vi.mock("../../../src/modules/deployments/build-pipeline", () => ({
   kickoffBuild,
   resolveServicePipelineMode,
+}));
+
+vi.mock("../../../src/modules/deployments/prepare.service", () => ({
+  resolveProjectInfo,
 }));
 
 vi.mock("../../../src/modules/domains/project-route.service", () => ({
@@ -257,11 +268,20 @@ describe("triggerDeployment", () => {
     repos.project.findById.mockResolvedValue(baseProject());
     repos.project.getEnvMap.mockResolvedValue({});
     repos.deployment.listByProject.mockResolvedValue({ rows: [] });
+    repos.deployment.findInProgressByCommit.mockResolvedValue(null);
     repos.deployment.getLatestSuccessfulForBranch.mockResolvedValue(null);
     repos.deployment.create.mockResolvedValue({ id: "dep-1", projectId: "project-1" });
     repos.deployment.createBuildSession.mockResolvedValue(undefined);
     repos.deployment.supersedeReconciling.mockResolvedValue(undefined);
     repos.deployment.supersedePendingDecisions.mockResolvedValue(undefined);
+    repos.service.listByProject.mockResolvedValue(composeServices);
+    repos.service.reconcileFromCompose.mockResolvedValue({
+      services: composeServices,
+      driftedNames: [],
+      commandArgvReviewNames: [],
+    });
+    resolveProjectInfo.mockResolvedValue({ services: composeServices });
+    hasLegacyFlattenedCommandArgvAmbiguity.mockReturnValue(false);
 
     assertGitHubRepoAccess.mockResolvedValue(undefined);
     resolveProjectRouteState.mockResolvedValue({
@@ -327,6 +347,96 @@ describe("triggerDeployment", () => {
         composeServices,
       }),
     );
+  });
+
+  it("blocks a git redeploy until ambiguous legacy command argv is reviewed", async () => {
+    repos.project.findById.mockResolvedValue(baseProject({
+      gitUrl: "https://github.com/acme/app.git",
+      localPath: null,
+      gitProvider: "github",
+      gitOwner: "acme",
+      gitRepo: "app",
+      composePath: "docker-compose.yml",
+    }));
+    repos.service.reconcileFromCompose.mockResolvedValue({
+      services: composeServices,
+      driftedNames: ["web"],
+      commandArgvReviewNames: ["web"],
+    });
+
+    await expect(triggerDeployment(ctx, {
+      projectId: "project-1",
+      branch: "main",
+      commitSha: "abc123",
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      code: "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
+    });
+
+    expect(repos.deployment.create).not.toHaveBeenCalled();
+    expect(kickoffBuild).not.toHaveBeenCalled();
+  });
+
+  it("keeps a persisted command argv review blocking a later non-Compose webhook", async () => {
+    const pending = {
+      ...composeServices[0],
+      command: "/bin/sh -ec echo grouped script",
+      commandArgv: ["/bin/sh", "-ec", "echo", "grouped", "script"],
+      driftSpec: {
+        command: "/bin/sh -ec echo grouped script",
+        commandArgv: ["/bin/sh", "-ec", "echo grouped script"],
+      },
+    };
+    repos.project.findById.mockResolvedValue(baseProject({
+      gitUrl: "https://github.com/acme/app.git",
+      localPath: null,
+      gitProvider: "github",
+      gitOwner: "acme",
+      gitRepo: "app",
+    }));
+    repos.service.listByProject.mockResolvedValue([pending]);
+    hasLegacyFlattenedCommandArgvAmbiguity.mockReturnValue(true);
+
+    await expect(triggerDeployment(ctx, {
+      projectId: "project-1",
+      branch: "main",
+      commitSha: "def456",
+      trigger: "webhook",
+      changedPaths: ["src/app.ts"],
+    })).rejects.toMatchObject({
+      code: "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
+    });
+
+    expect(resolveProjectInfo).not.toHaveBeenCalled();
+    expect(repos.service.reconcileFromCompose).not.toHaveBeenCalled();
+    expect(repos.deployment.create).not.toHaveBeenCalled();
+    expect(kickoffBuild).not.toHaveBeenCalled();
+  });
+
+  it("blocks requestBuildAccess on the same pending command argv review", async () => {
+    repos.project.findById.mockResolvedValue(baseProject({
+      gitUrl: "https://github.com/acme/app.git",
+      localPath: null,
+      gitProvider: "github",
+      gitOwner: "acme",
+      gitRepo: "app",
+      composePath: "docker-compose.yml",
+    }));
+    repos.service.reconcileFromCompose.mockResolvedValue({
+      services: composeServices,
+      driftedNames: ["web"],
+      commandArgvReviewNames: ["web"],
+    });
+
+    await expect(requestBuildAccess(ctx, {
+      projectId: "project-1",
+      branch: "main",
+    })).rejects.toMatchObject({
+      code: "COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED",
+    });
+
+    expect(repos.deployment.create).not.toHaveBeenCalled();
+    expect(kickoffBuild).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/test/modules/deployments/clone-plan.test.ts
+++ b/apps/api/test/modules/deployments/clone-plan.test.ts
@@ -4,18 +4,19 @@ import { resolveClonePlan, type ClonePlanInput } from "../../../src/modules/depl
 
 const base: ClonePlanInput = {
   effectiveTarget: "server",
-  serverId: "srv_1",
   runtimeIsBare: false,
   cloneStrategy: "api-host",
   buildStrategy: "server",
   isDesktop: false,
   forwardGitCredentials: false,
+  targetSourceCloneSupported: true,
 };
 
 describe("resolveClonePlan", () => {
   it("local build → clone runs locally with a local credential", () => {
     const plan = resolveClonePlan({ ...base, effectiveTarget: "server", buildStrategy: "local" });
     expect(plan.runsOnServer).toBe(false);
+    expect(plan.sourceSite).toBe("api-host");
     expect(plan.runsLocally).toBe(true);
     expect(plan.cloneBuildStrategy).toBe("local");
   });
@@ -23,6 +24,8 @@ describe("resolveClonePlan", () => {
   it("docker + server + api-host clone → api-host clone (local credential), not on server", () => {
     const plan = resolveClonePlan({ ...base, cloneStrategy: "api-host" });
     expect(plan.runsOnServer).toBe(false);
+    expect(plan.sourceSite).toBe("api-host");
+    expect(plan.targetCloneUnavailable).toBe(false);
     expect(plan.runsLocally).toBe(true);
     expect(plan.cloneBuildStrategy).toBe("local");
   });
@@ -30,16 +33,48 @@ describe("resolveClonePlan", () => {
   it("docker + server + clone-on-server → on-server clone with a shippable (server) credential", () => {
     const plan = resolveClonePlan({ ...base, cloneStrategy: "server" });
     expect(plan.runsOnServer).toBe(true);
+    expect(plan.sourceSite).toBe("target-host");
     expect(plan.dockerClonesOnServer).toBe(true);
     expect(plan.runsLocally).toBe(false);
     expect(plan.cloneBuildStrategy).toBe("server");
     expect(plan.relayEligible).toBe(false); // non-desktop
   });
 
+  it("docker + This Server/socket + clone-on-server → transparent api-host fallback", () => {
+    const plan = resolveClonePlan({
+      ...base,
+      cloneStrategy: "server",
+      targetSourceCloneSupported: false,
+    });
+    expect(plan.sourceSite).toBe("api-host");
+    expect(plan.runsOnServer).toBe(false);
+    expect(plan.dockerClonesOnServer).toBe(false);
+    expect(plan.targetCloneUnavailable).toBe(true);
+    expect(plan.cloneBuildStrategy).toBe("local");
+  });
+
+  it("an omitted clone strategy keeps Docker source acquisition on the api host", () => {
+    const plan = resolveClonePlan({ ...base, cloneStrategy: undefined });
+    expect(plan.sourceSite).toBe("api-host");
+    expect(plan.runsOnServer).toBe(false);
+  });
+
   it("bare + server → always clones on the server with a server credential", () => {
     const plan = resolveClonePlan({ ...base, runtimeIsBare: true, cloneStrategy: "api-host" });
     expect(plan.runsOnServer).toBe(true);
+    expect(plan.sourceSite).toBe("target-host");
     expect(plan.dockerClonesOnServer).toBe(false); // bare excluded from the docker warn-case
+    expect(plan.cloneBuildStrategy).toBe("server");
+  });
+
+  it("bare + server ignores buildStrategy=local because source still runs on the target", () => {
+    const plan = resolveClonePlan({
+      ...base,
+      runtimeIsBare: true,
+      cloneStrategy: "api-host",
+      buildStrategy: "local",
+    });
+    expect(plan.sourceSite).toBe("target-host");
     expect(plan.cloneBuildStrategy).toBe("server");
   });
 
@@ -68,10 +103,10 @@ describe("resolveClonePlan", () => {
     const plan = resolveClonePlan({
       ...base,
       effectiveTarget: "cloud",
-      serverId: null,
       buildStrategy: "server",
     });
     expect(plan.runsOnServer).toBe(false);
+    expect(plan.sourceSite).toBe("cloud");
     expect(plan.runsLocally).toBe(false);
     expect(plan.cloneBuildStrategy).toBe("server");
   });
@@ -88,11 +123,12 @@ describe("resolveClonePlan", () => {
    * available … (purpose: remote)" on a box that could clone perfectly well.
    */
   describe("local target — clone always runs on this host", () => {
-    const localBase: ClonePlanInput = { ...base, effectiveTarget: "local", serverId: null };
+    const localBase: ClonePlanInput = { ...base, effectiveTarget: "local" };
 
     it("defaulted buildStrategy=server still clones locally with a local credential", () => {
       const plan = resolveClonePlan({ ...localBase, buildStrategy: "server" });
       expect(plan.runsOnServer).toBe(false);
+      expect(plan.sourceSite).toBe("api-host");
       expect(plan.runsLocally).toBe(true);
       expect(plan.cloneBuildStrategy).toBe("local");
     });
@@ -104,8 +140,8 @@ describe("resolveClonePlan", () => {
     });
 
     it("a bare runtime on a local target does not become an on-server clone", () => {
-      // runsOnServer requires effectiveTarget==="server" AND a serverId; bare only
-      // forces on-server WITHIN that. A local target has neither.
+      // Bare only forces target-host acquisition within a server deploy. A local
+      // target has no separate deployment host.
       const plan = resolveClonePlan({ ...localBase, runtimeIsBare: true });
       expect(plan.runsOnServer).toBe(false);
       expect(plan.cloneBuildStrategy).toBe("local");

--- a/apps/api/test/modules/domains/domain-cert-reuse.test.ts
+++ b/apps/api/test/modules/domains/domain-cert-reuse.test.ts
@@ -14,6 +14,7 @@ const domainRepo = vi.hoisted(() => ({
   updateSsl: vi.fn(),
   listByProject: vi.fn().mockResolvedValue([]),
   setPrimary: vi.fn(),
+  recordVerifyFailure: vi.fn(),
 }));
 const projectRepo = vi.hoisted(() => ({ findById: vi.fn() }));
 const deploymentRepo = vi.hoisted(() => ({ findById: vi.fn() }));
@@ -27,6 +28,9 @@ const sslMocks = vi.hoisted(() => ({
 }));
 /** The adapter's proxy read api — swapped per test to stand in for a real proxy. */
 const edgeProxy = vi.hoisted(() => vi.fn());
+const convergeRoute = vi.hoisted(() => vi.fn());
+const convergeAllRoutes = vi.hoisted(() => vi.fn());
+const syncManagedEdge = vi.hoisted(() => vi.fn());
 // The host executor createHostExecutor() returns — swapped per test.
 const hostExec = vi.hoisted(() => ({ current: null as CommandExecutor | null }));
 
@@ -45,6 +49,13 @@ vi.mock("../../../src/lib/controller-helpers", async (importOriginal) => {
 });
 
 vi.mock("../../../src/lib/domain-ssl", () => sslMocks);
+vi.mock("../../../src/modules/domains/project-route.service", () => ({
+  convergeVerifiedDomainRoute: convergeRoute,
+  convergeAllProjectRoutes: convergeAllRoutes,
+}));
+vi.mock("../../../src/modules/projects/project-runtime.service", () => ({
+  syncProjectManagedEdge: syncManagedEdge,
+}));
 // Both accessors hand back the SAME host executor, which is the point: a local
 // server row and the host channel are one connection, so cert ops land on the
 // host's /etc/letsencrypt either way.
@@ -64,7 +75,11 @@ vi.mock("@repo/adapters", async (importOriginal) => {
 
 import { validateCertFor } from "@repo/adapters";
 import { makeTestCert } from "../../../../../packages/adapters/src/system/proxy/test-certs";
-import { reuseServerCertForDomain } from "../../../src/modules/domains/domain.service";
+import {
+  reuseServerCertForDomain,
+  verifyDomain,
+  verifyDomainSsl,
+} from "../../../src/modules/domains/domain.service";
 
 /**
  * Fake executor: `exists` answers the container markers from `container` and file
@@ -146,6 +161,10 @@ beforeEach(() => {
   serverRepo.getInOrganization.mockResolvedValue({ id: "srv_1", isLocal: true });
   sslMocks.verifyExistingCert.mockResolvedValue({ verified: false });
   sslMocks.installDomainCert.mockResolvedValue({ expiresAt: "2027-01-01T00:00:00.000Z", verified: true });
+  convergeRoute.mockResolvedValue(undefined);
+  convergeAllRoutes.mockResolvedValue(undefined);
+  syncManagedEdge.mockResolvedValue({ ok: true, failures: [] });
+  domainRepo.recordVerifyFailure.mockResolvedValue(1);
   edgeProxy.mockResolvedValue(null);
   hostExec.current = fakeExecutor({});
 });
@@ -168,6 +187,8 @@ describe("reuseServerCertForDomain", () => {
       "dom_1",
       expect.objectContaining({ sslStatus: "active" }),
     );
+    expect(convergeAllRoutes).toHaveBeenCalledWith(project);
+    expect(syncManagedEdge).toHaveBeenCalledWith(project, project.organizationId);
     expect(sslMocks.installDomainCert).not.toHaveBeenCalled();
   });
 
@@ -219,6 +240,18 @@ describe("reuseServerCertForDomain", () => {
 
     expect(ok).toBe(false);
     expect(sslMocks.installDomainCert).not.toHaveBeenCalled();
+    expect(domainRepo.markVerifiedActive).not.toHaveBeenCalled();
+  });
+
+  it("does not activate a reused cert when strict route convergence fails", async () => {
+    sslMocks.verifyExistingCert.mockResolvedValue({
+      verified: true,
+      issuer: "certbot",
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    });
+    convergeRoute.mockRejectedValue(new Error("vhost write failed"));
+
+    expect(await reuseServerCertForDomain(ctx, "dom_1")).toBe(false);
     expect(domainRepo.markVerifiedActive).not.toHaveBeenCalled();
   });
 
@@ -318,5 +351,168 @@ describe("reuseServerCertForDomain", () => {
 
     expect(ok).toBe(true);
     expect(sslMocks.installDomainCert).toHaveBeenCalled();
+  });
+});
+
+describe("verifyDomain route convergence", () => {
+  beforeEach(() => {
+    process.env.OPENSHIP_EDGE_MODE = "docker";
+    sslMocks.verifyExistingCert.mockResolvedValue({
+      verified: true,
+      issuer: "certbot",
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("writes the live route before marking a reused certificate active", async () => {
+    const order: string[] = [];
+    convergeRoute.mockImplementation(async () => { order.push("route"); });
+    domainRepo.markVerifiedActive.mockImplementation(async () => { order.push("active"); });
+
+    const result = await verifyDomain(ctx, "dom_1");
+
+    expect(result.verified).toBe(true);
+    expect(order).toEqual(["route", "active"]);
+    expect(convergeRoute).toHaveBeenCalledWith(expect.objectContaining({ id: "dom_1" }), project);
+    expect(convergeAllRoutes).toHaveBeenCalledWith(project);
+    expect(syncManagedEdge).toHaveBeenCalledWith(project, project.organizationId);
+  });
+
+  it("does not report success when the certificate exists but vhost apply fails", async () => {
+    convergeRoute.mockRejectedValue(new Error("openresty reload failed"));
+
+    const result = await verifyDomain(ctx, "dom_1");
+
+    expect(result).toMatchObject({ verified: false, sslStatus: "active" });
+    expect(result.message).toContain("openresty reload failed");
+    expect(domainRepo.markVerifiedActive).not.toHaveBeenCalled();
+    expect(domainRepo.recordVerifyFailure).toHaveBeenCalled();
+  });
+
+  it("re-applies the vhost when Verify is clicked for an already-verified domain", async () => {
+    domainRepo.findById.mockResolvedValue({ ...domainRow, verified: true, sslStatus: "active" });
+
+    const result = await verifyDomain(ctx, "dom_1");
+
+    expect(result).toMatchObject({ verified: true, sslStatus: "active" });
+    expect(result.message).toContain("live route re-applied");
+    expect(convergeRoute).toHaveBeenCalledOnce();
+    expect(sslMocks.verifyExistingCert).not.toHaveBeenCalled();
+    expect(syncManagedEdge).toHaveBeenCalledWith(project, project.organizationId);
+  });
+
+  it("applies the live route before activating a newly issued certificate", async () => {
+    const order: string[] = [];
+    sslMocks.provisionDomainCertForVerify.mockResolvedValue({
+      verified: true,
+      issuer: "certbot",
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    });
+    convergeRoute.mockImplementation(async () => { order.push("route"); });
+    domainRepo.markVerifiedActive.mockImplementation(async () => { order.push("active"); });
+
+    const result = await verifyDomain(ctx, "dom_1", { force: true });
+
+    expect(result.verified).toBe(true);
+    expect(order).toEqual(["route", "active"]);
+  });
+
+  it("keeps Action Required when a different verified route is still broken", async () => {
+    convergeAllRoutes.mockRejectedValue(new Error("sibling route failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await verifyDomain(ctx, "dom_1");
+
+    expect(result.verified).toBe(true);
+    expect(syncManagedEdge).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("still has unsynchronised routes"));
+    warn.mockRestore();
+  });
+
+  it("preserves an expired SSL state while repairing an already-verified route", async () => {
+    domainRepo.findById.mockResolvedValue({ ...domainRow, verified: true, sslStatus: "expired" });
+
+    const result = await verifyDomain(ctx, "dom_1");
+
+    expect(result).toMatchObject({ verified: true, sslStatus: "expired" });
+    expect(domainRepo.markVerified).toHaveBeenCalledWith("dom_1");
+    expect(domainRepo.markVerifiedActive).not.toHaveBeenCalled();
+    expect(sslMocks.verifyExistingCert).not.toHaveBeenCalled();
+  });
+
+  it("keeps Action Required when managed-edge reconciliation still fails", async () => {
+    syncManagedEdge.mockResolvedValue({ ok: false, failures: ["free.example.opsh.io"] });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await verifyDomain(ctx, "dom_1");
+
+    expect(result.verified).toBe(true);
+    expect(syncManagedEdge).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("still has unsynchronised routes"));
+    warn.mockRestore();
+  });
+});
+
+describe("verifyDomainSsl route recovery", () => {
+  beforeEach(() => {
+    sslMocks.manageDomainSsl.mockResolvedValue({
+      verified: true,
+      issuer: "certbot",
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    });
+    domainRepo.findById.mockResolvedValue({
+      ...domainRow,
+      verified: true,
+      sslStatus: "active",
+      sslIssuer: "certbot",
+      sslExpiresAt: new Date("2027-01-01T00:00:00.000Z"),
+    });
+  });
+
+  it("repairs the live vhost while rechecking an existing certificate", async () => {
+    const result = await verifyDomainSsl(ctx, "dom_1");
+
+    expect(result).toMatchObject({ verified: true, sslStatus: "active" });
+    expect(convergeRoute).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "dom_1" }),
+      project,
+    );
+    expect(convergeAllRoutes).toHaveBeenCalledWith(project);
+    expect(syncManagedEdge).toHaveBeenCalledWith(project, project.organizationId);
+  });
+
+  it("does not report a successful recheck when the vhost cannot be applied", async () => {
+    convergeRoute.mockRejectedValue(new Error("vhost write failed"));
+
+    await expect(verifyDomainSsl(ctx, "dom_1")).rejects.toThrow("vhost write failed");
+  });
+
+  it("does not rewrite routes for a cloud-workspace project on a local controller", async () => {
+    projectRepo.findById.mockResolvedValue({ ...project, cloudWorkspaceId: "ws_cloud" });
+
+    const result = await verifyDomainSsl(ctx, "dom_1");
+
+    expect(result).toMatchObject({ verified: true, sslStatus: "active" });
+    expect(convergeRoute).not.toHaveBeenCalled();
+    expect(convergeAllRoutes).not.toHaveBeenCalled();
+    expect(syncManagedEdge).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite routes when TLS terminates at an external ingress", async () => {
+    domainRepo.findById.mockResolvedValue({
+      ...domainRow,
+      verified: true,
+      sslStatus: "active",
+      sslIssuer: "certbot",
+      sslExpiresAt: new Date("2027-01-01T00:00:00.000Z"),
+      externalIngress: true,
+    });
+
+    const result = await verifyDomainSsl(ctx, "dom_1");
+
+    expect(result).toMatchObject({ verified: true, sslStatus: "active" });
+    expect(convergeRoute).not.toHaveBeenCalled();
+    expect(convergeAllRoutes).not.toHaveBeenCalled();
+    expect(syncManagedEdge).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/modules/domains/domain-cert-reuse.test.ts
+++ b/apps/api/test/modules/domains/domain-cert-reuse.test.ts
@@ -61,7 +61,9 @@ vi.mock("../../../src/modules/projects/project-runtime.service", () => ({
 // host's /etc/letsencrypt either way.
 vi.mock("../../../src/lib/ssh-manager", () => ({
   sshManager: {
-    withExecutor: vi.fn(async (_id: string, fn: (e: CommandExecutor) => unknown) => fn(hostExec.current!)),
+    withExecutor: vi.fn(async (_id: string, fn: (e: CommandExecutor) => unknown) =>
+      fn(hostExec.current!),
+    ),
     withHostExecutor: vi.fn(async (fn: (e: CommandExecutor) => unknown) => fn(hostExec.current!)),
   },
 }));
@@ -160,7 +162,10 @@ beforeEach(() => {
   deploymentRepo.findById.mockResolvedValue({ id: "dep_1", meta: { serverId: "srv_1" } });
   serverRepo.getInOrganization.mockResolvedValue({ id: "srv_1", isLocal: true });
   sslMocks.verifyExistingCert.mockResolvedValue({ verified: false });
-  sslMocks.installDomainCert.mockResolvedValue({ expiresAt: "2027-01-01T00:00:00.000Z", verified: true });
+  sslMocks.installDomainCert.mockResolvedValue({
+    expiresAt: "2027-01-01T00:00:00.000Z",
+    verified: true,
+  });
   convergeRoute.mockResolvedValue(undefined);
   convergeAllRoutes.mockResolvedValue(undefined);
   syncManagedEdge.mockResolvedValue({ ok: true, failures: [] });
@@ -178,7 +183,11 @@ afterEach(() => {
 
 describe("reuseServerCertForDomain", () => {
   it("reuses certbot's existing cert when the platform provider already sees it", async () => {
-    sslMocks.verifyExistingCert.mockResolvedValue({ verified: true, issuer: "certbot", expiresAt: "2027-01-01" });
+    sslMocks.verifyExistingCert.mockResolvedValue({
+      verified: true,
+      issuer: "certbot",
+      expiresAt: "2027-01-01",
+    });
 
     const ok = await reuseServerCertForDomain(ctx, "dom_1");
 
@@ -366,8 +375,12 @@ describe("verifyDomain route convergence", () => {
 
   it("writes the live route before marking a reused certificate active", async () => {
     const order: string[] = [];
-    convergeRoute.mockImplementation(async () => { order.push("route"); });
-    domainRepo.markVerifiedActive.mockImplementation(async () => { order.push("active"); });
+    convergeRoute.mockImplementation(async () => {
+      order.push("route");
+    });
+    domainRepo.markVerifiedActive.mockImplementation(async () => {
+      order.push("active");
+    });
 
     const result = await verifyDomain(ctx, "dom_1");
 
@@ -408,8 +421,12 @@ describe("verifyDomain route convergence", () => {
       issuer: "certbot",
       expiresAt: "2027-01-01T00:00:00.000Z",
     });
-    convergeRoute.mockImplementation(async () => { order.push("route"); });
-    domainRepo.markVerifiedActive.mockImplementation(async () => { order.push("active"); });
+    convergeRoute.mockImplementation(async () => {
+      order.push("route");
+    });
+    domainRepo.markVerifiedActive.mockImplementation(async () => {
+      order.push("active");
+    });
 
     const result = await verifyDomain(ctx, "dom_1", { force: true });
 
@@ -473,10 +490,7 @@ describe("verifyDomainSsl route recovery", () => {
     const result = await verifyDomainSsl(ctx, "dom_1");
 
     expect(result).toMatchObject({ verified: true, sslStatus: "active" });
-    expect(convergeRoute).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "dom_1" }),
-      project,
-    );
+    expect(convergeRoute).toHaveBeenCalledWith(expect.objectContaining({ id: "dom_1" }), project);
     expect(convergeAllRoutes).toHaveBeenCalledWith(project);
     expect(syncManagedEdge).toHaveBeenCalledWith(project, project.organizationId);
   });

--- a/apps/api/test/modules/domains/project-route.service.test.ts
+++ b/apps/api/test/modules/domains/project-route.service.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listByProject, findDeployment, resolveRuntime, reconcile, syncManagedEdge, deregisterManagedEdge } =
+const { listByProject, findDeployment, findService, listByDeployment, resolveRuntime, reconcile, applyCompiledRouting, syncManagedEdge, deregisterManagedEdge } =
   vi.hoisted(() => ({
     listByProject: vi.fn(),
     findDeployment: vi.fn(),
+    findService: vi.fn(),
+    listByDeployment: vi.fn(),
     resolveRuntime: vi.fn(),
     reconcile: vi.fn(),
+    applyCompiledRouting: vi.fn(),
     syncManagedEdge: vi.fn(),
     deregisterManagedEdge: vi.fn(),
   }));
@@ -14,6 +17,7 @@ vi.mock("@repo/db", () => ({
   repos: {
     domain: { listByProject },
     deployment: { findById: findDeployment },
+    service: { findById: findService, listByDeployment },
   },
 }));
 
@@ -30,6 +34,10 @@ vi.mock("../../../src/lib/route-apply.service", () => ({
   reconcileProjectRoutes: reconcile,
 }));
 
+vi.mock("../../../src/modules/domains/routing-apply.service", () => ({
+  applyProjectRouting: applyCompiledRouting,
+}));
+
 vi.mock("../../../src/modules/route-rules/route-rule.service", () => ({
   pushProjectRules: vi.fn().mockResolvedValue(undefined),
 }));
@@ -44,9 +52,321 @@ vi.mock("../../../src/lib/managed-edge-proxy", () => ({
 import {
   deriveEnvironmentPublicEndpoints,
   deriveNextProjectRouteState,
+  convergeAllProjectRoutes,
+  convergeVerifiedDomainRoute,
   reapplyProjectLiveRoutes,
   shouldRefuseLoopbackRoute,
 } from "../../../src/modules/domains/project-route.service";
+
+describe("convergeVerifiedDomainRoute", () => {
+  beforeEach(() => {
+    reconcile.mockReset().mockResolvedValue(undefined);
+    applyCompiledRouting.mockReset().mockResolvedValue(false);
+    listByProject.mockReset().mockResolvedValue([]);
+    findDeployment.mockReset().mockResolvedValue({ id: "dep-1", organizationId: "org-1" });
+    findService.mockReset().mockResolvedValue({
+      id: "svc-1",
+      projectId: "proj-1",
+      name: "zapbot",
+      kind: "compose",
+      enabled: true,
+      exposed: true,
+      exposedPort: "4000",
+      ports: ["4000:4000"],
+      domainType: "custom",
+      customDomain: "zapbot.example.com",
+      publicEndpoints: null,
+    });
+    listByDeployment.mockReset().mockResolvedValue([
+      { serviceId: "svc-1", ip: "172.18.0.9", hostPort: 49123 },
+    ]);
+    resolveRuntime.mockReset().mockResolvedValue({
+      routing: { provider: "local-edge" },
+      runtime: { name: "docker" },
+      effectiveTarget: "local",
+      serverId: null,
+    });
+  });
+
+  it("strictly restores a compose service domain from its live deployment row", async () => {
+    await convergeVerifiedDomainRoute(
+      {
+        id: "dom-1",
+        projectId: "proj-1",
+        serviceId: "svc-1",
+        hostname: "zapbot.example.com",
+        domainType: "custom",
+        targetPort: 4000,
+      } as never,
+      {
+        id: "proj-1",
+        slug: "zapbot",
+        organizationId: "org-1",
+        activeDeploymentId: "dep-1",
+        cloudWorkspaceId: null,
+        routeStrategy: "loopback-port",
+      } as never,
+    );
+
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "proj-1" }),
+      expect.objectContaining({
+        strict: true,
+        routing: { provider: "local-edge" },
+        registers: [{
+          hostname: "zapbot.example.com",
+          targetUrl: "http://127.0.0.1:49123",
+          port: 4000,
+          isCustomDomain: true,
+          tls: true,
+          terminatesTlsLocally: true,
+        }],
+      }),
+    );
+  });
+
+  it("preserves a canonical redirect when repairing one service hostname", async () => {
+    findService.mockResolvedValue({
+      id: "svc-1",
+      projectId: "proj-1",
+      name: "zapbot",
+      kind: "compose",
+      enabled: true,
+      exposed: true,
+      exposedPort: "4000",
+      ports: ["4000:4000"],
+      domainType: "custom",
+      customDomain: "www.example.com",
+      publicEndpoints: null,
+    });
+    listByProject.mockResolvedValue([
+      {
+        id: "dom-1",
+        hostname: "www.example.com",
+        serviceId: "svc-1",
+        redirectTo: "example.com",
+        redirectStatus: 308,
+      },
+      { id: "dom-2", hostname: "example.com", serviceId: "svc-1" },
+    ]);
+
+    await convergeVerifiedDomainRoute(
+      {
+        id: "dom-1",
+        projectId: "proj-1",
+        serviceId: "svc-1",
+        hostname: "www.example.com",
+        domainType: "custom",
+        redirectTo: "example.com",
+        redirectStatus: 308,
+      } as never,
+      {
+        id: "proj-1",
+        slug: "zapbot",
+        organizationId: "org-1",
+        activeDeploymentId: "dep-1",
+        cloudWorkspaceId: null,
+        routeStrategy: "loopback-port",
+      } as never,
+    );
+
+    expect(reconcile.mock.calls[0][1].registers[0].redirectHost).toEqual({
+      target: "example.com",
+      statusCode: 308,
+    });
+  });
+
+  it("includes an unverified sibling service before clearing a project routing warning", async () => {
+    listByProject.mockResolvedValue([
+      { id: "dom-1", projectId: "proj-1", serviceId: "svc-1", hostname: "one.example.com", verified: true },
+      { id: "dom-2", projectId: "proj-1", serviceId: "svc-2", hostname: "two.example.com", verified: false },
+    ]);
+    findService.mockImplementation(async (id: string) => ({
+      id,
+      projectId: "proj-1",
+      name: id,
+      kind: "compose",
+      enabled: true,
+      exposed: true,
+      exposedPort: id === "svc-1" ? "4001" : "4002",
+      ports: [id === "svc-1" ? "4001:4001" : "4002:4002"],
+      domainType: "custom",
+      customDomain: id === "svc-1" ? "one.example.com" : "two.example.com",
+      publicEndpoints: null,
+    }));
+    listByDeployment.mockResolvedValue([
+      { serviceId: "svc-1", ip: "172.18.0.11", hostPort: 49111 },
+      { serviceId: "svc-2", ip: "172.18.0.12", hostPort: 49112 },
+    ]);
+
+    await convergeAllProjectRoutes({
+      id: "proj-1",
+      slug: "zapbot",
+      organizationId: "org-1",
+      activeDeploymentId: "dep-1",
+      cloudWorkspaceId: null,
+      routeStrategy: "loopback-port",
+    } as never);
+
+    expect(reconcile).toHaveBeenCalledTimes(2);
+    expect(reconcile.mock.calls.map((call) => call[1].registers[0].hostname)).toEqual([
+      "one.example.com",
+      "two.example.com",
+    ]);
+  });
+
+  it("does not let an intentionally paused service pin the project routing warning", async () => {
+    listByProject.mockResolvedValue([
+      { id: "dom-1", projectId: "proj-1", serviceId: "svc-1", hostname: "live.example.com", verified: true },
+      { id: "dom-2", projectId: "proj-1", serviceId: "svc-paused", hostname: "paused.example.com", verified: false },
+    ]);
+    findService.mockImplementation(async (id: string) => ({
+      id,
+      projectId: "proj-1",
+      name: id,
+      kind: "compose",
+      enabled: id !== "svc-paused",
+      exposed: true,
+      exposedPort: "4000",
+      ports: ["4000:4000"],
+      domainType: "custom",
+      customDomain: id === "svc-paused" ? "paused.example.com" : "live.example.com",
+      publicEndpoints: null,
+    }));
+    listByDeployment.mockResolvedValue([
+      { serviceId: "svc-1", ip: "172.18.0.11", hostPort: 49111 },
+    ]);
+
+    await convergeAllProjectRoutes({
+      id: "proj-1",
+      slug: "zapbot",
+      organizationId: "org-1",
+      activeDeploymentId: "dep-1",
+      cloudWorkspaceId: null,
+      routeStrategy: "loopback-port",
+    } as never);
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0][1].registers[0].hostname).toBe("live.example.com");
+  });
+
+  it("fails closed when the compose service has no live upstream", async () => {
+    listByDeployment.mockResolvedValue([]);
+
+    await expect(
+      convergeVerifiedDomainRoute(
+        {
+          id: "dom-1",
+          projectId: "proj-1",
+          serviceId: "svc-1",
+          hostname: "zapbot.example.com",
+          domainType: "custom",
+        } as never,
+        {
+          id: "proj-1",
+          slug: "zapbot",
+          organizationId: "org-1",
+          activeDeploymentId: "dep-1",
+          cloudWorkspaceId: null,
+          routeStrategy: "loopback-port",
+        } as never,
+      ),
+    ).rejects.toThrow("no live deployment upstream");
+
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("delegates composite hostnames to the authoritative compiled route", async () => {
+    applyCompiledRouting.mockResolvedValue(true);
+
+    await convergeVerifiedDomainRoute(
+      {
+        id: "dom-1",
+        projectId: "proj-1",
+        serviceId: "svc-1",
+        hostname: "zapbot.example.com",
+        domainType: "custom",
+      } as never,
+      {
+        id: "proj-1",
+        slug: "zapbot",
+        organizationId: "org-1",
+        activeDeploymentId: "dep-1",
+        cloudWorkspaceId: null,
+      } as never,
+    );
+
+    expect(applyCompiledRouting).toHaveBeenCalledWith("proj-1", {
+      strict: true,
+      onlyHostname: "zapbot.example.com",
+    });
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["local", "local-edge"],
+    ["remote", "remote-edge"],
+  ])("restores a static service route through the %s provider", async (effectiveTarget, provider) => {
+    findService.mockResolvedValue({
+      id: "svc-1",
+      projectId: "proj-1",
+      name: "web",
+      kind: "monorepo",
+      framework: "vite",
+      startCommand: "",
+      enabled: true,
+      exposed: true,
+      exposedPort: "4173",
+      ports: ["4173"],
+      domainType: "custom",
+      customDomain: "static.example.com",
+      publicEndpoints: null,
+    });
+    listByDeployment.mockResolvedValue([
+      {
+        serviceId: "svc-1",
+        imageRef: "/opt/openship/static/proj-1/web",
+        ip: null,
+        hostPort: null,
+      },
+    ]);
+    resolveRuntime.mockResolvedValue({
+      routing: { provider },
+      runtime: { name: "docker" },
+      effectiveTarget,
+      serverId: effectiveTarget === "remote" ? "srv-1" : null,
+    });
+
+    await convergeVerifiedDomainRoute(
+      {
+        id: "dom-static",
+        projectId: "proj-1",
+        serviceId: "svc-1",
+        hostname: "static.example.com",
+        domainType: "custom",
+      } as never,
+      {
+        id: "proj-1",
+        slug: "static",
+        organizationId: "org-1",
+        activeDeploymentId: "dep-1",
+        cloudWorkspaceId: null,
+      } as never,
+    );
+
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        strict: true,
+        routing: { provider },
+        registers: [expect.objectContaining({
+          hostname: "static.example.com",
+          staticRoot: "/opt/openship/static/proj-1/web",
+        })],
+      }),
+    );
+  });
+});
 
 describe("shouldRefuseLoopbackRoute", () => {
   it("refuses a tenant project's public route to the dashboard port on loopback", () => {
@@ -155,7 +475,13 @@ describe("reapplyProjectLiveRoutes self-app loopback route (issue #129)", () => 
 
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0][1].registers).toEqual([
-      { hostname: "panel.example.com", targetUrl: "http://127.0.0.1:3001", isCustomDomain: false },
+      {
+        hostname: "panel.example.com",
+        targetUrl: "http://127.0.0.1:3001",
+        isCustomDomain: false,
+        tls: true,
+        terminatesTlsLocally: false,
+      },
     ]);
   });
 
@@ -164,6 +490,46 @@ describe("reapplyProjectLiveRoutes self-app loopback route (issue #129)", () => 
 
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0][1].registers).toEqual([]);
+  });
+
+  it("preserves a canonical redirect when strictly repairing one project hostname", async () => {
+    listByProject.mockResolvedValue([
+      {
+        id: "dom-www",
+        hostname: "www.example.com",
+        isPrimary: false,
+        serviceId: null,
+        targetPort: 3001,
+        targetPath: null,
+        domainType: "custom",
+        redirectTo: "example.com",
+        redirectStatus: 308,
+      },
+      {
+        id: "dom-root",
+        hostname: "example.com",
+        isPrimary: true,
+        serviceId: "svc-1",
+        targetPort: 3001,
+        targetPath: null,
+        domainType: "custom",
+      },
+    ]);
+
+    await reapplyProjectLiveRoutes(project, [], {
+      isSelfApp: true,
+      onlyHostname: "www.example.com",
+      strict: true,
+    });
+
+    expect(reconcile.mock.calls[0][1].registers).toEqual([{
+      hostname: "www.example.com",
+      targetUrl: "http://127.0.0.1:3001",
+      isCustomDomain: true,
+      tls: true,
+      terminatesTlsLocally: true,
+      redirectHost: { target: "example.com", statusCode: 308 },
+    }]);
   });
 });
 
@@ -234,6 +600,8 @@ describe("reapplyProjectLiveRoutes static (path-targeted) routes", () => {
         hostname: "sadsa.opsh.io",
         isCustomDomain: false,
         staticRoot: "/var/lib/openship/releases/site-42/dist",
+        tls: true,
+        terminatesTlsLocally: false,
       },
     ]);
   });

--- a/apps/api/test/modules/domains/project-route.service.test.ts
+++ b/apps/api/test/modules/domains/project-route.service.test.ts
@@ -1,17 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listByProject, findDeployment, findService, listByDeployment, resolveRuntime, reconcile, applyCompiledRouting, syncManagedEdge, deregisterManagedEdge } =
-  vi.hoisted(() => ({
-    listByProject: vi.fn(),
-    findDeployment: vi.fn(),
-    findService: vi.fn(),
-    listByDeployment: vi.fn(),
-    resolveRuntime: vi.fn(),
-    reconcile: vi.fn(),
-    applyCompiledRouting: vi.fn(),
-    syncManagedEdge: vi.fn(),
-    deregisterManagedEdge: vi.fn(),
-  }));
+const {
+  listByProject,
+  findDeployment,
+  findService,
+  listByDeployment,
+  resolveRuntime,
+  reconcile,
+  applyCompiledRouting,
+  syncManagedEdge,
+  deregisterManagedEdge,
+} = vi.hoisted(() => ({
+  listByProject: vi.fn(),
+  findDeployment: vi.fn(),
+  findService: vi.fn(),
+  listByDeployment: vi.fn(),
+  resolveRuntime: vi.fn(),
+  reconcile: vi.fn(),
+  applyCompiledRouting: vi.fn(),
+  syncManagedEdge: vi.fn(),
+  deregisterManagedEdge: vi.fn(),
+}));
 
 vi.mock("@repo/db", () => ({
   repos: {
@@ -77,9 +86,9 @@ describe("convergeVerifiedDomainRoute", () => {
       customDomain: "zapbot.example.com",
       publicEndpoints: null,
     });
-    listByDeployment.mockReset().mockResolvedValue([
-      { serviceId: "svc-1", ip: "172.18.0.9", hostPort: 49123 },
-    ]);
+    listByDeployment
+      .mockReset()
+      .mockResolvedValue([{ serviceId: "svc-1", ip: "172.18.0.9", hostPort: 49123 }]);
     resolveRuntime.mockReset().mockResolvedValue({
       routing: { provider: "local-edge" },
       runtime: { name: "docker" },
@@ -113,14 +122,16 @@ describe("convergeVerifiedDomainRoute", () => {
       expect.objectContaining({
         strict: true,
         routing: { provider: "local-edge" },
-        registers: [{
-          hostname: "zapbot.example.com",
-          targetUrl: "http://127.0.0.1:49123",
-          port: 4000,
-          isCustomDomain: true,
-          tls: true,
-          terminatesTlsLocally: true,
-        }],
+        registers: [
+          {
+            hostname: "zapbot.example.com",
+            targetUrl: "http://127.0.0.1:49123",
+            port: 4000,
+            isCustomDomain: true,
+            tls: true,
+            terminatesTlsLocally: true,
+          },
+        ],
       }),
     );
   });
@@ -178,8 +189,20 @@ describe("convergeVerifiedDomainRoute", () => {
 
   it("includes an unverified sibling service before clearing a project routing warning", async () => {
     listByProject.mockResolvedValue([
-      { id: "dom-1", projectId: "proj-1", serviceId: "svc-1", hostname: "one.example.com", verified: true },
-      { id: "dom-2", projectId: "proj-1", serviceId: "svc-2", hostname: "two.example.com", verified: false },
+      {
+        id: "dom-1",
+        projectId: "proj-1",
+        serviceId: "svc-1",
+        hostname: "one.example.com",
+        verified: true,
+      },
+      {
+        id: "dom-2",
+        projectId: "proj-1",
+        serviceId: "svc-2",
+        hostname: "two.example.com",
+        verified: false,
+      },
     ]);
     findService.mockImplementation(async (id: string) => ({
       id,
@@ -217,8 +240,20 @@ describe("convergeVerifiedDomainRoute", () => {
 
   it("does not let an intentionally paused service pin the project routing warning", async () => {
     listByProject.mockResolvedValue([
-      { id: "dom-1", projectId: "proj-1", serviceId: "svc-1", hostname: "live.example.com", verified: true },
-      { id: "dom-2", projectId: "proj-1", serviceId: "svc-paused", hostname: "paused.example.com", verified: false },
+      {
+        id: "dom-1",
+        projectId: "proj-1",
+        serviceId: "svc-1",
+        hostname: "live.example.com",
+        verified: true,
+      },
+      {
+        id: "dom-2",
+        projectId: "proj-1",
+        serviceId: "svc-paused",
+        hostname: "paused.example.com",
+        verified: false,
+      },
     ]);
     findService.mockImplementation(async (id: string) => ({
       id,
@@ -306,66 +341,71 @@ describe("convergeVerifiedDomainRoute", () => {
   it.each([
     ["local", "local-edge"],
     ["remote", "remote-edge"],
-  ])("restores a static service route through the %s provider", async (effectiveTarget, provider) => {
-    findService.mockResolvedValue({
-      id: "svc-1",
-      projectId: "proj-1",
-      name: "web",
-      kind: "monorepo",
-      framework: "vite",
-      startCommand: "",
-      enabled: true,
-      exposed: true,
-      exposedPort: "4173",
-      ports: ["4173"],
-      domainType: "custom",
-      customDomain: "static.example.com",
-      publicEndpoints: null,
-    });
-    listByDeployment.mockResolvedValue([
-      {
-        serviceId: "svc-1",
-        imageRef: "/opt/openship/static/proj-1/web",
-        ip: null,
-        hostPort: null,
-      },
-    ]);
-    resolveRuntime.mockResolvedValue({
-      routing: { provider },
-      runtime: { name: "docker" },
-      effectiveTarget,
-      serverId: effectiveTarget === "remote" ? "srv-1" : null,
-    });
-
-    await convergeVerifiedDomainRoute(
-      {
-        id: "dom-static",
+  ])(
+    "restores a static service route through the %s provider",
+    async (effectiveTarget, provider) => {
+      findService.mockResolvedValue({
+        id: "svc-1",
         projectId: "proj-1",
-        serviceId: "svc-1",
-        hostname: "static.example.com",
+        name: "web",
+        kind: "monorepo",
+        framework: "vite",
+        startCommand: "",
+        enabled: true,
+        exposed: true,
+        exposedPort: "4173",
+        ports: ["4173"],
         domainType: "custom",
-      } as never,
-      {
-        id: "proj-1",
-        slug: "static",
-        organizationId: "org-1",
-        activeDeploymentId: "dep-1",
-        cloudWorkspaceId: null,
-      } as never,
-    );
-
-    expect(reconcile).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        strict: true,
+        customDomain: "static.example.com",
+        publicEndpoints: null,
+      });
+      listByDeployment.mockResolvedValue([
+        {
+          serviceId: "svc-1",
+          imageRef: "/opt/openship/static/proj-1/web",
+          ip: null,
+          hostPort: null,
+        },
+      ]);
+      resolveRuntime.mockResolvedValue({
         routing: { provider },
-        registers: [expect.objectContaining({
+        runtime: { name: "docker" },
+        effectiveTarget,
+        serverId: effectiveTarget === "remote" ? "srv-1" : null,
+      });
+
+      await convergeVerifiedDomainRoute(
+        {
+          id: "dom-static",
+          projectId: "proj-1",
+          serviceId: "svc-1",
           hostname: "static.example.com",
-          staticRoot: "/opt/openship/static/proj-1/web",
-        })],
-      }),
-    );
-  });
+          domainType: "custom",
+        } as never,
+        {
+          id: "proj-1",
+          slug: "static",
+          organizationId: "org-1",
+          activeDeploymentId: "dep-1",
+          cloudWorkspaceId: null,
+        } as never,
+      );
+
+      expect(reconcile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          strict: true,
+          routing: { provider },
+          registers: [
+            expect.objectContaining({
+              hostname: "static.example.com",
+              staticRoot: "/opt/openship/static/proj-1/web",
+            }),
+          ],
+        }),
+      );
+    },
+  );
 });
 
 describe("shouldRefuseLoopbackRoute", () => {
@@ -392,23 +432,13 @@ describe("shouldRefuseLoopbackRoute", () => {
 
 describe("deriveEnvironmentPublicEndpoints", () => {
   it("clones an explicit proxy target without inventing a fallback port", () => {
-    expect(
-      deriveEnvironmentPublicEndpoints(
-        [{ port: 4010 }],
-        "preview-app",
-      ),
-    ).toEqual([
+    expect(deriveEnvironmentPublicEndpoints([{ port: 4010 }], "preview-app")).toEqual([
       { port: 4010, domain: "preview-app", domainType: "free" },
     ]);
   });
 
   it("clones an explicit static path target without inventing a port", () => {
-    expect(
-      deriveEnvironmentPublicEndpoints(
-        [{ targetPath: "/docs" }],
-        "preview-docs",
-      ),
-    ).toEqual([
+    expect(deriveEnvironmentPublicEndpoints([{ targetPath: "/docs" }], "preview-docs")).toEqual([
       { targetPath: "/docs", domain: "preview-docs", domainType: "free" },
     ]);
   });
@@ -522,14 +552,16 @@ describe("reapplyProjectLiveRoutes self-app loopback route (issue #129)", () => 
       strict: true,
     });
 
-    expect(reconcile.mock.calls[0][1].registers).toEqual([{
-      hostname: "www.example.com",
-      targetUrl: "http://127.0.0.1:3001",
-      isCustomDomain: true,
-      tls: true,
-      terminatesTlsLocally: true,
-      redirectHost: { target: "example.com", statusCode: 308 },
-    }]);
+    expect(reconcile.mock.calls[0][1].registers).toEqual([
+      {
+        hostname: "www.example.com",
+        targetUrl: "http://127.0.0.1:3001",
+        isCustomDomain: true,
+        tls: true,
+        terminatesTlsLocally: true,
+        redirectHost: { target: "example.com", statusCode: 308 },
+      },
+    ]);
   });
 });
 
@@ -719,7 +751,9 @@ describe("deriveNextProjectRouteState custom-hostname gate", () => {
 
   it("accepts a real hostname, scheme and all", () => {
     const state = deriveNextProjectRouteState(project, {
-      nextPublicEndpoints: [{ customDomain: "HTTPS://App.Example.com/", domainType: "custom", port: 3000 }],
+      nextPublicEndpoints: [
+        { customDomain: "HTTPS://App.Example.com/", domainType: "custom", port: 3000 },
+      ],
     });
 
     expect(state.publicEndpoints[0]).toMatchObject({ customDomain: "app.example.com" });
@@ -732,16 +766,18 @@ describe("deriveNextProjectRouteState custom-hostname gate", () => {
    * submission INTRODUCES are refused; the endpoint list is authoritative, so every
    * save echoes the stored set back.
    */
-  const legacyRow = [{
-    id: "dom-legacy",
-    hostname: "localhost",
-    isPrimary: true,
-    serviceId: null,
-    targetPort: 3000,
-    targetPath: null,
-    domainType: "custom",
-    verified: false,
-  }] as never;
+  const legacyRow = [
+    {
+      id: "dom-legacy",
+      hostname: "localhost",
+      isPrimary: true,
+      serviceId: null,
+      targetPort: 3000,
+      targetPath: null,
+      domainType: "custom",
+      verified: false,
+    },
+  ] as never;
 
   it("does not throw on a bad hostname that is already stored", () => {
     expect(() => deriveNextProjectRouteState(project, { projectDomains: legacyRow })).not.toThrow();
@@ -763,7 +799,9 @@ describe("deriveNextProjectRouteState custom-hostname gate", () => {
     expect(() =>
       deriveNextProjectRouteState(project, {
         projectDomains: legacyRow,
-        nextPublicEndpoints: [{ customDomain: "app.example.com", domainType: "custom", port: 3000 }],
+        nextPublicEndpoints: [
+          { customDomain: "app.example.com", domainType: "custom", port: 3000 },
+        ],
       }),
     ).not.toThrow();
   });

--- a/apps/api/test/modules/domains/routing-apply-strict.test.ts
+++ b/apps/api/test/modules/domains/routing-apply-strict.test.ts
@@ -95,11 +95,13 @@ describe("applyProjectRouting strict recovery", () => {
       { serviceId: "web", imageRef: "/opt/openship/static/proj-1/web" },
       { serviceId: "api", ip: "172.18.0.10", hostPort: 49300 },
     ]);
-    state.listDomains.mockResolvedValue([{
-      hostname: "app.example.com",
-      externalIngress: false,
-      manualSsl: false,
-    }]);
+    state.listDomains.mockResolvedValue([
+      {
+        hostname: "app.example.com",
+        externalIngress: false,
+        manualSsl: false,
+      },
+    ]);
     state.resolveRuntime.mockResolvedValue({
       routing: { provider: "remote-or-local-edge" },
       runtime: { name: "docker" },
@@ -118,22 +120,28 @@ describe("applyProjectRouting strict recovery", () => {
       expect.objectContaining({
         strict: true,
         routing: { provider: "remote-or-local-edge" },
-        registers: [{
-          hostname: "app.example.com",
-          isCustomDomain: true,
-          tls: true,
-          terminatesTlsLocally: true,
-          staticRoot: "/opt/openship/static/proj-1/web",
-          proxyLocations: [{
-            pathPrefix: "/backend/",
-            targetUrl: "http://127.0.0.1:49300",
-          }],
-          redirects: [{ path: "/old", exact: true, statusCode: 308, destination: "/new" }],
-          headerRules: [{
-            path: "/",
-            headers: [{ key: "X-Frame-Options", value: "DENY" }],
-          }],
-        }],
+        registers: [
+          {
+            hostname: "app.example.com",
+            isCustomDomain: true,
+            tls: true,
+            terminatesTlsLocally: true,
+            staticRoot: "/opt/openship/static/proj-1/web",
+            proxyLocations: [
+              {
+                pathPrefix: "/backend/",
+                targetUrl: "http://127.0.0.1:49300",
+              },
+            ],
+            redirects: [{ path: "/old", exact: true, statusCode: 308, destination: "/new" }],
+            headerRules: [
+              {
+                path: "/",
+                headers: [{ key: "X-Frame-Options", value: "DENY" }],
+              },
+            ],
+          },
+        ],
       }),
     );
   });
@@ -151,11 +159,13 @@ describe("applyProjectRouting strict recovery", () => {
   });
 
   it("preserves external-ingress TLS ownership on the compiled route", async () => {
-    state.listDomains.mockResolvedValue([{
-      hostname: "app.example.com",
-      externalIngress: true,
-      manualSsl: false,
-    }]);
+    state.listDomains.mockResolvedValue([
+      {
+        hostname: "app.example.com",
+        externalIngress: true,
+        manualSsl: false,
+      },
+    ]);
 
     await applyProjectRouting("proj-1", { strict: true, onlyHostname: "app.example.com" });
 
@@ -197,12 +207,14 @@ describe("applyProjectRouting strict recovery", () => {
     state.findProject.mockResolvedValue({
       ...project,
       routingConfig: null,
-      compositeRoutes: [{
-        hostname: "fanout.example.com",
-        isCustomDomain: true,
-        rootServiceId: "api",
-        locations: [{ pathPrefix: "/worker", serviceId: "worker" }],
-      }],
+      compositeRoutes: [
+        {
+          hostname: "fanout.example.com",
+          isCustomDomain: true,
+          rootServiceId: "api",
+          locations: [{ pathPrefix: "/worker", serviceId: "worker" }],
+        },
+      ],
     });
     state.listServices.mockResolvedValue([api, worker]);
     state.listLive.mockResolvedValue([{ serviceId: "api", ip: "172.18.0.10", hostPort: 49300 }]);
@@ -227,12 +239,14 @@ describe("applyProjectRouting strict recovery", () => {
     state.findProject.mockResolvedValue({
       ...project,
       routingConfig: null,
-      compositeRoutes: [{
-        hostname: "fanout.example.com",
-        isCustomDomain: true,
-        rootServiceId: "api",
-        locations: [{ pathPrefix: "/worker", serviceId: "worker" }],
-      }],
+      compositeRoutes: [
+        {
+          hostname: "fanout.example.com",
+          isCustomDomain: true,
+          rootServiceId: "api",
+          locations: [{ pathPrefix: "/worker", serviceId: "worker" }],
+        },
+      ],
     });
     state.listServices.mockResolvedValue([api, worker]);
     state.listLive.mockResolvedValue([

--- a/apps/api/test/modules/domains/routing-apply-strict.test.ts
+++ b/apps/api/test/modules/domains/routing-apply-strict.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  findProject: vi.fn(),
+  findDeployment: vi.fn(),
+  listServices: vi.fn(),
+  listLive: vi.fn(),
+  listDomains: vi.fn(),
+  resolveRuntime: vi.fn(),
+  reconcile: vi.fn(),
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    project: { findById: state.findProject },
+    deployment: { findById: state.findDeployment },
+    service: {
+      listByProject: state.listServices,
+      listByDeployment: state.listLive,
+    },
+    domain: { listByProject: state.listDomains },
+  },
+}));
+
+vi.mock("../../../src/lib/controller-helpers", () => ({
+  platform: () => ({ target: "local" }),
+}));
+
+vi.mock("../../../src/lib/deployment-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/lib/deployment-runtime")>()),
+  resolveDeploymentRuntime: state.resolveRuntime,
+  usesManagedRouting: () => true,
+}));
+
+vi.mock("../../../src/lib/route-apply.service", () => ({
+  reconcileProjectRoutes: state.reconcile,
+}));
+
+import { applyProjectRouting } from "../../../src/modules/domains/routing-apply.service";
+
+const project = {
+  id: "proj-1",
+  slug: "app",
+  activeDeploymentId: "dep-1",
+  routeStrategy: "loopback-port",
+  port: 4173,
+  compositeRoutes: null,
+  routingConfig: {
+    rewrites: [
+      { source: "/backend/(.*)", destination: "/backend/index.js" },
+      { source: "/(.*)", destination: "/index.html" },
+    ],
+    redirects: [{ source: "/old", destination: "/new", permanent: true }],
+    headers: [{ source: "/(.*)", headers: [{ key: "X-Frame-Options", value: "DENY" }] }],
+  },
+};
+
+const web = {
+  id: "web",
+  projectId: "proj-1",
+  name: "web",
+  kind: "monorepo",
+  framework: "vite",
+  startCommand: "",
+  enabled: true,
+  exposed: true,
+  exposedPort: "4173",
+  ports: ["4173"],
+  domainType: "custom",
+  customDomain: "app.example.com",
+  publicEndpoints: null,
+};
+
+const api = {
+  id: "api",
+  projectId: "proj-1",
+  name: "api",
+  kind: "monorepo",
+  framework: "express",
+  startCommand: "npm start",
+  enabled: true,
+  exposed: false,
+  exposedPort: "3000",
+  ports: ["3000"],
+  publicEndpoints: null,
+};
+
+describe("applyProjectRouting strict recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.findProject.mockResolvedValue(project);
+    state.findDeployment.mockResolvedValue({ id: "dep-1" });
+    state.listServices.mockResolvedValue([web, api]);
+    state.listLive.mockResolvedValue([
+      { serviceId: "web", imageRef: "/opt/openship/static/proj-1/web" },
+      { serviceId: "api", ip: "172.18.0.10", hostPort: 49300 },
+    ]);
+    state.listDomains.mockResolvedValue([{
+      hostname: "app.example.com",
+      externalIngress: false,
+      manualSsl: false,
+    }]);
+    state.resolveRuntime.mockResolvedValue({
+      routing: { provider: "remote-or-local-edge" },
+      runtime: { name: "docker" },
+      effectiveTarget: "server",
+    });
+    state.reconcile.mockResolvedValue(undefined);
+  });
+
+  it("retains static root, rewrites, redirects and headers for a composite hostname", async () => {
+    await expect(
+      applyProjectRouting("proj-1", { strict: true, onlyHostname: "app.example.com" }),
+    ).resolves.toBe(true);
+
+    expect(state.reconcile).toHaveBeenCalledWith(
+      project,
+      expect.objectContaining({
+        strict: true,
+        routing: { provider: "remote-or-local-edge" },
+        registers: [{
+          hostname: "app.example.com",
+          isCustomDomain: true,
+          tls: true,
+          terminatesTlsLocally: true,
+          staticRoot: "/opt/openship/static/proj-1/web",
+          proxyLocations: [{
+            pathPrefix: "/backend/",
+            targetUrl: "http://127.0.0.1:49300",
+          }],
+          redirects: [{ path: "/old", exact: true, statusCode: 308, destination: "/new" }],
+          headerRules: [{
+            path: "/",
+            headers: [{ key: "X-Frame-Options", value: "DENY" }],
+          }],
+        }],
+      }),
+    );
+  });
+
+  it("fails closed instead of replacing an incomplete composite with a plain route", async () => {
+    state.listLive.mockResolvedValue([
+      { serviceId: "web", imageRef: "/opt/openship/static/proj-1/web" },
+      { serviceId: "api", ip: null, hostPort: null },
+    ]);
+
+    await expect(
+      applyProjectRouting("proj-1", { strict: true, onlyHostname: "app.example.com" }),
+    ).rejects.toThrow("compiled route");
+    expect(state.reconcile).not.toHaveBeenCalled();
+  });
+
+  it("preserves external-ingress TLS ownership on the compiled route", async () => {
+    state.listDomains.mockResolvedValue([{
+      hostname: "app.example.com",
+      externalIngress: true,
+      manualSsl: false,
+    }]);
+
+    await applyProjectRouting("proj-1", { strict: true, onlyHostname: "app.example.com" });
+
+    expect(state.reconcile.mock.calls[0][1].registers[0]).toMatchObject({
+      hostname: "app.example.com",
+      tls: false,
+      terminatesTlsLocally: false,
+    });
+  });
+
+  it("preserves a canonical redirect on a repaired composite route", async () => {
+    state.listDomains.mockResolvedValue([
+      {
+        hostname: "app.example.com",
+        externalIngress: false,
+        manualSsl: false,
+        redirectTo: "canonical.example.com",
+        redirectStatus: 308,
+      },
+      { hostname: "canonical.example.com", externalIngress: false, manualSsl: false },
+    ]);
+
+    await applyProjectRouting("proj-1", { strict: true, onlyHostname: "app.example.com" });
+
+    expect(state.reconcile.mock.calls[0][1].registers[0]).toMatchObject({
+      hostname: "app.example.com",
+      redirectHost: { target: "canonical.example.com", statusCode: 308 },
+    });
+  });
+
+  it("fails closed when a strict fanout route has an unresolved secondary location", async () => {
+    const worker = {
+      ...api,
+      id: "worker",
+      name: "worker",
+      exposedPort: "3001",
+      ports: ["3001"],
+    };
+    state.findProject.mockResolvedValue({
+      ...project,
+      routingConfig: null,
+      compositeRoutes: [{
+        hostname: "fanout.example.com",
+        isCustomDomain: true,
+        rootServiceId: "api",
+        locations: [{ pathPrefix: "/worker", serviceId: "worker" }],
+      }],
+    });
+    state.listServices.mockResolvedValue([api, worker]);
+    state.listLive.mockResolvedValue([{ serviceId: "api", ip: "172.18.0.10", hostPort: 49300 }]);
+    state.listDomains.mockResolvedValue([
+      { hostname: "fanout.example.com", externalIngress: false, manualSsl: false },
+    ]);
+
+    await expect(
+      applyProjectRouting("proj-1", { strict: true, onlyHostname: "fanout.example.com" }),
+    ).rejects.toThrow("/worker upstream");
+    expect(state.reconcile).not.toHaveBeenCalled();
+  });
+
+  it("preserves a canonical redirect on a complete fanout route", async () => {
+    const worker = {
+      ...api,
+      id: "worker",
+      name: "worker",
+      exposedPort: "3001",
+      ports: ["3001"],
+    };
+    state.findProject.mockResolvedValue({
+      ...project,
+      routingConfig: null,
+      compositeRoutes: [{
+        hostname: "fanout.example.com",
+        isCustomDomain: true,
+        rootServiceId: "api",
+        locations: [{ pathPrefix: "/worker", serviceId: "worker" }],
+      }],
+    });
+    state.listServices.mockResolvedValue([api, worker]);
+    state.listLive.mockResolvedValue([
+      { serviceId: "api", ip: "172.18.0.10", hostPort: 49300 },
+      { serviceId: "worker", ip: "172.18.0.11", hostPort: 49301 },
+    ]);
+    state.listDomains.mockResolvedValue([
+      {
+        hostname: "fanout.example.com",
+        externalIngress: false,
+        manualSsl: false,
+        redirectTo: "canonical.example.com",
+        redirectStatus: 301,
+      },
+      { hostname: "canonical.example.com", externalIngress: false, manualSsl: false },
+    ]);
+
+    await applyProjectRouting("proj-1", { strict: true, onlyHostname: "fanout.example.com" });
+
+    expect(state.reconcile.mock.calls[0][1].registers[0]).toMatchObject({
+      hostname: "fanout.example.com",
+      targetUrl: "http://127.0.0.1:49300",
+      proxyLocations: [{ pathPrefix: "/worker", targetUrl: "http://127.0.0.1:49301" }],
+      redirectHost: { target: "canonical.example.com", statusCode: 301 },
+    });
+  });
+});

--- a/apps/api/test/modules/github/clone-auth-precedence.test.ts
+++ b/apps/api/test/modules/github/clone-auth-precedence.test.ts
@@ -45,16 +45,15 @@ beforeEach(() => {
 });
 
 describe("resolveBuildGitToken — local build", () => {
-  it("uses the local gh token directly, never touching the remote/server chain", async () => {
-    getLocalGhToken.mockResolvedValue("ghtok");
+  it("uses the unified local token chain, never touching the remote/server chain", async () => {
+    tokenFor.mockResolvedValue({ token: "ghtok", source: "gh-cli" });
     const res = await resolveBuildGitToken({ ...base, buildStrategy: "local" });
     expect(res).toEqual({ token: "ghtok" });
     expect(resolveServerGitCredential).not.toHaveBeenCalled();
-    expect(tokenFor).not.toHaveBeenCalled();
+    expect(tokenFor).toHaveBeenCalledWith(ctx, "local", expect.anything());
   });
 
-  it("falls through to the resolver chain when no local gh", async () => {
-    getLocalGhToken.mockResolvedValue(null);
+  it("uses a PAT returned by the local resolver chain", async () => {
     tokenFor.mockResolvedValue({ token: "pat" });
     const res = await resolveBuildGitToken({ ...base, buildStrategy: "local" });
     expect(res).toEqual({ token: "pat" });
@@ -122,7 +121,9 @@ describe("resolveBuildGitToken — server build, fall-through when server has no
   });
 
   it("degrades to an api-host clone (flagged) for docker clone-on-server", async () => {
-    getLocalGhToken.mockResolvedValue("localtok");
+    tokenFor.mockImplementation(async (_ctx, purpose) =>
+      purpose === "local" ? { token: "localtok" } : null,
+    );
     const res = await resolveBuildGitToken({
       ...base,
       buildStrategy: "server",

--- a/apps/api/test/modules/github/github.auth.test.ts
+++ b/apps/api/test/modules/github/github.auth.test.ts
@@ -1,8 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { APIError } from "better-auth/api";
 
-const { getAccessToken } = vi.hoisted(() => ({
+const {
+  getAccessToken,
+  unlinkProvider,
+  listMemberships,
+  setStoredDeviceToken,
+  setGithubCliDisabled,
+  setGhCliOperatorOptedIn,
+  isGithubCliDisabled,
+  invalidateByPrefix,
+} = vi.hoisted(() => ({
   getAccessToken: vi.fn(),
+  unlinkProvider: vi.fn(),
+  listMemberships: vi.fn(),
+  setStoredDeviceToken: vi.fn(),
+  setGithubCliDisabled: vi.fn(),
+  setGhCliOperatorOptedIn: vi.fn(),
+  isGithubCliDisabled: vi.fn(),
+  invalidateByPrefix: vi.fn(),
 }));
 
 vi.mock("@repo/db", () => ({
@@ -10,6 +26,8 @@ vi.mock("@repo/db", () => ({
     gitInstallation: {
       findByOwner: vi.fn(),
     },
+    account: { unlinkProvider },
+    member: { listByUser: listMemberships },
   },
 }));
 
@@ -27,15 +45,33 @@ vi.mock("../../../src/config/env", () => ({
 
 vi.mock("../../../src/modules/github/github.local-auth", () => ({
   getLocalGhToken: vi.fn(),
+  setStoredDeviceToken,
 }));
 
-import { getUserToken } from "../../../src/modules/github/github.auth";
+vi.mock("../../../src/modules/settings/settings.service", () => ({
+  setGithubCliDisabled,
+  setGhCliOperatorOptedIn,
+  isGithubCliDisabled,
+}));
+
+vi.mock("../../../src/lib/cache-store", () => ({
+  cacheStore: vi.fn(async () => ({ invalidateByPrefix })),
+}));
+
+import { disconnectUser, getUserToken } from "../../../src/modules/github/github.auth";
+
+beforeEach(() => {
+  getAccessToken.mockReset();
+  unlinkProvider.mockReset();
+  listMemberships.mockReset().mockResolvedValue([]);
+  setStoredDeviceToken.mockReset().mockResolvedValue(undefined);
+  setGithubCliDisabled.mockReset().mockResolvedValue(undefined);
+  setGhCliOperatorOptedIn.mockReset().mockResolvedValue(undefined);
+  isGithubCliDisabled.mockReset().mockResolvedValue(false);
+  invalidateByPrefix.mockReset().mockResolvedValue(undefined);
+});
 
 describe("getUserToken", () => {
-  beforeEach(() => {
-    getAccessToken.mockReset();
-  });
-
   it("uses Better Auth to resolve the GitHub OAuth token", async () => {
     getAccessToken.mockResolvedValue({ accessToken: "github-user-token" });
 
@@ -63,5 +99,21 @@ describe("getUserToken", () => {
     getAccessToken.mockRejectedValue(new Error("boom"));
 
     await expect(getUserToken("user-1")).rejects.toThrow("boom");
+  });
+});
+
+describe("disconnectUser", () => {
+  it("clears the stored credential and both local authorization gates", async () => {
+    await disconnectUser("user-1", "cli");
+
+    expect(setGithubCliDisabled).toHaveBeenCalledWith("user-1", true);
+    expect(setGhCliOperatorOptedIn).toHaveBeenCalledWith("user-1", false);
+    expect(setStoredDeviceToken).toHaveBeenCalledWith(null);
+  });
+
+  it("fails instead of reporting a successful disconnect when token removal fails", async () => {
+    setStoredDeviceToken.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(disconnectUser("user-1", "cli")).rejects.toThrow("database unavailable");
   });
 });

--- a/apps/api/test/modules/github/github.controller.test.ts
+++ b/apps/api/test/modules/github/github.controller.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { linkSocialAccount, getGitHubAuthMode } = vi.hoisted(() => ({
-  linkSocialAccount: vi.fn(),
-  getGitHubAuthMode: vi.fn(),
-}));
+const { linkSocialAccount, getGitHubAuthMode, getLocalGhStatus, isGithubCliDisabled } = vi.hoisted(
+  () => ({
+    linkSocialAccount: vi.fn(),
+    getGitHubAuthMode: vi.fn(),
+    getLocalGhStatus: vi.fn(),
+    isGithubCliDisabled: vi.fn(),
+  }),
+);
 
 vi.mock("../../../src/lib/auth", () => ({
   auth: {
@@ -17,10 +21,11 @@ vi.mock("../../../src/modules/github/github.auth", () => ({
   getGitHubAuthMode,
 }));
 
-vi.mock("../../../src/modules/github/github.local-auth", () => ({}));
+vi.mock("../../../src/modules/github/github.local-auth", () => ({ getLocalGhStatus }));
 vi.mock("../../../src/modules/github/github.service", () => ({}));
+vi.mock("../../../src/modules/settings/settings.service", () => ({ isGithubCliDisabled }));
 
-import { connectRedirect } from "../../../src/modules/github/github.controller";
+import { connectRedirect, getLocalStatus } from "../../../src/modules/github/github.controller";
 
 function createContext(headers: Headers) {
   return {
@@ -44,6 +49,29 @@ describe("connectRedirect", () => {
   beforeEach(() => {
     getGitHubAuthMode.mockReset();
     linkSocialAccount.mockReset();
+    getLocalGhStatus.mockReset();
+    isGithubCliDisabled.mockReset().mockResolvedValue(false);
+  });
+
+  it("reports local GitHub auth unavailable after the user disconnects it", async () => {
+    getGitHubAuthMode.mockReturnValue("cli");
+    isGithubCliDisabled.mockResolvedValue(true);
+    getLocalGhStatus.mockResolvedValue({
+      available: true,
+      login: "stale-login",
+      method: "host-cli",
+    });
+    const ctx = {
+      get: () => ({ userId: "user-1" }),
+      json: (body: unknown) => body,
+    } as any;
+
+    await expect(getLocalStatus(ctx)).resolves.toEqual({
+      available: false,
+      method: null,
+      activeMode: "cli",
+    });
+    expect(getLocalGhStatus).not.toHaveBeenCalled();
   });
 
   it("starts a GitHub link flow and forwards the OAuth state cookie", async () => {
@@ -51,12 +79,15 @@ describe("connectRedirect", () => {
     const headers = new Headers({ cookie: "openship.session_token=test" });
 
     linkSocialAccount.mockResolvedValue(
-      new Response(JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }), {
-        headers: {
-          "content-type": "application/json",
-          "set-cookie": "oauth_state=test-state; Path=/; HttpOnly",
+      new Response(
+        JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }),
+        {
+          headers: {
+            "content-type": "application/json",
+            "set-cookie": "oauth_state=test-state; Path=/; HttpOnly",
+          },
         },
-      }),
+      ),
     );
 
     const response = await connectRedirect(createContext(headers));
@@ -82,11 +113,14 @@ describe("connectRedirect", () => {
     getGitHubAuthMode.mockReturnValue("app");
 
     linkSocialAccount.mockResolvedValue(
-      new Response(JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }), {
-        headers: {
-          "content-type": "application/json",
+      new Response(
+        JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }),
+        {
+          headers: {
+            "content-type": "application/json",
+          },
         },
-      }),
+      ),
     );
 
     await connectRedirect(createContext(new Headers()));

--- a/apps/api/test/modules/github/list-repos-for-owner.test.ts
+++ b/apps/api/test/modules/github/list-repos-for-owner.test.ts
@@ -26,6 +26,10 @@ const { getLocalGhToken, listLocalGhRepos } = vi.hoisted(() => ({
   listLocalGhRepos: vi.fn(),
 }));
 
+const { isGithubCliDisabled } = vi.hoisted(() => ({
+  isGithubCliDisabled: vi.fn(),
+}));
+
 vi.mock("../../../src/modules/github/github.auth", () => ({
   githubFetch,
   resolveGitHubAuthMode,
@@ -47,6 +51,10 @@ vi.mock("../../../src/modules/github/github.local-auth", () => ({
   listLocalGhRepos,
   listLocalGhOrgs: vi.fn(),
   getLocalGhStatus: vi.fn(),
+}));
+
+vi.mock("../../../src/modules/settings/settings.service", () => ({
+  isGithubCliDisabled,
 }));
 
 // env: {} → CLOUD_MODE is falsy, so createGitHubSource takes the LOCAL branch
@@ -83,6 +91,7 @@ beforeEach(() => {
   githubFetch.mockReset();
   getLocalGhToken.mockReset();
   listLocalGhRepos.mockReset();
+  isGithubCliDisabled.mockReset().mockResolvedValue(false);
 });
 
 describe("listReposForOwner — source dispatch", () => {
@@ -158,6 +167,18 @@ describe("listReposForOwner — source dispatch", () => {
       expect(repos).toHaveLength(1);
       expect(repos?.[0].full_name).toBe("acme/site");
       expect(githubFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not reuse the instance credential after this user disconnects it", async () => {
+      isGithubCliDisabled.mockResolvedValue(true);
+      resolveGitHubAuthMode.mockResolvedValue("cloud-app");
+      getUserStatus.mockResolvedValue({ connected: false });
+      getLocalGhToken.mockResolvedValue("gho_token");
+      getInstallationToken.mockResolvedValue(null);
+
+      expect(await call("acme")).toEqual([]);
+      expect(getLocalGhToken).not.toHaveBeenCalled();
+      expect(listLocalGhRepos).not.toHaveBeenCalled();
     });
 
     it("returns [] when no gh token and the App install yields no token", async () => {

--- a/apps/api/test/modules/github/tokenFor.test.ts
+++ b/apps/api/test/modules/github/tokenFor.test.ts
@@ -55,11 +55,17 @@ const withOwner = { projectId: "p1", owner: "acme", repo: "app" };
 function setProjectPat(tok: string | null) {
   findProjectById.mockResolvedValue(tok ? { cloneTokenEncrypted: `ENC:${tok}` } : null);
 }
-function setSettings(opts: { userPat?: string | null; asDefault?: boolean; ghOptIn?: boolean }) {
+function setSettings(opts: {
+  userPat?: string | null;
+  asDefault?: boolean;
+  ghOptIn?: boolean;
+  ghDisabled?: boolean;
+}) {
   findSettingsByUser.mockResolvedValue({
     cloneTokenEncrypted: opts.userPat ? `ENC:${opts.userPat}` : null,
     cloneTokenAsDefault: opts.asDefault ?? true,
     ghCliOperatorOptedIn: opts.ghOptIn ?? false,
+    githubCliDisabled: opts.ghDisabled ?? false,
   });
 }
 function setApp(present: boolean) {
@@ -183,6 +189,13 @@ describe("tokenFor — gh-CLI authorization gate (HIGH #7)", () => {
     envMock.GITHUB_AUTH_MODE = "cli";
     setGh("ghtok");
     expect(await tokenFor(ctxOrg, "local", withOwner)).toEqual({ token: "ghtok", source: "gh-cli" });
+  });
+
+  it("refuses gh after the user disconnects it, including instance-wide cli mode", async () => {
+    envMock.GITHUB_AUTH_MODE = "cli";
+    setGh("ghtok");
+    setSettings({ ghOptIn: true, ghDisabled: true });
+    expect(await tokenFor(ctxOrg, "local", withOwner)).toBeNull();
   });
 });
 

--- a/apps/api/test/modules/projects/retry-routing.test.ts
+++ b/apps/api/test/modules/projects/retry-routing.test.ts
@@ -15,7 +15,12 @@ vi.mock("@repo/db", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@repo/db")>();
   return {
     ...actual,
-    repos: { ...actual.repos, project: projectRepo, deployment: deploymentRepo, domain: domainRepo },
+    repos: {
+      ...actual.repos,
+      project: projectRepo,
+      deployment: deploymentRepo,
+      domain: domainRepo,
+    },
   };
 });
 
@@ -89,8 +94,8 @@ describe("retryProjectRouting — safe self-heal", () => {
     convergeAllProjectRoutes.mockResolvedValue(undefined);
     syncManagedEdgeRoutes.mockResolvedValue({ failures: [] });
     // withExecutor(serverId, fn) → run fn with a dummy executor.
-    withExecutor.mockImplementation(async (_serverId: string, fn: (e: unknown) => Promise<unknown>) =>
-      fn({}),
+    withExecutor.mockImplementation(
+      async (_serverId: string, fn: (e: unknown) => Promise<unknown>) => fn({}),
     );
     edgeProxy.mockResolvedValue({ siteFor });
   });
@@ -115,18 +120,16 @@ describe("retryProjectRouting — safe self-heal", () => {
 
     expect(result).toEqual({
       ok: false,
-      warning: "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.",
+      warning:
+        "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.",
     });
-    expect(deploymentRepo.updateStatus).toHaveBeenLastCalledWith(
-      "dep_1",
-      "ready",
-      {
-        meta: expect.objectContaining({
-          edgeUnsynced: true,
-          deployWarning: "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.",
-        }),
-      },
-    );
+    expect(deploymentRepo.updateStatus).toHaveBeenLastCalledWith("dep_1", "ready", {
+      meta: expect.objectContaining({
+        edgeUnsynced: true,
+        deployWarning:
+          "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.",
+      }),
+    });
   });
 
   it("leaves the row unchanged when the edge has no live upstream (never guesses)", async () => {
@@ -167,11 +170,9 @@ describe("retryProjectRouting — safe self-heal", () => {
 
     await retryProjectRouting("proj_1", "org_1");
 
-    expect(deploymentRepo.updateStatus).toHaveBeenCalledWith(
-      "dep_1",
-      "ready",
-      { meta: expect.objectContaining({ serverId: "srv_1", deployTarget: "server" }) },
-    );
+    expect(deploymentRepo.updateStatus).toHaveBeenCalledWith("dep_1", "ready", {
+      meta: expect.objectContaining({ serverId: "srv_1", deployTarget: "server" }),
+    });
   });
 
   it("is a no-op for a cloud project (no server edge to repair)", async () => {

--- a/apps/api/test/modules/projects/retry-routing.test.ts
+++ b/apps/api/test/modules/projects/retry-routing.test.ts
@@ -8,7 +8,7 @@ const domainRepo = vi.hoisted(() => ({ listByProject: vi.fn(), update: vi.fn() }
 const edgeProxy = vi.hoisted(() => vi.fn());
 const siteFor = vi.hoisted(() => vi.fn());
 const withExecutor = vi.hoisted(() => vi.fn());
-const applyProjectRouting = vi.hoisted(() => vi.fn());
+const convergeAllProjectRoutes = vi.hoisted(() => vi.fn());
 const syncManagedEdgeRoutes = vi.hoisted(() => vi.fn());
 
 vi.mock("@repo/db", async (importOriginal) => {
@@ -35,8 +35,8 @@ vi.mock("../../../src/lib/deployment-runtime", () => ({
   resolveDeploymentRuntime: vi.fn(),
 }));
 
-vi.mock("../../../src/modules/domains/routing-apply.service", () => ({
-  applyProjectRouting,
+vi.mock("../../../src/modules/domains/project-route.service", () => ({
+  convergeAllProjectRoutes,
 }));
 
 import { retryProjectRouting } from "../../../src/modules/projects/project-runtime.service";
@@ -86,7 +86,7 @@ describe("retryProjectRouting — safe self-heal", () => {
     deploymentRepo.updateStatus.mockResolvedValue(undefined);
     domainRepo.listByProject.mockResolvedValue([]);
     domainRepo.update.mockResolvedValue(undefined);
-    applyProjectRouting.mockResolvedValue(undefined);
+    convergeAllProjectRoutes.mockResolvedValue(undefined);
     syncManagedEdgeRoutes.mockResolvedValue({ failures: [] });
     // withExecutor(serverId, fn) → run fn with a dummy executor.
     withExecutor.mockImplementation(async (_serverId: string, fn: (e: unknown) => Promise<unknown>) =>
@@ -103,6 +103,30 @@ describe("retryProjectRouting — safe self-heal", () => {
 
     expect(result).toEqual({ ok: true });
     expect(domainRepo.update).toHaveBeenCalledWith("dom_api", { targetPort: 4000 });
+    expect(convergeAllProjectRoutes).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "proj_1" }),
+    );
+  });
+
+  it("keeps Action Required when strict route convergence fails", async () => {
+    convergeAllProjectRoutes.mockRejectedValue(new Error("vhost write failed"));
+
+    const result = await retryProjectRouting("proj_1", "org_1");
+
+    expect(result).toEqual({
+      ok: false,
+      warning: "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.",
+    });
+    expect(deploymentRepo.updateStatus).toHaveBeenLastCalledWith(
+      "dep_1",
+      "ready",
+      {
+        meta: expect.objectContaining({
+          edgeUnsynced: true,
+          deployWarning: "Couldn't re-apply the project's routes at the edge — retry once the server is reachable.",
+        }),
+      },
+    );
   });
 
   it("leaves the row unchanged when the edge has no live upstream (never guesses)", async () => {
@@ -162,7 +186,7 @@ describe("retryProjectRouting — safe self-heal", () => {
     const result = await retryProjectRouting("proj_1", "org_1");
 
     expect(result).toEqual({ ok: true });
-    expect(applyProjectRouting).not.toHaveBeenCalled();
+    expect(convergeAllProjectRoutes).not.toHaveBeenCalled();
     expect(withExecutor).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/test/modules/services/service-routing-patch.test.ts
+++ b/apps/api/test/modules/services/service-routing-patch.test.ts
@@ -137,29 +137,35 @@ describe("service routing patch", () => {
   it("exposes an actionable argv diff for an ambiguity-only review", async () => {
     const command = "/bin/sh -ec echo grouped script";
     const incomingArgv = ["/bin/sh", "-ec", "echo grouped script"];
-    serviceRepo.listByProject.mockResolvedValue([{
-      ...multiRouteService(),
-      command,
-      commandArgv: ["/bin/sh", "-ec", "echo", "grouped", "script"],
-      importedSpec: { command, commandArgv: incomingArgv },
-      driftSpec: { command, commandArgv: incomingArgv },
-    }]);
+    serviceRepo.listByProject.mockResolvedValue([
+      {
+        ...multiRouteService(),
+        command,
+        commandArgv: ["/bin/sh", "-ec", "echo", "grouped", "script"],
+        importedSpec: { command, commandArgv: incomingArgv },
+        driftSpec: { command, commandArgv: incomingArgv },
+      },
+    ]);
 
     const [service] = await listServices(ctx, project.id);
 
-    expect(service.drift?.changes).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        field: "commandArgv",
-        from: ["/bin/sh", "-ec", "echo", "grouped", "script"],
-        to: incomingArgv,
-      }),
-    ]));
+    expect(service.drift?.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: "commandArgv",
+          from: ["/bin/sh", "-ec", "echo", "grouped", "script"],
+          to: incomingArgv,
+        }),
+      ]),
+    );
   });
 
   /** What the edge was asked to stop serving on this save. */
   const removedHosts = () =>
-    ((reconcileProjectRoutes.mock.calls.at(-1)?.[1] as { removes?: Array<{ hostname: string }> })
-      ?.removes ?? []).map((r) => r.hostname);
+    (
+      (reconcileProjectRoutes.mock.calls.at(-1)?.[1] as { removes?: Array<{ hostname: string }> })
+        ?.removes ?? []
+    ).map((r) => r.hostname);
 
   it("persists a scalar custom-domain patch and keeps the sibling route", async () => {
     await updateService(ctx, project.id, "svc_1", {
@@ -258,10 +264,11 @@ describe("service routing patch", () => {
 
     await updateService(ctx, project.id, "svc_1", { exposed: false } as never);
 
-    expect(removedHosts().map((h) => h.split(".")[0]).sort()).toEqual([
-      "acme-backend",
-      "acme-backend-http",
-    ]);
+    expect(
+      removedHosts()
+        .map((h) => h.split(".")[0])
+        .sort(),
+    ).toEqual(["acme-backend", "acme-backend-http"]);
     // Config is untouched, so nothing is de-configured — a mere pause must never
     // delete a domain row the operator verified.
     expect(domainService.removeServiceDomain).not.toHaveBeenCalled();
@@ -292,9 +299,9 @@ describe("service routing patch", () => {
   });
 
   it("refuses a cleared subdomain instead of dropping the sibling route", async () => {
-    await expect(
-      updateService(ctx, project.id, "svc_1", { domain: "" } as never),
-    ).rejects.toThrow(/free route needs a subdomain/i);
+    await expect(updateService(ctx, project.id, "svc_1", { domain: "" } as never)).rejects.toThrow(
+      /free route needs a subdomain/i,
+    );
 
     expect(serviceRepo.update).not.toHaveBeenCalled();
     expect(reconcileProjectRoutes).not.toHaveBeenCalled();
@@ -383,7 +390,7 @@ describe("service routing patch", () => {
       expect(serviceRepo.create).not.toHaveBeenCalled();
     });
 
-    it("create: a normalized-duplicate name is rejected (\"My DB\" vs \"my-db\")", async () => {
+    it('create: a normalized-duplicate name is rejected ("My DB" vs "my-db")', async () => {
       serviceRepo.listByProject.mockResolvedValue([{ id: "svc_2", name: "My DB" }]);
 
       await expect(

--- a/apps/api/test/modules/services/service-routing-patch.test.ts
+++ b/apps/api/test/modules/services/service-routing-patch.test.ts
@@ -53,7 +53,12 @@ vi.mock("../../../src/lib/controller-helpers", async (importOriginal) => {
   return { ...actual, platform: () => ({ runtime: { name: "docker" } }) };
 });
 
-import { createService, updateService } from "../../../src/modules/services/service.service";
+import {
+  acceptServiceDrift,
+  createService,
+  listServices,
+  updateService,
+} from "../../../src/modules/services/service.service";
 
 const ctx = { organizationId: "org_1" } as never;
 const project = { id: "proj_1", organizationId: "org_1", slug: "acme" };
@@ -108,6 +113,47 @@ describe("service routing patch", () => {
     domainService.ensurePendingServiceDomain.mockReset().mockResolvedValue({ created: false });
     domainService.removeServiceDomain.mockReset().mockResolvedValue(undefined);
     domainService.reuseServerCertForDomain.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("accepting Compose drift promotes its structured command argv", async () => {
+    const commandArgv = ["/bin/sh", "-ec", "echo one argument"];
+    serviceRepo.findById.mockResolvedValue({
+      ...multiRouteService(),
+      driftSpec: {
+        command: "/bin/sh -ec echo one argument",
+        commandArgv,
+      },
+    });
+
+    await acceptServiceDrift(ctx, project.id, "svc_1");
+
+    expect(writtenPatch()).toMatchObject({
+      command: "/bin/sh -ec echo one argument",
+      commandArgv,
+      driftSpec: null,
+    });
+  });
+
+  it("exposes an actionable argv diff for an ambiguity-only review", async () => {
+    const command = "/bin/sh -ec echo grouped script";
+    const incomingArgv = ["/bin/sh", "-ec", "echo grouped script"];
+    serviceRepo.listByProject.mockResolvedValue([{
+      ...multiRouteService(),
+      command,
+      commandArgv: ["/bin/sh", "-ec", "echo", "grouped", "script"],
+      importedSpec: { command, commandArgv: incomingArgv },
+      driftSpec: { command, commandArgv: incomingArgv },
+    }]);
+
+    const [service] = await listServices(ctx, project.id);
+
+    expect(service.drift?.changes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        field: "commandArgv",
+        from: ["/bin/sh", "-ec", "echo", "grouped", "script"],
+        to: incomingArgv,
+      }),
+    ]));
   });
 
   /** What the edge was asked to stop serving on this save. */

--- a/apps/dashboard/src/app/(dashboard)/settings/_components/GitHubConnection.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/_components/GitHubConnection.tsx
@@ -450,6 +450,13 @@ export function GitHubConnection() {
               manageUrl={ghManageUrl}
               manageLabel={ghManageLabel}
               onRecheck={() => void loadStatus(true)}
+              onRemove={() =>
+                promptDisconnect(
+                  "cli",
+                  ghMethodLabel,
+                  t.settings.github.ghCli.disconnectBody,
+                )
+              }
             />
           )}
           <MethodChooser
@@ -491,8 +498,11 @@ function CredentialProblem(props: {
   /** Re-run the verify. The card checks on load, but "unreachable" is usually
    *  transient and re-checking beats making the operator reload the page. */
   onRecheck: () => void;
+  /** Remove the unusable credential from Openship so a replacement can be
+   *  connected. This must remain available even though `available` is false. */
+  onRemove: () => void;
 }) {
-  const { problem, methodLabel, checkedAt, manageUrl, manageLabel, onRecheck } = props;
+  const { problem, methodLabel, checkedAt, manageUrl, manageLabel, onRecheck, onRemove } = props;
   const { t } = useI18n();
   const rejected = problem === "rejected";
   // Locale-formatted and only as precise as it needs to be. Invalid/absent
@@ -545,6 +555,14 @@ function CredentialProblem(props: {
           >
             <RefreshCw className="size-3" />
             {t.settings.github.ghCli.recheck}
+          </button>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="inline-flex items-center gap-1 text-xs font-medium text-danger underline underline-offset-2 hover:text-danger/80"
+          >
+            <Unplug className="size-3" />
+            {t.settings.github.removeFromOpenship}
           </button>
           {checked && (
             <span className="text-xs text-muted-foreground/70">

--- a/apps/dashboard/src/i18n/locales/ar/settings.json
+++ b/apps/dashboard/src/i18n/locales/ar/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "لقطع الاتصال، شغّل",
       "disconnectSuffix": "في طرفيتك.",
       "use": "استخدام gh CLI"
-    }
+    },
+    "removeFromOpenship": "إزالة من Openship"
   },
   "deployDefaults": {
     "title": "إعدادات النشر الافتراضية",

--- a/apps/dashboard/src/i18n/locales/de/settings.json
+++ b/apps/dashboard/src/i18n/locales/de/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "Zum Trennen führe",
       "disconnectSuffix": "in deinem Terminal aus.",
       "use": "gh CLI verwenden"
-    }
+    },
+    "removeFromOpenship": "Aus Openship entfernen"
   },
   "deployDefaults": {
     "title": "Deploy-Standardwerte",

--- a/apps/dashboard/src/i18n/locales/en/settings.json
+++ b/apps/dashboard/src/i18n/locales/en/settings.json
@@ -177,6 +177,7 @@
     "manageTokensOnGithub": "Manage tokens on GitHub",
     "manageAccessOnGithub": "Manage access on GitHub",
     "disconnectScopeNote": "Disconnect removes this credential from Openship and stops using it for clones. It stays valid at GitHub until you revoke it there.",
+    "removeFromOpenship": "Remove from Openship",
     "credentialRejected": "GitHub rejected the stored {method}.",
     "credentialRejectedImpact": "It was revoked, expired, or lost a required scope. Deploys that clone with it will keep failing until you reconnect below.",
     "credentialUnreachable": "Couldn't reach GitHub to check the stored {method}.",

--- a/apps/dashboard/src/i18n/locales/es/settings.json
+++ b/apps/dashboard/src/i18n/locales/es/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "Para desconectar, ejecuta",
       "disconnectSuffix": "en tu terminal.",
       "use": "Usar gh CLI"
-    }
+    },
+    "removeFromOpenship": "Eliminar de Openship"
   },
   "deployDefaults": {
     "title": "Valores predeterminados de despliegue",

--- a/apps/dashboard/src/i18n/locales/fr/settings.json
+++ b/apps/dashboard/src/i18n/locales/fr/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "Pour déconnecter, exécutez",
       "disconnectSuffix": "dans votre terminal.",
       "use": "Utiliser la CLI gh"
-    }
+    },
+    "removeFromOpenship": "Supprimer d’Openship"
   },
   "deployDefaults": {
     "title": "Valeurs par défaut de déploiement",

--- a/apps/dashboard/src/i18n/locales/ja/settings.json
+++ b/apps/dashboard/src/i18n/locales/ja/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "切断するには、次を実行してください:",
       "disconnectSuffix": "ターミナルで実行します。",
       "use": "gh CLI を使用"
-    }
+    },
+    "removeFromOpenship": "Openship から削除"
   },
   "deployDefaults": {
     "title": "デプロイのデフォルト",

--- a/apps/dashboard/src/i18n/locales/pt/settings.json
+++ b/apps/dashboard/src/i18n/locales/pt/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "Para desconectar, execute",
       "disconnectSuffix": "no seu terminal.",
       "use": "Usar gh CLI"
-    }
+    },
+    "removeFromOpenship": "Remover do Openship"
   },
   "deployDefaults": {
     "title": "Padrões de Implantação",

--- a/apps/dashboard/src/i18n/locales/tr/settings.json
+++ b/apps/dashboard/src/i18n/locales/tr/settings.json
@@ -142,7 +142,8 @@
       "disconnectPrefix": "Bağlantıyı kesmek için terminalinizde",
       "disconnectSuffix": "çalıştırın.",
       "use": "gh CLI Kullan"
-    }
+    },
+    "removeFromOpenship": "Openship'ten kaldır"
   },
   "deployDefaults": {
     "title": "Dağıtım Varsayılanları",

--- a/apps/dashboard/src/i18n/locales/zh/settings.json
+++ b/apps/dashboard/src/i18n/locales/zh/settings.json
@@ -102,7 +102,8 @@
       "disconnectPrefix": "要断开连接，请运行",
       "disconnectSuffix": "在你的终端中。",
       "use": "使用 gh CLI"
-    }
+    },
+    "removeFromOpenship": "从 Openship 中移除"
   },
   "deployDefaults": {
     "title": "部署默认设置",

--- a/packages/adapters/src/platform-explicit-local-edge.test.ts
+++ b/packages/adapters/src/platform-explicit-local-edge.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  localProvider: { kind: "local-edge" },
+  remoteProvider: { kind: "remote-edge" },
+  localCalls: [] as string[],
+  remoteCalls: [] as string[],
+  dockerCreates: 0,
+}));
+
+vi.mock("./system/setup", () => ({ SystemManager: class {} }));
+vi.mock("./runtime/bare", () => ({
+  BareRuntime: class {
+    constructor(readonly options: unknown) {}
+  },
+}));
+vi.mock("./runtime/docker", () => ({
+  DockerRuntime: {
+    create: vi.fn(async () => {
+      h.dockerCreates++;
+      return { name: "docker" };
+    }),
+  },
+}));
+vi.mock("./system/proxy/ensure-container-edge", () => ({
+  localContainerEdgeProvider: vi.fn(async (container: string) => {
+    h.localCalls.push(container);
+    return h.localProvider;
+  }),
+  containerEdgeProvider: vi.fn(async (_executor: unknown, container: string) => {
+    h.remoteCalls.push(container);
+    return h.remoteProvider;
+  }),
+}));
+vi.mock("./system/proxy/detect", () => ({
+  resolveOurEdgeContainer: vi.fn(async () => "remote-edge"),
+}));
+
+import { createPlatform } from "./platform";
+
+const executor = {
+  exec: vi.fn(async () => ""),
+  mkdir: vi.fn(async () => undefined),
+  writeFile: vi.fn(async () => undefined),
+  readFile: vi.fn(async () => ""),
+  exists: vi.fn(async () => false),
+  rm: vi.fn(async () => undefined),
+  streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+  transferIn: vi.fn(async () => undefined),
+  dispose: vi.fn(async () => undefined),
+};
+
+beforeEach(() => {
+  h.localCalls = [];
+  h.remoteCalls = [];
+  h.dockerCreates = 0;
+  vi.stubEnv("OPENSHIP_EDGE_MODE", "docker");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("createPlatform — explicit local edge topology", () => {
+  it.each(["bare", "docker"] as const)(
+    "uses mounted local-edge files independently from the %s workload executor",
+    async (runtime) => {
+      const platform = await createPlatform({
+        target: "selfhosted",
+        runtime,
+        executor: executor as never,
+        docker: runtime === "docker" ? { transport: "socket" } : undefined,
+        localEdgeContainer: "openship-edge",
+      });
+
+      expect(platform.executor).toBe(executor);
+      expect(platform.routing).toBe(h.localProvider);
+      expect(platform.ssl).toBe(h.localProvider);
+      expect(h.localCalls).toEqual(["openship-edge"]);
+      expect(h.remoteCalls).toEqual([]);
+      expect(h.dockerCreates).toBe(runtime === "docker" ? 1 : 0);
+    },
+  );
+
+  it("retains remote edge discovery when the topology is not explicitly local", async () => {
+    const platform = await createPlatform({
+      target: "selfhosted",
+      runtime: "bare",
+      executor: executor as never,
+    });
+
+    expect(platform.routing).toBe(h.remoteProvider);
+    expect(h.localCalls).toEqual([]);
+    expect(h.remoteCalls).toEqual(["remote-edge"]);
+  });
+});

--- a/packages/adapters/src/platform.ts
+++ b/packages/adapters/src/platform.ts
@@ -60,8 +60,8 @@ export interface PlatformConfig {
    * Runtime mode for self-hosted (ignored for cloud/desktop).
    *
    * This is the ONLY choice for self-hosted - everything else follows:
-  *   - "docker" → Docker containers + Nginx + certbot (default)
-  *   - "bare"   → Node.js processes + Nginx + certbot
+   *   - "docker" → Docker containers + Nginx + certbot (default)
+   *   - "bare"   → Node.js processes + Nginx + certbot
    */
   runtime?: "docker" | "bare";
   /** Docker connection options (only for docker runtime) */
@@ -90,7 +90,7 @@ export interface PlatformConfig {
   /**
    * SSH config for remote server management (self-hosted only).
    *
-  * When provided, all system checks, installations, and Nginx file
+   * When provided, all system checks, installations, and Nginx file
    * operations run on the remote server via SSH instead of locally.
    * When omitted, everything runs on the current machine.
    */
@@ -238,9 +238,8 @@ async function createInfraProvider(
   // paths/pin decision for the edge image. Constructing the provider here too is
   // what let the two drift — and pointing `sitesDir` at a directory the edge never
   // reads fails silently, with the box dark.
-  const { containerEdgeProvider, localContainerEdgeProvider } = await import(
-    "./system/proxy/ensure-container-edge"
-  );
+  const { containerEdgeProvider, localContainerEdgeProvider } =
+    await import("./system/proxy/ensure-container-edge");
 
   // LOCAL containerized edge (compose): the api shares the routing mounts with the
   // `openship-edge` container and reaches it over the mounted Docker socket.
@@ -278,9 +277,8 @@ async function createInfraProvider(
 
   // Bare host OpenResty: legacy boxes not yet converted, and Docker-less servers.
   // No longer something we install — see `installContainerEdge`.
-  const { detectOpenRestyPaths, ensureOpenRestyConfig, ensureLuaScripts } = await import(
-    "./infra/openresty-lua"
-  );
+  const { detectOpenRestyPaths, ensureOpenRestyConfig, ensureLuaScripts } =
+    await import("./infra/openresty-lua");
   const paths = await detectOpenRestyPaths(executor);
 
   // Idempotent, but writes the SHARED nginx.conf (grep||sed). Concurrent deploys
@@ -406,9 +404,7 @@ export async function initPlatform(config: PlatformConfig): Promise<Platform> {
  */
 export function getPlatform(): Platform {
   if (!_platform) {
-    throw new Error(
-      "Platform not initialized. Call initPlatform() at server startup.",
-    );
+    throw new Error("Platform not initialized. Call initPlatform() at server startup.");
   }
   return _platform;
 }

--- a/packages/adapters/src/platform.ts
+++ b/packages/adapters/src/platform.ts
@@ -105,6 +105,16 @@ export interface PlatformConfig {
    */
   executor?: CommandExecutor;
   /**
+   * Name of an edge container whose routing state is mounted into this process.
+   *
+   * This is deliberately independent from `executor`: an API running in the
+   * compose stack may still need a host executor to run a bare workload on its
+   * own server, while vhost/certificate files must be read through the API's
+   * shared mounts and edge commands through the local Docker socket. Remote
+   * servers leave this unset and keep using their host/SSH edge provider.
+   */
+  localEdgeContainer?: string;
+  /**
    * Custom state store for caching setup results.
    * Defaults to FileStateStore. The API layer can provide a DB-backed store.
    */
@@ -310,9 +320,13 @@ async function createSelfHostedPlatform(config: PlatformConfig): Promise<Platfor
   // it needs the dockerode executor. A REMOTE box's container edge is resolved by
   // probing that box (createInfraProvider) — not from this env, which describes
   // the control plane and says nothing about the target.
-  const useDockerEdge =
+  const implicitLocalDockerEdge =
     !config.executor && !config.ssh && process.env.OPENSHIP_EDGE_MODE === "docker";
-  const edgeContainer = process.env.OPENSHIP_EDGE_CONTAINER?.trim() || "openship-edge";
+  const localEdgeContainer =
+    config.localEdgeContainer?.trim() ||
+    (implicitLocalDockerEdge
+      ? process.env.OPENSHIP_EDGE_CONTAINER?.trim() || "openship-edge"
+      : undefined);
 
   // Executor - use injected (managed/pooled) executor, or create a fresh one
   let executor: CommandExecutor;
@@ -323,16 +337,19 @@ async function createSelfHostedPlatform(config: PlatformConfig): Promise<Platfor
     executor = createExecutor(config.ssh);
   }
 
-  // System - runtime mode determines all required components. In docker-edge
-  // mode the stack provides docker (socket) + OpenResty/certbot (edge image), so
-  // the api installs nothing on its container/host.
+  // System - runtime mode determines all required components. In the implicit
+  // local compose case the stack provides docker + OpenResty/certbot, so the API
+  // installs nothing in its own container. An EXPLICIT local edge can coexist
+  // with a host executor (notably for bare workloads), whose prerequisites must
+  // still be managed on that host — edge location and workload location are
+  // separate topology decisions.
   const { SystemManager } = await import("./system/setup");
   const system = new SystemManager(runtimeMode, {
     executor,
     stateStore: config.stateStore,
     installerConfig: config.installerConfig,
     provisionLock: config.provisionLock,
-    assumeInstalled: useDockerEdge,
+    assumeInstalled: implicitLocalDockerEdge,
   });
 
   // Runtime
@@ -350,7 +367,7 @@ async function createSelfHostedPlatform(config: PlatformConfig): Promise<Platfor
     runtimeMode,
     config,
     executor,
-    useDockerEdge ? edgeContainer : undefined,
+    localEdgeContainer,
   );
 
   return {

--- a/packages/adapters/src/runtime/bare.ts
+++ b/packages/adapters/src/runtime/bare.ts
@@ -101,6 +101,7 @@ export class BareRuntime implements RuntimeAdapter {
   readonly capabilities: ReadonlySet<RuntimeCapability> = new Set<RuntimeCapability>([
     "build",
     "deploy",
+    "targetSourceClone",
     "stop",
     "start",
     "restart",

--- a/packages/adapters/src/runtime/docker-clone-site.test.ts
+++ b/packages/adapters/src/runtime/docker-clone-site.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { assertCloneOnServerTransport } from "./docker";
+
+describe("assertCloneOnServerTransport", () => {
+  it("accepts target-host acquisition only with SSH plus a command executor", () => {
+    expect(() => assertCloneOnServerTransport("ssh", true, true)).not.toThrow();
+  });
+
+  it.each(["socket", "tcp"] as const)("rejects cloneOnServer for the %s transport", (kind) => {
+    expect(() => assertCloneOnServerTransport(kind, false, true)).toThrow(
+      /requires the Docker SSH transport/,
+    );
+  });
+
+  it("rejects an SSH transport without a target command executor", () => {
+    expect(() => assertCloneOnServerTransport("ssh", false, true)).toThrow(
+      /requires the Docker SSH transport/,
+    );
+  });
+
+  it("allows API-host staging on every transport", () => {
+    expect(() => assertCloneOnServerTransport("socket", false, false)).not.toThrow();
+    expect(() => assertCloneOnServerTransport("tcp", false, undefined)).not.toThrow();
+  });
+});

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -139,6 +139,25 @@ interface DockerSystemManager {
   ensureFeature(feature: Feature, onLog?: (log: SystemLog) => void): Promise<void>;
 }
 
+/**
+ * Fail closed when a caller asks this runtime to clone on the deployment
+ * target but the selected Docker transport has no target-host command path.
+ * Socket/TCP builds stage source from the API process; silently accepting
+ * `cloneOnServer` there makes credential planning describe a different machine
+ * from the one that actually runs git.
+ */
+export function assertCloneOnServerTransport(
+  transportKind: DockerTransport["kind"],
+  hasTargetExecutor: boolean,
+  cloneOnServer: boolean | undefined,
+): void {
+  if (cloneOnServer && (transportKind !== "ssh" || !hasTargetExecutor)) {
+    throw new Error(
+      `Clone-on-server requires the Docker SSH transport with a target executor; ${transportKind} stages source on the API host`,
+    );
+  }
+}
+
 // ─── Shared Docker helpers ───────────────────────────────────────────────────
 
 const RESTART_POLICIES: Record<string, { Name: string; MaximumRetryCount: number }> = {
@@ -666,27 +685,7 @@ export function parseContainerEventLine(line: string): ContainerLifecycleEvent |
 
 export class DockerRuntime implements RuntimeAdapter {
   readonly name = "docker";
-  readonly capabilities: ReadonlySet<RuntimeCapability> = new Set<RuntimeCapability>([
-    "build",
-    "deploy",
-    "multiServiceDeploy",
-    "stop",
-    "start",
-    "restart",
-    "destroy",
-    "containerInfo",
-    "runtimeLogs",
-    "streamLogs",
-    "usage",
-    "containerIp",
-    "rollback",
-    "serviceShell",
-    "projectContainerSweep",
-    "deploymentContainerQuery",
-    "hostContainerQuery",
-    "stabilityProbe",
-    "containerEvents",
-  ]);
+  readonly capabilities: ReadonlySet<RuntimeCapability>;
 
   /** Docker honors every extended compose key we currently support. */
   readonly unsupportedComposeKeys: ReadonlySet<keyof ComposeAdvanced> = new Set();
@@ -710,6 +709,30 @@ export class DockerRuntime implements RuntimeAdapter {
   ) {
     this.connectionOptions = opts;
     this.transport = resolveDockerTransport(opts);
+    this.capabilities = new Set<RuntimeCapability>([
+      "build",
+      "deploy",
+      ...(this.transport.kind === "ssh" && opts?.executor
+        ? (["targetSourceClone"] as const)
+        : []),
+      "multiServiceDeploy",
+      "stop",
+      "start",
+      "restart",
+      "destroy",
+      "containerInfo",
+      "runtimeLogs",
+      "streamLogs",
+      "usage",
+      "containerIp",
+      "rollback",
+      "serviceShell",
+      "projectContainerSweep",
+      "deploymentContainerQuery",
+      "hostContainerQuery",
+      "stabilityProbe",
+      "containerEvents",
+    ]);
     this.systemManager = systemManager ?? null;
     this.provisionLock = provisionLock;
   }
@@ -1421,6 +1444,12 @@ export class DockerRuntime implements RuntimeAdapter {
       const sshExecutor =
         this.transport.kind === "ssh" ? this.connectionOptions?.executor : null;
 
+      assertCloneOnServerTransport(
+        this.transport.kind,
+        !!this.connectionOptions?.executor,
+        config.cloneOnServer,
+      );
+
       // ── Clone-on-server path ───────────────────────────────────────────
       // Clone the repo ON the remote host and build there — no local clone and
       // no context transfer. Only for SSH server builds that opted in.
@@ -1866,6 +1895,11 @@ export class DockerRuntime implements RuntimeAdapter {
     // Every service in a compose/monorepo build shares ONE repo+branch+commit,
     // so the first spec's source config drives the single clone.
     const source = specs[0]!.config;
+    assertCloneOnServerTransport(
+      this.transport.kind,
+      !!this.connectionOptions?.executor,
+      source.cloneOnServer,
+    );
     const isSsh = this.transport.kind === "ssh" && !!this.connectionOptions?.executor;
     const cloneOnServer = isSsh && !!source.cloneOnServer;
     const remoteContextDir = `/tmp/openship-build-${source.sessionId}`;

--- a/packages/adapters/src/runtime/types.ts
+++ b/packages/adapters/src/runtime/types.ts
@@ -41,6 +41,10 @@ import type { ContainerStabilitySample } from "./stability";
 export type RuntimeCapability =
   | "build"
   | "deploy"
+  /** Runtime can acquire repository source directly on the deployment target.
+   *  This is topology-sensitive: Docker-over-SSH supports it, while Docker via
+   *  the API host's socket/TCP transport does not. */
+  | "targetSourceClone"
   | "multiServiceDeploy"
   | "stop"
   | "start"

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -62,6 +62,7 @@ export {
   toComposeSpec,
   composeSpecsEqual,
   composeSpecDiff,
+  hasLegacyFlattenedCommandArgvAmbiguity,
   createSettingsRepo,
   createServerRepo,
   createServerGithubAuthRepo,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22,10 +22,7 @@ export type {
   IncomingWebhookAuthMode,
 } from "./schema/incoming-webhook";
 export { INCIDENT_KINDS, type IncidentKind } from "./schema/service-incident";
-export {
-  RESOURCE_BUCKET_MINUTES,
-  SINGLE_APP_SERVICE_KEY,
-} from "./schema/resource-usage";
+export { RESOURCE_BUCKET_MINUTES, SINGLE_APP_SERVICE_KEY } from "./schema/resource-usage";
 
 // ─── Dump / restore (team-mode migration + project transfer) ─────────────────
 export {

--- a/packages/db/src/repos/index.ts
+++ b/packages/db/src/repos/index.ts
@@ -81,6 +81,7 @@ export {
   toComposeSpec,
   composeSpecsEqual,
   composeSpecDiff,
+  hasLegacyFlattenedCommandArgvAmbiguity,
   type Service,
   type NewService,
   type ServiceDeployment,

--- a/packages/db/src/repos/index.ts
+++ b/packages/db/src/repos/index.ts
@@ -20,7 +20,11 @@ export {
   type CreatePatInput,
 } from "./personal-access-token.repo";
 export { createOAuthRepo } from "./oauth.repo";
-export { createProjectGroupRepo, type ProjectGroup, type NewProjectGroup } from "./project-group.repo";
+export {
+  createProjectGroupRepo,
+  type ProjectGroup,
+  type NewProjectGroup,
+} from "./project-group.repo";
 export {
   createProjectRepo,
   type Project,
@@ -37,10 +41,26 @@ export {
 } from "./deployment.repo";
 export { createDomainRepo, type Domain, type NewDomain } from "./domain.repo";
 export { createRouteRuleRepo, type RouteRule, type NewRouteRule } from "./route-rule.repo";
-export { createWebhookSourceRepo, type WebhookSource, type NewWebhookSource } from "./webhook-source.repo";
-export { createIncomingWebhookRepo, type IncomingWebhook, type NewIncomingWebhook } from "./incoming-webhook.repo";
-export { createSystemNoticeRepo, type SystemNotice, type NewSystemNotice } from "./system-notice.repo";
-export { createUpdateStatusRepo, type UpdateStatus, type NewUpdateStatus } from "./update-status.repo";
+export {
+  createWebhookSourceRepo,
+  type WebhookSource,
+  type NewWebhookSource,
+} from "./webhook-source.repo";
+export {
+  createIncomingWebhookRepo,
+  type IncomingWebhook,
+  type NewIncomingWebhook,
+} from "./incoming-webhook.repo";
+export {
+  createSystemNoticeRepo,
+  type SystemNotice,
+  type NewSystemNotice,
+} from "./system-notice.repo";
+export {
+  createUpdateStatusRepo,
+  type UpdateStatus,
+  type NewUpdateStatus,
+} from "./update-status.repo";
 export {
   createServerModuleStatusRepo,
   type ServerModuleStatus,
@@ -113,11 +133,7 @@ export {
   type ServerTunnel,
   type NewServerTunnel,
 } from "./server-tunnel.repo";
-export {
-  createMailServerRepo,
-  type MailServer,
-  type NewMailServer,
-} from "./mail-server.repo";
+export { createMailServerRepo, type MailServer, type NewMailServer } from "./mail-server.repo";
 export {
   createAnalyticsRepo,
   type ServerAnalyticsRow,

--- a/packages/db/src/repos/service-command-reconcile.test.ts
+++ b/packages/db/src/repos/service-command-reconcile.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { commandToArgv } from "@repo/core";
+import type { Database } from "../client";
+import { createServiceRepo, toComposeSpec } from "./service.repo";
+
+const script = `if [ "\${RUN_APP:-false}" != "true" ]; then
+  echo "disabled"
+  exec sleep 2147483647
+fi
+exec bin/app start`;
+const structuredArgv = ["/bin/sh", "-ec", script];
+const displayCommand = structuredArgv.join(" ");
+const flattenedArgv = commandToArgv(displayCommand)!;
+
+function fakeRepoRow(opts: { baseline: "none" | "structured"; argv?: string[] }) {
+  const row = {
+    id: "svc_1",
+    projectId: "proj_1",
+    name: "app",
+    kind: "compose",
+    command: displayCommand,
+    commandArgv: opts.argv ?? flattenedArgv,
+    importedSpec:
+      opts.baseline === "structured"
+        ? toComposeSpec({ command: displayCommand, commandArgv: structuredArgv })
+        : null,
+    driftSpec: null,
+  };
+  const writes: Array<Record<string, unknown>> = [];
+  const db = {
+    query: { service: { findMany: async () => [row] } },
+    update: () => ({
+      set: (data: Record<string, unknown>) => {
+        writes.push(data);
+        return { where: async () => undefined };
+      },
+    }),
+  } as unknown as Database;
+  return { repo: createServiceRepo(db), writes };
+}
+
+describe("reconcileFromCompose reviews pre-#332 command argv", () => {
+  it("requires review instead of clobbering a flattened argv while bootstrapping", async () => {
+    const { repo, writes } = fakeRepoRow({ baseline: "none" });
+
+    const result = await repo.reconcileFromCompose("proj_1", [
+      { name: "app", command: displayCommand, commandArgv: structuredArgv },
+    ]);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].commandArgv).toBeUndefined();
+    expect((writes[0].importedSpec as { commandArgv: string[] }).commandArgv).toEqual(
+      structuredArgv,
+    );
+    expect((writes[0].driftSpec as { commandArgv: string[] }).commandArgv).toEqual(
+      structuredArgv,
+    );
+    expect(result.commandArgvReviewNames).toEqual(["app"]);
+  });
+
+  it("requires review when a structured baseline exists but operational argv is flattened", async () => {
+    const { repo, writes } = fakeRepoRow({ baseline: "structured" });
+
+    const result = await repo.reconcileFromCompose("proj_1", [
+      { name: "app", command: displayCommand, commandArgv: structuredArgv },
+    ]);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].commandArgv).toBeUndefined();
+    expect((writes[0].driftSpec as { commandArgv: string[] }).commandArgv).toEqual(
+      structuredArgv,
+    );
+    expect(result.commandArgvReviewNames).toEqual(["app"]);
+  });
+
+  it("preserves a genuine operator argv edit", async () => {
+    const operatorArgv = ["/bin/sh", "-ec", "echo operator override"];
+    const { repo, writes } = fakeRepoRow({ baseline: "structured", argv: operatorArgv });
+
+    await repo.reconcileFromCompose("proj_1", [
+      { name: "app", command: displayCommand, commandArgv: structuredArgv },
+    ]);
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it("does not overwrite the exact collision with a possible operator override", async () => {
+    const { repo, writes } = fakeRepoRow({
+      baseline: "structured",
+      argv: commandToArgv(displayCommand)!,
+    });
+
+    const result = await repo.reconcileFromCompose("proj_1", [
+      { name: "app", command: displayCommand, commandArgv: structuredArgv },
+    ]);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].commandArgv).toBeUndefined();
+    expect(result.commandArgvReviewNames).toEqual(["app"]);
+  });
+
+  it("requires review before auto-applying an unrelated upstream field change", async () => {
+    const { repo, writes } = fakeRepoRow({ baseline: "structured" });
+
+    const result = await repo.reconcileFromCompose("proj_1", [
+      {
+        name: "app",
+        image: "acme/app:new",
+        command: displayCommand,
+        commandArgv: structuredArgv,
+      },
+    ]);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].image).toBeUndefined();
+    expect(writes[0].commandArgv).toBeUndefined();
+    expect((writes[0].driftSpec as { image: string }).image).toBe("acme/app:new");
+    expect(result.commandArgvReviewNames).toEqual(["app"]);
+  });
+});

--- a/packages/db/src/repos/service-command-reconcile.test.ts
+++ b/packages/db/src/repos/service-command-reconcile.test.ts
@@ -52,9 +52,7 @@ describe("reconcileFromCompose reviews pre-#332 command argv", () => {
     expect((writes[0].importedSpec as { commandArgv: string[] }).commandArgv).toEqual(
       structuredArgv,
     );
-    expect((writes[0].driftSpec as { commandArgv: string[] }).commandArgv).toEqual(
-      structuredArgv,
-    );
+    expect((writes[0].driftSpec as { commandArgv: string[] }).commandArgv).toEqual(structuredArgv);
     expect(result.commandArgvReviewNames).toEqual(["app"]);
   });
 
@@ -67,9 +65,7 @@ describe("reconcileFromCompose reviews pre-#332 command argv", () => {
 
     expect(writes).toHaveLength(1);
     expect(writes[0].commandArgv).toBeUndefined();
-    expect((writes[0].driftSpec as { commandArgv: string[] }).commandArgv).toEqual(
-      structuredArgv,
-    );
+    expect((writes[0].driftSpec as { commandArgv: string[] }).commandArgv).toEqual(structuredArgv);
     expect(result.commandArgvReviewNames).toEqual(["app"]);
   });
 

--- a/packages/db/src/repos/service.repo.ts
+++ b/packages/db/src/repos/service.repo.ts
@@ -79,6 +79,36 @@ const canonicalize = (value: unknown): unknown => {
 const canonicalSpec = (s: ComposeServiceSpec): string =>
   JSON.stringify(canonicalize(toComposeSpec(s)));
 
+const argvEqual = (a: string[] | null | undefined, b: string[] | null | undefined) =>
+  JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+
+/**
+ * Detect the exact representation written by pre-#332 Compose imports: a list
+ * command was first joined for display and that display string was then split
+ * back into argv, losing argument boundaries (most visibly the script passed to
+ * `sh -c`). A current parse of the same Compose file has the same display text
+ * but a different, authoritative structured argv.
+ *
+ * This is deliberately narrower than "stored argv differs from Compose". Even
+ * this exact shape can be an intentional operator override, so callers must
+ * surface it for explicit review rather than auto-repairing it.
+ */
+export function hasLegacyFlattenedCommandArgvAmbiguity(
+  stored: Pick<ComposeServiceSpec, "command" | "commandArgv">,
+  parsed: Pick<ComposeServiceSpec, "command" | "commandArgv">,
+): boolean {
+  const command = stored.command ?? null;
+  const parsedCommand = parsed.command ?? null;
+  const storedArgv = stored.commandArgv;
+  const parsedArgv = parsed.commandArgv;
+
+  if (!command || command !== parsedCommand) return false;
+  if (!Array.isArray(storedArgv) || !Array.isArray(parsedArgv)) return false;
+  if (argvEqual(storedArgv, parsedArgv)) return false;
+
+  return argvEqual(storedArgv, commandToArgv(command));
+}
+
 /** Compose-field equality (ignores routing + ordering-insensitive env). */
 export const composeSpecsEqual = (a: ComposeServiceSpec, b: ComposeServiceSpec) =>
   canonicalSpec(a) === canonicalSpec(b);
@@ -580,6 +610,7 @@ export function createServiceRepo(db: Database) {
       const existingByName = new Map(composeExisting.map((s) => [s.name, s]));
       const incomingNames = new Set(composeParsed.map((s) => s.name));
       const driftedNames: string[] = [];
+      const commandArgvReviewNames: string[] = [];
 
       for (let i = 0; i < composeParsed.length; i++) {
         const p = composeParsed[i];
@@ -612,11 +643,45 @@ export function createServiceRepo(db: Database) {
         const base = ex.importedSpec ?? null;
         const ours = toComposeSpec(ex);
 
+        // A pre-#332 importer flattened list-form commands before persisting
+        // them. That representation is indistinguishable from an operator who
+        // intentionally supplied the same tokenized argv, so NEVER auto-repair
+        // it. Surface the authoritative structured Compose value as drift and
+        // require the operator to accept it explicitly.
+        //
+        // Use the raw row, not `ours`: toComposeSpec normalizes a null argv from
+        // the display string and would erase the only provenance we still have.
+        const commandArgvNeedsReview = hasLegacyFlattenedCommandArgvAmbiguity(
+          { command: ex.command, commandArgv: ex.commandArgv },
+          theirs,
+        );
+
         // Bootstrap: no baseline yet → adopt theirs as baseline, keep ours.
         // sortOrder is NEVER reset by reconcile — it's user-editable (dashboard
         // reordering) and the compose file has no ordering to authoritatively sync.
         if (base === null) {
-          await this.update(ex.id, { importedSpec: theirs, driftSpec: null });
+          await this.update(ex.id, {
+            importedSpec: theirs,
+            driftSpec: commandArgvNeedsReview ? theirs : null,
+          });
+          if (commandArgvNeedsReview) {
+            driftedNames.push(p.name);
+            commandArgvReviewNames.push(p.name);
+          }
+          continue;
+        }
+
+        // Ambiguous command provenance always wins over the ordinary 3-way
+        // branches below. Even if the repo changed another field and the rest
+        // of the row is unedited, spreading `theirs` would silently choose one
+        // meaning for the argv collision. Keep the whole row untouched and ask
+        // the operator to accept the authoritative Compose spec explicitly.
+        if (commandArgvNeedsReview) {
+          if (!ex.driftSpec || !composeSpecsEqual(ex.driftSpec, theirs)) {
+            await this.update(ex.id, { driftSpec: theirs });
+          }
+          driftedNames.push(p.name);
+          commandArgvReviewNames.push(p.name);
           continue;
         }
 
@@ -624,7 +689,9 @@ export function createServiceRepo(db: Database) {
         // reverted to base); otherwise skip entirely so we don't churn updatedAt
         // on every deploy.
         if (composeSpecsEqual(theirs, base)) {
-          if (ex.driftSpec) await this.update(ex.id, { driftSpec: null });
+          if (ex.driftSpec) {
+            await this.update(ex.id, { driftSpec: null });
+          }
           continue;
         }
 
@@ -669,7 +736,7 @@ export function createServiceRepo(db: Database) {
       }
 
       const services = await this.listByProject(projectId);
-      return { services, driftedNames };
+      return { services, driftedNames, commandArgvReviewNames };
     },
 
     // ── Service Deployments ────────────────────────────────────────────

--- a/packages/db/src/repos/service.repo.ts
+++ b/packages/db/src/repos/service.repo.ts
@@ -1,5 +1,11 @@
 import { eq, and, asc, inArray } from "drizzle-orm";
-import { commandToArgv, generateId, mergeAdvanced, normalizeCustomHostname, type ComposeAdvanced } from "@repo/core";
+import {
+  commandToArgv,
+  generateId,
+  mergeAdvanced,
+  normalizeCustomHostname,
+  type ComposeAdvanced,
+} from "@repo/core";
 import type { Database } from "../client";
 import { service, serviceDeployment } from "../schema";
 import type { ComposeServiceSpec, ServicePublicEndpoint } from "../schema/service";
@@ -142,7 +148,17 @@ function composeWritePatch(
 /** Per-field diff of two specs — powers the drift UI. */
 export function composeSpecDiff(base: ComposeServiceSpec, next: ComposeServiceSpec) {
   const fields: (keyof ComposeServiceSpec)[] = [
-    "image", "build", "dockerfile", "ports", "dependsOn", "environment", "volumes", "command", "commandArgv", "restart", "advanced",
+    "image",
+    "build",
+    "dockerfile",
+    "ports",
+    "dependsOn",
+    "environment",
+    "volumes",
+    "command",
+    "commandArgv",
+    "restart",
+    "advanced",
   ];
   // Compare each field key-order-insensitively (matching canonicalSpec/
   // composeSpecsEqual) so a reordered `environment` or nested `advanced` block
@@ -216,11 +232,19 @@ export function normalizeServicePublicEndpoints(
     if (port === null || seenPorts.has(port)) continue;
     const domainType = endpoint.domainType === "custom" ? "custom" : "free";
     const domain = domainType === "free" ? endpoint.domain?.trim() || undefined : undefined;
-    const customDomain = domainType === "custom" ? normalizeCustomHostname(endpoint.customDomain ?? "") || undefined : undefined;
+    const customDomain =
+      domainType === "custom"
+        ? normalizeCustomHostname(endpoint.customDomain ?? "") || undefined
+        : undefined;
     if (domainType === "free" && !domain) continue;
     if (domainType === "custom" && !customDomain) continue;
     seenPorts.add(port);
-    out.push({ port, domainType, ...(domain ? { domain } : {}), ...(customDomain ? { customDomain } : {}) });
+    out.push({
+      port,
+      domainType,
+      ...(domain ? { domain } : {}),
+      ...(customDomain ? { customDomain } : {}),
+    });
   }
   return out;
 }
@@ -273,8 +297,8 @@ export function normalizeRoutingFields(input: {
     return {
       exposed,
       exposedPort: String(primary.port),
-      domain: primary.domainType === "free" ? primary.domain ?? null : null,
-      customDomain: primary.domainType === "custom" ? primary.customDomain ?? null : null,
+      domain: primary.domainType === "free" ? (primary.domain ?? null) : null,
+      customDomain: primary.domainType === "custom" ? (primary.customDomain ?? null) : null,
       domainType: primary.domainType,
       publicEndpoints: endpoints,
     };
@@ -287,7 +311,8 @@ export function normalizeRoutingFields(input: {
     exposed,
     exposedPort: trimOrNull(input.exposedPort),
     domain: domainType === "free" ? trimOrNull(input.domain) : null,
-    customDomain: domainType === "custom" ? normalizeCustomHostname(input.customDomain ?? "") || null : null,
+    customDomain:
+      domainType === "custom" ? normalizeCustomHostname(input.customDomain ?? "") || null : null,
     domainType,
     publicEndpoints: [],
   };
@@ -308,7 +333,8 @@ export function createServiceRepo(db: Database) {
     /** Batch id → display name, for naming services in list responses. */
     async listNamesByIds(ids: string[]): Promise<{ id: string; name: string }[]> {
       if (ids.length === 0) return [];
-      return db.select({ id: service.id, name: service.name })
+      return db
+        .select({ id: service.id, name: service.name })
         .from(service)
         .where(inArray(service.id, ids));
     },
@@ -422,7 +448,8 @@ export function createServiceRepo(db: Database) {
 
         const routing = normalizeRoutingFields({
           exposed: app.exposed ?? ex?.exposed ?? true,
-          exposedPort: app.exposedPort ?? ex?.exposedPort ?? (app.port != null ? String(app.port) : null),
+          exposedPort:
+            app.exposedPort ?? ex?.exposedPort ?? (app.port != null ? String(app.port) : null),
           domain: app.domain ?? ex?.domain,
           customDomain: app.customDomain ?? ex?.customDomain,
           domainType: app.domainType ?? ex?.domainType,


### PR DESCRIPTION
## Summary

Keep self-hosted deployment state aligned with the machine that actually performs each operation:

- authenticate private GitHub clones at the real source-acquisition site;
- let rejected local GitHub credentials be removed and replaced;
- converge local-edge routes and certificates before reporting SSL active;
- stop ambiguous legacy Compose command arrays from being silently reused.

## Motivation

A private GitHub Compose deployment could report that the build server had ambient `gh` or SSH access, then still execute an unauthenticated HTTPS clone on the API host. This happened because GitHub repositories implicitly forced the logical clone plan to the server, while Docker socket/TCP transports physically stage source in the API process.

The same state drift affected credential lifecycle: disconnect could report success while the stored device/PAT secret remained, and discovery/status/clone paths could continue using a locally available token after the user had disconnected it.

Two additional self-hosted paths had the same underlying consistency problem:

- certificate issuance could succeed on the local edge while the API process checked the wrong filesystem and therefore never materialized the TLS virtual host;
- services imported before structured Compose commands were preserved could retain flattened shell tokens indefinitely, while later redeploys appeared successful even though the workloads exited with shell syntax errors.

## Related issue

None - bug fix.

## Changes

### Source acquisition and GitHub credentials

- Introduce `SourceExecutionSite` (`api-host`, `target-host`, `cloud`) as the shared source of truth for preflight, credential purpose, and the build pipeline.
- Keep repository provider and source location independent; GitHub no longer overrides an explicit API-host clone.
- Resolve target-clone capability from the concrete runtime topology, including Docker socket deployments used by "This Server".
- Fall back explicitly to API-host clone plus context transfer when a transport cannot acquire source on the target.
- Route local private clones through the unified token resolver so configured PAT/device credentials authenticate HTTPS clones without requiring SSH.
- Make disconnect fail closed, clear the stored secret and authorization gates, and apply the disabled state consistently to clone, discovery, connection status, and local status.
- Show "Remove from Openship" for rejected or unreachable stored GitHub credentials so they can be replaced from Settings.

### Local-edge routes and certificates

- Treat a self-hosted container edge as an explicit local execution site instead of probing certificate files from the API container filesystem.
- Reconcile the route and TLS virtual host through the edge executor before marking a domain active.
- Reuse a valid certificate already present on the edge and record its expiry even when the preceding Certbot call returned a misleading missing-path error.
- Keep HTTP routing available while reporting actionable route/SSL failures, and make retry paths converge the complete route state.

### Legacy Compose command reconciliation

- Detect the exact ambiguous legacy representation where a structured Compose command was previously flattened into shell tokens.
- Preserve possible operator edits: do not auto-clobber the live value.
- Persist the drift marker and block all deployment entry points with `COMPOSE_COMMAND_ARGV_REVIEW_REQUIRED` until it is reviewed.
- Present an actionable current-to-upstream `commandArgv` diff in Apps & Services.
- Make "Accept upstream" promote the structured command atomically; preserve existing behavior for ordinary drift.

## Verification

```text
Full affected workspace suites:
- apps/api:          242 files; 2,959 passed, 3 skipped
- packages/adapters: 102 files; 967 passed
- packages/db:        15 files; 86 passed
- apps/dashboard:     32 files; 447 passed (credential UI change)

Typecheck/lint and production builds:
- apps/api: passed
- packages/adapters: passed
- packages/db: passed
- apps/dashboard: passed (credential UI change)

Formatting:
- Prettier check for every file changed by the addendum: passed
- git diff --check / git show --check: passed

The API and adapters suites were rerun outside the restricted test sandbox.
Their listener/socket tests pass there; the sandbox-only EPERM/timeouts are not
product failures.
```

Runtime smoke on a self-hosted Linux x86_64 instance:

- built and rolled out the API runtime as `linux/amd64`;
- API health and dashboard proxy/public route passed after rollout;
- cloned a private GitHub repository over HTTPS using the configured token only;
- issued/reused a Let’s Encrypt certificate for a test hostname;
- verified the domain in the dashboard, materialized the OpenResty vhost, and completed a public TLS handshake with the expected certificate/SNI;
- detected six ambiguous legacy Compose commands, blocked redeploy, displayed all six current-to-upstream diffs, and accepted them explicitly in the dashboard;
- completed the self-hosted deployment with all imported containers running.


The root aggregate commands still include unrelated workspaces and generated-source baselines outside this diff; affected workspaces and runtime paths above are green.

## Checklist

- [x] One coherent change - keep self-hosted deployment state consistent with its real execution site
- [x] The diff is scoped; no unrelated generated artifacts or secrets
- [x] Regression coverage exercises the previous clone, credential, route/certificate, and command-drift failures
- [x] All affected workspace tests, typechecks, builds, and changed-file formatting checks pass
- [x] Linux x86_64 self-hosted runtime smoke completed with browser and server evidence
- [x] I understand every line of this diff and can explain it in review

