### PR TITLE
fix(core): Rails loses storage/ on every redeploy and installs its gems twice

### DIFF
--- a/packages/core/src/languages/ruby.ts
+++ b/packages/core/src/languages/ruby.ts
@@ -19,9 +19,81 @@ function parseGemfile(content: string): Record<string, string> {
   return deps;
 }
 
+/**
+ * `Gemfile.lock` - the RESOLVED gem set, with exact versions. A Gemfile names
+ * direct dependencies only, so transitive gems are invisible to `parseGemfile`.
+ *
+ * Reads top-level entries of every `specs:` block (GEM, GIT, PATH). Skips the
+ * 6-space requirement lines and the DEPENDENCIES section - both list
+ * constraints, not what bundler installed.
+ */
+function parseGemfileLock(content: string): Record<string, string> {
+  const deps: Record<string, string> = {};
+  let inSpecs = false;
+
+  for (const line of content.split("\n")) {
+    if (/^ {2}specs:\s*$/.test(line)) {
+      inSpecs = true;
+      continue;
+    }
+    if (!inSpecs) continue;
+
+    // Block ends at the blank line before the next section header.
+    if (!line.trim() || !/^\s/.test(line)) {
+      inSpecs = false;
+      continue;
+    }
+
+    const spec = line.match(/^ {4}([A-Za-z0-9._-]+) \(([^)]+)\)\s*$/);
+    if (spec) deps[spec[1].toLowerCase()] = spec[2];
+  }
+
+  return deps;
+}
+
+/**
+ * The Ruby version pinned in `.ruby-version`, a lockfile, or a Gemfile. Returns
+ * a bare `X.Y[.Z]` or null. Precedence between the three is the caller's call.
+ *
+ * A range is not a pin: `ruby "~> 3.3"` returns null rather than guessing.
+ */
+export function parseRubyVersion(filename: string, content: string): string | null {
+  const version = String.raw`(\d+\.\d+(?:\.\d+)?)`;
+
+  switch (filename.toLowerCase()) {
+    case ".ruby-version": {
+      // `3.3.6`, or `ruby-3.3.6` from the managers that prefix it.
+      const m = content.trim().match(new RegExp(`^(?:ruby-)?${version}`));
+      return m ? m[1] : null;
+    }
+    case "gemfile.lock": {
+      // "RUBY VERSION\n   ruby 3.3.6p108"
+      const m = content.match(new RegExp(String.raw`^RUBY VERSION\s*\n\s*ruby\s+${version}`, "m"));
+      return m ? m[1] : null;
+    }
+    case "gemfile": {
+      // The quote right after `ruby` rejects `ruby file:`; anchoring the digits
+      // to it rejects `~> 3.3`.
+      const m = content.match(new RegExp(String.raw`^\s*ruby\s+['"](?:ruby-)?${version}`, "m"));
+      return m ? m[1] : null;
+    }
+    default:
+      return null;
+  }
+}
+
 export const rubyLanguageDetector: LanguageDetector = {
   id: "ruby",
   label: "Ruby",
-  manifestFiles: ["gemfile"],
-  parseManifest: (_filename, content) => parseGemfile(content),
+  manifestFiles: ["gemfile", "gemfile.lock"],
+  parseManifest(filename, content) {
+    switch (filename.toLowerCase()) {
+      case "gemfile":
+        return parseGemfile(content);
+      case "gemfile.lock":
+        return parseGemfileLock(content);
+      default:
+        return {};
+    }
+  },
 };

--- a/packages/core/src/stacks.ts
+++ b/packages/core/src/stacks.ts
@@ -657,8 +657,18 @@ export const STACKS = {
     category: "fullstack",
     outputDirectory: ".",
     defaultPort: 3000,
-    defaultBuildCommand: "bundle install && bundle exec rails assets:precompile",
-    defaultStartCommand: "bundle exec rails server -b 0.0.0.0",
+    // Precompile only — `bundle install` is already the install step. The dummy
+    // secret is what Rails' own Dockerfile sets: an app touching credentials
+    // during eager load raises without it.
+    defaultBuildCommand:
+      "RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile",
+    // Stock config/puma.rb reads PORT, but a trimmed one falls back to 3000.
+    defaultStartCommand: 'bundle exec rails server -b 0.0.0.0 -p "${PORT:-3000}"',
+    // Rails 8 keeps the SQLite database AND Active Storage here; Rails' own
+    // Dockerfile declares `VOLUME /rails/storage`. Not `db/` — it holds
+    // migrations, so mounting over it would shadow later releases'.
+    persistentPaths: ["storage"],
+    cacheDirs: ["tmp/cache", "tmp/pids"],
     detection: {
       // Rails: Gemfile is required; bin/rails or config/routes.rb confirms.
       // The conjunction is encoded as an override in stack-detector.

--- a/packages/core/test/rails-stack.test.ts
+++ b/packages/core/test/rails-stack.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { STACKS } from "../src/stacks";
+import { resolveStackVolumes } from "../src/volumes";
+
+describe("rails stack definition", () => {
+  it("persists storage/ — Rails 8 keeps SQLite AND Active Storage there", () => {
+    expect(STACKS.rails.persistentPaths).toEqual(["storage"]);
+  });
+
+  it("mounts it the same way laravel's storage/ is mounted", () => {
+    expect(resolveStackVolumes("rails")).toEqual(["storage:/app/storage"]);
+    expect(resolveStackVolumes("rails")).toEqual(resolveStackVolumes("laravel"));
+  });
+
+  it("does NOT persist a directory that also holds code", () => {
+    // Mounting over `db/` would shadow migrations a later release ships.
+    for (const path of STACKS.rails.persistentPaths ?? []) {
+      expect(["db", "app", "config", "lib", "bin"]).not.toContain(path);
+    }
+  });
+
+  it("does not repeat `bundle install` — that is already the install step", () => {
+    expect(STACKS.rails.defaultBuildCommand).not.toContain("bundle install");
+  });
+
+  it("precompiles with the dummy secret, as Rails' own Dockerfile does", () => {
+    expect(STACKS.rails.defaultBuildCommand).toContain("SECRET_KEY_BASE_DUMMY=1");
+    expect(STACKS.rails.defaultBuildCommand).toContain("assets:precompile");
+  });
+
+  it("precompiles in production, so the output is production assets", () => {
+    expect(STACKS.rails.defaultBuildCommand).toContain("RAILS_ENV=production");
+  });
+
+  it("binds the injected $PORT rather than a hardcoded 3000", () => {
+    expect(STACKS.rails.defaultStartCommand).toContain("PORT");
+  });
+
+  it("still declares a build step, so preflight keeps warning on a missing one", () => {
+    expect(STACKS.rails.defaultBuildCommand.trim()).not.toBe("");
+  });
+});

--- a/packages/core/test/ruby-language.test.ts
+++ b/packages/core/test/ruby-language.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRubyVersion, rubyLanguageDetector } from "../src/languages/ruby";
+
+/** A stock Rails 8 lockfile, trimmed to the sections that matter here. */
+const LOCKFILE = `GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (8.0.1)
+      actionview (= 8.0.1)
+      rack (>= 2.2.4)
+    pg (1.5.9)
+    sidekiq (7.3.6)
+      redis-client (>= 0.22.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails (~> 8.0)
+
+RUBY VERSION
+   ruby 3.3.6p108
+
+BUNDLED WITH
+   2.5.23
+`;
+
+describe("rubyLanguageDetector", () => {
+  it("claims both Gemfile and Gemfile.lock", () => {
+    expect(rubyLanguageDetector.manifestFiles).toContain("gemfile");
+    expect(rubyLanguageDetector.manifestFiles).toContain("gemfile.lock");
+  });
+
+  it("reads gems from the lockfile that the Gemfile never names", () => {
+    const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
+    expect(deps.pg).toBe("1.5.9");
+    expect(deps.sidekiq).toBe("7.3.6");
+    expect(deps.actionpack).toBe("8.0.1");
+  });
+
+  it("does NOT treat a spec's own requirements as installed gems", () => {
+    // Six-space lines are what that gem requires, not what bundler resolved.
+    const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
+    expect(deps["redis-client"]).toBeUndefined();
+    expect(deps.rack).toBeUndefined();
+    expect(deps.actionview).toBeUndefined();
+  });
+
+  it("stops at the end of the specs block, so DEPENDENCIES aren't specs", () => {
+    // `rails (~> 8.0)` under DEPENDENCIES is a constraint, not a resolution.
+    const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
+    expect(deps.rails).toBeUndefined();
+  });
+
+  it("reads specs from a GIT source as well as the GEM source", () => {
+    const deps = rubyLanguageDetector.parseManifest(
+      "Gemfile.lock",
+      `GIT
+  remote: https://github.com/example/vendored.git
+  revision: abc123
+  specs:
+    vendored (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    pg (1.5.9)
+
+PLATFORMS
+  ruby
+`,
+    );
+    expect(deps.vendored).toBe("0.1.0");
+    expect(deps.pg).toBe("1.5.9");
+  });
+
+  it("still parses a plain Gemfile, skipping commented gems", () => {
+    const deps = rubyLanguageDetector.parseManifest(
+      "Gemfile",
+      `source "https://rubygems.org"\nruby "3.3.6"\ngem "rails", "~> 8.0"\n# gem "commented"\n`,
+    );
+    expect(deps.rails).toBe("*");
+    expect(deps.commented).toBeUndefined();
+  });
+
+  it("returns {} for a filename it does not handle", () => {
+    expect(rubyLanguageDetector.parseManifest("Rakefile", "task :default")).toEqual({});
+  });
+});
+
+describe("parseRubyVersion", () => {
+  it("reads the RUBY VERSION stanza from a lockfile, dropping the patch suffix", () => {
+    expect(parseRubyVersion("Gemfile.lock", LOCKFILE)).toBe("3.3.6");
+  });
+
+  it("reads a bare .ruby-version file", () => {
+    expect(parseRubyVersion(".ruby-version", "3.4.1\n")).toBe("3.4.1");
+  });
+
+  it("strips the `ruby-` prefix some version managers write", () => {
+    expect(parseRubyVersion(".ruby-version", "ruby-3.2.2\n")).toBe("3.2.2");
+  });
+
+  it("reads the ruby directive from a Gemfile", () => {
+    expect(parseRubyVersion("Gemfile", `source "x"\nruby "3.3.0"\ngem "rails"\n`)).toBe("3.3.0");
+  });
+
+  it("ignores `ruby file:` — that names a file, not a version", () => {
+    expect(parseRubyVersion("Gemfile", `ruby file: ".ruby-version"\ngem "rails"\n`)).toBeNull();
+  });
+
+  it("ignores a constraint like `ruby \"~> 3.3\"` — not a pin", () => {
+    expect(parseRubyVersion("Gemfile", `ruby "~> 3.3"\n`)).toBeNull();
+  });
+
+  it("returns null when there is no version to find", () => {
+    expect(parseRubyVersion("Gemfile", `gem "rails"\n`)).toBeNull();
+    expect(parseRubyVersion(".ruby-version", "  \n")).toBeNull();
+    expect(parseRubyVersion("Gemfile.lock", "GEM\n  specs:\n    pg (1.5.9)\n")).toBeNull();
+  });
+});


### PR DESCRIPTION
Rails deployments currently discard `storage/`, repeat `bundle install`, and precompile without the production environment/dummy secret used by Rails' generated Dockerfile. Preserve storage through the existing stack-volume mechanism and correct the default build/start commands. The existing Ruby detector also reads resolved Gemfile.lock dependencies without treating constraints as installed gems.

Adapted the original contribution to the current integration branch in #892. The final change uses existing stack/detection primitives and keeps migrations in the application image. Release phases and new process roles remain separate work under #231.

Validation: 1,059 core tests and 224 API language/stack-detection cases pass. Nine new regression cases fail against current main. Real Ruby image/build validation is handled with the companion build-recipe repair in #469.
