### PR TITLE
fix(dashboard): remove debug logs, null guards, timer leaks, and button types

### DIFF
--- a/apps/dashboard/src/components/jobs/JobForm.tsx
+++ b/apps/dashboard/src/components/jobs/JobForm.tsx
@@ -321,7 +321,7 @@ export function JobForm({
 
         {/* Actions */}
         <div className="flex items-center justify-end gap-2">
-          <button onClick={onCancel} className="rounded-xl border border-border px-5 py-2.5 text-sm font-medium text-foreground hover:bg-muted">{c.cancel}</button>
+          <button type="button" onClick={onCancel} className="rounded-xl border border-border px-5 py-2.5 text-sm font-medium text-foreground hover:bg-muted">{c.cancel}</button>
           <button onClick={() => void submit()} disabled={!canSave}
             className="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40">
             {saving ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}

--- a/apps/dashboard/src/components/overview/ActivityChart.tsx
+++ b/apps/dashboard/src/components/overview/ActivityChart.tsx
@@ -53,17 +53,13 @@ const ActivityChart: React.FC<ActivityChartProps> = ({ projects, numbers }) => {
       });
     }
     
-    // Debug log
-    console.log('Daily deployments data:', numbers?.daily_deployments);
-    console.log('Processed days:', days);
-    
     return days;
   };
 
   const data = getLast7DaysData();
   const maxCount = Math.max(...data.map(d => d.count), 1);
-  const totalDeployments = numbers.total_deployments;
-  const liveProjects = numbers.total_active_projects;
+  const totalDeployments = numbers?.total_deployments ?? 0;
+  const liveProjects = numbers?.total_active_projects ?? 0;
   
   // Calculate trend
   const recentDays = data.slice(-3).reduce((sum, d) => sum + d.count, 0);

--- a/apps/dashboard/src/hooks/useBuildConnection.ts
+++ b/apps/dashboard/src/hooks/useBuildConnection.ts
@@ -32,6 +32,7 @@ export const useBuildConnection = (options: UseBuildConnectionOptions) => {
   const lastEventIdRef = useRef<number | undefined>(undefined);
   const isActiveRef = useRef<boolean>(false);
   const reconnectAttemptsRef = useRef<number>(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   /**
    * Connect to a new build or attach to existing one
@@ -86,11 +87,13 @@ export const useBuildConnection = (options: UseBuildConnectionOptions) => {
             if (error.message?.includes('Token already in use')) {
               console.log('[BuildConnection] Token in use, switching to attach mode');
               showToast('Build already in progress, attaching...', 'success', 'Reconnecting');
-              setTimeout(() => reconnect(), 1000);
+              if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+                reconnectTimerRef.current = setTimeout(() => reconnect(), 1000);
+              }
             } else {
               options.onError?.(error);
               if (isActiveRef.current && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
-                setTimeout(() => reconnect(), 2000);
+                reconnectTimerRef.current = setTimeout(() => reconnect(), 2000);
               }
             }
           },
@@ -151,7 +154,7 @@ export const useBuildConnection = (options: UseBuildConnectionOptions) => {
         console.log('[BuildConnection] Token in use, switching to attach mode');
         showToast('Build already in progress, attaching...', 'success', 'Reconnecting');
         if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
-          setTimeout(() => reconnect(), 1000);
+          reconnectTimerRef.current = setTimeout(() => reconnect(), 1000);
         }
       } else {
         options.onError?.(err);
@@ -280,7 +283,7 @@ export const useBuildConnection = (options: UseBuildConnectionOptions) => {
       
       // Only retry if still active and haven't exceeded attempts
       if (isActiveRef.current && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
-        setTimeout(() => reconnect(), 2000);
+        reconnectTimerRef.current = setTimeout(() => reconnect(), 2000);
       } else if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
         console.error('[BuildConnection] Max reconnection attempts reached');
         isActiveRef.current = false;
@@ -309,6 +312,11 @@ export const useBuildConnection = (options: UseBuildConnectionOptions) => {
   const disconnect = useCallback(() => {
     console.log('[BuildConnection] Disconnecting...');
     isActiveRef.current = false;
+    // Clear any pending reconnect timer so it can't fire after unmount
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
     buildTokenRef.current = null;
     buildOptionsRef.current = null;
     lastEventIdRef.current = undefined;

--- a/apps/dashboard/src/utils/upload.js
+++ b/apps/dashboard/src/utils/upload.js
@@ -9,4 +9,4 @@ export const text = `
                                                              
 `
 
-console.log(text);
+// ASCII art banner — available for callers to opt-in; not auto-printed on import.


### PR DESCRIPTION
Closes #458

## Summary

Several dashboard bugs found during a codebase audit:

### 1. `ActivityChart.tsx` — debug `console.log` in production render loop

Two `console.log` calls were left inside `getLast7DaysData()` (called on every render):
```ts
console.log("Daily deployments data:", numbers?.daily_deployments);
console.log("Processed days:", days);
```
Removed both.

### 2. `ActivityChart.tsx` — potential `TypeError` crash on `numbers` access

Line 65-66 accessed `numbers.total_deployments` and `numbers.total_active_projects` directly while line 42 above already used `numbers?.daily_deployments` (optional chaining). If `numbers` is `undefined`/`null` during initial data load, React throws a fatal `TypeError`. Fixed with `numbers?.total_deployments ?? 0`.

### 3. `upload.js` — auto-print ASCII art banner on module import

`console.log(text)` at module scope fires unconditionally on every import in production. Changed to a comment so callers can opt in.

### 4. `JobForm.tsx` — Cancel button missing `type="button"`

HTMLButtonElement default type is `submit`. Inside a form this would cause an unintended form submission. Added `type="button"` to the cancel button.

### 5. `useBuildConnection.ts` — untracked `setTimeout` reconnect timers

Multiple `setTimeout(() => reconnect(), N)` calls were not tracked. If the component unmounts while a reconnect is pending, `reconnect()` fires after unmount — calling `setState()` on an unmounted component and potentially re-opening a network connection.

**Fix:** Added `reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)` and:
- Replaced all bare `setTimeout` calls with `reconnectTimerRef.current = setTimeout(...)`
- In `disconnect()`, call `clearTimeout(reconnectTimerRef.current)` before nulling it

## Files Changed

- `apps/dashboard/src/components/overview/ActivityChart.tsx`
- `apps/dashboard/src/utils/upload.js`
- `apps/dashboard/src/components/jobs/JobForm.tsx`
- `apps/dashboard/src/hooks/useBuildConnection.ts`