### PR TITLE
fix(deployments): don't let an all-carried compose redeploy take over the active deployment

### DIFF
--- a/apps/api/src/lib/container-ref.ts
+++ b/apps/api/src/lib/container-ref.ts
@@ -1,0 +1,20 @@
+/**
+ * The `deployment.container_id` / `image_ref` sentinel, and the one predicate for
+ * "is this a reference I can hand to a runtime".
+ *
+ * A leaf module on purpose: the sentinel is read on the write path (compose
+ * deploy, reconcile), the read path (logs, container info, routing upstreams) and
+ * in rollback planning, and every open-coded `=== "compose"` was a place that
+ * could forget.
+ */
+
+/** Stored in `deployment.container_id` / `image_ref` when a release has no single
+ *  primary container/image. A marker, never a real Docker reference — treating it
+ *  as one is what made compose rollback try `createContainer({ Image: "compose" })`
+ *  and made a project pause report success having stopped nothing. */
+export const COMPOSE_SENTINEL = "compose";
+
+/** True when a stored reference names something a runtime can actually act on. */
+export function isRealContainerRef(ref: string | null | undefined): ref is string {
+  return !!ref && ref !== COMPOSE_SENTINEL;
+}

--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -22,6 +22,7 @@ import {
   type RuntimeMode,
 } from "@repo/core";
 import { env } from "../config";
+import { isRealContainerRef } from "./container-ref";
 import { cloudClient, getOrgCloudToken } from "./cloud/client";
 import { resolveOrgCloudUserId } from "./cloud/transport";
 import { platform } from "./controller-helpers";
@@ -109,6 +110,13 @@ export interface DeploymentMeta {
    * agree on one path.
    */
   staticServeOutputDir?: string;
+  /** This deploy carried every service forward and shipped nothing, so it never
+   *  became the active release (see `onNoChanges`). Mirrors the row's
+   *  `no_changes` status for clients reading meta rather than status. */
+  noChanges?: boolean;
+  /** Compose roll-up. Loosely typed on purpose — the pipeline writes a wider
+   *  object than any one reader needs. */
+  composeDeployment?: { warningMessage?: string } & Record<string, unknown>;
 }
 
 /**
@@ -791,7 +799,9 @@ export async function deploymentContainerIds(
   const rows = await repos.service.listByDeployment(dep.id);
   const serviceIds = [...new Set(rows.map((r) => r.containerId).filter((id): id is string => !!id))];
   if (serviceIds.length > 0) return serviceIds;
-  return dep.containerId ? [dep.containerId] : [];
+  // The compose sentinel is a marker, not a container: returning it made a pause
+  // report success having stopped nothing (docker 404 → `isAbsent` → swallowed).
+  return isRealContainerRef(dep.containerId) ? [dep.containerId] : [];
 }
 
 /**

--- a/apps/api/src/lib/notification-categories.ts
+++ b/apps/api/src/lib/notification-categories.ts
@@ -247,6 +247,10 @@ const EVENT_TYPE_TO_CATEGORY: Record<string, string> = {
   // Deploy
   "deployment.failed": "deploy.failed",
   "deployment.succeeded": "deploy.succeeded",
+  // A no-op redeploy is a SUCCESSFUL outcome, so it rides the succeeded toggle —
+  // not "cancelled", which tells the operator to try again. Its own headline below
+  // keeps the message honest about nothing having shipped.
+  "deployment.no_changes": "deploy.succeeded",
   "deployment.cancelled": "deploy.cancelled",
   "build.failed": "deploy.failed",
   "build.fatal_error": "deploy.failed",
@@ -317,6 +321,12 @@ export const EVENT_HEADLINES: Record<string, { title: string; description: strin
   "server.reachable": {
     title: "Server reachable",
     description: "A server's Docker daemon is answering again, with how long it was gone.",
+  },
+  // Same reasoning: it subscribes as a success, but "Deploy succeeded" over a body
+  // saying nothing shipped is the exact mismatch this override exists for.
+  "deployment.no_changes": {
+    title: "No changes to deploy",
+    description: "A redeploy found every service already up to date; the live release didn't move.",
   },
 };
 

--- a/apps/api/src/lib/public-endpoints.ts
+++ b/apps/api/src/lib/public-endpoints.ts
@@ -929,6 +929,25 @@ export function pickCanonicalDomainRow<
 }
 
 /**
+ * The service a PROJECT-level question about "the container" means — its logs,
+ * its container info, the upstream a project-level domain proxies to. Keyed off
+ * the canonical domain row first, so the answer agrees with the access URL.
+ *
+ * The thing it replaces is `find((s) => s.containerId)` over a service list in
+ * topoSort order: dependencies come first there, so for an app that `dependsOn`
+ * its database that find answered "postgres" (#498).
+ */
+export function pickPrimaryServiceId<S extends { id: string; exposed?: boolean | null }>(
+  services: S[],
+  domainRows?: Array<Pick<ProjectDomainRow, "verified" | "isPrimary" | "serviceId">> | null,
+): string | null {
+  if (services.length === 0) return null;
+  const canonical = pickCanonicalDomainRow(domainRows)?.serviceId;
+  if (canonical && services.some((svc) => svc.id === canonical)) return canonical;
+  return (services.find((svc) => svc.exposed) ?? services[0]).id;
+}
+
+/**
  * The canonical access URL for a project, computed from ALL its domain rows +
  * the effective deploy target + port. Correct for a project whose only domains
  * are service-scoped — the project-level publicEndpoints resolver excludes those,

--- a/apps/api/src/modules/analytics/analytics.service.ts
+++ b/apps/api/src/modules/analytics/analytics.service.ts
@@ -19,6 +19,7 @@ import { repos } from "@repo/db";
 import { NotFoundError, AppError, safeErrorMessage } from "@repo/core";
 import type { ResourceUsage } from "@repo/adapters";
 import { resolveDeploymentRuntimeForRead } from "../../lib/deployment-runtime";
+import { livePrimaryContainerId } from "../services/service-container";
 import {
   resolveProjectTrafficSources,
   fetchMgmt,
@@ -597,7 +598,10 @@ export async function getDeploymentStats(
  * Container info (status, IP, uptime) for a project's primary container.
  *
  * Genuinely single-container by nature — this describes the deployment's own
- * container, not the stack — so it is not duplicating the usage collector.
+ * container, not the stack — so it is not duplicating the usage collector. Which
+ * container that is comes from `livePrimaryContainerId`, for the same reason the
+ * usage collector was rewritten: `deployment.containerId` names one service in
+ * dependency order, so it answered for the database (#498).
  *
  * Uses the READ-ONLY resolver: building a full platform here runs
  * `detectOpenRestyPaths` plus the edge-Lua self-heal inside the provision lock,
@@ -617,7 +621,8 @@ export async function getContainerInfo(ctx: RequestContext, projectId: string) {
 
   const { runtime } = await resolveDeploymentRuntimeForRead(dep);
   try {
-    return await runtime.getContainerInfo(dep.containerId);
+    const containerId = await livePrimaryContainerId(runtime, dep);
+    return containerId ? await runtime.getContainerInfo(containerId) : null;
   } finally {
     void Promise.resolve(runtime.dispose?.()).catch(() => {});
   }

--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -49,6 +49,7 @@ import {
   resolveEffectiveTarget,
   hostChannelDeployNotice,
 } from "../../lib/deployment-runtime";
+import { isRealContainerRef } from "../../lib/container-ref";
 import { ensureRoutingReady } from "../../lib/edge-reconcile";
 import { sshManager } from "../../lib/ssh-manager";
 import {
@@ -236,7 +237,7 @@ async function markDeploymentFailedFromOutside(deploymentId: string, error: unkn
   try {
     const dep = await repos.deployment.findById(deploymentId).catch(() => null);
     if (!dep) return;
-    if (["failed", "ready", "cancelled", "action_required"].includes(dep.status)) {
+    if (["failed", "ready", "cancelled", "action_required", "no_changes"].includes(dep.status)) {
       // Inner onFailure already ran (or the deploy somehow succeeded). Nothing to do.
       // `action_required` counts as "already ran": onFailure wrote it deliberately
       // along with the blocker's code + details, and this function's blind
@@ -1884,7 +1885,7 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
       .listByDeployment(prevDep.id)
       .catch(() => []);
     for (const sd of prevServiceDeps) {
-      if (!sd.containerId || sd.containerId === "compose" || sd.containerId === prevDep.containerId) {
+      if (!isRealContainerRef(sd.containerId) || sd.containerId === prevDep.containerId) {
         continue;
       }
       try {

--- a/apps/api/src/modules/deployments/build-status.service.ts
+++ b/apps/api/src/modules/deployments/build-status.service.ts
@@ -240,6 +240,10 @@ export async function getBuildSessionStatus(deploymentId: string) {
     // the server-backed keep/reject decision so the "Action Required" banner +
     // modal reappear after a refresh, until the user keeps or rejects.
     deploymentStatus: dep.status,
+    // A settled deploy that shipped nothing. Distinct from `ready` for a client
+    // that wants to say so, but still a healthy terminal state — the SSE status
+    // above stays "ready", so the build page renders as finished either way.
+    noChanges: snapshot?.noChanges === true,
     decisionPending: snapshot?.composeDeployment?.decision === "pending",
     partial: snapshot?.composeDeployment
       ? {

--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -251,10 +251,16 @@ export interface DeploymentConfigSnapshot {
   /** STATIC twin: a retained release DIRECTORY on the host to promote again
    *  (static releases have no image). Set by a rollback restore. */
   handoverStaticDir?: string;
+  /** This deploy carried every service forward and shipped nothing, so it never
+   *  became the active release (`onNoChanges`). Mirrors the row's `no_changes`
+   *  status for clients reading the snapshot rather than the status. */
+  noChanges?: boolean;
   /** Summary of a compose deployment fan-out, when applicable. */
   composeDeployment?: {
     totalServices: number;
     successfulServices: number;
+    /** Of those, the ones actually (re)created — the rest were carried forward. */
+    deployedServices?: number;
     failedServices: number;
     failedServiceNames: string[];
     warningMessage?: string;
@@ -1579,7 +1585,7 @@ export async function startBuild(deploymentId: string) {
   // be overwritten mid-flight. Resolving a blocker creates a NEW deployment
   // (redeploy), it never restarts this one.
   if (
-    ["building", "deploying", "ready", "failed", "cancelled", "action_required"].includes(
+    ["building", "deploying", "ready", "failed", "cancelled", "action_required", "no_changes"].includes(
       dep.status,
     )
   ) {

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -67,7 +67,11 @@ import {
   toRoutedDomainInputs,
   type PlannedRouteDomain,
 } from "../../../lib/routing-domains";
-import { resolveServiceEndpointUrls, resolveServicePublicEndpoints } from "../../../lib/public-endpoints";
+import {
+  pickPrimaryServiceId,
+  resolveServiceEndpointUrls,
+  resolveServicePublicEndpoints,
+} from "../../../lib/public-endpoints";
 import { ensureManagedEdgeProxy } from "../../../lib/managed-edge-proxy";
 import { ensureRoutingReady } from "../../../lib/edge-reconcile";
 import * as sessionManager from "../session-manager";
@@ -84,6 +88,7 @@ import {
   hostChannelDeployNotice,
   type PortCheckResult,
 } from "../../../lib/deployment-runtime";
+import { isRealContainerRef } from "../../../lib/container-ref";
 import { resolveServicePort } from "./domain-helpers";
 import { compileProjectRoutingFields } from "../../../lib/project-routing-fields";
 import { buildCompositeRegistration, buildDomainFanoutRegistrations } from "./composite-route";
@@ -98,13 +103,28 @@ export interface ComposeDeployResult {
   status: "ready" | "failed" | "reconciling";
   summary: {
     total: number;
+    /** Services that came up — INCLUDING the ones merely carried forward. */
     successful: number;
+    /** Services this pass actually (re)created or (re)served. Derived from the
+     *  per-service `carried` flag rather than counted alongside `successful`, so a
+     *  future success site can't forget to increment it. `deployed === 0` with
+     *  `successful > 0` is the all-carried no-op (`composeDeployMadeNoChanges`). */
+    deployed: number;
     failed: number;
     /** Services whose container started but whose outcome is unverified
      *  (connection lost mid-deploy). Neither success nor failure yet. */
     indeterminate: number;
+    /** This pass changed state OUTSIDE the per-service deploy branch — it reaped a
+     *  de-listed container or persisted env. Keeps such a run from being read as a
+     *  no-op just because every surviving service was carried. */
+    mutated: boolean;
     failedServices: string[];
   };
+  /** The container the project's canonical route points at — the primary service's
+   *  (`pickPrimaryServiceId`), not `services.find((s) => s.containerId)`, which
+   *  follows topoSort order and so named the database an app `dependsOn` (#498).
+   *  Undefined when no service came up with a container. */
+  primaryContainerId?: string;
   services: Array<{
     serviceId: string;
     serviceName: string;
@@ -113,6 +133,8 @@ export interface ComposeDeployResult {
     ip?: string;
     hostPort?: number;
     error?: string;
+    /** Kept running exactly as-is: nothing built, created, or port-probed. */
+    carried?: true;
     /**
      * Host directory this service's built files live in — set INSTEAD of
      * containerId/ip/hostPort for a self-hosted static sub-app, which the edge
@@ -130,6 +152,31 @@ export interface ComposeDeployResult {
   publicUrl?: string;
   /** Advisory per-service port-probe results (exposed services only). */
   portChecks?: PortCheckResult[];
+}
+
+/**
+ * True when this pass created, rebuilt, re-served, reaped and persisted NOTHING —
+ * every service was carried forward. Such a run owns no containers and no image of
+ * its own, so promoting it to the live release points the project at an empty
+ * record (#498).
+ *
+ * Gated POSITIVELY on `ready` + a non-empty service set rather than on
+ * `failed === 0`: the prepare-failure return reports `status: "failed"` with
+ * `failed === 0`, and the no-services return reports zeroes for everything, so a
+ * negative test would reclassify both as "no changes".
+ *
+ * Lives here rather than inside `deployComposeServices` because
+ * `provisionServiceContainer` calls that directly and needs a genuine failure to
+ * keep throwing — only the pipeline settles a deployment row.
+ */
+export function composeDeployMadeNoChanges(result: ComposeDeployResult): boolean {
+  return (
+    result.status === "ready" &&
+    result.summary.total > 0 &&
+    result.summary.deployed === 0 &&
+    result.summary.failed === 0 &&
+    !result.summary.mutated
+  );
 }
 
 /**
@@ -753,8 +800,10 @@ export async function deployComposeServices(
       summary: {
         total: 0,
         successful: 0,
+        deployed: 0,
         failed: 0,
         indeterminate: 0,
+        mutated: false,
         failedServices: [],
       },
       services: [],
@@ -922,6 +971,12 @@ export async function deployComposeServices(
   );
   const isExternalUnchanged = (svc: Service): boolean => {
     if (dep.trigger === "update") return false; // update = force re-pull + recreate every image service
+    // A rollback REPLAYS a release: its frozen env (`frozenEnvWins` above) and its
+    // pinned images only reach the container by recreating it. Carrying an
+    // external forward instead applies neither, so the restore reports success
+    // having changed nothing — the same silent-no-op `newerThanRestoredRelease`
+    // guards against from the other direction.
+    if (dep.trigger === "rollback") return false;
     if (opts?.targetServiceIds) return false; // smart subset already carries non-targets forward
     if (!carryAnchor) return false; // never deployed → deploy it
     if (svc.build || !svc.image) return false; // must be image-only (external); buildables always rebuild
@@ -929,7 +984,12 @@ export async function deployComposeServices(
     if (carryProjectEnvChanged || carryEnvChangedServiceIds.has(svc.id)) return false; // env changed
     const prev = previousByServiceId.get(svc.id);
     if (!prev?.containerId) return false; // nothing running to carry
-    if (prev.imageRef && prev.imageRef !== svc.image) return false; // image tag changed
+    // Against the image this deploy INTENDS, not the service row's: a pinned ref
+    // (rollback, `--image-version`) arrives via `builtImages` and is first read
+    // past the carry `continue`, so comparing `svc.image` carried a service whose
+    // intended image differed from the running one.
+    const intended = opts?.builtImages?.get(svc.id) ?? svc.image;
+    if (prev.imageRef && prev.imageRef !== intended) return false;
     return true;
   };
 
@@ -1006,6 +1066,9 @@ export async function deployComposeServices(
   // never fatal). Aggregated into the deployment's routing action-required signal.
   const composeRouteWarnings: string[] = [];
   let successful = 0;
+  /** Set by the state this pass changed OUTSIDE the per-service deploy branch — a
+   *  reaped container, persisted env. See `ComposeDeployResult.summary.mutated`. */
+  let mutated = false;
   let firstPublicUrl: string | undefined;
   const seenRouteDomains = new Set<string>();
   const unavailableServiceNames = new Set<string>();
@@ -1177,6 +1240,28 @@ export async function deployComposeServices(
           hostPort: carriedHostPort,
           ip: carriedIp,
         });
+        // The #506 correction above has to land on the ACTIVE deployment's row too:
+        // that is the row the next deploy reads (`previousByServiceId`), and an
+        // all-carried pass never becomes active — so writing it only under `dep.id`
+        // discards the fix and the stale binding comes back next time.
+        if (
+          project.activeDeploymentId &&
+          project.activeDeploymentId !== dep.id &&
+          (carriedIp !== (carried.ip ?? null) || carriedHostPort !== (carried.hostPort ?? null))
+        ) {
+          await repos.service
+            .upsertServiceDeployment({
+              deploymentId: project.activeDeploymentId,
+              serviceId: svc.id,
+              serviceName: svc.name,
+              containerId: carried.containerId,
+              status: "success",
+              imageRef: carried.imageRef ?? null,
+              hostPort: carriedHostPort,
+              ip: carriedIp,
+            })
+            .catch(() => {});
+        }
         // Decoupled single-service add on a mesh runtime (cloud): this peer is
         // carried (not redeployed), so it's absent from the group's in-memory
         // mesh state. Seed it so the finalize pass rewrites the FULL mesh and
@@ -1197,6 +1282,7 @@ export async function deployComposeServices(
           status: carried.status,
           ip: carriedIp ?? undefined,
           hostPort: carriedHostPort ?? undefined,
+          carried: true,
         });
         // A carried-forward container is a valid namespace provider — it's running,
         // which is the only thing a dependent needs from it.
@@ -2235,6 +2321,7 @@ export async function deployComposeServices(
             [],
             service.id,
           );
+          mutated = true; // persisted env — this pass is not a no-op
           logger.log(`Prepared ${step.capture} → ${step.persistAs.key}\n`, "info");
         }
       } catch (err) {
@@ -2253,6 +2340,30 @@ export async function deployComposeServices(
       sessionManager.broadcastInstallPhase(dep.id, { id: "app-setup", status: "done" });
     }
   }
+  // Services this pass actually stood up, derived from the results rather than
+  // counted next to `successful` — a future success branch that forgets to
+  // increment would otherwise re-open #498 silently.
+  const deployed = results.filter((r) => r.status !== "failed" && !r.carried).length;
+
+  // The container a project-level question resolves to, picked the same way the
+  // access URL is. The fallbacks cover a primary with no container of its own (a
+  // static-served app, a failed one): any other exposed service, then the
+  // topo-first row — for a worker-only stack there is no better answer, and a
+  // wrong container still beats the sentinel's guaranteed 404.
+  const primaryContainerId = await (async () => {
+    const withContainer = results.filter((r) => r.containerId);
+    if (withContainer.length === 0) return undefined;
+    const domainRows = needsDomainMap
+      ? [...domainByHostname.values()]
+      : await repos.domain.listByProject(project.id).catch(() => []);
+    const primaryId = pickPrimaryServiceId(ordered, domainRows);
+    return (
+      withContainer.find((r) => r.serviceId === primaryId)?.containerId ??
+      withContainer.find((r) => ordered.find((s) => s.id === r.serviceId)?.exposed)?.containerId ??
+      withContainer[0].containerId
+    );
+  })();
+
   if (prepareFailure) {
     sessionManager.broadcastInstallPhase(dep.id, { id: "app-setup", status: "failed" });
     const failedNow = results.filter((r) => r.status === "failed");
@@ -2262,11 +2373,14 @@ export async function deployComposeServices(
       summary: {
         total: ordered.length,
         successful,
+        deployed,
         failed: failedNow.length,
         indeterminate: 0,
+        mutated,
         failedServices: failedNow.map((r) => r.serviceName),
       },
       services: results,
+      primaryContainerId,
       error: prepareFailure,
       publicUrl: firstPublicUrl,
       portChecks,
@@ -2421,6 +2535,7 @@ export async function deployComposeServices(
       if (!previous.containerId || enabledServiceIds.has(previous.serviceId)) continue;
       try {
         await runtime.destroy(previous.containerId);
+        mutated = true; // reaped a container — this pass is not a no-op
         logger.log(`Stopped disabled service container (${previous.containerId.slice(0, 12)}).\n`);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";
@@ -2452,13 +2567,13 @@ export async function deployComposeServices(
       previousServiceDeps.map((row) => row.containerId).filter((id): id is string => !!id),
     );
     if (
-      prevContainerId &&
-      prevContainerId !== "compose" &&
+      isRealContainerRef(prevContainerId) &&
       !prevWasServices &&
       !handledContainerIds.has(prevContainerId)
     ) {
       try {
         await runtime.destroy(prevContainerId);
+        mutated = true; // reaped a container — this pass is not a no-op
         logger.log(`Stopped previous single-app container (${prevContainerId.slice(0, 12)}).\n`);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";
@@ -2501,11 +2616,14 @@ export async function deployComposeServices(
       summary: {
         total: ordered.length,
         successful,
+        deployed,
         failed: failed.length,
         indeterminate: indeterminate.length,
+        mutated,
         failedServices: failedNames,
       },
       services: results,
+      primaryContainerId,
       warning: `Connection lost — verifying ${indeterminate.length} service(s): ${names}`,
       publicUrl: firstPublicUrl,
       portChecks,
@@ -2534,11 +2652,14 @@ export async function deployComposeServices(
     summary: {
       total: ordered.length,
       successful,
+      deployed,
       failed: failed.length,
       indeterminate: 0,
+      mutated,
       failedServices: failedNames,
     },
     services: results,
+    primaryContainerId,
     warning,
     ...(composeRouteWarnings.length ? { routeWarnings: composeRouteWarnings } : {}),
     error: successful > 0 ? undefined : (firstFailure ?? "No services deployed successfully"),

--- a/apps/api/src/modules/deployments/compose/pipeline.ts
+++ b/apps/api/src/modules/deployments/compose/pipeline.ts
@@ -29,6 +29,7 @@ import type { BuildConfigSnapshotLike } from "../build-config";
 import {
   cleanupBuildArtifact,
   onFailure,
+  onNoChanges,
   onReconciling,
   onSuccess,
   routeIssuesWarning,
@@ -39,7 +40,8 @@ import type { DeployableService } from "../../../lib/deployable-service";
 import { webhookProxyTarget } from "../../../config";
 
 import { buildComposeImages } from "./build.service";
-import { deployComposeServices } from "./deploy.service";
+import { composeDeployMadeNoChanges, deployComposeServices } from "./deploy.service";
+import { COMPOSE_SENTINEL } from "../../../lib/container-ref";
 import { safeErrorMessage } from "@repo/core";
 import * as sessionManager from "../session-manager";
 
@@ -181,9 +183,8 @@ export async function executeComposePipeline(opts: ComposePipelineOpts): Promise
   // running fine. Persist `reconciling` and leave the images in place (reconcile
   // may confirm ready; cleaning up now would hit the same dead connection).
   if (composeResult.status === "reconciling") {
-    const primary = composeResult.services.find((s) => s.containerId);
     await onReconciling(ctx, {
-      containerId: primary?.containerId,
+      containerId: composeResult.primaryContainerId,
       warningMessage:
         composeResult.warning ?? "Connection lost during deploy — verifying remote state.",
     });
@@ -214,7 +215,6 @@ export async function executeComposePipeline(opts: ComposePipelineOpts): Promise
     });
   }
 
-  const primary = composeResult.services.find((s) => s.containerId);
   // Routing failures are best-effort (domains are optional — never fail the
   // deploy). Fold them into the SAME top-level "action required" signal the
   // single-app pipeline uses (`edgeUnsynced` + `deployWarning` → routingUnsynced
@@ -224,8 +224,22 @@ export async function executeComposePipeline(opts: ComposePipelineOpts): Promise
     : undefined;
   const successWarning = routingWarning ?? composeResult.warning;
   sessionManager.broadcastInstallPhase(dep.id, { id: "ready", status: "done" });
+
+  // Every service was carried forward: this row owns no container and no image, so
+  // promoting it would point the project at an empty release and offer it as a
+  // rollback target (#498). Settle it without advancing. NOT via onFailure /
+  // onCancelled — both destroy the deployment's service containers, which here are
+  // the live ones still serving.
+  if (composeDeployMadeNoChanges(composeResult)) {
+    await onNoChanges(ctx, {
+      warningMessage: successWarning,
+      durationMs: composeBuild.durationMs,
+    });
+    return;
+  }
+
   await onSuccess(ctx, {
-    containerId: primary?.containerId ?? "compose",
+    containerId: composeResult.primaryContainerId ?? COMPOSE_SENTINEL,
     url: composeResult.publicUrl,
     durationMs: composeBuild.durationMs,
     warningMessage: successWarning,
@@ -233,6 +247,7 @@ export async function executeComposePipeline(opts: ComposePipelineOpts): Promise
       composeDeployment: {
         totalServices: composeResult.summary.total,
         successfulServices: composeResult.summary.successful,
+        deployedServices: composeResult.summary.deployed,
         failedServices: composeResult.summary.failed,
         failedServiceNames: composeResult.summary.failedServices,
         warningMessage: composeResult.warning,

--- a/apps/api/src/modules/deployments/deployment-lifecycle.ts
+++ b/apps/api/src/modules/deployments/deployment-lifecycle.ts
@@ -71,7 +71,7 @@ export interface LifecycleContext {
    * through onFailure — that inverts a working deploy and tears down its
    * containers.
    */
-  settled?: "ready" | "failed" | "cancelled" | "reconciling";
+  settled?: "ready" | "failed" | "cancelled" | "reconciling" | "no_changes";
 }
 
 /** Build the persistable log array. Collapsing/sanitizing it is observability
@@ -303,6 +303,78 @@ export async function onReconciling(
     warningMessage:
       result.warningMessage ?? "Connection lost during deploy — verifying remote state.",
   });
+}
+
+/**
+ * NO-OP completion: a compose deploy that carried EVERY service forward, so it
+ * built, created and probed nothing (`composeDeployMadeNoChanges`).
+ *
+ * Like onReconciling and unlike onSuccess: does NOT advance the active pointer and
+ * does NOT record a container. The CURRENT active deployment still owns the live
+ * containers and the image they run; this row owns nothing, so promoting it would
+ * make an empty release the newest `ready` one and a rollback target.
+ *
+ * Tears nothing down, deliberately: `onFailure` and `onCancelled` both destroy the
+ * deployment's service containers, and the containers listed under THIS row are
+ * the ones still serving.
+ */
+export async function onNoChanges(
+  ctx: LifecycleContext,
+  result: { warningMessage?: string; durationMs?: number },
+): Promise<void> {
+  const { project, buildSessionId, dep } = ctx;
+
+  const collapsed = collectLogs(ctx);
+  const reason =
+    result.warningMessage ??
+    "No changes to deploy — every service was already up to date, so the current release stayed live.";
+  // Under `composeDeployment.warningMessage` because that is where the build-status
+  // refresh path reads a persisted deploy note from; `noChanges` is the flag
+  // clients branch on. Sanitized like onSuccess's meta — a NUL in the reason must
+  // not fail the write.
+  const previousMeta = (dep.meta as DeploymentMeta | null) ?? {};
+  const mergedMeta = sanitizeStorableStrings({
+    ...previousMeta,
+    noChanges: true,
+    composeDeployment: { ...(previousMeta.composeDeployment ?? {}), warningMessage: reason },
+  });
+  await recordOutcome(dep.id, "no_changes", { errorMessage: null, meta: mergedMeta }, ["meta"]);
+  ctx.settled = "no_changes";
+  // The SSE layer has no third terminal state, so the stream closes "ready" and
+  // the dashboard reads `no_changes` off the row (same split as onReconciling).
+  await finishSession(buildSessionId, "ready", result.durationMs ?? 0, collapsed);
+  sessionManager.updateStatus(dep.id, "ready", { warningMessage: reason });
+
+  notification.emit({
+    organizationId: dep.organizationId,
+    eventType: "deployment.no_changes",
+    resourceType: "deployment",
+    resourceId: dep.id,
+    payload: {
+      projectName: project.name,
+      branch: dep.branch,
+      commitSha: dep.commitSha,
+      durationMs: result.durationMs,
+      message: reason,
+    },
+  });
+
+  audit.recordAsync(
+    { organizationId: dep.organizationId, actorUserId: null, source: "system" },
+    {
+      eventType: "deployment.no_changes",
+      resourceType: "deployment",
+      resourceId: dep.id,
+      before: { status: dep.status },
+      after: {
+        status: "no_changes",
+        projectId: project.id,
+        branch: dep.branch,
+        commitSha: dep.commitSha,
+        durationMs: result.durationMs,
+      },
+    },
+  );
 }
 
 export async function onFailure(

--- a/apps/api/src/modules/deployments/deployment.service.ts
+++ b/apps/api/src/modules/deployments/deployment.service.ts
@@ -34,6 +34,7 @@ import {
   type RestorePlan,
 } from "./rollback";
 import { checkNoActiveBuild } from "./build.service";
+import { livePrimaryContainerId } from "../services/service-container";
 import { decryptEnvMap } from "../../lib/encryption";
 
 /**
@@ -522,9 +523,14 @@ export async function getDeploymentLogs(
     return buildSessions.logs as LogEntry[];
   }
 
-  const containerId = dep.containerId;
-  if (containerId) {
-    return withDeploymentRuntime(dep, (runtime) => runtime.getRuntimeLogs(containerId, tail));
+  if (dep.containerId) {
+    return withDeploymentRuntime(dep, async (runtime) => {
+      // Live, and the PRIMARY service on a compose release — `dep.containerId` is
+      // one service in dependency order, i.e. the database (#498).
+      const containerId = await livePrimaryContainerId(runtime, dep);
+      if (!containerId) throw new ForbiddenError("Deployment has no container");
+      return runtime.getRuntimeLogs(containerId, tail);
+    });
   }
 
   return [];
@@ -562,8 +568,11 @@ export async function getContainerInfo(
   if (!dep.containerId) {
     throw new ForbiddenError("Deployment has no container");
   }
-  const containerId = dep.containerId;
-  return withDeploymentRuntime(dep, (runtime) => runtime.getContainerInfo(containerId));
+  return withDeploymentRuntime(dep, async (runtime) => {
+    const containerId = await livePrimaryContainerId(runtime, dep);
+    if (!containerId) throw new ForbiddenError("Deployment has no container");
+    return runtime.getContainerInfo(containerId);
+  });
 }
 
 /**
@@ -587,8 +596,11 @@ export async function getContainerUsage(
   if (!dep.containerId) {
     throw new ForbiddenError("Deployment has no container");
   }
-  const containerId = dep.containerId;
-  return withDeploymentRuntime(dep, (runtime) => runtime.getUsage(containerId));
+  return withDeploymentRuntime(dep, async (runtime) => {
+    const containerId = await livePrimaryContainerId(runtime, dep);
+    if (!containerId) throw new ForbiddenError("Deployment has no container");
+    return runtime.getUsage(containerId);
+  });
 }
 
 export async function getBuildLogs(

--- a/apps/api/src/modules/deployments/reconcile.service.ts
+++ b/apps/api/src/modules/deployments/reconcile.service.ts
@@ -23,6 +23,7 @@
 import { repos, type Deployment } from "@repo/db";
 import { safeErrorMessage } from "@repo/core";
 import { disposeRuntime, resolveDeploymentRuntime } from "../../lib/deployment-runtime";
+import { isRealContainerRef } from "../../lib/container-ref";
 import { createReachabilityProbe } from "../../lib/server-reachability";
 import { isConnectionLoss } from "../../lib/remote-state";
 
@@ -103,7 +104,7 @@ export async function reconcileDeployment(deploymentId: string): Promise<Reconci
         name: sd.serviceName ?? undefined,
         isService: true,
       }));
-    if (targets.length === 0 && dep.containerId && dep.containerId !== "compose") {
+    if (targets.length === 0 && isRealContainerRef(dep.containerId)) {
       targets.push({ rowId: dep.id, containerId: dep.containerId, name: undefined, isService: false });
     }
 

--- a/apps/api/src/modules/deployments/rollback/restore-plan.ts
+++ b/apps/api/src/modules/deployments/rollback/restore-plan.ts
@@ -35,11 +35,9 @@
  * same shape as image-gc's `computeKeepSet`.
  */
 
-/** Compose deploys store this in `deployment.container_id` / `image_ref` when
- *  there is no single primary container/image for the release. It is a marker,
- *  never a real Docker reference — treating it as one is what made compose
- *  rollback try to `createContainer({ Image: "compose" })`. */
-export const COMPOSE_SENTINEL = "compose";
+import { COMPOSE_SENTINEL } from "../../../lib/container-ref";
+
+export { COMPOSE_SENTINEL };
 
 export const ROLLBACK_ERROR_CODES = {
   NOT_READY: "ROLLBACK_NOT_READY",

--- a/apps/api/src/modules/domains/project-route.service.ts
+++ b/apps/api/src/modules/domains/project-route.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../../lib/public-endpoints";
 import { assertValidCustomDomain, assertValidCustomDomains } from "../../lib/custom-domain-guard";
 import { resolveLiveUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
+import { isRealContainerRef } from "../../lib/container-ref";
 import { deregisterManagedEdgeRoutes, syncManagedEdgeRoutes } from "../../lib/managed-edge-proxy";
 import { syncProjectPublicRoutes } from "../../lib/project-route-store";
 import { resolveRouteRedirect } from "../../lib/domain-redirect";
@@ -451,11 +452,14 @@ export async function reapplyProjectLiveRoutes(
     };
 
     const containerId = deployment.containerId;
-    if (!containerId) {
+    if (!isRealContainerRef(containerId)) {
       // Compose/multi-service deployments track containers per-service, so the
-      // parent deployment row has no containerId — nothing to point a single-app
-      // route at (per-service routes are handled in updateService). Still tear
-      // down any dropped hostnames on the correct host.
+      // parent row carries the `"compose"` sentinel or one service's container —
+      // never a single-app upstream to point a project-level route at (per-service
+      // routes are handled in updateService). Testing only for null let a compose
+      // project's project-level domain fall through to the port published by
+      // whichever service the row named, which in dependency order was its database.
+      // Still tear down any dropped hostnames on the correct host.
       console.warn(
         `[project-route] ${project.slug}: deployment ${deployment.id} has no containerId (target=${effectiveTarget}) — skipping single-app route registration`,
       );

--- a/apps/api/src/modules/migration/migration.orchestrator.ts
+++ b/apps/api/src/modules/migration/migration.orchestrator.ts
@@ -236,6 +236,10 @@ const TERMINAL_DEPLOY = new Set([
   "failed",
   "action_required",
   "cancelled",
+  // A no-op settle, for the poll only. The `status !== "ready"` abort downstream is
+  // still right for a migration — a move must actually deploy — and unreachable in
+  // practice, since moveData stops the scanned containers so nothing can be carried.
+  "no_changes",
 ]);
 /** How many volumes move concurrently — a few in flight without saturating one SSH link. */
 const TRANSFER_CONCURRENCY = 3;

--- a/apps/api/src/modules/projects/project-logs-container.test.ts
+++ b/apps/api/src/modules/projects/project-logs-container.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Which container "the project's logs" mean.
+ *
+ * `deployment.container_id` holds ONE service's container, written by the compose
+ * deploy loop — and that loop walks services in dependency order, so for an app
+ * that `dependsOn` postgres the column named POSTGRES. Project logs therefore
+ * streamed the database while the app served traffic (#498), and no migration can
+ * fix the rows already written that way.
+ *
+ * So the id is resolved LIVE from the host through the shared service matcher,
+ * against the PRIMARY service — the one the access URL points at. Colocated in
+ * `src/` deliberately: `apps/api/tsconfig.json` includes only `src/**`, so a test
+ * under `test/**` is never typechecked and its fixtures can drift from the real
+ * shapes.
+ */
+
+const h = vi.hoisted(() => ({
+  containerId: "cid-db" as string | null,
+  services: [] as Array<{ id: string; name: string; enabled: boolean; exposed: boolean }>,
+  serviceRows: [] as Array<{ id: string; serviceId: string; containerId: string | null }>,
+  live: [] as Array<{ id: string; names: string[]; state: string; labels: Record<string, string> }>,
+  logTargets: [] as string[],
+  healed: [] as Array<{ rowId: string; containerId: string }>,
+  listByProjectCalls: 0,
+  listByDeploymentCalls: 0,
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    project: {
+      findById: async () => ({
+        id: "proj_1",
+        slug: "stack",
+        organizationId: "org_1",
+        activeDeploymentId: "dep_1",
+      }),
+    },
+    deployment: {
+      findById: async () => ({
+        id: "dep_1",
+        projectId: "proj_1",
+        organizationId: "org_1",
+        containerId: h.containerId,
+        status: "ready",
+        meta: { deployTarget: "server", serverId: "srv_1" },
+      }),
+    },
+    service: {
+      listByProject: async () => {
+        h.listByProjectCalls += 1;
+        return h.services;
+      },
+      listByDeployment: async () => {
+        h.listByDeploymentCalls += 1;
+        return h.serviceRows;
+      },
+      updateServiceDeployment: async (rowId: string, patch: { containerId?: string }) => {
+        if (patch.containerId) h.healed.push({ rowId, containerId: patch.containerId });
+      },
+    },
+    domain: { listByProject: async () => [] },
+  },
+}));
+
+// The seam: a runtime that can enumerate the host's containers. The real matcher
+// (services/live-state) runs against it unmocked — the label tiers are the thing
+// under test as much as the picker is.
+vi.mock("../../lib/deployment-runtime", () => ({
+  withDeploymentRuntime: async (_dep: unknown, fn: (runtime: unknown) => Promise<unknown>) =>
+    fn({
+      supports: (cap: string) => cap === "hostContainerQuery",
+      listAllContainers: async () => h.live,
+      getRuntimeLogs: async (id: string) => {
+        h.logTargets.push(id);
+        return [];
+      },
+    }),
+  resolveDeploymentRuntimeForRead: async () => {
+    throw new Error("not used by getRuntimeLogs");
+  },
+  deploymentContainerIds: async () => [],
+  withDeploymentPlatform: async () => {
+    throw new Error("not used by getRuntimeLogs");
+  },
+}));
+
+vi.mock("@repo/adapters", () => ({
+  checkEdge: async () => ({ healthy: true, message: "" }),
+  edgeProxy: async () => null,
+  isRuntimeNotFoundError: () => false,
+}));
+
+const { getRuntimeLogs } = await import("./project-runtime.service");
+
+/** `openship.service` carries the service NAME, not its id — see live-state's
+ *  label tier. */
+const container = (serviceName: string, id: string) => ({
+  id,
+  names: [`/openship-stack-${serviceName}`],
+  state: "running",
+  labels: { "openship.project": "proj_1", "openship.service": serviceName },
+});
+
+beforeEach(() => {
+  h.containerId = "cid-db";
+  h.services = [];
+  h.serviceRows = [];
+  h.live = [];
+  h.logTargets = [];
+  h.healed = [];
+  h.listByProjectCalls = 0;
+  h.listByDeploymentCalls = 0;
+});
+
+describe("project logs target the primary service, not the recorded database", () => {
+  it("streams the exposed app even though the deployment row records the db", async () => {
+    h.services = [
+      { id: "svc_db", name: "db", enabled: true, exposed: false },
+      { id: "svc_app", name: "app", enabled: true, exposed: true },
+    ];
+    h.serviceRows = [
+      { id: "row_db", serviceId: "svc_db", containerId: "cid-db" },
+      { id: "row_app", serviceId: "svc_app", containerId: "cid-app" },
+    ];
+    h.live = [container("db", "cid-db"), container("app", "cid-app")];
+
+    await getRuntimeLogs("proj_1", "org_1");
+
+    expect(h.logTargets).toEqual(["cid-app"]);
+  });
+
+  it("heals a stale service row from the live host instead of handing docker a dead id", async () => {
+    h.services = [{ id: "svc_app", name: "app", enabled: true, exposed: true }];
+    h.serviceRows = [{ id: "row_app", serviceId: "svc_app", containerId: "cid-old" }];
+    h.live = [container("app", "cid-new")];
+
+    await getRuntimeLogs("proj_1", "org_1");
+
+    expect(h.logTargets).toEqual(["cid-new"]);
+    expect(h.healed).toEqual([{ rowId: "row_app", containerId: "cid-new" }]);
+  });
+
+  it("uses the recorded id for a single-app deployment and never reads service rows", async () => {
+    h.containerId = "cid-single";
+
+    await getRuntimeLogs("proj_1", "org_1");
+
+    expect(h.logTargets).toEqual(["cid-single"]);
+    // One project-services read to establish there are none, and nothing further:
+    // opening logs must not fan out per call.
+    expect(h.listByProjectCalls).toBe(1);
+    expect(h.listByDeploymentCalls).toBe(0);
+  });
+
+  it("refuses the compose sentinel rather than dialling a container named 'compose'", async () => {
+    h.containerId = "compose";
+
+    await expect(getRuntimeLogs("proj_1", "org_1")).rejects.toThrow(
+      /No running container for project/,
+    );
+    expect(h.logTargets).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/projects/project-runtime.service.ts
+++ b/apps/api/src/modules/projects/project-runtime.service.ts
@@ -20,6 +20,7 @@ import { sshManager } from "../../lib/ssh-manager";
 import { applyProjectRouting } from "../domains/routing-apply.service";
 import { reapplyProjectLiveRoutes } from "../domains/project-route.service";
 import { deploymentWorkload } from "../deployments/deployment-class";
+import { livePrimaryContainerId } from "../services/service-container";
 
 // ─── Runtime logs ────────────────────────────────────────────────────────────
 
@@ -36,12 +37,20 @@ export async function getRuntimeLogs(
   }
 
   const dep = await repos.deployment.findById(p.activeDeploymentId);
-  if (!dep?.containerId) {
+  if (!dep) {
     throw new NotFoundError("No running container for project", projectId);
   }
 
-  const containerId = dep.containerId;
-  return withDeploymentRuntime(dep, (runtime) => runtime.getRuntimeLogs(containerId, tail));
+  // Resolved live inside the runtime, not read off `dep.containerId`: on a
+  // multi-service project that column names one service, and in dependency order
+  // that was the database (#498) — so "the project's logs" were postgres's.
+  return withDeploymentRuntime(dep, async (runtime) => {
+    const containerId = await livePrimaryContainerId(runtime, dep);
+    if (!containerId) {
+      throw new NotFoundError("No running container for project", projectId);
+    }
+    return runtime.getRuntimeLogs(containerId, tail);
+  });
 }
 
 export async function streamRuntimeLogs(
@@ -58,7 +67,7 @@ export async function streamRuntimeLogs(
   }
 
   const dep = await repos.deployment.findById(p.activeDeploymentId);
-  if (!dep?.containerId) {
+  if (!dep) {
     throw new NotFoundError("No running container for project", projectId);
   }
 
@@ -66,7 +75,12 @@ export async function streamRuntimeLogs(
   // runtime is disposed in the stream's cleanup instead — same shape as
   // streamServiceRuntimeLogs. Disposing here would kill the live stream.
   const { runtime, serverId } = await resolveDeploymentRuntimeForRead(dep);
-  const stop = await runtime.streamRuntimeLogs(dep.containerId, onLog, opts);
+  const containerId = await livePrimaryContainerId(runtime, dep).catch(() => null);
+  if (!containerId) {
+    void Promise.resolve(runtime.dispose?.()).catch(() => {});
+    throw new NotFoundError("No running container for project", projectId);
+  }
+  const stop = await runtime.streamRuntimeLogs(containerId, onLog, opts);
   const cleanup = () => {
     try {
       stop();

--- a/apps/api/src/modules/projects/project.controller.ts
+++ b/apps/api/src/modules/projects/project.controller.ts
@@ -18,6 +18,7 @@ import {
   isLoopbackHost,
   isReservedLoopbackPort,
   pickCanonicalDomainRow,
+  pickPrimaryServiceId,
   resolveProjectAccess,
 } from "../../lib/public-endpoints";
 import {
@@ -1793,8 +1794,24 @@ async function reRegisterDomainRoute(
 
     // Find the service deployment to get the container target. Prefer a row with
     // a container to inspect — a stored ip alone is just the last-known value.
+    //
+    // Which service is "primary" comes from the same picker the access URL uses:
+    // `service_deployment` rows come back in insertion (dependency) order, so
+    // taking the first one with a container pointed the webhook vhost at whatever
+    // an exposed app depends on — its database (#498).
     const svcDeps = await repos.service.listByDeployment(project.activeDeploymentId);
-    const primarySvc = svcDeps.find((s) => s.containerId) ?? svcDeps.find((s) => s.ip);
+    const [projectServices, domainRows] = await Promise.all([
+      repos.service.listByProject(project.id).catch(() => []),
+      repos.domain.listByProject(project.id).catch(() => []),
+    ]);
+    const primaryId = pickPrimaryServiceId(
+      projectServices.filter((s) => s.enabled),
+      domainRows,
+    );
+    const primarySvc =
+      svcDeps.find((s) => s.serviceId === primaryId && (s.containerId || s.ip)) ??
+      svcDeps.find((s) => s.containerId) ??
+      svcDeps.find((s) => s.ip);
     if (!primarySvc) return;
 
     // The port the app LISTENS on. `hostPort` is a publish, not a container port,

--- a/apps/api/src/modules/services/service-container.ts
+++ b/apps/api/src/modules/services/service-container.ts
@@ -5,6 +5,8 @@ import {
   resolveDeploymentRuntimeForRead,
 } from "../../lib/deployment-runtime";
 import { resolveLiveServiceState } from "./live-state";
+import { isRealContainerRef } from "../../lib/container-ref";
+import { pickPrimaryServiceId } from "../../lib/public-endpoints";
 import type { DeploymentConfigSnapshot } from "../deployments/build.service";
 
 /**
@@ -113,6 +115,56 @@ export async function liveContainerIdWithRuntime(
       trackedIds: { [args.service.id]: args.tracked },
     }).get(args.service.id)?.containerId ?? null
   );
+}
+
+/**
+ * The container a PROJECT-level question means — "its logs", "its container info",
+ * "its resource usage" — resolved live, using a runtime the caller already holds.
+ *
+ * `deployment.containerId` cannot answer it for a multi-service project: it holds
+ * ONE service's container, and because the deploy loop walks services in
+ * dependency order that service was the database an app `dependsOn` — so project
+ * logs answered for postgres while the app served traffic (#498). It can also hold
+ * the `"compose"` sentinel, which is no container at all.
+ *
+ * So: pick the primary service the same way the access URL does, then resolve ITS
+ * container against the host and heal the record, exactly as the per-service path
+ * does. Single-app deployments (no service rows) short-circuit to the recorded id
+ * and issue no extra queries.
+ *
+ * Null means the primary service's container is genuinely gone — callers should
+ * surface "not deployed" rather than hand a dead id to docker.
+ */
+export async function livePrimaryContainerId(
+  runtime: HostContainerLister | null | undefined,
+  dep: { id: string; projectId: string; containerId: string | null },
+): Promise<string | null> {
+  const recorded = isRealContainerRef(dep.containerId) ? dep.containerId : null;
+  const services = (await repos.service.listByProject(dep.projectId).catch(() => [])).filter(
+    (svc) => svc.enabled,
+  );
+  if (services.length === 0) return recorded;
+
+  const [project, domainRows, rows] = await Promise.all([
+    repos.project.findById(dep.projectId).catch(() => null),
+    repos.domain.listByProject(dep.projectId).catch(() => []),
+    repos.service.listByDeployment(dep.id).catch(() => []),
+  ]);
+  const primaryId = pickPrimaryServiceId(services, domainRows);
+  const svc = services.find((s) => s.id === primaryId);
+  if (!svc || !project) return recorded;
+
+  const row = rows.find((r) => r.serviceId === svc.id);
+  const live = await liveContainerIdWithRuntime(runtime, {
+    service: { id: svc.id, name: svc.name },
+    projectId: dep.projectId,
+    slug: project.slug,
+    tracked: row?.containerId ?? null,
+  });
+  if (row && live && row.containerId !== live) {
+    await repos.service.updateServiceDeployment(row.id, { containerId: live }).catch(() => {});
+  }
+  return live ?? recorded;
 }
 
 /**

--- a/apps/api/test/modules/deployments/compose-noop-settle.test.ts
+++ b/apps/api/test/modules/deployments/compose-noop-settle.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The two halves of #498, driven through the REAL `executeComposePipeline` with a
+ * canned `deployComposeServices` result:
+ *
+ *   (a) an all-carried result settles as a non-advancing `no_changes` row and
+ *       destroys nothing — the containers listed under it are the live ones;
+ *   (b) a result that actually deployed something advances the pointer AND records
+ *       the primary service's container, never the topo-first dependency.
+ *
+ * Boundaries are faked the same way `deploy-outcome-vs-logs.test.ts` does it.
+ * `deployComposeServices` is overridden while its pure siblings stay real
+ * (importOriginal), so the pipeline's own no-op decision runs for real.
+ */
+
+const h = vi.hoisted(() => ({
+  activePointer: [] as string[],
+  statusWrites: [] as Array<{ id: string; status: string; extra?: Record<string, unknown> }>,
+  containerIdWrites: [] as Array<string | undefined>,
+  notifications: [] as string[],
+  audits: [] as string[],
+  destroyed: [] as string[],
+  deployResult: null as unknown,
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    deployment: {
+      setContainerId: async (_id: string, containerId?: string) => {
+        h.containerIdWrites.push(containerId);
+      },
+      updateStatus: async (id: string, status: string, extra?: Record<string, unknown>) => {
+        h.statusWrites.push({ id, status, extra });
+      },
+      findReadyVersionByCommit: async () => 7,
+      getNextReadyVersion: async () => 7,
+      supersedePendingDecisions: async () => {},
+      finishBuildSession: async () => {},
+    },
+    project: {
+      setActiveDeployment: async (projectId: string, depId: string) => {
+        h.activePointer.push(`${projectId}:${depId}`);
+      },
+      setCloudWorkspaceId: async () => {},
+      update: async () => {},
+    },
+    service: { listByDeployment: async () => [] },
+  },
+}));
+
+vi.mock("../../../src/modules/deployments/session-manager", () => ({
+  updateStatus: () => {},
+  broadcastServiceStatus: () => {},
+  broadcastInstallPhase: () => {},
+  appendLog: () => {},
+}));
+
+vi.mock("../../../src/lib/notification-dispatcher", () => ({
+  notification: { emit: (e: { eventType: string }) => h.notifications.push(e.eventType) },
+}));
+vi.mock("../../../src/lib/audit", () => ({
+  audit: { recordAsync: (_c: unknown, e: { eventType: string }) => h.audits.push(e.eventType) },
+}));
+vi.mock("../../../src/lib/favicon-detector", () => ({ detectAndStoreFavicon: async () => {} }));
+vi.mock("../../../src/modules/mail/webmail/webmail-install.service", () => ({
+  onWebmailDeployed: async () => {},
+}));
+
+// Not under test — a zero-image, zero-failure build.
+vi.mock("../../../src/modules/deployments/compose/build.service", () => ({
+  buildComposeImages: async () => ({
+    imageRefs: new Map<string, string>(),
+    builtImageRefs: new Map<string, string>(),
+    buildFailures: new Map<string, string>(),
+    durationMs: 4200,
+  }),
+}));
+
+vi.mock("../../../src/modules/deployments/compose/deploy.service", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../src/modules/deployments/compose/deploy.service")
+  >()),
+  deployComposeServices: async () => h.deployResult,
+}));
+
+const { executeComposePipeline } = await import("../../../src/modules/deployments/compose/pipeline");
+type PipelineOpts = Parameters<typeof executeComposePipeline>[0];
+
+/** db first, app second — topoSort's dependency-first order, i.e. the order in
+ *  which `services.find((s) => s.containerId)` answered "postgres". */
+const services = [
+  { serviceId: "db", serviceName: "db", containerId: "cid-db", status: "running", carried: true },
+  { serviceId: "app", serviceName: "app", containerId: "cid-app", status: "running", carried: true },
+];
+
+function optsFor(): PipelineOpts {
+  const dep = {
+    id: "dep_1",
+    projectId: "prj_1",
+    organizationId: "org_1",
+    branch: "main",
+    commitSha: "abc123",
+    status: "deploying",
+    meta: null,
+  };
+  return {
+    project: { id: "prj_1", name: "stack", slug: "stack", framework: "docker-compose" },
+    dep,
+    runtime: { name: "docker", destroy: async (id: string) => void h.destroyed.push(id) },
+    routing: {},
+    ssl: {},
+    system: null,
+    executor: null,
+    usesManagedRouting: false,
+    logger: { log: () => {} },
+    ctx: {
+      project: { id: "prj_1", name: "stack", slug: "stack", framework: "docker-compose" },
+      dep,
+      buildSessionId: "bld_1",
+      persistLogs: () => [],
+      provisioned: {},
+    },
+    snapshot: {},
+    buildSessionId: "bld_1",
+    buildEnvVars: {},
+    buildResources: {},
+    runtimeResources: {},
+  } as never;
+}
+
+beforeEach(() => {
+  h.activePointer = [];
+  h.statusWrites = [];
+  h.containerIdWrites = [];
+  h.notifications = [];
+  h.audits = [];
+  h.destroyed = [];
+  h.deployResult = null;
+});
+
+describe("executeComposePipeline — an all-carried redeploy must not take over", () => {
+  it("settles no_changes without advancing the pointer, recording a container, or destroying anything", async () => {
+    h.deployResult = {
+      status: "ready",
+      summary: {
+        total: 2,
+        successful: 2,
+        deployed: 0,
+        failed: 0,
+        indeterminate: 0,
+        mutated: false,
+        failedServices: [],
+      },
+      services,
+      primaryContainerId: undefined,
+      portChecks: [],
+    };
+
+    await executeComposePipeline(optsFor());
+
+    // THE bug: an empty release must not become the live pointer.
+    expect(h.activePointer).toEqual([]);
+    const settle = h.statusWrites.find((w) => w.status === "no_changes");
+    expect(settle, "a no-op must record a no_changes row").toBeTruthy();
+    expect((settle!.extra?.meta as { noChanges?: boolean } | undefined)?.noChanges).toBe(true);
+    expect(h.containerIdWrites).toEqual([]);
+    expect(h.notifications).toEqual(["deployment.no_changes"]);
+    expect(h.audits).toEqual(["deployment.no_changes"]);
+    // The containers under this row are the LIVE ones. This is the guard against
+    // a future reviewer folding onNoChanges into onFailure/onCancelled, both of
+    // which destroy every service container the deployment lists.
+    expect(h.destroyed).toEqual([]);
+  });
+
+  it("records the primary service's container, not the topo-first dependency", async () => {
+    h.deployResult = {
+      status: "ready",
+      summary: {
+        total: 2,
+        successful: 2,
+        deployed: 1,
+        failed: 0,
+        indeterminate: 0,
+        mutated: false,
+        failedServices: [],
+      },
+      services,
+      primaryContainerId: "cid-app",
+      portChecks: [{ serviceName: "app" }],
+    };
+
+    await executeComposePipeline(optsFor());
+
+    expect(h.activePointer).toEqual(["prj_1:dep_1"]);
+    expect(h.containerIdWrites).toEqual(["cid-app"]);
+    expect(h.containerIdWrites).not.toContain("cid-db");
+    expect(h.notifications).toContain("deployment.succeeded");
+    expect(h.statusWrites.some((w) => w.status === "no_changes")).toBe(false);
+  });
+
+  it("a carried pass that reaped a container or persisted env is NOT a no-op", async () => {
+    // `mutated` is the one term that can't be derived from the service results:
+    // the de-listed-service reaper and the app-prepare env write both change real
+    // state while every surviving service reads as carried.
+    h.deployResult = {
+      status: "ready",
+      summary: {
+        total: 2,
+        successful: 2,
+        deployed: 0,
+        failed: 0,
+        indeterminate: 0,
+        mutated: true,
+        failedServices: [],
+      },
+      services,
+      primaryContainerId: "cid-app",
+      portChecks: [],
+    };
+
+    await executeComposePipeline(optsFor());
+
+    expect(h.statusWrites.some((w) => w.status === "no_changes")).toBe(false);
+    expect(h.activePointer).toEqual(["prj_1:dep_1"]);
+  });
+});

--- a/apps/api/test/modules/deployments/deployment-status.test.ts
+++ b/apps/api/test/modules/deployments/deployment-status.test.ts
@@ -54,7 +54,7 @@ const SETTLED_STATUS_GUARDS: Array<{
   {
     what: "markDeploymentFailedFromOutside already-settled guard",
     file: "apps/api/src/modules/deployments/build-pipeline.ts",
-    anchor: '["failed", "ready", "cancelled", "action_required"]',
+    anchor: '["failed", "ready", "cancelled", "action_required"',
     breaks: "an outer throw overwrites the recorded blocker with a bare `failed`",
   },
   {
@@ -156,14 +156,21 @@ describe("the in-flight vocabulary stays one vocabulary", () => {
   });
 });
 
-describe("settled-status guards know about action_required", () => {
+/**
+ * Every settled status a guard list has to name. Parameterized rather than
+ * hardcoded so adding the NEXT value is one line here and then seven failing
+ * tests naming exactly what to teach — the mistake this ratchet exists to catch.
+ */
+const SETTLED_STATUSES = ["action_required", "no_changes"] as const;
+
+describe("settled-status guards know about every settled status", () => {
   for (const guard of SETTLED_STATUS_GUARDS) {
     it(`${guard.what} — else ${guard.breaks}`, () => {
       const source = readFileSync(join(REPO_ROOT, guard.file), "utf8");
       expect(source, `${guard.file}: guard moved or was rewritten`).toContain(guard.anchor);
-      expect(source, `${guard.file}: guard no longer handles action_required`).toContain(
-        "action_required",
-      );
+      for (const status of SETTLED_STATUSES) {
+        expect(source, `${guard.file}: guard no longer handles ${status}`).toContain(status);
+      }
     });
   }
 });

--- a/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
@@ -600,7 +600,10 @@ export default function AppInstallPage() {
       /* fall back to the SSE outcome below */
     }
     const failed = ["failed", "cancelled", "partial_failure", "action_required", "rejected"];
-    if (status === "ready" || (status === "" && fallback.ok)) {
+    // `no_changes` is a SUCCESS: every service was already up to date and the live
+    // stack is the one this install wanted. Treating it as terminal-but-unhandled
+    // would show "Install failed" over a working app.
+    if (status === "ready" || status === "no_changes" || (status === "" && fallback.ok)) {
       await deriveLiveUrl(s?.config);
       setPhase("done");
     } else if (failed.includes(status) || (status === "" && !fallback.ok)) {
@@ -668,7 +671,7 @@ export default function AppInstallPage() {
         const status: string = s.deploymentStatus ?? s.status ?? "";
         if (typeof s.progress === "number") setProgress(s.progress);
         if (
-          ["ready", "failed", "cancelled", "partial_failure", "action_required", "rejected"].includes(
+          ["ready", "failed", "cancelled", "partial_failure", "action_required", "rejected", "no_changes"].includes(
             status,
           )
         ) {

--- a/apps/dashboard/src/app/(dashboard)/apps/new/mail/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/apps/new/mail/page.tsx
@@ -126,7 +126,9 @@ export default function MailWizardPage() {
         const status: string = s.deploymentStatus ?? s.status ?? "queued";
         setProgress(typeof s.progress === "number" ? s.progress : 0);
         setPhaseLabel(labelForStatus(status, w));
-        if (status === "ready") {
+        // `no_changes` settles as a success: nothing shipped because the stack was
+        // already up to date, so the install is done.
+        if (status === "ready" || status === "no_changes") {
           setLiveUrl(firstPublicHost(s?.config?.publicEndpoints, baseDomain));
           setPhase("done");
         } else if (

--- a/apps/dashboard/src/app/(dashboard)/deployments/components/DeploymentCard.tsx
+++ b/apps/dashboard/src/app/(dashboard)/deployments/components/DeploymentCard.tsx
@@ -136,6 +136,7 @@ export const DeploymentCard: React.FC<DeploymentCardProps> = ({
     action_required: t.deployments.status.actionRequired,
     rejected: t.deployments.status.rejected,
     reconciling: t.deployments.status.verifying,
+    no_changes: t.deployments.status.noChanges,
   };
   const statusLabel = statusLabelMap[deployment.status] ?? t.deployments.status.pending;
 

--- a/apps/dashboard/src/app/(dashboard)/deployments/types.ts
+++ b/apps/dashboard/src/app/(dashboard)/deployments/types.ts
@@ -26,8 +26,10 @@ export interface Deployment {
   /** Monotonic per-project version (v1, v2, …). Null for legacy rows. */
   version: number | null;
   /** `action_required` = failed on a named, clearable cause (see the API's
-   *  blocking-errors module). Settled, like failed — not in flight. */
-  status: "success" | "failed" | "building" | "pending" | "canceled" | "cancelled" | "partial_failure" | "action_required" | "rejected" | "reconciling";
+   *  blocking-errors module). Settled, like failed — not in flight.
+   *  `no_changes` = every service was already up to date, so this deploy shipped
+   *  nothing and the previous release is still live. Settled and HEALTHY. */
+  status: "success" | "failed" | "building" | "pending" | "canceled" | "cancelled" | "partial_failure" | "action_required" | "rejected" | "reconciling" | "no_changes";
   domain: string;
   framework: string;
   commit: {

--- a/apps/dashboard/src/app/(dashboard)/deployments/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/deployments/utils.ts
@@ -125,6 +125,18 @@ export const getStatusConfig = (status: string) => {
         borderColor: "border-border/50",
         label: "Canceled",
       };
+    case "no_changes":
+      // Nothing shipped because nothing had changed — a healthy outcome, so
+      // neutral rather than the warning tone a "didn't land" state gets. Kept out
+      // of `statusMap` above so it isn't folded into "canceled", which would tell
+      // the operator to redeploy something that is already current.
+      return {
+        icon: 'checkmark-72-1658234612.png',
+        color: "var(--color-neutral)",
+        bgColor: "bg-muted/60",
+        borderColor: "border-border/50",
+        label: "No changes",
+      };
     case "partial_failure":
       // Some services succeeded, others failed. Treated as a
       // deployed-with-warnings state — dashboard still shows the

--- a/apps/dashboard/src/i18n/locales/ar/deployments.json
+++ b/apps/dashboard/src/i18n/locales/ar/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "إجراء مطلوب",
     "rejected": "مرفوضة",
     "verifying": "قيد التحقق",
+    "noChanges": "لا تغييرات",
     "pending": "قيد الانتظار"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/de/deployments.json
+++ b/apps/dashboard/src/i18n/locales/de/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "Aktion erforderlich",
     "rejected": "Abgelehnt",
     "verifying": "Wird überprüft",
+    "noChanges": "Keine Änderungen",
     "pending": "Ausstehend"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/en/deployments.json
+++ b/apps/dashboard/src/i18n/locales/en/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "Action required",
     "rejected": "Rejected",
     "verifying": "Verifying",
+    "noChanges": "No changes",
     "pending": "Pending"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/es/deployments.json
+++ b/apps/dashboard/src/i18n/locales/es/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "Acción requerida",
     "rejected": "Rechazado",
     "verifying": "Verificando",
+    "noChanges": "Sin cambios",
     "pending": "Pendiente"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/fr/deployments.json
+++ b/apps/dashboard/src/i18n/locales/fr/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "Action requise",
     "rejected": "Rejeté",
     "verifying": "Vérification",
+    "noChanges": "Aucun changement",
     "pending": "En attente"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/ja/deployments.json
+++ b/apps/dashboard/src/i18n/locales/ja/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "対応が必要",
     "rejected": "却下",
     "verifying": "検証中",
+    "noChanges": "変更なし",
     "pending": "保留中"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/pt/deployments.json
+++ b/apps/dashboard/src/i18n/locales/pt/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "Ação necessária",
     "rejected": "Rejeitada",
     "verifying": "A verificar",
+    "noChanges": "Sem alterações",
     "pending": "Pendente"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/tr/deployments.json
+++ b/apps/dashboard/src/i18n/locales/tr/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "İşlem gerekiyor",
     "rejected": "Reddedildi",
     "verifying": "Doğrulanıyor",
+    "noChanges": "Değişiklik yok",
     "pending": "Beklemede"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/i18n/locales/zh/deployments.json
+++ b/apps/dashboard/src/i18n/locales/zh/deployments.json
@@ -69,6 +69,7 @@
     "actionRequired": "需要处理",
     "rejected": "已拒绝",
     "verifying": "验证中",
+    "noChanges": "无变更",
     "pending": "待处理"
   },
   "serviceStatus": {

--- a/apps/dashboard/src/utils/deployment.ts
+++ b/apps/dashboard/src/utils/deployment.ts
@@ -54,6 +54,15 @@ export const getStatusConfig = (status: string) => {
         borderColor: "border-neutral-border",
         label: "Canceled",
       };
+    case "no_changes":
+      // Settled and healthy: nothing shipped because nothing had changed.
+      return {
+        icon: 'checkmark-72-1658234612.png',
+        color: "var(--color-neutral)",
+        bgColor: "bg-neutral-bg",
+        borderColor: "border-neutral-border",
+        label: "No changes",
+      };
     case "building":
       return {
         icon: 'loading-51-1663582768.png',

--- a/apps/dashboard/src/utils/project-status.ts
+++ b/apps/dashboard/src/utils/project-status.ts
@@ -116,10 +116,12 @@ export function projectStatusLabel(status: ProjectStatus, t: Dictionary): string
  * the literal "failed" only, so `partial_failure`, `rejected`, `reconciling` —
  * and any status added later — still came back green "Live" over a deploy that
  * never landed. `ready` is a landed deploy; `cancelled` is the operator's own
- * deliberate stop, which needs nothing from them and must not nag forever.
+ * deliberate stop, which needs nothing from them and must not nag forever;
+ * `no_changes` found every service already up to date and deliberately kept the
+ * live release, so the project is exactly as healthy as before it ran.
  * Everything else is "the newest deploy did not land".
  */
-const SETTLED_HEALTHY_STATUSES = new Set(["ready", "cancelled"]);
+const SETTLED_HEALTHY_STATUSES = new Set(["ready", "cancelled", "no_changes"]);
 
 /** Why a project reads "attention". Null when it doesn't. */
 export type ProjectAttentionReason =

--- a/packages/core/src/audit-taxonomy.ts
+++ b/packages/core/src/audit-taxonomy.ts
@@ -113,6 +113,14 @@ export const AUDIT_EVENTS: Record<string, AuditEventDef> = {
     tone: "warning",
     description: "A deployment was stopped before it finished.",
   },
+  "deployment.no_changes": {
+    category: "deployments",
+    action: "found no changes to deploy for",
+    label: "No changes to deploy",
+    tone: "info",
+    description:
+      "A redeploy found every service already up to date, so the current release stayed live.",
+  },
   "deployment:write": {
     category: "deployments",
     action: "started a deploy for",


### PR DESCRIPTION
## The bug (#498)

On a multi-service (compose) project, a redeploy where **every service is carried forward** built, created and probed nothing — yet was recorded `ready`, advanced `activeDeploymentId` onto itself, and recorded the **database** as the deployment's container (the result list follows `topoSort`, so the first row with a container is the dependency an app `dependsOn`). Routing keys on a fixed per-project host port, so the site kept serving: the dashboard read **Stopped**, rollback had no image to restore, and logs/info/usage answered for Postgres.

## What changed since the first version of this PR

This is a re-implementation on current `main` rather than a rebase. Reviewing the original against `main` turned up four things worth stating plainly, because two of them made the original fix unsafe:

1. **The no-op verdict was unsound.** `deployed === 0 && failed === 0 && portChecks.length === 0` is also true of the prepare-failure return (which reports `status: "failed"` with `failed === 0`) and of the no-services return. Only branch ordering in `pipeline.ts` kept those from being classified "no changes". It also missed two ways a carried pass mutates real state — the de-listed-service reaper destroys containers, and an app-prepare step persists env — while the counters read zero.
2. **The guard would have broken rollback.** `isExternalUnchanged` excludes `trigger === "update"` but **not** `"rollback"`, and compares the running image against `svc.image` rather than the image this deploy intends (a rollback's pinned refs arrive via `opts.builtImages`, first read *past* the carry `continue`). So a rollback of an image-only compose stack carries everything forward and replays neither its frozen env nor its pinned images. That is already wrong on `main`; with a non-advancing no-op guard on top, `ROLLBACK_ALREADY_ACTIVE` would never trip and the operator could click Rollback forever. Its sibling `newerThanRestoredRelease` guards this exact hazard from the other direction and says so in its docblock. **Fixed at the cause**, which is a prerequisite for the guard.
3. **`primaryContainerId` was never set when the exposed app was itself carried** — it was assigned inside the real-deploy branch — so any partial redeploy that recreated a sidecar while carrying the app fell back to the topo-first row and recorded the database again. It is now derived at return time.
4. **Half the read-path change is now a regression.** `main` changed `enableProject`/`disableProject` to act on `deploymentContainerIds(dep)` — every container — and pins it with `project-toggle.test.ts`. Narrowing them to one exposed container would undo that, and also drop `isEdgeServedStatic`, the `isAbsent`/`isAlreadyInState` classification, and `disableProject`'s `disabledAt` rollback-on-failure. **Dropped**; the read-path change is scoped to logs and container info.

## The fix

**Prevent it (write path).** `summary.deployed` counts only the services actually (re)created or (re)served — derived from a per-service `carried` flag rather than a counter kept alongside `successful`, so a future success branch cannot silently forget it — plus `summary.mutated` for state changed outside that loop. `composeDeployMadeNoChanges` is gated *positively* on `ready` + a non-empty service set, so no reordering can reclassify a failure. An all-carried pass settles through a new `onNoChanges`: it records the row and nothing else — no pointer advance, no container. Deliberately **not** `onFailure`/`onCancelled`, both of which `runtime.destroy()` every service container the deployment lists; here those are the live ones still serving.

**Resolve the primary container once.** New `pickPrimaryServiceId` (beside `pickCanonicalDomainRow`, so the answer agrees with the access URL): the canonical verified domain's service, else the first exposed one, else the first. It feeds the deployment's recorded container on both the success and reconcile legs — the reconciler promotes its row to active without rewriting `containerId`, so it was a second producer of corrupted records.

**Heal what is already broken (read path).** Project logs, deployment logs, container info and usage resolve through `livePrimaryContainerId`, which asks the host via the existing `live-state` matcher and heals the `service_deployment` row — the same thing the per-service path already does. That fixes rows written wrong before this change without a migration. Single-app deployments short-circuit to the recorded id and issue no extra queries.

**Two more sites had the same defect, on public paths.** `project-route.service.ts` guarded on `!containerId`, which the `"compose"` sentinel passes — so a compose project's *project-level* custom domain fell through to whichever service the row named. And the webhook-domain vhost took `svcDeps.find((s) => s.containerId)` over rows returned in insertion (dependency) order. Both could `proxy_pass` at Postgres, which is a worse symptom than the one #498 reports. `COMPOSE_SENTINEL` + `isRealContainerRef` are now one module instead of one constant and three open-coded literals; `deploymentContainerIds` no longer returns the sentinel as a container (it made a pause report success having stopped nothing).

## Your two questions, answered by `main`

**1. What terminal state should a no-op show?** A new **`no_changes`**, not `cancelled`.

`deployment.status` is free text with no check constraint *specifically* so values can be added without a migration — its own docblock says so and names `deployment-status.test.ts` as the ratchet enumerating the guards a new value must reach. `reconciling` is the working precedent. So the cost is five mechanical guard edits and one i18n key, all of which that test names for you.

`cancelled` was the wrong side of the trade: `deployment.cancelled` has **no producer today**, so a successful no-op would have become its only one — a warning-toned audit line reading "System cancelled the deploy of X", a notification asserting someone stopped it, and "Install failed" in both install wizards. It also makes the drift-banner follow-up below inexpressible.

Wired: neutral **"No changes"** chip (both `getStatusConfig` copies), `SETTLED_HEALTHY_STATUSES`, `DeploymentCard` label, both install wizards routed to *done* rather than *failed*, `deployment.no_changes` in the audit taxonomy (`tone: "info"`) and in the notification map under `deploy.succeeded` with an `EVENT_HEADLINES` override so the title is not "Deploy succeeded" over a body saying nothing shipped. The SSE session still closes `ready` — `BuildSessionState` has no third terminal state — so the build page and CLI exit code are unchanged; the reason is persisted where the refresh path reads it. One key × 9 locales, all translated. **No migration.**

**2. Should disable stop the whole stack?** **Yes, and `main` already does it.** `enableProject`/`disableProject` fan out over `deploymentContainerIds(dep)`, with the reason in the comment and `project-toggle.test.ts` pinning it. Nothing to decide, and nothing here touches those paths.

## Notes

- One behaviour to know: a compose project containing a **static** service can never reach `deployed === 0` (a static row carries no container, so it is never carried), so the guard will not fire for those. Safe false-negative, documented in the code.
- The carried-row `ip`/`hostPort` correction (#506) is now mirrored onto the **active** deployment's row. That is the row the next deploy reads, and a non-advancing settle would otherwise strand the fix and let the stale binding come back.
- **Tests:** `compose-noop-settle.test.ts` drives the real `executeComposePipeline` — all-carried settles `no_changes`, does not advance, records no container, and **destroys nothing** (that last assertion is the guard against a future collapse into `onCancelled`); a deployed pass advances and records the app, not the db; a `mutated` pass is not a no-op. `project-logs-container.test.ts` is colocated in `src/` so `tsc` actually covers it (`tsconfig` includes only `src/**`, which is how the previous version's `as never` fixtures went unchecked) and runs the real live matcher. **Every one of them fails on unfixed code — verified by reverting each hunk.** The status ratchet now loops over the settled statuses instead of hardcoding one, so the next value gets seven failing tests naming exactly what to teach.
- **Green:** `tsc --noEmit` clean in `apps/api` and `apps/dashboard`; api 322 files / 3816 passed, dashboard 714, core 575, adapters 2832, db 89, cli 416.

## Deliberately left as follow-ups

1. **Pre-flight no-op detection at the trigger layer** — `webhook-push.ts` already returns `{skipped: true}` without creating a row, so ideally a no-op never mints a deployment at all. Also fixes the success-rate metric being diluted by no-op rows.
2. **The drift banner** reads the *active* row's `commitSha`, so a no-op carrying a new commit leaves "project outdated" on. Reachable only for a git-source project whose services are all image-only externals; the Update button is immune. A real status value is what makes the fix expressible.
3. **Webhook commit dedup is anchored on the active pointer** — extend it to any settled non-failed row for the commit.
4. **A port→container reconciler** for the parent id (`edgeProxy().byPort` exists with no consumer) — catches the *next* divergence (a hand-run `docker compose up`, an adoption) rather than only healing on read.
5. **`ORDER BY` on `listByDeployment`**, and moving the three remaining ad-hoc exposed-first orderings onto `pickPrimaryServiceId`.
6. **A one-shot backfill** of `deployment.container_id` for already-corrupted rows. Feasible as a pure `UPDATE`; deferred because the read-heal covers the surfaces that matter and the multi-exposed tie-break belongs with (5).

Fixes #498
