### PR TITLE
fix(api): drop a sub-1MB numeric mem_limit instead of reading it as unlimited

### DIFF
--- a/apps/api/src/lib/compose-parser.ts
+++ b/apps/api/src/lib/compose-parser.ts
@@ -298,8 +298,15 @@ function parseAdvanced(svc: Record<string, unknown>, env: Record<string, string>
  */
 function parseComposeMemory(raw: unknown): number | undefined {
   if (typeof raw === "number") {
-    // Bare number = bytes (compose treats an unsuffixed value as bytes).
-    return raw > 0 ? Math.floor(raw / (1024 * 1024)) : undefined;
+    // Bare number = bytes (compose treats an unsuffixed value as bytes). Apply
+    // the SAME sub-1-MB guard the string path uses below: a value that floors to
+    // 0 MB (e.g. `mem_limit: 512`, usually a typo for `512m`) must return
+    // undefined, not 0 — `memoryMb: 0` reads downstream as "no limit"
+    // (resources.ts hasMemoryLimit / UNLIMITED_RESOURCES), so returning 0 turns
+    // a tiny cap into an UNLIMITED one, the exact failure this parser documents
+    // it avoids. Without the guard the number and string paths disagree.
+    const mb = raw / (1024 * 1024);
+    return mb >= 1 ? Math.floor(mb) : undefined;
   }
   if (typeof raw !== "string") return undefined;
   const m = raw.trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*([kmgt]?)b?$/);

--- a/apps/api/test/lib/compose-parser.test.ts
+++ b/apps/api/test/lib/compose-parser.test.ts
@@ -807,6 +807,18 @@ describe("parseComposeFile — service resource limits", () => {
     expect(parsed.services[0]?.advanced?.resources).toBeUndefined();
   });
 
+  // A sub-1-MB numeric limit (often `mem_limit: 512` written meaning 512m) floors
+  // to 0 MB, and memoryMb:0 reads downstream as "no limit" — so it must be DROPPED
+  // like the equivalent string form already is, never kept as an accidental
+  // unlimited. The number and string byte paths must agree.
+  it("drops a numeric byte limit under 1 MB instead of reading it as unlimited", () => {
+    const mem = (v: string) =>
+      parseComposeFile(svc(`    mem_limit: ${v}\n`)).services[0]?.advanced?.resources?.memoryMb;
+    expect(mem("512")).toBeUndefined(); // 512 bytes → <1 MB
+    expect(mem("1048575")).toBeUndefined(); // one byte under 1 MB
+    expect(mem("1048576")).toBe(1); // exactly 1 MB still parses
+  });
+
   it("keeps a healthcheck and resources side by side in one advanced blob", () => {
     const parsed = parseComposeFile(
       svc("    mem_limit: 1g\n    healthcheck:\n      test: 'curl -f localhost'\n"),


### PR DESCRIPTION
## Problem

`parseComposeMemory` (`apps/api/src/lib/compose-parser.ts`) parses a service's `mem_limit` / `deploy.resources.limits.memory` to MB. The **string** path already refuses a value that rounds below 1 MB (`mb >= 1 ? … : undefined`), but the **number** path did not:

```ts
// number path (before)
return raw > 0 ? Math.floor(raw / (1024 * 1024)) : undefined;
```

`Math.floor(bytes / 1MB)` is `0` for anything under a megabyte, so the two paths disagree for the same byte count:

```ts
parseComposeMemory(512)     // 0          parseComposeMemory("512")     // undefined
parseComposeMemory(1048575) // 0          parseComposeMemory("1048575") // undefined
```

`0` is not inert here. In `packages/core/src/resources.ts`, `UNLIMITED_RESOURCES` is `{ memoryMb: 0, … }` and `hasMemoryLimit` returns false for `memoryMb: 0`, and `parseServiceResources` keeps `memoryMb: 0` (it only drops `undefined`). So a service written as:

```yaml
services:
  api:
    image: nginx
    mem_limit: 512        # a bare YAML number → 512 *bytes*; almost always a typo for 512m
```

parses to **no memory limit at all** instead of a cap. That's the exact *"a malformed limit must not silently become a tiny cap"* failure this parser's own doc-comment and the #333 resource-limit tests exist to prevent — here it's worse, silently becoming **unlimited**.

## Fix

Apply the same sub-1MB guard on the number path so it agrees with the string path:

```ts
const mb = raw / (1024 * 1024);
return mb >= 1 ? Math.floor(mb) : undefined;
```

Values ≥ 1 MB are unchanged — the existing bare-bytes case `mem_limit: 1073741824 → 1024 MB` still passes, as do all suffix spellings and the swarm form. Only sub-1MB numeric byte values change (`0` → `undefined`), which then drops out of `parseServiceResources` instead of masquerading as unlimited.

## Tests

Added to the existing "service resource limits" block:

```ts
expect(mem("512")).toBeUndefined();      // 512 bytes → <1 MB
expect(mem("1048575")).toBeUndefined();  // one byte under 1 MB
expect(mem("1048576")).toBe(1);          // exactly 1 MB still parses
```

Verified against the function logic: before the fix `512`/`1048575` return `0`; after, they return `undefined` (matching the string path), while every value ≥ 1 MB (incl. the pinned `1073741824 → 1024`) is unchanged.
