### PR TITLE
fix(migrate+domains): expose unreachable static roots in preflight & log SSL provisioning

### DIFF
--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -866,9 +866,20 @@ export async function verifyDomain(
     // Background SSL provisioning. Don't await — the verify response stays fast
     // and the SSL status pill updates on the next list read. Failure is
     // non-fatal: HTTP route stays up, Renew + the ssl-scheduler recover it.
+    //
+    // Log before firing — this produces a visible "[DOMAIN] provisioning HTTPS"
+    // line in the deploy log so operators know the ~1 min window is expected,
+    // not a sign that SSL is broken (two users reported it as such: TODO.md).
+    console.log(`[DOMAIN] provisioning HTTPS for ${domain.hostname} — route is live on HTTP; certificate expected in ~1 min`);
     void manageDomainSsl(domain.hostname, {
       action: "provision",
       projectId: domain.projectId ?? undefined,
+    }).then((result) => {
+      if (result.verified) {
+        console.log(`[DOMAIN] HTTPS certificate issued for ${domain.hostname}${result.expiresAt ? ` (expires ${new Date(result.expiresAt).toISOString().slice(0, 10)})` : ""}`);
+      } else {
+        console.warn(`[DOMAIN] HTTPS provisioning completed but cert not verified for ${domain.hostname}`);
+      }
     }).catch((err) => {
       console.error(
         `[DOMAIN] Background SSL provisioning failed for ${domain.hostname}:`,

--- a/apps/api/src/modules/system/self-app.controller.ts
+++ b/apps/api/src/modules/system/self-app.controller.ts
@@ -447,7 +447,7 @@ export async function selfEdgePreflight(c: Context) {
   }
 
   try {
-    const { detectEdge, importSites } = await import("@repo/adapters");
+    const { detectEdge, importSites, unreachableStaticRoots } = await import("@repo/adapters");
     // Host-op executor: LocalExecutor bare, SSH→host.docker.internal when
     // containerized (OPENSHIP_HOST_SSH_* set). Inspecting the api container's
     // own netns would return a wrong migrate/takeover prompt in docker mode.
@@ -459,7 +459,13 @@ export async function selfEdgePreflight(c: Context) {
       const scanned = await importSites(executor, detected);
       return { status: detected, sites: scanned.sites, warnings: scanned.warnings };
     });
-    return c.json({ status, sites, warnings });
+    // Identify static sites whose docroot is outside the edge container's bind
+    // mounts — migrating them verbatim produces a 500 (try_files can't find the
+    // index in a directory that isn't mounted). Surfacing this BEFORE cutover
+    // lets the wizard prompt the operator to copy/mount/skip each path.
+    const containerEdge = process.env.OPENSHIP_EDGE_MODE === "docker";
+    const unreachable = unreachableStaticRoots(sites, { containerEdge });
+    return c.json({ status, sites, warnings, unreachableStaticRoots: unreachable });
   } catch (err) {
     return c.json({ error: safeErrorMessage(err) }, 500);
   }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -264,6 +264,8 @@ export {
 } from "./system/proxy/takeover-journal";
 // The consolidated reverse-proxy / edge facade (single point for the chain).
 export { detectEdge, importSites, takeoverOnMigrate, foreignProxyOnEdge, ensureEdge } from "./system/proxy";
+export { unreachableStaticRoots } from "./system/proxy/import";
+export type { UnreachableStaticRoot } from "./system/proxy/import";
 // The reverse-proxy READ api: sites, by-port index, per-host vhost + cert.
 export { edgeProxy, edgeProxyFor, buildProxyRouteIndex, collectProxyCerts } from "./system/proxy/api";
 export type {


### PR DESCRIPTION
Closes #456
Closes #457

## Summary

Two silent failure modes that caused user confusion, both documented in `TODO.md`:

---

### 1. fix(migrate/edge): surface unreachable static roots in edge preflight API

**Fixes #456**

`unreachableStaticRoots()` already detected static sites whose docroot lies outside the edge container's bind mounts — but the result was never propagated anywhere. After a migrate/takeover, those sites returned **500 errors** silently. Found on a live 15-site migration where 2 sites broke with no prior warning.

**Changes:**
- Export `unreachableStaticRoots` + `UnreachableStaticRoot` from `@repo/adapters/src/index.ts`
- In `POST /api/system/self-edge/preflight`, call `unreachableStaticRoots()` and include `unreachableStaticRoots[]` in the response
- The CLI/wizard can now warn the operator before cutover and prompt a resolution per site (copy / mount / accept)

---

### 2. fix(domains): log SSL provisioning start and completion

**Fixes #457**

After a domain is verified, there was a ~1 minute silent window where the site only answered HTTP. Two operators reported this as "SSL is broken". Now:
- Log `[DOMAIN] provisioning HTTPS for <host> — route is live on HTTP; certificate expected in ~1 min` before firing the background job
- Log success with expiry date on `.then()`, or warn if cert is not verified
- Keep existing `.catch()` for hard failures

---

## Files Changed

- `packages/adapters/src/index.ts`
- `apps/api/src/modules/system/self-app.controller.ts`
- `apps/api/src/modules/domains/domain.service.ts`