### PR TITLE
fix(core): refuse `..` traversal in app volume paths

### DIFF
--- a/packages/core/src/volumes.ts
+++ b/packages/core/src/volumes.ts
@@ -52,8 +52,8 @@ export function volumeAutoName(path: string): string {
  * `<autoname>:<absolute target>`. Anything already in `source:target` form (a
  * named volume or a host bind mount) passes through untouched, so a user who
  * wants a bind mount or a shared volume name keeps full control. Returns null
- * for input that can't be a mount (empty, or a target outside the app dir given
- * as a relative path that normalises away).
+ * for input that can't be a mount (empty, a target outside the app dir given as
+ * a relative path that normalises away, or a path with a `..` traversal segment).
  */
 export function normalizeAppVolume(spec: string, appDir: string = APP_DIR): string | null {
   const raw = spec.trim();
@@ -68,6 +68,13 @@ export function normalizeAppVolume(spec: string, appDir: string = APP_DIR): stri
 
   const path = body.replace(/^\.\//, "").replace(/\/+$/g, "");
   if (!path) return null;
+  // A `..` segment resolves the mount outside the app dir (`../secret`,
+  // `/app/../secret` → `/secret`) — which the app-relative auto-name and the
+  // bare runtime's symlink logic below can't represent, and which the doc says
+  // returns null. Refuse traversal outright, the way normalizeRepoPath does in
+  // source-access.ts. Explicit `source:target` binds are handled above and keep
+  // full control.
+  if (path.split("/").includes("..")) return null;
   const target = path.startsWith("/") ? path : `${appDir.replace(/\/+$/, "")}/${path}`;
   // The auto-name is derived from the path RELATIVE to the app dir, so
   // `storage` and `/app/storage` produce the same volume — declaring it either

--- a/packages/core/test/app-volumes.test.ts
+++ b/packages/core/test/app-volumes.test.ts
@@ -41,6 +41,19 @@ describe("normalizeAppVolume", () => {
     expect(normalizeAppVolume("   ")).toBeNull();
     expect(normalizeAppVolume("./")).toBeNull();
   });
+
+  it("refuses a `..` traversal path instead of mounting outside the app dir", () => {
+    // `/app/../secret` resolves to `/secret`; the doc-comment says such a path
+    // returns null, and normalizeRepoPath (source-access.ts) refuses `..` too.
+    expect(normalizeAppVolume("../secret")).toBeNull();
+    expect(normalizeAppVolume("..")).toBeNull();
+    expect(normalizeAppVolume("/app/../secret")).toBeNull();
+    expect(normalizeAppVolume("storage/../secret")).toBeNull();
+    // The dropped entry doesn't take down the rest of the list.
+    expect(normalizeAppVolumes(["../secret", "storage"])).toEqual([
+      `storage:${APP_DIR}/storage`,
+    ]);
+  });
 });
 
 describe("volumeAutoName", () => {


### PR DESCRIPTION
## Problem

`normalizeAppVolume` (`packages/core/src/volumes.ts`) expands a bare app-relative volume path into a mount on the app dir, but it never rejected `..` segments — so a declared volume resolves **outside** the app dir:

```ts
normalizeAppVolume("../secret")      // "..-secret:/app/../secret"   (target = /secret)
normalizeAppVolume("/app/../secret") // "..-secret:/app/../secret"
normalizeAppVolume("..")             // "..:/app/.."
normalizeAppVolume("storage/../secret") // "storage-..-secret:/app/storage/../secret"
```

`/app/../secret` resolves to `/secret`, and `appVolumeTargets` then hands the bare runtime `../secret` to symlink into its shared dir — escaping the release directory. The `..` also survives into the auto-derived volume name (`..-secret`).

This contradicts the function's **own doc-comment**, which says it "Returns null for input that can't be a mount (empty, or a target outside the app dir given as a relative path that normalises away)" — a `../…` path is exactly that. And the sibling normalizer `normalizeRepoPath` (`source-access.ts`) already refuses traversal (`if (raw === "..") return null; // traversal: refuse, never resolve`); only this one let it through.

## Fix

Reject any **bare** path containing a `..` segment, right where the existing empty-path check lives:

```ts
if (path.split("/").includes("..")) return null;
```

- Explicit `source:target` binds (a named volume or host bind mount) are handled earlier and still pass through untouched — a user who wants a bind mount keeps full control.
- Every non-traversal path is unchanged: bare (`storage`), in-app absolute (`/app/storage`), out-of-app absolute (`/var/lib/thing`, intentional passthrough), bind modes (`:ro`), and dedup all behave exactly as before.

## Tests

Added a regression case under `normalizeAppVolume` covering `../secret`, `..`, `/app/../secret`, `storage/../secret` → `null`, plus `normalizeAppVolumes(["../secret", "storage"])` dropping only the bad entry.

Verified against the exact function logic: before the fix all four traversal inputs return a non-null spec (`../secret` → `..-secret:/app/../secret`); after, they return `null`, while all eight existing legit inputs are byte-for-byte unchanged.
