### PR TITLE
fix(dashboard): show ConnectionCard for non-catalog internal projects

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/OverviewTab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/OverviewTab.tsx
@@ -174,12 +174,13 @@ export const OverviewTab = () => {
 
   return (
     <div className="space-y-5">
-      {/* Only a catalog app's curated connection (URLs + generated keys) belongs on
-          the overview. A plain project's synthesized internal address is edited in
-          Settings → Advanced (single-app alias) and shown per service in the service
-          detail panel — surfacing it here too just clutters a plain project. Card
-          self-hides when the app declares no connection outputs. */}
-      {projectData.isApp && (
+      {/* Connection details — a catalog app's curated URLs+keys, OR (for a plain
+          app / raw compose / monorepo) its synthesized internal address so it can
+          be a "Use in a project" source. Card self-hides when it has no outputs.
+          Non-app mount is scoped to internally-reachable projects: static apps
+          have no listening port, and cloud sources can't be linked internally
+          yet (createConnection steers those to Public), so both are excluded. */}
+      {(projectData.isApp || (!isStaticRuntime && deployTarget !== "cloud")) && (
         <ConnectionCard
           projectId={projectData.id}
           appTemplateId={projectData.appTemplateId}


### PR DESCRIPTION
Plain self-hosted apps had resolved internal connection outputs but no Overview path to use them in another project. The card now consumes the existing connection endpoint for non-catalog self-hosted projects as well as catalog apps.

The backend determines which outputs exist; empty views stay hidden, and a static parent can still expose a reachable attached service. Synthesized Docker-network addresses remain excluded for cloud projects. No second address resolver or connection workflow is introduced.

Five React cases exercise discovery, opening the existing handover, catalog compatibility, empty outputs, attached services and the cloud boundary. The relevant cases fail on current main; dashboard TypeScript passes. The original contributor commit is retained and updated to the current workload model.

Fixes #504.
