### PR TITLE
fix(adapters): folder deploy takes down the API; SSH channel drops mid-build

### DIFF
--- a/packages/adapters/src/runtime/docker-build-context.test.ts
+++ b/packages/adapters/src/runtime/docker-build-context.test.ts
@@ -151,4 +151,31 @@ describe("createDockerBuildContext", () => {
     expect(context.dockerfileName).toBe("Dockerfile");
     expect(context.usesRepositoryDockerfile).toBe(true);
   });
+
+  /**
+   * dockerode's tar-fs pack `lstat`s every name in `contextEntries` and emits an
+   * unhandled 'error' event on a miss — which kills the API process, not just the
+   * build. A wide `.dockerignore` prunes many paths right before this list is
+   * read, so every returned name must still resolve.
+   */
+  it("only lists context entries that still exist after pruning", async () => {
+    const repo = await makeRepo("*.md\n.gitignore\ndocs\n");
+    await writeFile(join(repo, "README.md"), "# readme\n");
+    await writeFile(join(repo, "NOTES.md"), "# notes\n");
+    await writeFile(join(repo, ".gitignore"), "nothing\n");
+    await mkdir(join(repo, "docs"), { recursive: true });
+    await writeFile(join(repo, "docs", "guide.md"), "# guide\n");
+    await exec("git", ["-C", repo, "add", "-A", "-f"]);
+    await exec("git", ["-C", repo, "commit", "-q", "-m", "pruned files"]);
+
+    const context = await createDockerBuildContext(config(repo), {
+      requireRepositoryDockerfile: true,
+    });
+    cleanups.push(context.cleanup);
+
+    const onDisk = new Set(await readdir(context.contextDir));
+    for (const entry of context.contextEntries) expect(onDisk.has(entry)).toBe(true);
+    expect(context.contextEntries).not.toContain("NOTES.md");
+    expect(context.contextEntries).not.toContain("docs");
+  });
 });

--- a/packages/adapters/src/runtime/docker-build-context.ts
+++ b/packages/adapters/src/runtime/docker-build-context.ts
@@ -180,17 +180,21 @@ async function applyDockerignore(contextDir: string, config: BuildConfig): Promi
 
   const prune = async (currentPath: string): Promise<void> => {
     const entries = await readdir(currentPath, { withFileTypes: true });
-    await Promise.all(
-      entries.map(async (entry) => {
-        const absolutePath = join(currentPath, entry.name);
-        const relativePath = toPosixPath(relative(contextDir, absolutePath));
-        if (!buildFiles.has(relativePath) && matcher.ignores(relativePath)) {
-          await rm(absolutePath, { recursive: true, force: true });
-          return;
-        }
-        if (entry.isDirectory()) await prune(absolutePath);
-      }),
-    );
+    // Sequential, not Promise.all: a wide `.dockerignore` (every *.md, .github/,
+    // .gitignore …) fans out to hundreds of concurrent `rm`s, and on Windows the
+    // directory listing then lags behind the deletes — a later `readdir` still
+    // reports names whose inode is already gone, so the very next `lstat` throws
+    // ENOENT. Deleting in order keeps the tree and its listing in step; the cost
+    // is negligible next to the build that follows.
+    for (const entry of entries) {
+      const absolutePath = join(currentPath, entry.name);
+      const relativePath = toPosixPath(relative(contextDir, absolutePath));
+      if (!buildFiles.has(relativePath) && matcher.ignores(relativePath)) {
+        await rm(absolutePath, { recursive: true, force: true });
+        continue;
+      }
+      if (entry.isDirectory()) await prune(absolutePath);
+    }
   };
   await prune(contextDir);
 }
@@ -429,7 +433,23 @@ export async function resolveServiceDockerfile(
     );
   }
 
-  const contextEntries = await readdir(contextDir);
+  // Confirm each name still resolves before handing the list to dockerode. Its
+  // tar-fs pack `lstat`s every entry and emits an unhandled 'error' on a miss,
+  // which takes the whole API process down (not just the build). A name that
+  // vanished between this readdir and the pack — a pruned path whose deletion
+  // the directory listing hadn't caught up with — must simply not be offered.
+  const contextEntries = (
+    await Promise.all(
+      (await readdir(contextDir)).map(async (name) =>
+        (await access(join(contextDir, name)).then(
+          () => true,
+          () => false,
+        ))
+          ? name
+          : null,
+      ),
+    )
+  ).filter((name): name is string => name !== null);
 
   return {
     contextEntries,

--- a/packages/adapters/src/system/ssh-client.ts
+++ b/packages/adapters/src/system/ssh-client.ts
@@ -32,11 +32,15 @@ function toConnectConfig(config: SshConfig): ConnectConfig {
     agent: config.sshAgent,
     tryKeyboard: false,
     keepaliveInterval: 15_000,
-    // 10 (~150s) rather than 3 (45s): a small server pegged by a heavy
-    // `docker build` / `bun install` can briefly starve sshd of keepalive
-    // replies, and 45s was dropping the SSH channel mid-build (build failed with
-    // a bare "exited with code 1"). Still detects a truly-dead link within ~2.5m.
-    keepaliveCountMax: 10,
+    // 240 (~60m) rather than 10 (~150s): 150s still dropped the channel during a
+    // real build. A `COPY --from=deps` of a large node_modules, or a Next.js
+    // compile, pins disk and CPU for minutes with no channel traffic, and sshd
+    // under that load misses more than ten consecutive keepalive replies — the
+    // client then tears down a link that is merely busy, surfacing as "remote
+    // channel closed without an exit status" mid-build. The exec paths carry
+    // their own idle timeouts, so liveness is still bounded; this only stops the
+    // transport from quitting on a server that is working hard.
+    keepaliveCountMax: 240,
   };
 }
 


### PR DESCRIPTION
Two independent failures we hit deploying a local folder (large pnpm/turbo monorepo, Windows orchestrator → Ubuntu server). Both are reproducible and both are fixed here; each commit stands alone.

Fixes #448.

## 1. A missing context file kills the whole API

`prepareSourceTree` stages the repo, then `applyDockerignore` prunes it with `Promise.all` — a wide `.dockerignore` (every `*.md`, `.github/`, `.gitignore` …) fans out to hundreds of concurrent `rm`s. The directory listing can lag behind those deletes, so `readdir` still reports a name whose inode is gone. dockerode's tar-fs pack then `lstat`s it, emits an **unhandled** `'error'`, and the process exits:

```
Error: ENOENT: no such file or directory, lstat 'C:\…\openship-docker-context-AEUppo\.mcp.json.example'
    at Pack.destroy (tar-stream/pack.js:202:17)
    at onstat (tar-fs/index.js:101:26)
```

Not a failed build — the control plane goes down with it. Two narrow changes: prune sequentially so the tree and its listing stay in step, and verify each name still resolves before the list is handed to dockerode. A test pins the invariant (every returned entry exists after a pruning `.dockerignore`).

## 2. `remote channel closed without an exit status`

With #1 fixed the build ran, then died in `COPY --from=deps` and again during `next build`. `keepaliveCountMax: 10` (~150s) is short for a real build: a large `node_modules` copy or a Next.js compile pins disk/CPU for minutes with no channel traffic, sshd misses ten consecutive keepalive replies, and the client tears down a link that is only busy. Raised to 240 (~60m); the exec paths keep their own idle timeouts so liveness is still bounded.

## One more, not fixed here

After both fixes the image built successfully, but a build longer than **5 minutes** still lost its connection until I raised `DEFAULTS.idleTimeoutMs` in `apps/api/src/lib/ssh-manager.ts` locally. `touchIdleTimer` skips the timer while `retainCounts > 0`, so the mechanism exists — it looks like the server-build exec simply isn't retaining the connection for its duration. Bumping the default is the wrong fix, so I've left it out; you'll know the right place to `retain`/`release`. Happy to send it as a follow-up if you point me at it.

## Verification

Real deploy of a ~2000-package pnpm/turbo monorepo to a self-hosted Ubuntu server:

| | before | after |
|---|---|---|
| control plane during folder deploy | died within seconds, every attempt | stayed up through a 6-minute build |
| build | never reached Docker | image built and finalized |
| a failing build | took the API with it | reported as a build failure |

Also ran the isolated race repro (400 files + a wide `.dockerignore`): the old parallel prune leaves stale names in the listing, the new path doesn't.