### PR TITLE
fix(api): normalize FrameworkEnum at schema boundary & guard STACKS lookups

### DIFF
--- a/apps/api/src/modules/projects/project-crud.service.ts
+++ b/apps/api/src/modules/projects/project-crud.service.ts
@@ -434,7 +434,7 @@ async function persistMonorepoApps(
     data.monorepoApps.map((app) => ({
       name: app.name,
       rootDirectory: app.rootDirectory,
-      framework: app.framework ?? null,
+      framework: app.framework ? normalizeFramework(app.framework) : null,
       packageManager: app.packageManager ?? null,
       buildImage: app.buildImage ?? null,
       installCommand: app.installCommand ?? null,
@@ -1111,7 +1111,11 @@ export async function updateProject(
     // no sibling fan-out. gitUrl is derived by the linker, so it's not set here
     // either (deriving it from an owner/repo we don't apply would desync it).
     if (GIT_SOURCE_IDENTITY_KEYS.has(key)) continue;
-    if (raw[key] !== undefined) update[key] = raw[key];
+    if (key === "framework" && raw.framework !== undefined) {
+      update.framework = typeof raw.framework === "string" ? normalizeFramework(raw.framework) : raw.framework;
+    } else if (raw[key] !== undefined) {
+      update[key] = raw[key];
+    }
   }
   if (data.name && data.name !== p.name) {
     const newSlug = slugify(data.name);

--- a/apps/api/src/modules/projects/project.schema.ts
+++ b/apps/api/src/modules/projects/project.schema.ts
@@ -15,12 +15,18 @@ import {
   type ResourceTier,
 } from "@repo/core";
 
+import { normalizeFramework } from "@repo/core";
+
 // ─── Shared enums (derived from registry) ────────────────────────────────────
 
-export const FrameworkEnum = Type.String({
-  maxLength: 100,
-  description: "Framework stack ID or display label (e.g. 'static', 'nextjs', 'Static Site').",
-});
+export const FrameworkEnum = Type.Transform(
+  Type.String({
+    maxLength: 100,
+    description: "Framework stack ID or display label (e.g. 'static', 'nextjs', 'Static Site').",
+  }),
+)
+  .Decode((val) => normalizeFramework(val))
+  .Encode((val) => val);
 
 export const PackageManagerEnum = Type.Union(
   ALL_PACKAGE_MANAGERS.map((pm) => Type.Literal(pm)) as [TLiteral<string>, ...TLiteral<string>[]],

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -3,7 +3,7 @@
  */
 
 import { normalizeRoutingFields, repos, composeSpecDiff, type Project, type Service, type ServicePublicEndpoint } from "@repo/db";
-import { aliasConflictsWithSiblings, ForbiddenError, getProjectType, mergeAdvanced, normalizeServiceLabel, normalizeAliasStrict, withTimeout, type ComposeAdvanced, type ServiceContainerState, type StackId } from "@repo/core";
+import { aliasConflictsWithSiblings, ForbiddenError, getProjectType, mergeAdvanced, normalizeServiceLabel, normalizeAliasStrict, normalizeFramework, withTimeout, type ComposeAdvanced, type ServiceContainerState, type StackId } from "@repo/core";
 import {
   BuildLogger,
   DockerRuntime,
@@ -485,7 +485,7 @@ export async function createService(
     buildCommand: kind === "monorepo" ? trimOrNull(data.buildCommand) : null,
     startCommand: kind === "monorepo" ? trimOrNull(data.startCommand) : null,
     outputDirectory: kind === "monorepo" ? trimOrNull(data.outputDirectory) : null,
-    framework: kind === "monorepo" ? trimOrNull(data.framework) : null,
+    framework: kind === "monorepo" && data.framework ? normalizeFramework(data.framework) : null,
     packageManager: kind === "monorepo" ? trimOrNull(data.packageManager) : null,
     buildImage: kind === "monorepo" ? trimOrNull(data.buildImage) : null,
   });
@@ -575,13 +575,16 @@ export async function updateService(
     "buildCommand",
     "startCommand",
     "outputDirectory",
-    "framework",
     "packageManager",
     "buildImage",
   ] as const) {
     if (key in patch) {
       patch[key] = trimOrNull(patch[key]);
     }
+  }
+  if ("framework" in patch) {
+    const trimmed = trimOrNull(patch.framework);
+    patch.framework = trimmed ? normalizeFramework(trimmed) : null;
   }
 
   const touchesRouting = [

--- a/apps/api/test/modules/projects/framework-normalization.test.ts
+++ b/apps/api/test/modules/projects/framework-normalization.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { Value } from "@sinclair/typebox/value";
+import { FrameworkEnum } from "../../../src/modules/projects/project.schema";
+
+describe("FrameworkEnum schema boundary normalization", () => {
+  it("decodes raw framework labels like 'Static Site' to canonical stack IDs", () => {
+    const decoded = Value.Decode(FrameworkEnum, "Static Site");
+    expect(decoded).toBe("static");
+  });
+
+  it("decodes 'Next.js' to 'nextjs'", () => {
+    const decoded = Value.Decode(FrameworkEnum, "Next.js");
+    expect(decoded).toBe("nextjs");
+  });
+
+  it("passes through canonical stack IDs unchanged", () => {
+    const decoded = Value.Decode(FrameworkEnum, "static");
+    expect(decoded).toBe("static");
+  });
+});

--- a/packages/core/src/stacks.ts
+++ b/packages/core/src/stacks.ts
@@ -1057,7 +1057,7 @@ const BUN_ELIGIBLE_LANGUAGES: ReadonlySet<string> = new Set(["javascript", "type
 
 /** Get the resolved Docker build image for a stack */
 export function getBuildImage(stackId: StackId, packageManager?: string): string {
-  const stack = STACKS[stackId] as StackDefinition;
+  const stack = (Object.hasOwn(STACKS, stackId) ? STACKS[stackId] : STACKS["unknown"]) as StackDefinition;
   if (packageManager === "bun" && BUN_ELIGIBLE_LANGUAGES.has(stack.language)) {
     return "oven/bun:latest";
   }
@@ -1090,7 +1090,7 @@ export function packageManagerEnsureCommand(packageManager?: string): string {
 
 /** Get the resolved Docker runtime image for a stack */
 export function getRuntimeImage(stackId: StackId, packageManager?: string): string {
-  const stack = STACKS[stackId] as StackDefinition;
+  const stack = (Object.hasOwn(STACKS, stackId) ? STACKS[stackId] : STACKS["unknown"]) as StackDefinition;
   if (packageManager === "bun" && BUN_ELIGIBLE_LANGUAGES.has(stack.language)) {
     return "oven/bun:latest";
   }
@@ -1100,7 +1100,7 @@ export function getRuntimeImage(stackId: StackId, packageManager?: string): stri
 
 /** Get the full stack definition with resolved images */
 export function getStackDefaults(stackId: StackId, packageManager?: string) {
-  const stack = STACKS[stackId] as StackDefinition;
+  const stack = (Object.hasOwn(STACKS, stackId) ? STACKS[stackId] : STACKS["unknown"]) as StackDefinition;
   return {
     ...stack,
     buildImage: getBuildImage(stackId, packageManager),
@@ -1110,7 +1110,8 @@ export function getStackDefaults(stackId: StackId, packageManager?: string) {
 
 /** Derive the project type from a stack ID */
 export function getProjectType(stackId: StackId): ProjectType {
-  const cat = (STACKS[stackId] as StackDefinition).category;
+  const stack = Object.hasOwn(STACKS, stackId) ? (STACKS[stackId] as StackDefinition) : undefined;
+  const cat = stack?.category;
   if (cat === "docker") return "docker";
   if (cat === "services") return "services";
   return "app";
@@ -1125,7 +1126,7 @@ export function normalizeFramework(framework?: string | null): string {
   const trimmed = framework.trim();
   if (!trimmed) return "unknown";
   const lower = trimmed.toLowerCase();
-  if (lower in STACKS) return lower;
+  if (Object.hasOwn(STACKS, lower)) return lower;
   for (const [id, def] of Object.entries(STACKS)) {
     if (def.name.toLowerCase() === lower) return id;
   }

--- a/packages/core/test/is-services-framework.test.ts
+++ b/packages/core/test/is-services-framework.test.ts
@@ -41,5 +41,11 @@ describe("normalizeFramework", () => {
     expect(normalizeFramework(null)).toBe("unknown");
     expect(normalizeFramework(undefined)).toBe("unknown");
   });
+
+  it("does not match prototype chain properties", () => {
+    expect(normalizeFramework("constructor")).toBe("constructor");
+    expect(normalizeFramework("__proto__")).toBe("__proto__");
+    expect(normalizeFramework("toString")).toBe("tostring");
+  });
 });
 


### PR DESCRIPTION
### Summary of Changes

1. **Schema Boundary Transformation**: Converted `FrameworkEnum` to use TypeBox `Type.Transform` (`normalizeFramework`) so framework display labels (e.g., "Static Site", "Next.js") are normalized to canonical stack IDs during request body decoding.
2. **Explicit Service & Project Write Path Normalization**:
   - `updateProject` (`PATCH /projects/:id`): Explicitly normalized `raw.framework` in the update loop.
   - `syncMonorepoApps`: Normalized `app.framework` before saving monorepo sub-apps.
   - `createService` & `updateService`: Normalized `framework` for monorepo sub-app writes.
3. **Prototype Chain Guard**: Replaced `lower in STACKS` with `Object.hasOwn(STACKS, lower)` in `normalizeFramework` and added `Object.hasOwn` guards to `STACKS` lookups in `getBuildImage`, `getRuntimeImage`, `getStackDefaults`, and `getProjectType`.