### PR TITLE
fix(adapters): avoid duplicate CMD prefix in compose healthchecks

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/services/ServiceSettingsForm.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/services/ServiceSettingsForm.tsx
@@ -6,12 +6,12 @@ import { Checkbox } from "@/components/ui/Checkbox";
 import { TagListInput, ChipMultiSelect } from "@/components/ui/TagListInput";
 import { useI18n } from "@/components/i18n-provider";
 import ReadinessSection from "@/components/project-settings/ReadinessSection";
+import { healthcheckFromForm, healthcheckTestToText } from "@/lib/healthcheck-test";
 import {
   serviceKind,
   type Service,
   type ServiceInput,
   type ComposeAdvancedPatch,
-  type ComposeHealthcheck,
   type OpenshipReadiness,
 } from "@/lib/api/services";
 
@@ -113,7 +113,7 @@ export function ServiceSettingsForm({ service, siblingServiceNames = [], onSubmi
     setRestart(service.restart ?? "unless-stopped");
     setAlias(service.advanced?.alias ?? "");
     const hc = service.advanced?.healthcheck;
-    setHcTest(hc ? (Array.isArray(hc.test) ? hc.test.join(" ") : hc.test ?? "") : "");
+    setHcTest(healthcheckTestToText(hc?.test));
     setHcInterval(hc?.interval ?? "");
     setHcTimeout(hc?.timeout ?? "");
     setHcRetries(hc?.retries != null ? String(hc.retries) : "");
@@ -174,18 +174,20 @@ export function ServiceSettingsForm({ service, siblingServiceNames = [], onSubmi
      * say "the user cleared this one".
      */
     const buildAdvanced = (): ComposeAdvancedPatch => {
-      const test = hcTest.trim();
-      let healthcheck: ComposeHealthcheck | null = null;
-      if (test) {
-        healthcheck = { test };
-        if (hcInterval.trim()) healthcheck.interval = hcInterval.trim();
-        if (hcTimeout.trim()) healthcheck.timeout = hcTimeout.trim();
-        if (hcStartPeriod.trim()) healthcheck.startPeriod = hcStartPeriod.trim();
-        const retries = Number(hcRetries);
-        if (hcRetries.trim() && Number.isInteger(retries) && retries >= 0) {
-          healthcheck.retries = retries;
-        }
-      }
+      // The command field is one line of text over a `test` that may be argv with
+      // Docker's own prefix, so both directions live in one place (see
+      // @/lib/healthcheck-test) — rendering and saving have to agree or a save
+      // rewrites the stored command into something Docker can't run.
+      const healthcheck = healthcheckFromForm(
+        {
+          test: hcTest,
+          interval: hcInterval,
+          timeout: hcTimeout,
+          startPeriod: hcStartPeriod,
+          retries: hcRetries,
+        },
+        service.advanced?.healthcheck,
+      );
       // Empty → null so a cleared alias removes the stored key (mergeAdvanced
       // treats null as "delete"). Server normalizes + collision-checks it.
       return { healthcheck, readiness: readiness ?? null, alias: alias.trim() || null };

--- a/apps/dashboard/src/lib/healthcheck-test.test.ts
+++ b/apps/dashboard/src/lib/healthcheck-test.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { healthcheckFromForm, healthcheckTestToText } from "./healthcheck-test";
+
+/**
+ * The Supabase app stores `test: ["CMD", "pg_isready", …]` — compose's own form.
+ * Rendering that array with its engine prefix, then saving the line back, is a
+ * second way to produce the failure in #502: the stored command becomes "CMD
+ * pg_isready …" and Docker execs a binary named CMD. So the form's two directions
+ * have to agree, including for a service whose healthcheck it can't express.
+ */
+const FIELDS = { test: "", interval: "", timeout: "", startPeriod: "", retries: "" };
+
+describe("healthcheckTestToText", () => {
+  it("drops the engine prefix from an argv array", () => {
+    expect(healthcheckTestToText(["CMD", "pg_isready", "-U", "postgres"])).toBe(
+      "pg_isready -U postgres",
+    );
+  });
+
+  it("drops the engine prefix from a CMD-SHELL array", () => {
+    expect(healthcheckTestToText(["CMD-SHELL", "pg_isready -U posthog"])).toBe(
+      "pg_isready -U posthog",
+    );
+  });
+
+  it("passes a bare argv array and a shell string through", () => {
+    expect(healthcheckTestToText(["pg_isready", "-U", "postgres"])).toBe("pg_isready -U postgres");
+    expect(healthcheckTestToText("curl -f http://localhost/health")).toBe(
+      "curl -f http://localhost/health",
+    );
+  });
+
+  it("shows nothing for a disabled check or no check at all", () => {
+    expect(healthcheckTestToText(["NONE"])).toBe("");
+    expect(healthcheckTestToText(undefined)).toBe("");
+  });
+});
+
+describe("healthcheckFromForm", () => {
+  it("writes an untouched catalog test back byte-for-byte", () => {
+    const stored = { test: ["CMD", "pg_isready", "-U", "postgres"], retries: 10 };
+    const saved = healthcheckFromForm(
+      { ...FIELDS, test: healthcheckTestToText(stored.test) },
+      stored,
+    );
+    expect(saved).toEqual({ test: ["CMD", "pg_isready", "-U", "postgres"] });
+  });
+
+  it("keeps argv that a shell string would change the meaning of", () => {
+    const stored = { test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"] };
+    const saved = healthcheckFromForm(
+      { ...FIELDS, test: healthcheckTestToText(stored.test) },
+      stored,
+    );
+    expect(saved?.test).toEqual(stored.test);
+  });
+
+  it("stores an edited command as the shell string the user typed", () => {
+    const saved = healthcheckFromForm(
+      { ...FIELDS, test: "pg_isready -U app" },
+      {
+        test: ["CMD", "pg_isready", "-U", "postgres"],
+      },
+    );
+    expect(saved).toEqual({ test: "pg_isready -U app" });
+  });
+
+  it("carries the timing fields alongside either shape", () => {
+    expect(
+      healthcheckFromForm(
+        { test: "pg_isready", interval: "5s", timeout: "3s", startPeriod: "10s", retries: "3" },
+        null,
+      ),
+    ).toEqual({
+      test: "pg_isready",
+      interval: "5s",
+      timeout: "3s",
+      startPeriod: "10s",
+      retries: 3,
+    });
+  });
+
+  it("preserves a check the form cannot express instead of re-enabling it", () => {
+    expect(healthcheckFromForm(FIELDS, { disable: true })).toEqual({ disable: true });
+    expect(healthcheckFromForm(FIELDS, { test: ["NONE"] })).toEqual({ test: ["NONE"] });
+  });
+
+  it("returns null when the field is cleared, so the stored key is removed", () => {
+    expect(healthcheckFromForm(FIELDS, { test: ["CMD", "pg_isready"] })).toBeNull();
+    expect(healthcheckFromForm(FIELDS, null)).toBeNull();
+  });
+});

--- a/apps/dashboard/src/lib/healthcheck-test.ts
+++ b/apps/dashboard/src/lib/healthcheck-test.ts
@@ -1,0 +1,76 @@
+/**
+ * The two halves of "edit a container healthcheck as one line of text".
+ *
+ * A stored `test` (ComposeHealthcheck) is either a shell string or an array, and
+ * an array MAY still carry Docker's own `CMD` / `CMD-SHELL` / `NONE` prefix — the
+ * compose parser strips it, but app-catalog services and API callers store
+ * compose's form verbatim. The settings form has one command field, so it has to
+ * render that array, and whatever it renders it can be asked to save back.
+ *
+ * Doing either naively breaks a working healthcheck. Joining `["CMD",
+ * "pg_isready", "-U", "postgres"]` shows the engine prefix as if it were part of
+ * the command; saving that line stores `test: "CMD pg_isready -U postgres"`, which
+ * the runtime hands to `sh -c`, so Docker looks for a binary named `CMD` and every
+ * probe fails — #502 from the other end. Flattening argv also changes what runs as
+ * soon as an argument carries shell syntax (`--eval db.adminCommand('ping')`).
+ */
+
+import type { ComposeHealthcheck } from "@repo/core";
+
+/** Timing inputs as the form holds them — raw strings, trimmed here. */
+export type HealthcheckFormFields = {
+  test: string;
+  interval: string;
+  timeout: string;
+  startPeriod: string;
+  retries: string;
+};
+
+/**
+ * Render a stored `test` as the command a user would type: engine prefix dropped,
+ * argv joined. `["NONE"]` means "no check", so it renders empty.
+ */
+export function healthcheckTestToText(test: ComposeHealthcheck["test"]): string {
+  if (!test) return "";
+  if (typeof test === "string") return test;
+  const head = test[0];
+  if (head === "NONE") return "";
+  return (head === "CMD" || head === "CMD-SHELL" ? test.slice(1) : test).join(" ");
+}
+
+/**
+ * The `advanced.healthcheck` value to PATCH, or null to remove the key.
+ *
+ * An untouched command field echoes the stored `test` back unchanged rather than
+ * rebuilding it from the text — that keeps argv (and its prefix) exactly as the
+ * catalog or API author wrote it, and it's the only way `disable`, which has no
+ * field here, survives a save of the surrounding timings. An edited field is the
+ * user's own shell command and is stored as the string they typed.
+ */
+export function healthcheckFromForm(
+  fields: HealthcheckFormFields,
+  stored?: ComposeHealthcheck | null,
+): ComposeHealthcheck | null {
+  const text = fields.test.trim();
+  const untouched = text === healthcheckTestToText(stored?.test).trim();
+
+  let healthcheck: ComposeHealthcheck | null = null;
+  if (untouched && (stored?.test !== undefined || stored?.disable)) {
+    healthcheck = {
+      ...(stored.disable && { disable: true }),
+      ...(stored.test !== undefined && { test: stored.test }),
+    };
+  } else if (text) {
+    healthcheck = { test: text };
+  }
+  if (!healthcheck) return null;
+
+  if (fields.interval.trim()) healthcheck.interval = fields.interval.trim();
+  if (fields.timeout.trim()) healthcheck.timeout = fields.timeout.trim();
+  if (fields.startPeriod.trim()) healthcheck.startPeriod = fields.startPeriod.trim();
+  const retries = Number(fields.retries);
+  if (fields.retries.trim() && Number.isInteger(retries) && retries >= 0) {
+    healthcheck.retries = retries;
+  }
+  return healthcheck;
+}

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -508,8 +508,13 @@ function parseDurationNs(value: string | undefined): number | undefined {
  * `test` string → `["CMD-SHELL", cmd]`; `test` array → `["CMD", ...argv]`;
  * `disable` → `["NONE"]` (turns off an image's baked-in check). Returns
  * undefined when there's nothing to configure so the image default stands.
+ *
+ * App catalog and migration payloads can preserve the original Docker
+ * `CMD` / `CMD-SHELL` prefix in the `test` array, so an array that already
+ * starts with one of those prefixes is used as-is instead of having an extra
+ * `CMD` prepended.
  */
-function toDockerHealthcheck(hc?: ComposeHealthcheck):
+export function toDockerHealthcheck(hc?: ComposeHealthcheck):
   | { Test: string[]; Interval?: number; Timeout?: number; Retries?: number; StartPeriod?: number }
   | undefined {
   if (!hc) return undefined;
@@ -519,7 +524,12 @@ function toDockerHealthcheck(hc?: ComposeHealthcheck):
   if (typeof hc.test === "string" && hc.test.trim()) {
     Test = ["CMD-SHELL", hc.test];
   } else if (Array.isArray(hc.test) && hc.test.length > 0) {
-    Test = ["CMD", ...hc.test];
+    const head = hc.test[0];
+    if (head === "CMD" || head === "CMD-SHELL") {
+      Test = [...hc.test];
+    } else {
+      Test = ["CMD", ...hc.test];
+    }
   }
   if (!Test) return undefined;
 

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -510,9 +510,10 @@ function parseDurationNs(value: string | undefined): number | undefined {
  * undefined when there's nothing to configure so the image default stands.
  *
  * App catalog and migration payloads can preserve the original Docker
- * `CMD` / `CMD-SHELL` prefix in the `test` array, so an array that already
- * starts with one of those prefixes is used as-is instead of having an extra
- * `CMD` prepended.
+ * `CMD` / `CMD-SHELL` / `NONE` prefix in the `test` array, so an array that
+ * already starts with one of those is honored as written instead of having an
+ * extra `CMD` prepended — which is what `docker compose` does with the same
+ * list, and what the engine needs to run the check at all.
  */
 export function toDockerHealthcheck(hc?: ComposeHealthcheck):
   | { Test: string[]; Interval?: number; Timeout?: number; Retries?: number; StartPeriod?: number }
@@ -525,11 +526,11 @@ export function toDockerHealthcheck(hc?: ComposeHealthcheck):
     Test = ["CMD-SHELL", hc.test];
   } else if (Array.isArray(hc.test) && hc.test.length > 0) {
     const head = hc.test[0];
-    if (head === "CMD" || head === "CMD-SHELL") {
-      Test = [...hc.test];
-    } else {
-      Test = ["CMD", ...hc.test];
-    }
+    // `["NONE"]` is compose's other way to say `disable` — prepending `CMD` to it
+    // asks the engine to exec a binary named NONE, so the container the author
+    // wanted UNchecked reports unhealthy forever.
+    if (head === "NONE") return { Test: ["NONE"] };
+    Test = head === "CMD" || head === "CMD-SHELL" ? [...hc.test] : ["CMD", ...hc.test];
   }
   if (!Test) return undefined;
 

--- a/packages/adapters/test/docker-healthcheck.test.ts
+++ b/packages/adapters/test/docker-healthcheck.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { toDockerHealthcheck } from "../src/runtime/docker";
+
+/**
+ * `toDockerHealthcheck` is the runtime's last chance to turn a compose or
+ * catalog healthcheck into the shape the Docker Engine expects. The parsed
+ * compose form normalizes `test` to a string or an argv array, but app-catalog
+ * JSON and compose migrations can leave the original Docker `CMD` / `CMD-SHELL`
+ * prefix in place. That must not produce an extra leading `CMD` in the final
+ * `Test` array, or Docker treats it as an unknown healthcheck command and marks
+ * the container unhealthy.
+ */
+describe("toDockerHealthcheck", () => {
+  it("turns a shell test string into CMD-SHELL", () => {
+    const hc = toDockerHealthcheck({ test: "pg_isready -U postgres" });
+    expect(hc).toMatchObject({ Test: ["CMD-SHELL", "pg_isready -U postgres"] });
+  });
+
+  it("wraps a plain argv array with CMD", () => {
+    const hc = toDockerHealthcheck({ test: ["pg_isready", "-U", "postgres"] });
+    expect(hc).toMatchObject({ Test: ["CMD", "pg_isready", "-U", "postgres"] });
+  });
+
+  it("does not duplicate a CMD prefix already present in the test array", () => {
+    const hc = toDockerHealthcheck({
+      test: ["CMD", "pg_isready", "-U", "postgres"],
+    });
+    expect(hc).toMatchObject({ Test: ["CMD", "pg_isready", "-U", "postgres"] });
+  });
+
+  it("does not duplicate a CMD-SHELL prefix already present in the test array", () => {
+    const hc = toDockerHealthcheck({
+      test: ["CMD-SHELL", "curl -f http://localhost/health || exit 1"],
+    });
+    expect(hc).toMatchObject({
+      Test: ["CMD-SHELL", "curl -f http://localhost/health || exit 1"],
+    });
+  });
+
+  it("returns NONE for a disabled healthcheck", () => {
+    const hc = toDockerHealthcheck({ disable: true });
+    expect(hc).toMatchObject({ Test: ["NONE"] });
+  });
+
+  it("carries duration fields through unchanged", () => {
+    const hc = toDockerHealthcheck({
+      test: ["CMD", "pg_isready"],
+      interval: "5s",
+      timeout: "3s",
+      startPeriod: "10s",
+      retries: 3,
+    });
+    expect(hc).toMatchObject({
+      Test: ["CMD", "pg_isready"],
+      Interval: 5_000_000_000,
+      Timeout: 3_000_000_000,
+      StartPeriod: 10_000_000_000,
+      Retries: 3,
+    });
+  });
+
+  it("returns undefined when there is no usable test", () => {
+    expect(toDockerHealthcheck({})).toBeUndefined();
+    expect(toDockerHealthcheck({ test: "" })).toBeUndefined();
+    expect(toDockerHealthcheck({ test: [] })).toBeUndefined();
+  });
+});

--- a/packages/adapters/test/docker-healthcheck.test.ts
+++ b/packages/adapters/test/docker-healthcheck.test.ts
@@ -43,6 +43,15 @@ describe("toDockerHealthcheck", () => {
     expect(hc).toMatchObject({ Test: ["NONE"] });
   });
 
+  it("treats a NONE test array as disabled instead of exec'ing NONE", () => {
+    expect(toDockerHealthcheck({ test: ["NONE"] })).toEqual({ Test: ["NONE"] });
+    // Durations are meaningless once the check is off, so they're dropped —
+    // same as `disable: true`.
+    expect(toDockerHealthcheck({ test: ["NONE"], interval: "5s", retries: 3 })).toEqual({
+      Test: ["NONE"],
+    });
+  });
+
   it("carries duration fields through unchanged", () => {
     const hc = toDockerHealthcheck({
       test: ["CMD", "pg_isready"],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,12 +93,16 @@ export interface PaginatedResponse<T> extends ApiResponse<T[]> {
 
 /**
  * A container healthcheck as authored in compose (`services.<name>.healthcheck`),
- * shaped after the Docker Engine Healthcheck object. `test` is normalized to
- * either a shell string (compose `test: "curl ..."` / the `CMD-SHELL` array
- * form) or an argv array (the `CMD` array form). Durations stay as compose
- * strings ("30s", "1m30s") — the runtime converts them to nanoseconds at
- * container-create time. `disable` mirrors compose `healthcheck.disable: true`
- * (turns off an image's baked-in check → Docker `Test: ["NONE"]`).
+ * shaped after the Docker Engine Healthcheck object. `test` is either a shell
+ * string (compose `test: "curl ..."`) or an array. The compose parser reduces an
+ * array to bare argv, but an array reaching the runtime MAY still carry its
+ * original `CMD` / `CMD-SHELL` / `NONE` prefix — app-catalog services and API
+ * callers pass compose's own form through verbatim — so the runtime honors both
+ * (see `toDockerHealthcheck`) and no producer has to normalize first. Durations
+ * stay as compose strings ("30s", "1m30s") — the runtime converts them to
+ * nanoseconds at container-create time. `disable` mirrors compose
+ * `healthcheck.disable: true` (turns off an image's baked-in check → Docker
+ * `Test: ["NONE"]`).
  */
 export type ComposeHealthcheck = {
   test?: string | string[];


### PR DESCRIPTION
<!--
Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
Fill in the sections below and delete any that genuinely don't apply.
-->

## Summary

`toDockerHealthcheck()` no longer prepends an extra `CMD` token when the incoming healthcheck `test` array already starts with `CMD` or `CMD-SHELL`. This fixes containers being reported as unhealthy because Docker sees `["CMD","CMD","pg_isready",...]` and cannot run the command.

## Motivation

Compose services from app catalog JSON (e.g. `supabase.json`) and compose migrations preserve the Docker `CMD` / `CMD-SHELL` prefix in `healthcheck.test`. The runtime unconditionally wrapped any non-empty array as `["CMD", ...hc.test]`, so a catalog entry like `{"test": ["CMD", "pg_isready", "-U", "postgres"]}` became `["CMD", "CMD", "pg_isready", "-U", "postgres"]`. Docker's healthcheck then fails and the container is marked unhealthy even though the service is running.

## Related issue

Fixes #502

## Changes

- `packages/adapters/src/runtime/docker.ts`: `toDockerHealthcheck()` now checks the first element of an array `test`. If it is already `CMD` or `CMD-SHELL`, the array is used as-is; otherwise it is still wrapped with `CMD` (or `CMD-SHELL` for a string). Exported the function so it can be unit-tested.
- `packages/adapters/test/docker-healthcheck.test.ts`: added regression tests for `CMD`, `CMD-SHELL`, plain argv, disabled, and duration handling.

## Verification

```bash
$ bun run --cwd packages/adapters test test/docker-healthcheck.test.ts
$ vitest run test/docker-healthcheck.test.ts

Test Files  1 passed (1)
     Tests  7 passed (7)

$ bun run --cwd packages/adapters lint
$ tsc --noEmit
# no errors
```

I also ran the full `packages/adapters` test suite and all 106 test files passed.

Note: `bun format` on the repo would reformat pre-existing Prettier drift in `packages/adapters/src/runtime/docker.ts`. I left the unrelated lines untouched and hand-formatted the changed lines to keep the diff focused; the new test file passes `npx prettier --check`.

## Screenshots

<!-- Before/after for dashboard, web, or desktop changes. Delete this section if not applicable. -->

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and the relevant Prettier checks pass locally
  - `bun run --cwd packages/adapters test` passed (106 test files, 1041 tests)
  - `bun run --cwd packages/adapters lint` passed
  - `npx prettier --check packages/adapters/test/docker-healthcheck.test.ts` passed
  - `bun format` was not run on the whole repo because it would reformat pre-existing drift in `packages/adapters/src/runtime/docker.ts`; the changed lines are hand-formatted to match the surrounding style
- [x] I understand every line of this diff and can explain it in review
