### PR TITLE
fix(compose): ensure /var/lib/openship/app-config exists before writing app template files

### DIFF
--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -31,6 +31,7 @@ import {
   DockerRuntime,
   allocateHostPort,
   runDeployPipeline,
+  sq,
   type CommandExecutor,
   type DeployConfig,
   type DeployEnvironment,
@@ -350,6 +351,58 @@ function appConfigHostPath(projectId: string, serviceName: string, containerPath
     throw new Error(`Unsafe app-config path (directory traversal): ${containerPath}`);
   }
   return `${APP_CONFIG_HOST_ROOT}/${projectId}/${safeSvc}/${rel}`;
+}
+
+/**
+ * Ensure the persistent on-host root for generated app-template config files
+ * exists and is writable by the executor's user. Fresh self-hosted installs
+ * (Compose or bare) don't create `/var/lib/openship/app-config`, and the
+ * SFTP write path turns that into a cryptic "No such file".
+ *
+ * We first ask the host directly (works if the installer or a prior deploy
+ * already created it), then try `sudo` to create + chown under the common
+ * root-owned `/var/lib/openship` parent, then fall back to a clear manual
+ * instruction instead of the misleading ENOENT.
+ */
+export async function ensureAppConfigRoot(executor: CommandExecutor, root: string): Promise<void> {
+  const user = await executor.exec("id -un").catch(() => "openship");
+
+  const isWritable = await executor.exec(`test -w ${sq(root)}`).then(
+    () => true,
+    () => false,
+  );
+  if (isWritable) return;
+
+  try {
+    await executor.exec(`sudo mkdir -p ${sq(root)} && sudo chown -R ${sq(user)} ${sq(root)}`);
+    return;
+  } catch {
+    // Parent may be user-writable (bare install or operator pre-created).
+  }
+
+  try {
+    await executor.mkdir(root);
+  } catch {
+    throw new Error(
+      `Could not create or own the app-config host directory ${root} as ${user}. ` +
+        `Create it and re-run the deploy:\n` +
+        `  sudo mkdir -p ${root}\n` +
+        `  sudo chown -R ${user} ${root}`,
+    );
+  }
+
+  const ok = await executor.exec(`test -w ${sq(root)}`).then(
+    () => true,
+    () => false,
+  );
+  if (!ok) {
+    throw new Error(
+      `Could not create or own the app-config host directory ${root} as ${user}. ` +
+        `Create it and re-run the deploy:\n` +
+        `  sudo mkdir -p ${root}\n` +
+        `  sudo chown -R ${user} ${root}`,
+    );
+  }
 }
 
 /** A service's public endpoints as DeployConfig entries (free slug resolved via
@@ -1303,6 +1356,7 @@ export async function deployComposeServices(
           { serviceName: svc.name },
         );
       } else {
+        await ensureAppConfigRoot(opts.executor, APP_CONFIG_HOST_ROOT);
         for (const file of advancedFiles) {
           // Token-local on purpose: one unresolved URL must not blank the whole
           // file (the mount is required — a missing kong.yml is a dead service),

--- a/apps/api/test/modules/deployments/compose/app-config-root.test.ts
+++ b/apps/api/test/modules/deployments/compose/app-config-root.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ensureAppConfigRoot } from "../../../../src/modules/deployments/compose/deploy.service";
+import type { CommandExecutor } from "@repo/adapters";
+
+const DEFAULT_ROOT = "/var/lib/openship/app-config";
+
+function makeExecutor({
+  user = "ubuntu",
+  initialWritable = false,
+  sudoWorks = false,
+  mkdirWorks = false,
+  writableAfterMkdir = true,
+}: {
+  user?: string;
+  initialWritable?: boolean;
+  sudoWorks?: boolean;
+  mkdirWorks?: boolean;
+  writableAfterMkdir?: boolean;
+} = {}): { executor: CommandExecutor; calls: string[] } {
+  let writable = initialWritable;
+  const calls: string[] = [];
+  const exec = vi.fn(async (command: string) => {
+    calls.push(command);
+    if (command === "id -un") return user;
+    if (command.startsWith("test -w")) {
+      if (writable) return "";
+      throw new Error("test -w: non-zero exit");
+    }
+    if (command.startsWith("sudo")) {
+      if (sudoWorks) {
+        writable = true;
+        return "";
+      }
+      throw new Error("sudo: command not found");
+    }
+    throw new Error(`unexpected exec: ${command}`);
+  });
+  const mkdir = vi.fn(async (path: string) => {
+    calls.push(`mkdir:${path}`);
+    if (mkdirWorks) {
+      if (writableAfterMkdir) writable = true;
+      return;
+    }
+    throw new Error("EACCES");
+  });
+  return { executor: { exec, mkdir } as unknown as CommandExecutor, calls };
+}
+
+describe("ensureAppConfigRoot", () => {
+  it("returns early when the host root is already writable", async () => {
+    const { executor, calls } = makeExecutor({ initialWritable: true });
+    await ensureAppConfigRoot(executor, DEFAULT_ROOT);
+    expect(calls).toEqual(["id -un", `test -w '${DEFAULT_ROOT}'`]);
+  });
+
+  it("creates and chowns the root with sudo when missing", async () => {
+    const { executor, calls } = makeExecutor({ sudoWorks: true });
+    await ensureAppConfigRoot(executor, DEFAULT_ROOT);
+    expect(calls).toEqual([
+      "id -un",
+      `test -w '${DEFAULT_ROOT}'`,
+      `sudo mkdir -p '${DEFAULT_ROOT}' && sudo chown -R 'ubuntu' '${DEFAULT_ROOT}'`,
+    ]);
+  });
+
+  it("falls back to executor mkdir when sudo is unavailable", async () => {
+    const { executor, calls } = makeExecutor({ mkdirWorks: true });
+    await ensureAppConfigRoot(executor, DEFAULT_ROOT);
+    expect(calls).toEqual([
+      "id -un",
+      `test -w '${DEFAULT_ROOT}'`,
+      `sudo mkdir -p '${DEFAULT_ROOT}' && sudo chown -R 'ubuntu' '${DEFAULT_ROOT}'`,
+      `mkdir:${DEFAULT_ROOT}`,
+      `test -w '${DEFAULT_ROOT}'`,
+    ]);
+  });
+
+  it("throws a helpful manual instruction when the root cannot be created", async () => {
+    const { executor } = makeExecutor();
+    await expect(ensureAppConfigRoot(executor, DEFAULT_ROOT)).rejects.toThrow(
+      `sudo mkdir -p ${DEFAULT_ROOT}`,
+    );
+  });
+
+  it("throws when executor mkdir succeeds but the directory is not writable", async () => {
+    const { executor } = makeExecutor({ mkdirWorks: true, writableAfterMkdir: false });
+    await expect(ensureAppConfigRoot(executor, DEFAULT_ROOT)).rejects.toThrow(
+      `sudo chown -R ubuntu ${DEFAULT_ROOT}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Ensures the host directory for generated app-template config files (`/var/lib/openship/app-config` by default) exists and is writable before `deployComposeServices` writes `advanced.files` onto a self-hosted host.

## Motivation

On a fresh self-hosted Compose install the `app-config` host root is never created, and the SSH/SFTP executor used for host file writes does not create parent directories. When a catalog app (e.g. Supabase) tries to deploy generated config files, `opts.executor.writeFile(hostPath, …)` fails with a misleading `No such file` error (oblien/openship#438).

## Related issue

Closes #438

## Changes

- `apps/api/src/modules/deployments/compose/deploy.service.ts`
  - Added `ensureAppConfigRoot(executor, root)` next to `appConfigHostPath`.
  - It checks whether the host root is already writable; if not, it attempts `sudo mkdir -p && sudo chown -R <user>`, then falls back to `executor.mkdir`, and finally fails with an explicit manual-recovery message instead of the cryptic ENOENT.
  - Called `ensureAppConfigRoot(opts.executor, APP_CONFIG_HOST_ROOT)` immediately before the `advanced.files` loop in `deployComposeServices`.
  - Re-used `sq` from `@repo/adapters` for shell quoting.
- `apps/api/test/modules/deployments/compose/app-config-root.test.ts`
  - Added unit tests covering: already-writable root, sudo creation, sudo-unavailable fallback, unrecoverable failure, and mkdir-succeeds-but-unwritable.

## Verification

```bash
bun run --cwd apps/api lint   # tsc --noEmit — passed
bun run --cwd apps/api test app-config-root
# test/modules/deployments/compose/app-config-root.test.ts — 5/5 passed
bun run --cwd apps/api test compose
# 9 test files, 130 tests — all passed
bun run --cwd apps/api test
# 240/241 test files passed, 2911/2915 tests passed
# 1 unrelated environment failure in test/modules/github/gh-identity-health.test.ts
# (expects no local `gh` credential, but this dev box has `gh` authenticated)
```

The new unit test would fail before the change (`ensureAppConfigRoot` does not exist / does not create the directory) and passes with it.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test`, `bun run --cwd apps/api lint`, and `bun format` were run
- [x] I understand every line of this diff and can explain it in review
