### PR TITLE
feat(core): pin the Ruby image to the version the project declares

### DIFF
--- a/apps/api/src/lib/stack-detector.ts
+++ b/apps/api/src/lib/stack-detector.ts
@@ -26,6 +26,7 @@ import {
   OUTPUT_DIRECTORIES,
   getProjectType,
   getBuildImage,
+  parseRubyVersion,
   LANGUAGE_MANIFEST_FILES,
   collectDependencies,
   detectPort as detectPortFromLanguages,
@@ -198,6 +199,19 @@ function hasBackendMarker(fileSet: Set<string>): boolean {
     fileSet.has("gemfile") || // Rails (Ruby)
     fileSet.has("mix.exs") // Phoenix (Elixir)
   );
+}
+
+/** The Ruby this project pins, in the order bundler trusts: `.ruby-version`,
+ *  then the lockfile stanza, then the Gemfile directive. First hit wins;
+ *  undefined leaves the language default in place. */
+function detectRubyVersion(fileContents: Record<string, string>): string | undefined {
+  for (const name of [".ruby-version", "gemfile.lock", "gemfile"]) {
+    const content = fileContents[name];
+    if (!content) continue;
+    const version = parseRubyVersion(name, content);
+    if (version) return version;
+  }
+  return undefined;
 }
 
 /** True if any of the stack's deps appears in the dep map. */
@@ -511,7 +525,7 @@ export function detectStack(
     installCommand: projectType === "docker" ? "" : getInstallCommand(pm),
     buildCommand: getBuildCommand(pm, matched, packageJson, files),
     startCommand,
-    buildImage: getBuildImage(matched, pm),
+    buildImage: getBuildImage(matched, pm, detectRubyVersion(fc)),
     outputDirectory: OUTPUT_DIRECTORIES[matched] ?? "dist",
     productionPaths,
     port: detectPortFromLanguages({ packageJson, fileContents: fc }) ?? stackDef.defaultPort,

--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -23,6 +23,7 @@ import {
   STACKS,
   safeErrorMessage,
   getRuntimeImage,
+  runtimeVersionFromImage,
   isReleaseProvider,
   resolveProjectVolumes,
   type StackId,
@@ -606,7 +607,14 @@ function resolveRuntimeImage(project: Project): string {
     return getRuntimeImage("static", project.packageManager ?? undefined);
   }
 
-  return getRuntimeImage(stackId, project.packageManager ?? undefined);
+  // Follows the buildImage detection stored on the project, so a pinned Ruby
+  // cannot end up with a runtime on a different one (bundler installs into a
+  // version-scoped path, so a mismatch leaves the runtime with no gems).
+  return getRuntimeImage(
+    stackId,
+    project.packageManager ?? undefined,
+    runtimeVersionFromImage(project.buildImage),
+  );
 }
 
 /** Parse productionPaths from DB text (comma-separated) with STACKS fallback. */

--- a/packages/core/src/languages/index.ts
+++ b/packages/core/src/languages/index.ts
@@ -11,6 +11,9 @@ import type { LanguageDetector, PortDetectionContext } from "./types";
 
 export type { LanguageDetector, PortDetectionContext } from "./types";
 
+/** Ruby's version files carry no deps, so this sits outside the detector API. */
+export { parseRubyVersion } from "./ruby";
+
 /**
  * All registered language detectors. Add a language family by:
  *   1. Implementing `LanguageDetector` in its own file under languages/.

--- a/packages/core/src/languages/ruby.ts
+++ b/packages/core/src/languages/ruby.ts
@@ -85,7 +85,8 @@ export function parseRubyVersion(filename: string, content: string): string | nu
 export const rubyLanguageDetector: LanguageDetector = {
   id: "ruby",
   label: "Ruby",
-  manifestFiles: ["gemfile", "gemfile.lock"],
+  // `.ruby-version` carries no deps; it is listed so callers fetch it.
+  manifestFiles: ["gemfile", "gemfile.lock", ".ruby-version"],
   parseManifest(filename, content) {
     switch (filename.toLowerCase()) {
       case "gemfile":

--- a/packages/core/src/languages/ruby.ts
+++ b/packages/core/src/languages/ruby.ts
@@ -19,9 +19,81 @@ function parseGemfile(content: string): Record<string, string> {
   return deps;
 }
 
+/**
+ * `Gemfile.lock` - the RESOLVED gem set, with exact versions. A Gemfile names
+ * direct dependencies only, so transitive gems are invisible to `parseGemfile`.
+ *
+ * Reads top-level entries of every `specs:` block (GEM, GIT, PATH). Skips the
+ * 6-space requirement lines and the DEPENDENCIES section - both list
+ * constraints, not what bundler installed.
+ */
+function parseGemfileLock(content: string): Record<string, string> {
+  const deps: Record<string, string> = {};
+  let inSpecs = false;
+
+  for (const line of content.split("\n")) {
+    if (/^ {2}specs:\s*$/.test(line)) {
+      inSpecs = true;
+      continue;
+    }
+    if (!inSpecs) continue;
+
+    // Block ends at the blank line before the next section header.
+    if (!line.trim() || !/^\s/.test(line)) {
+      inSpecs = false;
+      continue;
+    }
+
+    const spec = line.match(/^ {4}([A-Za-z0-9._-]+) \(([^)]+)\)\s*$/);
+    if (spec) deps[spec[1].toLowerCase()] = spec[2];
+  }
+
+  return deps;
+}
+
+/**
+ * The Ruby version pinned in `.ruby-version`, a lockfile, or a Gemfile. Returns
+ * a bare `X.Y[.Z]` or null. Precedence between the three is the caller's call.
+ *
+ * A range is not a pin: `ruby "~> 3.3"` returns null rather than guessing.
+ */
+export function parseRubyVersion(filename: string, content: string): string | null {
+  const version = String.raw`(\d+\.\d+(?:\.\d+)?)`;
+
+  switch (filename.toLowerCase()) {
+    case ".ruby-version": {
+      // `3.3.6`, or `ruby-3.3.6` from the managers that prefix it.
+      const m = content.trim().match(new RegExp(`^(?:ruby-)?${version}`));
+      return m ? m[1] : null;
+    }
+    case "gemfile.lock": {
+      // "RUBY VERSION\n   ruby 3.3.6p108"
+      const m = content.match(new RegExp(String.raw`^RUBY VERSION\s*\n\s*ruby\s+${version}`, "m"));
+      return m ? m[1] : null;
+    }
+    case "gemfile": {
+      // The quote right after `ruby` rejects `ruby file:`; anchoring the digits
+      // to it rejects `~> 3.3`.
+      const m = content.match(new RegExp(String.raw`^\s*ruby\s+['"](?:ruby-)?${version}`, "m"));
+      return m ? m[1] : null;
+    }
+    default:
+      return null;
+  }
+}
+
 export const rubyLanguageDetector: LanguageDetector = {
   id: "ruby",
   label: "Ruby",
-  manifestFiles: ["gemfile"],
-  parseManifest: (_filename, content) => parseGemfile(content),
+  manifestFiles: ["gemfile", "gemfile.lock"],
+  parseManifest(filename, content) {
+    switch (filename.toLowerCase()) {
+      case "gemfile":
+        return parseGemfile(content);
+      case "gemfile.lock":
+        return parseGemfileLock(content);
+      default:
+        return {};
+    }
+  },
 };

--- a/packages/core/src/stacks.ts
+++ b/packages/core/src/stacks.ts
@@ -1065,13 +1065,38 @@ export const STACK_ROOT_MARKERS: ReadonlySet<string> = new Set(
 /** JS/TS languages that should use oven/bun when the package manager is bun */
 const BUN_ELIGIBLE_LANGUAGES: ReadonlySet<string> = new Set(["javascript", "typescript"]);
 
+/** Only Ruby pins a runtime version today: bundler enforces the Gemfile's ruby
+ *  directive, so a hardcoded image fails before installing a single gem. */
+const RUNTIME_VERSION_RE = /^\d+\.\d+(?:\.\d+)?$/;
+
+/** Swap the version segment of a `ruby:<version><suffix>` tag, preserving the
+ *  variant (`-slim`). The version comes from a file in the repo being deployed,
+ *  so anything but a plain X.Y[.Z] is ignored rather than spliced into a tag. */
+function applyRuntimeVersion(image: string, language: Language, version?: string): string {
+  if (language !== "ruby" || !version || !RUNTIME_VERSION_RE.test(version)) return image;
+  return image.replace(/^ruby:[^-]+(-.*)?$/, (_full, suffix) => `ruby:${version}${suffix ?? ""}`);
+}
+
+/** The version back out of a pinned Ruby image. Lets the deploy path recompute a
+ *  runtime image that matches the project's stored buildImage — bundler installs
+ *  into a version-scoped path, so a mismatch leaves the runtime with no gems. */
+export function runtimeVersionFromImage(image?: string | null): string | undefined {
+  const m = image?.match(/^ruby:(\d+\.\d+(?:\.\d+)?)/);
+  return m ? m[1] : undefined;
+}
+
 /** Get the resolved Docker build image for a stack */
-export function getBuildImage(stackId: StackId, packageManager?: string): string {
+export function getBuildImage(
+  stackId: StackId,
+  packageManager?: string,
+  runtimeVersion?: string,
+): string {
   const stack = STACKS[stackId] as StackDefinition;
   if (packageManager === "bun" && BUN_ELIGIBLE_LANGUAGES.has(stack.language)) {
     return "oven/bun:latest";
   }
-  return stack.buildImage ?? LANGUAGES[stack.language].buildImage;
+  const image = stack.buildImage ?? LANGUAGES[stack.language].buildImage;
+  return applyRuntimeVersion(image, stack.language, runtimeVersion);
 }
 
 /**
@@ -1099,12 +1124,17 @@ export function packageManagerEnsureCommand(packageManager?: string): string {
 }
 
 /** Get the resolved Docker runtime image for a stack */
-export function getRuntimeImage(stackId: StackId, packageManager?: string): string {
+export function getRuntimeImage(
+  stackId: StackId,
+  packageManager?: string,
+  runtimeVersion?: string,
+): string {
   const stack = STACKS[stackId] as StackDefinition;
   if (packageManager === "bun" && BUN_ELIGIBLE_LANGUAGES.has(stack.language)) {
     return "oven/bun:latest";
   }
-  return stack.runtimeImage ?? LANGUAGES[stack.language].runtimeImage;
+  const image = stack.runtimeImage ?? LANGUAGES[stack.language].runtimeImage;
+  return applyRuntimeVersion(image, stack.language, runtimeVersion);
 }
 
 

--- a/packages/core/src/stacks.ts
+++ b/packages/core/src/stacks.ts
@@ -657,8 +657,18 @@ export const STACKS = {
     category: "fullstack",
     outputDirectory: ".",
     defaultPort: 3000,
-    defaultBuildCommand: "bundle install && bundle exec rails assets:precompile",
-    defaultStartCommand: "bundle exec rails server -b 0.0.0.0",
+    // Precompile only — `bundle install` is already the install step. The dummy
+    // secret is what Rails' own Dockerfile sets: an app touching credentials
+    // during eager load raises without it.
+    defaultBuildCommand:
+      "RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile",
+    // Stock config/puma.rb reads PORT, but a trimmed one falls back to 3000.
+    defaultStartCommand: 'bundle exec rails server -b 0.0.0.0 -p "${PORT:-3000}"',
+    // Rails 8 keeps the SQLite database AND Active Storage here; Rails' own
+    // Dockerfile declares `VOLUME /rails/storage`. Not `db/` — it holds
+    // migrations, so mounting over it would shadow later releases'.
+    persistentPaths: ["storage"],
+    cacheDirs: ["tmp/cache", "tmp/pids"],
     detection: {
       // Rails: Gemfile is required; bin/rails or config/routes.rb confirms.
       // The conjunction is encoded as an override in stack-detector.

--- a/packages/core/test/rails-stack.test.ts
+++ b/packages/core/test/rails-stack.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { STACKS } from "../src/stacks";
+import { resolveStackVolumes } from "../src/volumes";
+
+describe("rails stack definition", () => {
+  it("persists storage/ — Rails 8 keeps SQLite AND Active Storage there", () => {
+    expect(STACKS.rails.persistentPaths).toEqual(["storage"]);
+  });
+
+  it("mounts it the same way laravel's storage/ is mounted", () => {
+    expect(resolveStackVolumes("rails")).toEqual(["storage:/app/storage"]);
+    expect(resolveStackVolumes("rails")).toEqual(resolveStackVolumes("laravel"));
+  });
+
+  it("does NOT persist a directory that also holds code", () => {
+    // Mounting over `db/` would shadow migrations a later release ships.
+    for (const path of STACKS.rails.persistentPaths ?? []) {
+      expect(["db", "app", "config", "lib", "bin"]).not.toContain(path);
+    }
+  });
+
+  it("does not repeat `bundle install` — that is already the install step", () => {
+    expect(STACKS.rails.defaultBuildCommand).not.toContain("bundle install");
+  });
+
+  it("precompiles with the dummy secret, as Rails' own Dockerfile does", () => {
+    expect(STACKS.rails.defaultBuildCommand).toContain("SECRET_KEY_BASE_DUMMY=1");
+    expect(STACKS.rails.defaultBuildCommand).toContain("assets:precompile");
+  });
+
+  it("precompiles in production, so the output is production assets", () => {
+    expect(STACKS.rails.defaultBuildCommand).toContain("RAILS_ENV=production");
+  });
+
+  it("binds the injected $PORT rather than a hardcoded 3000", () => {
+    expect(STACKS.rails.defaultStartCommand).toContain("PORT");
+  });
+
+  it("still declares a build step, so preflight keeps warning on a missing one", () => {
+    expect(STACKS.rails.defaultBuildCommand.trim()).not.toBe("");
+  });
+});

--- a/packages/core/test/ruby-image-pin.test.ts
+++ b/packages/core/test/ruby-image-pin.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { getBuildImage, getRuntimeImage, runtimeVersionFromImage } from "../src/stacks";
+
+describe("Ruby image pinning", () => {
+  it("uses the language default when the project pins nothing", () => {
+    expect(getBuildImage("rails")).toBe("ruby:3.3-slim");
+    expect(getRuntimeImage("rails")).toBe("ruby:3.3-slim");
+  });
+
+  it("pins the project's Ruby when one was detected", () => {
+    expect(getBuildImage("rails", undefined, "3.4.1")).toBe("ruby:3.4.1-slim");
+    expect(getRuntimeImage("rails", undefined, "3.4.1")).toBe("ruby:3.4.1-slim");
+  });
+
+  it("keeps build and runtime on the SAME tag", () => {
+    // Bundler installs into a version-scoped path under BUNDLE_PATH, so a
+    // runtime on a different Ruby finds no gems at all.
+    expect(getBuildImage("rails", undefined, "3.2.2")).toBe(
+      getRuntimeImage("rails", undefined, "3.2.2"),
+    );
+  });
+
+  it("applies to sinatra too — it is the language, not the stack", () => {
+    expect(getBuildImage("sinatra", undefined, "3.4.1")).toBe("ruby:3.4.1-slim");
+  });
+
+  it("ignores a version override for a non-Ruby stack", () => {
+    expect(getBuildImage("nextjs", undefined, "3.4.1")).toBe("node:22");
+    expect(getBuildImage("django", undefined, "3.4.1")).toBe("python:3.12-slim");
+  });
+
+  it("rejects anything that is not a plain X.Y[.Z]", () => {
+    // The value comes from a file in the repo being deployed, so it is
+    // attacker-controlled input to an image reference.
+    for (const bad of ["3.3-slim && rm -rf /", "latest", "", "../../evil", "3"]) {
+      expect(getBuildImage("rails", undefined, bad)).toBe("ruby:3.3-slim");
+    }
+  });
+});
+
+describe("runtimeVersionFromImage", () => {
+  it("reads the version back out of a pinned Ruby image", () => {
+    expect(runtimeVersionFromImage("ruby:3.4.1-slim")).toBe("3.4.1");
+    expect(runtimeVersionFromImage("ruby:3.3-slim")).toBe("3.3");
+  });
+
+  it("returns undefined for a non-Ruby image or no image", () => {
+    expect(runtimeVersionFromImage("node:22")).toBeUndefined();
+    expect(runtimeVersionFromImage(undefined)).toBeUndefined();
+    expect(runtimeVersionFromImage(null)).toBeUndefined();
+    expect(runtimeVersionFromImage("")).toBeUndefined();
+  });
+
+  it("round-trips, so a stored buildImage can pin the runtime to match", () => {
+    // This is how the deploy path keeps the two in lockstep: buildImage is
+    // persisted on the project, runtimeImage is recomputed from it.
+    const built = getBuildImage("rails", undefined, "3.4.1");
+    expect(getRuntimeImage("rails", undefined, runtimeVersionFromImage(built))).toBe(built);
+  });
+});

--- a/packages/core/test/ruby-language.test.ts
+++ b/packages/core/test/ruby-language.test.ts
@@ -32,6 +32,11 @@ describe("rubyLanguageDetector", () => {
     expect(rubyLanguageDetector.manifestFiles).toContain("gemfile.lock");
   });
 
+  it("claims .ruby-version so callers fetch it, but reads no deps from it", () => {
+    expect(rubyLanguageDetector.manifestFiles).toContain(".ruby-version");
+    expect(rubyLanguageDetector.parseManifest(".ruby-version", "3.4.1")).toEqual({});
+  });
+
   it("reads gems from the lockfile that the Gemfile never names", () => {
     const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
     expect(deps.pg).toBe("1.5.9");

--- a/packages/core/test/ruby-language.test.ts
+++ b/packages/core/test/ruby-language.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRubyVersion, rubyLanguageDetector } from "../src/languages/ruby";
+
+/** A stock Rails 8 lockfile, trimmed to the sections that matter here. */
+const LOCKFILE = `GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (8.0.1)
+      actionview (= 8.0.1)
+      rack (>= 2.2.4)
+    pg (1.5.9)
+    sidekiq (7.3.6)
+      redis-client (>= 0.22.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails (~> 8.0)
+
+RUBY VERSION
+   ruby 3.3.6p108
+
+BUNDLED WITH
+   2.5.23
+`;
+
+describe("rubyLanguageDetector", () => {
+  it("claims both Gemfile and Gemfile.lock", () => {
+    expect(rubyLanguageDetector.manifestFiles).toContain("gemfile");
+    expect(rubyLanguageDetector.manifestFiles).toContain("gemfile.lock");
+  });
+
+  it("reads gems from the lockfile that the Gemfile never names", () => {
+    const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
+    expect(deps.pg).toBe("1.5.9");
+    expect(deps.sidekiq).toBe("7.3.6");
+    expect(deps.actionpack).toBe("8.0.1");
+  });
+
+  it("does NOT treat a spec's own requirements as installed gems", () => {
+    // Six-space lines are what that gem requires, not what bundler resolved.
+    const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
+    expect(deps["redis-client"]).toBeUndefined();
+    expect(deps.rack).toBeUndefined();
+    expect(deps.actionview).toBeUndefined();
+  });
+
+  it("stops at the end of the specs block, so DEPENDENCIES aren't specs", () => {
+    // `rails (~> 8.0)` under DEPENDENCIES is a constraint, not a resolution.
+    const deps = rubyLanguageDetector.parseManifest("Gemfile.lock", LOCKFILE);
+    expect(deps.rails).toBeUndefined();
+  });
+
+  it("reads specs from a GIT source as well as the GEM source", () => {
+    const deps = rubyLanguageDetector.parseManifest(
+      "Gemfile.lock",
+      `GIT
+  remote: https://github.com/example/vendored.git
+  revision: abc123
+  specs:
+    vendored (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    pg (1.5.9)
+
+PLATFORMS
+  ruby
+`,
+    );
+    expect(deps.vendored).toBe("0.1.0");
+    expect(deps.pg).toBe("1.5.9");
+  });
+
+  it("still parses a plain Gemfile, skipping commented gems", () => {
+    const deps = rubyLanguageDetector.parseManifest(
+      "Gemfile",
+      `source "https://rubygems.org"\nruby "3.3.6"\ngem "rails", "~> 8.0"\n# gem "commented"\n`,
+    );
+    expect(deps.rails).toBe("*");
+    expect(deps.commented).toBeUndefined();
+  });
+
+  it("returns {} for a filename it does not handle", () => {
+    expect(rubyLanguageDetector.parseManifest("Rakefile", "task :default")).toEqual({});
+  });
+});
+
+describe("parseRubyVersion", () => {
+  it("reads the RUBY VERSION stanza from a lockfile, dropping the patch suffix", () => {
+    expect(parseRubyVersion("Gemfile.lock", LOCKFILE)).toBe("3.3.6");
+  });
+
+  it("reads a bare .ruby-version file", () => {
+    expect(parseRubyVersion(".ruby-version", "3.4.1\n")).toBe("3.4.1");
+  });
+
+  it("strips the `ruby-` prefix some version managers write", () => {
+    expect(parseRubyVersion(".ruby-version", "ruby-3.2.2\n")).toBe("3.2.2");
+  });
+
+  it("reads the ruby directive from a Gemfile", () => {
+    expect(parseRubyVersion("Gemfile", `source "x"\nruby "3.3.0"\ngem "rails"\n`)).toBe("3.3.0");
+  });
+
+  it("ignores `ruby file:` — that names a file, not a version", () => {
+    expect(parseRubyVersion("Gemfile", `ruby file: ".ruby-version"\ngem "rails"\n`)).toBeNull();
+  });
+
+  it("ignores a constraint like `ruby \"~> 3.3\"` — not a pin", () => {
+    expect(parseRubyVersion("Gemfile", `ruby "~> 3.3"\n`)).toBeNull();
+  });
+
+  it("returns null when there is no version to find", () => {
+    expect(parseRubyVersion("Gemfile", `gem "rails"\n`)).toBeNull();
+    expect(parseRubyVersion(".ruby-version", "  \n")).toBeNull();
+    expect(parseRubyVersion("Gemfile.lock", "GEM\n  specs:\n    pg (1.5.9)\n")).toBeNull();
+  });
+});


### PR DESCRIPTION
> **Stacked on #468** — it branches from that work, so its two commits show here until #468 merges. Opened as a draft; review the top commit only, or wait for #468. Happy to rebase once that lands.

## Problem

`LANGUAGES.ruby` hardcodes `ruby:3.3-slim`. Nothing reads `.ruby-version`, the lockfile's `RUBY VERSION` stanza, or the Gemfile's `ruby` directive, so any app pinning a different Ruby fails bundler's version check before it installs a single gem. The pin is the one piece of the toolchain the project genuinely gets to choose.

## Changes

`getBuildImage` / `getRuntimeImage` take an optional version and swap the version segment of a `ruby:<version><suffix>` tag, preserving the variant. Both new parameters are optional, so every existing call site is untouched. `stack-detector.ts` resolves the version in the order bundler trusts: `.ruby-version`, then the lockfile stanza, then the Gemfile directive.

**The part that needed the most care.** Build and runtime images have to move together — bundler installs into a version-scoped path under `BUNDLE_PATH`, so a runtime on a different Ruby finds no gems at all. But the two are resolved in different places: `buildImage` is persisted on the project from detection, while `runtimeImage` is recomputed at deploy time from the DB row (`build.service.ts:598` `resolveRuntimeImage`). Pinning only the build image would have produced exactly that mismatch.

Rather than add a column and a migration, `resolveRuntimeImage` now derives the tag from the already-persisted `project.buildImage` via a new `runtimeVersionFromImage` helper. The two are in lockstep by construction, and there is no schema change.

**Security note:** the version originates in a file inside the repo being deployed, so it is attacker-controlled input to an image reference. It is validated against `^\d+\.\d+(?:\.\d+)?$` before it reaches a tag; anything else (`latest`, `3.3-slim && rm -rf /`, a traversal) falls back to the language default. There is a test covering that.

`.ruby-version` is added to `rubyLanguageDetector.manifestFiles` so callers fetch it; `parseManifest` returns `{}` for it, so it contributes no phantom deps. It has no effect on project-root detection — roots come from `STACK_ROOT_MARKERS`, and the `manifestFiles` use at `project-root-detector.ts:271` is against `WORKSPACE_DETECTORS`, a separate registry.

## Testing

10 new tests, including the round-trip that keeps build and runtime aligned and the tag-injection rejection cases. Full `packages/core` suite: **437 passing, 0 failures**. `tsc --noEmit` clean in `packages/core` and `apps/api`.
