### PR TITLE
fix(core): keep backslashes inside double quotes in shellSplitWords

### DIFF
--- a/packages/core/src/shell-split.ts
+++ b/packages/core/src/shell-split.ts
@@ -24,6 +24,16 @@ export function shellSplitWords(value: string): string[] {
 
   for (const char of value.trim()) {
     if (escaped) {
+      // Unquoted, a backslash escapes any single following char (the backslash
+      // is dropped). Inside double quotes it is NOT that permissive: POSIX keeps
+      // the backslash LITERAL unless it precedes a character a double quote can
+      // itself escape (`"`, `\`, `$`, or a backtick). Without this carve-out a
+      // double-quoted regex/path/escape ("\d+", "C:\app", "s/\r//g") silently
+      // lost its backslashes — while the single-quoted form kept them — so the
+      // same command tokenized differently depending on the quote style.
+      if (inDouble && char !== '"' && char !== "\\" && char !== "$" && char !== "`") {
+        current += "\\";
+      }
       current += char;
       escaped = false;
       continue;

--- a/packages/core/test/shell-split.test.ts
+++ b/packages/core/test/shell-split.test.ts
@@ -20,6 +20,16 @@ describe("shellSplitWords", () => {
     ]);
     expect(shellSplitWords(`grep -E '\\d+' file.txt`)).toEqual(["grep", "-E", "\\d+", "file.txt"]);
   });
+  it("keeps backslashes literal inside double quotes (except real escapes)", () => {
+    // Same regex as the single-quoted case above — must tokenize identically.
+    expect(shellSplitWords(`grep -E "\\d+" file.txt`)).toEqual(["grep", "-E", "\\d+", "file.txt"]);
+    expect(shellSplitWords(`sed "s/\\r//g" /data/in`)).toEqual(["sed", "s/\\r//g", "/data/in"]);
+    expect(shellSplitWords(`run "C:\\app\\bin"`)).toEqual(["run", "C:\\app\\bin"]);
+    // A double quote CAN escape these four, so the backslash is consumed there.
+    expect(shellSplitWords(`echo "a\\"b"`)).toEqual(["echo", `a"b`]);
+    expect(shellSplitWords(`echo "a\\\\b"`)).toEqual(["echo", "a\\b"]);
+    expect(shellSplitWords(`echo "\\$HOME"`)).toEqual(["echo", "$HOME"]);
+  });
   it("keeps an empty quoted word as an empty argument", () => {
     expect(shellSplitWords(`node app.js --base-href ""`)).toEqual([
       "node",


### PR DESCRIPTION
## Problem

`shellSplitWords` (`packages/core/src/shell-split.ts`) drops **every** backslash inside a double-quoted span. On seeing `\` it sets the escape flag whenever it isn't in single quotes, so the next character is always taken literally and the backslash is discarded — regardless of whether it's inside double quotes.

Single quotes already preserve backslashes (and a test pins that: `'\d+'` → `\d+`). So the **same command tokenizes differently depending on quote style**:

```
grep -E '\d+' file.txt   ->  ["grep","-E","\d+","file.txt"]   ✅ backslash kept
grep -E "\d+" file.txt   ->  ["grep","-E","d+","file.txt"]    ❌ backslash lost
```

More examples of the silent corruption:

| input (compose `command` string) | current argv | expected |
|---|---|---|
| `sed "s/\r//g" /data/in` | `s/r//g` | `s/\r//g` |
| `run "C:\app\bin"` | `C:appbin` | `C:\app\bin` |
| `printf "a\tb"` | `atb` | `a\tb` |

`shellSplitWords`/`commandToArgv` is shared by the compose parser (`apps/api/src/lib/compose-parser.ts`), the CLI compose ingestion (`apps/cli/src/commands/service.ts`), and the Dockerfile compiler (`packages/adapters/src/dockerfile/compiler.ts`), so a double-quoted backslash in a service's `command`/`entrypoint` reaches real deployments as a wrong argv — the container runs a different command than was written.

## Fix

Apply POSIX double-quote semantics: inside double quotes a backslash stays **literal** unless it precedes one of the characters a double quote can actually escape — `"`, `\`, `$`, or a backtick. Unquoted (`a\ b` → `a b`) and single-quoted behavior is unchanged, so every existing assertion still holds.

The change is a small carve-out in the existing escape branch; no restructuring.

## Tests

Added a regression case (`keeps backslashes literal inside double quotes (except real escapes)`) covering the double-quoted regex/path cases plus the four genuine escapes (`\"`, `\\`, `\$`).

Verified against the real source with Node's TS type-stripping:
- **before** the fix, the three new double-quoted cases fail (`\d+`→`d+`, `s/\r//g`→`s/r//g`, `C:\app\bin`→`C:appbin`);
- **after**, all pass, and every pre-existing `shellSplitWords`/`commandToArgv` assertion (unquoted escapes, single-quote spans, `\"`/`\\` escapes, empty args, operators-stay-literal) still passes unchanged.
