### PR TITLE
fix(cli): refuse to regenerate POSTGRES_PASSWORD when a data volume already exists

### DIFF
--- a/apps/cli/src/lib/compose.ts
+++ b/apps/cli/src/lib/compose.ts
@@ -432,7 +432,35 @@ volumes:
 
 /** Persist a stable secret in the compose .env — regenerated only if absent. */
 function keepSecret(existing: Record<string, string>, key: string): string {
-  return existing[key] || randomBytes(32).toString("hex");
+  const value = existing[key];
+  if (value) return value;
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Preserve the Postgres password, or generate one on a genuine first install.
+ *
+ * Postgres only applies `POSTGRES_PASSWORD` when it initialises an EMPTY data
+ * dir. If a `<project>_postgres_data` volume already exists, generating a new
+ * password would leave the volume on the old password and the API on the new
+ * one — the api then crash-loops on `password authentication failed for user`
+ * (28P01). So: carry the existing password when we have one. If we don't have
+ * one and a volume exists, refuse rather than silently break the database. On a
+ * true fresh install (no volume), generate a new password.
+ */
+function keepPostgresPassword(existing: Record<string, string>, dryRun = false): string {
+  const value = existing.POSTGRES_PASSWORD;
+  if (value) return value;
+  const project = composeProjectName(existing);
+  if (dbVolumeExists(project)) {
+    const msg =
+      `Existing Postgres data volume ${project}_postgres_data already has a password, but POSTGRES_PASSWORD is missing from ${ENV_FILE}. ` +
+      `A new password cannot be safely generated for this volume. ` +
+      `Restore the previous .env or run \`openship uninstall\` to start fresh (this destroys DB data).`;
+    if (dryRun) return randomBytes(32).toString("hex"); // placeholder for the preview
+    throw new Error(msg);
+  }
+  return randomBytes(32).toString("hex");
 }
 
 /** Parse the existing .env so re-running `up` preserves generated secrets. */
@@ -1086,6 +1114,7 @@ function renderEnv(
   opts: ComposeUpOpts,
   host: { user: string; keyPath: string } | null,
   cfg: ReturnType<typeof resolveEnvConfig>,
+  dryRun = false,
 ): string {
   const prev = readEnvFile();
   const lines: string[] = [
@@ -1100,7 +1129,7 @@ function renderEnv(
     `OPENSHIP_HOST_CONTROL=${cfg.hostControl ? "true" : "false"}`,
     `OPENSHIP_IMAGE_REGISTRY=${cfg.registry}`,
     `OPENSHIP_VERSION=${opts.version || (typeof __CLI_VERSION__ === "string" ? __CLI_VERSION__ : "latest")}`,
-    `POSTGRES_PASSWORD=${keepSecret(prev, "POSTGRES_PASSWORD")}`,
+    `POSTGRES_PASSWORD=${keepPostgresPassword(prev, dryRun)}`,
     // Pinned once (see resolvePgData): fresh install → subdir, existing volume → root.
     `OPENSHIP_PGDATA=${resolvePgData(prev)}`,
     `BETTER_AUTH_SECRET=${keepSecret(prev, "BETTER_AUTH_SECRET")}`,
@@ -1240,6 +1269,8 @@ export interface ComposePlan {
   buildDir: string | null;
   /** The container→host SSH channel this run would provision, if any. */
   hostChannel: { user: string; keyPath: string } | null;
+  /** Non-fatal warnings the operator should see before applying the plan. */
+  warnings: string[];
 }
 
 export function composePlan(opts: ComposeUpOpts): ComposePlan {
@@ -1249,12 +1280,28 @@ export function composePlan(opts: ComposeUpOpts): ComposePlan {
   const hostChannel = plannedHostChannel(cfg.hostControl);
   const settings: Array<{ key: string; value: string }> = [];
   const newSecrets: string[] = [];
-  for (const line of renderEnv(opts, hostChannel, cfg).split("\n")) {
+  const warnings: string[] = [];
+  const project = composeProjectName(prev);
+  const pgValue = prev.POSTGRES_PASSWORD;
+  const pgVolumeExists = dbVolumeExists(project);
+  for (const line of renderEnv(opts, hostChannel, cfg, true).split("\n")) {
     const at = line.indexOf("=");
     if (at < 1 || line.startsWith("#")) continue;
     const key = line.slice(0, at);
     if (!SECRET_ENV_KEY.test(key)) {
       settings.push({ key, value: line.slice(at + 1) });
+      continue;
+    }
+    if (key === "POSTGRES_PASSWORD" && !pgValue && pgVolumeExists) {
+      warnings.push(
+        `Existing Postgres data volume ${project}_postgres_data already has a password, but POSTGRES_PASSWORD is missing from ${ENV_FILE}. ` +
+          `A real run would refuse to overwrite the volume with a new generated password. ` +
+          `Restore the previous .env or run \`openship uninstall\` to start fresh (this destroys DB data).`,
+      );
+      settings.push({
+        key,
+        value: "<cannot be generated — existing Postgres data volume has an unknown password>",
+      });
       continue;
     }
     // Generated once and preserved (see keepSecret) — say WHICH, never the value.
@@ -1274,6 +1321,7 @@ export function composePlan(opts: ComposeUpOpts): ComposePlan {
     mountDirs: EDGE_CONTAINER_MOUNTS.map((m) => m.host),
     buildDir,
     hostChannel,
+    warnings,
   };
 }
 

--- a/apps/cli/src/lib/up-plan.ts
+++ b/apps/cli/src/lib/up-plan.ts
@@ -262,7 +262,12 @@ export function renderUpPlan(plan: UpPlan): string {
 
   if (plan.compose) {
     head("Compose stack");
-    item(plan.compose.existing ? "re-runs an existing install (secrets preserved)" : "fresh install");
+    const composeNote = plan.compose.warnings.length
+      ? ` (warning: ${plan.compose.warnings.join("; ")})`
+      : plan.compose.newSecrets.length
+        ? ` (generates: ${plan.compose.newSecrets.join(", ")})`
+        : " (secrets preserved)";
+    item(`${plan.compose.existing ? "re-runs an existing install" : "fresh install"}${composeNote}`);
     for (const { key, value } of plan.compose.settings) item(`${key}=${value}`);
   }
 

--- a/apps/cli/test/e2e/up-dry-run.test.ts
+++ b/apps/cli/test/e2e/up-dry-run.test.ts
@@ -57,6 +57,7 @@ vi.mock("../../src/lib/compose", () => ({
     mountDirs: ["/var/lib/openship/edge/sites-enabled"],
     buildDir: null,
     hostControl: true,
+    warnings: [],
   }),
   resolveComposePorts: async (_p: unknown, opts?: { persist?: boolean }) => {
     c.portOpts.push(opts);

--- a/apps/cli/test/unit/compose-env-preserve.test.ts
+++ b/apps/cli/test/unit/compose-env-preserve.test.ts
@@ -21,6 +21,8 @@ const h = vi.hoisted(() => ({
   composeCalls: [] as string[][],
   /** `docker ps` rows for the port query: "<config_files>\t<published ports>". */
   dockerPsPorts: "",
+  /** Whether `docker volume inspect <project>_postgres_data` reports the volume exists. */
+  pgVolumeExists: false,
 }));
 
 vi.mock("node:child_process", () => ({
@@ -29,9 +31,10 @@ vi.mock("node:child_process", () => ({
     cb(null, { stdout: "" }),
   spawnSync: (cmd: string, args: string[] = []) => {
     if (cmd === "docker" && args[0] === "compose") h.composeCalls.push(args);
-    // No pre-existing db volume → the password-reconcile path stays out of the
-    // compose sequences these tests assert on.
-    if (cmd === "docker" && args[0] === "volume") return { status: 1, stdout: "", stderr: "" };
+    // Default to no pre-existing db volume; tests can flip `h.pgVolumeExists`.
+    if (cmd === "docker" && args[0] === "volume") {
+      return { status: h.pgVolumeExists ? 0 : 1, stdout: "", stderr: "" };
+    }
     // Only the published-ports query (composeHeldPorts), not the container sweep
     // orphanedStackContainers runs with its own format.
     if (cmd === "docker" && args[0] === "ps" && args.some((a) => a.includes("{{.Ports}}"))) {
@@ -79,6 +82,7 @@ import {
   composeEnvPorts,
   composeHeldPorts,
   composePaths,
+  composePlan,
   composeUp,
   composeUpdate,
   resolveComposePorts,
@@ -151,6 +155,7 @@ beforeEach(() => {
   h.written = new Map();
   h.composeCalls = [];
   h.dockerPsPorts = "";
+  h.pgVolumeExists = false;
 });
 
 describe("resolveEnvConfig", () => {
@@ -387,6 +392,39 @@ describe("compose port resolution", () => {
   it("writes an explicit 0.0.0.0 to .env for a remote install (public URL set)", async () => {
     await composeUp({ publicUrl: "https://remote.example.com" });
     expect(writtenEnv().OPENSHIP_BIND_ADDR).toBe("0.0.0.0");
+  });
+});
+
+describe("POSTGRES_PASSWORD preservation with an existing data volume", () => {
+  it("preserves the existing password on a re-run when the data volume exists", async () => {
+    h.pgVolumeExists = true;
+    seedEnv(CONFIGURED);
+    const res = await composeUp({});
+    expect(res.ok).toBe(true);
+    expect(writtenEnv().POSTGRES_PASSWORD).toBe("pg-secret");
+    expect(verbs()).toContainEqual(["up", "-d", "--force-recreate", "api", "dashboard", "edge"]);
+  });
+
+  it("refuses to generate a new password when the volume exists but POSTGRES_PASSWORD is missing", async () => {
+    h.pgVolumeExists = true;
+    const env = { ...CONFIGURED };
+    delete (env as any).POSTGRES_PASSWORD;
+    seedEnv(env);
+    await expect(composeUp({})).rejects.toThrow(
+      /Existing Postgres data volume .* already has a password/,
+    );
+  });
+
+  it("dry-run warns instead of claiming a new password will be generated", async () => {
+    h.pgVolumeExists = true;
+    const env = { ...CONFIGURED };
+    delete (env as any).POSTGRES_PASSWORD;
+    seedEnv(env);
+    const plan = composePlan({});
+    expect(plan.warnings.length).toBeGreaterThan(0);
+    const pg = plan.settings.find((s) => s.key === "POSTGRES_PASSWORD");
+    expect(pg?.value).toContain("cannot be generated");
+    expect(plan.newSecrets).not.toContain("POSTGRES_PASSWORD");
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
-->

## Summary

`openship up --compose` no longer silently mints a new `POSTGRES_PASSWORD` when an existing `<project>_postgres_data` volume is present and the current `.env` is missing the key. The dry-run plan now reports this unsafe case, and a real run throws a clear recovery message instead of overwriting the secret.

## Motivation

Fixes #488. Re-running `openship up` over an existing install could show `POSTGRES_PASSWORD=<preserved>` in the dry-run plan while the `.env` it wrote contained a newly generated value. Postgres only applies `POSTGRES_PASSWORD` at `initdb` time, so the volume kept the old password while the API used the new one, failing with `password authentication failed for user "openship"` (28P01).

## Related issue

Closes #488

## Changes

- `apps/cli/src/lib/compose.ts`
  - Add `keepPostgresPassword`: carry the existing `.env` value, generate only on a genuine fresh install, and refuse (real run) or warn (dry run) when an initialized data volume exists but `POSTGRES_PASSWORD` is missing.
  - Thread a `dryRun` flag through `renderEnv` so the preview renders a placeholder while the real run enforces the guard.
  - Add `warnings` to `ComposePlan` and emit the volume-warning message in `composePlan` instead of claiming the secret is preserved.
- `apps/cli/src/lib/up-plan.ts`: print compose plan warnings in the dry-run summary.
- `apps/cli/test/unit/compose-env-preserve.test.ts`: add tests for preservation, refusal, and dry-run warning.
- `apps/cli/test/e2e/up-dry-run.test.ts`: update the `composePlan` mock to include `warnings`.

## Verification

```bash
cd apps/cli
bun run lint            # tsc --noEmit, exit 0
bun run test            # 27 files, 228 tests pass
bun run test -- compose-env-preserve  # 28 tests pass
bun run test -- up-dry-run            # 7 tests pass
```

Note on `bun format`: running the root `bun format` script rewrites pre-existing prettier drift in files I did not change (e.g. `apps/cli/src/lib/compose.ts` has unrelated long-line formatting drift). I left that untouched and hand-formatted the changed lines to the repo's existing style, matching the approach in #385.

## Checklist

- [x] One change per PR — one bug, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test` and `bun run --cwd apps/cli lint` pass locally
- [x] I understand every line of this diff and can explain it in review