### PR TITLE
feat(cli): add shell completion (bash/zsh/fish) via @bomb.sh/tab #233

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ openship deploy
 Full server guide + complete CLI reference: **[openship.io/docs](https://openship.io/docs)**.
 
 <details>
+<summary>Shell completion (bash/zsh/fish)</summary>
+
+Two ways to enable Tab-completion for `openship`:
+
+| | Setup | Trade-off |
+|---|---|---|
+| **Static file** (recommended) | `openship completion <shell> > <path>` | Instant shell startup. Regenerate after upgrading to pick up newly added commands. |
+| **Live-sourced** | add `source <(openship completion <shell>)` to your shell config | Always reflects the currently installed version. Adds a small delay to every new shell session. |
+
+**Static file:**
+```bash
+openship completion bash > /etc/bash_completion.d/openship
+openship completion zsh  > ~/.zsh/completions/_openship
+openship completion fish > ~/.config/fish/completions/openship.fish
+```
+Open a new terminal — done.
+
+**Live-sourced** (zsh example):
+```bash
+echo 'source <(openship completion zsh)' >> ~/.zshrc
+```
+
+</details>
+
+<details>
 <summary>Self-host with raw Docker Compose (no CLI)</summary>
 
 The self-hosted stack lives in **`docker/docker-compose.yml`** and **pulls** published images from GitHub Container Registry (`ghcr.io/oblien/*`) — no build tooling, no monorepo compile. Run it from the repo root:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,14 +35,16 @@
     "prepack": "cp ../../README.md README.md"
   },
   "dependencies": {
+    "@bomb.sh/tab": "^0.0.22",
     "@clack/prompts": "^0.11.0",
     "@repo/adapters": "workspace:*",
     "@repo/core": "workspace:*",
     "@repo/onboarding": "workspace:*",
-    "commander": "^14.0.3",
     "chalk": "^5.6.2",
+    "commander": "^14.0.3",
     "dockerode": "^4.0.9",
     "open": "^10.2.0",
+    "openship": "^0.5.0",
     "ora": "^9.3.0",
     "ssh2": "^1.17.0"
   },

--- a/apps/cli/src/commands/completion.ts
+++ b/apps/cli/src/commands/completion.ts
@@ -1,0 +1,6 @@
+import { Command } from "commander";
+import tab from "@bomb.sh/tab/commander";
+
+export function attachCompletion(program: Command) {
+  tab(program, { completionCommandName: "completion" });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -47,6 +47,9 @@ import { runWizard, runControl, isSetupInProgress } from "./commands/wizard";
 import { serviceStatus } from "./lib/service";
 import { readInstallMethod } from "./lib/compose";
 
+//completion
+import { attachCompletion } from "./commands/completion";
+
 // Injected at build time by tsup (define). Always present in the built binary.
 declare const __CLI_VERSION__: string;
 
@@ -115,5 +118,8 @@ program.addCommand(resetAdminCommand);
 
 // `cache` is a maintenance concern of `install`, not a top-level verb.
 installCommand.addCommand(cacheCommand);
+
+// for autocomplete
+attachCompletion(program);
 
 program.parse();

--- a/apps/cli/test/e2e/completion.test.ts
+++ b/apps/cli/test/e2e/completion.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Black-box e2e: spawn the real assembled CLI (src/index.ts via tsx) and
+ * verify shell completion works end to end. No mocks — same approach as
+ * smoke.test.ts, since this needs the fully-wired `program`, including
+ * attachCompletion(program), exactly as the built binary runs it.
+ */
+import { execFile } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(here, "..", "..");
+const inject = join(here, "..", "helpers", "inject-version.mjs");
+const entry = join(cliRoot, "src", "index.ts");
+const NO_FILE_COMP_DIRECTIVE = ":4";
+
+// tab always appends one trailing protocol line after the real candidates e.g. ":4",
+// which is ShellCompDirectiveNoFileComp, telling the shell 
+// "these ARE the complete results, don't fall back to filesystem path completion."
+// It's present on every response, whether there are 0 or 10 real candidates,
+// so tests need to strip it before asserting on the actual suggestion list.
+// See https://github.com/bombshell-dev/tab (dist/index.mjs).
+function candidatesFrom(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && line !== NO_FILE_COMP_DIRECTIVE);
+}
+
+function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  const runtime = process.execPath.toLowerCase().endsWith("bun") ? "node" : process.execPath;
+  return new Promise((resolve) => {
+    execFile(
+      runtime,
+      ["--import", "tsx", "--import", pathToFileURL(inject).href, entry, ...args],
+      { cwd: cliRoot, env: { ...process.env } },
+      (error, stdout, stderr) => {
+        const code =
+          error && typeof (error as { code?: number }).code === "number"
+            ? (error as { code: number }).code
+            : error
+              ? 1
+              : 0;
+        resolve({ stdout, stderr, code });
+      },
+    );
+  });
+}
+
+describe("cli completion", { timeout: 40_000 }, () => {
+
+    it.each([
+    { shell: "bash", marker: "complete -F __openship_complete openship" },
+    { shell: "zsh", marker: "#compdef openship" },
+    { shell: "fish", marker: "complete -c openship -e" },
+    ])(
+    "generates a valid %s completion script",
+    async ({ shell, marker }) => {
+        const { stdout, stderr, code } = await runCli(["completion", shell]);
+
+        expect(code).toBe(0);
+        expect(stderr).toBe("");
+        expect(stdout).toContain(marker);
+    },
+    );
+
+  it("suggests known top-level commands when nothing is typed yet", async () => {
+    const { stdout, code } = await runCli(["complete", "--", ""]);
+    expect(code).toBe(0);
+    for (const cmd of ["deploy", "project", "service", "login"]) {
+      expect(stdout).toContain(cmd);
+    }
+  });
+
+  it("suggests matching subcommands for a partial word", async () => {
+    // "proj" should resolve to "project"
+    const { stdout, code } = await runCli(["complete", "--", "proj"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("project");
+  });
+
+    it("never suggests its own hidden completion plumbing", async () => {
+    const { stdout } = await runCli(["complete", "--", ""]);
+    expect(stdout).not.toContain("complete");
+  });
+
+  it("suggests flags for a known command", async () => {
+    // Directly exercises the scenario named in the original issue:
+    // `openship deploy --project <TAB>`.
+    const { stdout, code } = await runCli(["complete", "--", "deploy", "--pro"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("--project");
+  });
+
+  it("suggests nothing for an unmatched prefix", async () => {
+    const { stdout, code } = await runCli(["complete", "--", "zzz-not-real"]);
+    expect(code).toBe(0);
+    expect(candidatesFrom(stdout)).toEqual([]);
+  });
+  
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openship",
@@ -16,7 +17,7 @@
     },
     "apps/api": {
       "name": "@repo/api",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "@better-auth/drizzle-adapter": "^1.5.4",
         "@hono/node-server": "^1.19.15",
@@ -50,11 +51,12 @@
     },
     "apps/cli": {
       "name": "openship",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "bin": {
         "openship": "./dist/index.js",
       },
       "dependencies": {
+        "@bomb.sh/tab": "^0.0.22",
         "@clack/prompts": "^0.11.0",
         "@repo/adapters": "workspace:*",
         "@repo/core": "workspace:*",
@@ -63,6 +65,7 @@
         "commander": "^14.0.3",
         "dockerode": "^4.0.9",
         "open": "^10.2.0",
+        "openship": "^0.5.0",
         "ora": "^9.3.0",
         "ssh2": "^1.17.0",
       },
@@ -115,7 +118,7 @@
     },
     "apps/desktop": {
       "name": "@repo/desktop",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "@repo/core": "workspace:*",
         "@repo/onboarding": "workspace:*",
@@ -138,11 +141,11 @@
     },
     "apps/email": {
       "name": "@repo/email",
-      "version": "0.3.0",
+      "version": "0.5.0",
     },
     "apps/web": {
       "name": "@repo/web",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "@repo/core": "workspace:*",
         "@repo/ui": "workspace:*",
@@ -275,6 +278,7 @@
   },
   "trustedDependencies": [
     "esbuild",
+    "electron",
   ],
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -364,6 +368,8 @@
     "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
+    "@bomb.sh/tab": ["@bomb.sh/tab@0.0.22", "", { "peerDependencies": { "cac": "^6.7.14 || ^7.0.0", "citty": "^0.1.6 || ^0.2.0", "commander": "^13.1.0 || ^14.0.0 || ^15.0.0" }, "optionalPeers": ["cac", "citty", "commander"], "bin": { "tab": "dist/bin/cli.mjs" } }, "sha512-l5IuWpV7szqG4MM6A7I+qPMmP2qPMq2TD4veIXaOH0sD53dV0Tv8WZPARp5O5Kp4+y4fnVCl3VL1HZKNghO1yg=="],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@10.5.0", "", { "dependencies": { "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw=="],
 
@@ -3274,6 +3280,8 @@
     "oas-resolver/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 
     "oas-validator/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+
+    "openship/openship": ["openship@0.5.0", "", { "dependencies": { "@clack/prompts": "^0.11.0", "chalk": "^5.6.2", "commander": "^14.0.3", "dockerode": "^4.0.9", "open": "^10.2.0", "ora": "^9.3.0", "ssh2": "^1.17.0" }, "bin": { "openship": "dist/index.js" } }, "sha512-1x0kT1OKQpZ0R+7BCLII41TscVHw1gGlyLbHGaHBZ9Flfzmp0IsaTuq0WtkOBNVRo/3Mtb7II5+yiMeiRv9mIQ=="],
 
     "ora/log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 


### PR DESCRIPTION
Closes #233

## Summary

Adds shell auto-completion support to the Openship CLI using `@bomb.sh/tab`.

This introduces a new `completion` command that generates completion scripts for Bash, Zsh, and Fish from the live Commander command tree, ensuring commands, subcommands, and flags stay in sync automatically as the CLI evolves.

## Scope

This PR implements **static shell completion** (commands, subcommands, and flags) only.

Dynamic value completion (e.g. project IDs, service names), as suggested in the issue, is intentionally left for a follow-up PR to keep this change focused and reviewable.

## Changes

- Added `openship completion <bash|zsh|fish>`.
- Integrated `@bomb.sh/tab` with the CLI.
- Added end-to-end tests
- Documented shell completion setup in the README, including:
  - static completion scripts (recommended);
  - live-sourced completion.

## Usage

```bash
openship completion bash
openship completion zsh
openship completion fish
```

## Validation

- Completion scripts are generated successfully for Bash, Zsh, and Fish.
- Commands, subcommands, and flags complete as expected.
- Internal completion commands are not suggested.
- Existing CLI behavior remains unchanged.