### PR TITLE
fix(routing): fall back to container IP when loopback port is not published

### DIFF
--- a/apps/api/src/lib/upstream-url.test.ts
+++ b/apps/api/src/lib/upstream-url.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildUpstreamUrl, resolveRouteStrategy, resolveUpstreamUrl } from "./upstream-url";
+
+describe("buildUpstreamUrl", () => {
+  it("uses the loopback host port when one is provided", () => {
+    expect(
+      buildUpstreamUrl({
+        strategy: "loopback-port",
+        ip: "172.18.0.5",
+        hostPort: 4000,
+        containerPort: 3001,
+      }),
+    ).toBe("http://127.0.0.1:4000");
+  });
+
+  it("falls back to the container IP when no loopback host port is bound", () => {
+    expect(
+      buildUpstreamUrl({
+        strategy: "loopback-port",
+        ip: "172.18.0.5",
+        containerPort: 3001,
+      }),
+    ).toBe("http://172.18.0.5:3001");
+  });
+
+  it("returns null when neither loopback host port nor container IP is known", () => {
+    expect(
+      buildUpstreamUrl({
+        strategy: "loopback-port",
+        containerPort: 3001,
+      }),
+    ).toBeNull();
+  });
+
+  it("always uses the container IP for the explicit container-ip strategy", () => {
+    expect(
+      buildUpstreamUrl({
+        strategy: "container-ip",
+        ip: "172.18.0.5",
+        hostPort: 4000,
+        containerPort: 3001,
+      }),
+    ).toBe("http://172.18.0.5:3001");
+  });
+});
+
+describe("resolveRouteStrategy", () => {
+  it("resolves auto to loopback-port", () => {
+    expect(resolveRouteStrategy("auto")).toBe("loopback-port");
+  });
+
+  it("preserves the explicit container-ip strategy", () => {
+    expect(resolveRouteStrategy("container-ip")).toBe("container-ip");
+  });
+});
+
+describe("resolveUpstreamUrl", () => {
+  it("falls back to the container IP when the container has no loopback host port", async () => {
+    const runtime = {
+      supports: (cap: string) => cap === "containerIp",
+      getContainerIp: vi.fn().mockResolvedValue("172.18.0.5"),
+    };
+
+    const url = await resolveUpstreamUrl({
+      strategy: "loopback-port",
+      runtime,
+      containerId: "abc123",
+      containerPort: 3001,
+    });
+
+    expect(url).toBe("http://172.18.0.5:3001");
+    expect(runtime.getContainerIp).toHaveBeenCalledWith("abc123");
+  });
+
+  it("uses the provided loopback host port when one is bound", async () => {
+    const runtime = {
+      supports: () => false,
+      getContainerIp: vi.fn(),
+    };
+
+    const url = await resolveUpstreamUrl({
+      strategy: "loopback-port",
+      runtime,
+      containerId: "abc123",
+      containerPort: 3001,
+      hostPort: 4000,
+    });
+
+    expect(url).toBe("http://127.0.0.1:4000");
+    expect(runtime.getContainerIp).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the container IP cannot be resolved", async () => {
+    const runtime = {
+      supports: () => true,
+      getContainerIp: vi.fn().mockResolvedValue(null),
+    };
+
+    const url = await resolveUpstreamUrl({
+      strategy: "loopback-port",
+      runtime,
+      containerId: "missing",
+      containerPort: 3001,
+    });
+
+    expect(url).toBeNull();
+  });
+});

--- a/apps/api/src/modules/domains/routing-apply.service.test.ts
+++ b/apps/api/src/modules/domains/routing-apply.service.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectRepo = vi.hoisted(() => ({ findById: vi.fn() }));
+const deploymentRepo = vi.hoisted(() => ({ findById: vi.fn() }));
+const serviceRepo = vi.hoisted(() => ({ listByProject: vi.fn(), listByDeployment: vi.fn() }));
+
+const resolveDeploymentRuntime = vi.hoisted(() => vi.fn());
+const usesManagedRouting = vi.hoisted(() => vi.fn().mockReturnValue(false));
+const reconcileProjectRoutes = vi.hoisted(() => vi.fn());
+
+vi.mock("@repo/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/db")>();
+  return {
+    ...actual,
+    repos: {
+      ...actual.repos,
+      project: projectRepo,
+      deployment: deploymentRepo,
+      service: serviceRepo,
+    },
+  };
+});
+
+vi.mock("../../lib/deployment-runtime", () => ({
+  resolveDeploymentRuntime,
+  usesManagedRouting,
+}));
+
+vi.mock("../../lib/route-apply.service", () => ({
+  reconcileProjectRoutes,
+}));
+
+vi.mock("../../lib/controller-helpers", () => ({
+  platform: () => ({ target: "selfhosted" }),
+}));
+
+import { applyProjectRouting } from "./routing-apply.service";
+
+describe("applyProjectRouting - same-server migration fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    projectRepo.findById.mockResolvedValue({
+      id: "proj_1",
+      activeDeploymentId: "dep_1",
+      routeStrategy: "auto",
+      routingConfig: null,
+      compositeRoutes: [
+        {
+          hostname: "app.example.com",
+          isCustomDomain: true,
+          rootServiceId: "svc_1",
+          locations: [],
+        },
+      ],
+      slug: "app",
+      cloudWorkspaceId: null,
+      webhookDomain: null,
+    });
+
+    deploymentRepo.findById.mockResolvedValue({
+      id: "dep_1",
+      organizationId: "org_1",
+      meta: { deployTarget: "local", runtimeMode: "docker" },
+    });
+
+    serviceRepo.listByProject.mockResolvedValue([
+      {
+        id: "svc_1",
+        projectId: "proj_1",
+        name: "web",
+        enabled: true,
+        exposed: true,
+        exposedPort: "3001",
+        domain: null,
+        customDomain: "app.example.com",
+        domainType: "custom",
+        publicEndpoints: null,
+        ports: [],
+        kind: "compose",
+      },
+    ]);
+
+    serviceRepo.listByDeployment.mockResolvedValue([
+      {
+        id: "sd_1",
+        serviceId: "svc_1",
+        deploymentId: "dep_1",
+        containerId: "container_1",
+        ip: null,
+        hostPort: null,
+      },
+    ]);
+
+    resolveDeploymentRuntime.mockResolvedValue({
+      runtime: {
+        name: "docker",
+        supports: (cap: string) => cap === "containerIp",
+        getContainerInfo: vi.fn().mockResolvedValue({
+          containerId: "container_1",
+          ip: "172.18.0.5",
+          hostPort: undefined,
+        }),
+        getContainerIp: vi.fn().mockResolvedValue("172.18.0.5"),
+      },
+      routing: { registerRoute: vi.fn() },
+      effectiveTarget: "local",
+    });
+
+    usesManagedRouting.mockReturnValue(false);
+    reconcileProjectRoutes.mockResolvedValue(undefined);
+  });
+
+  it("falls back to the container IP when a migrated container has no loopback host port", async () => {
+    await applyProjectRouting("proj_1");
+
+    expect(reconcileProjectRoutes).toHaveBeenCalledTimes(1);
+    const [projectArg, optsArg] = reconcileProjectRoutes.mock.calls[0];
+    expect(projectArg.id).toBe("proj_1");
+    expect(optsArg.registers).toHaveLength(1);
+    expect(optsArg.registers[0]).toMatchObject({
+      hostname: "app.example.com",
+      targetUrl: "http://172.18.0.5:3001",
+    });
+  });
+
+  it("uses a live loopback host port when the container has one bound", async () => {
+    resolveDeploymentRuntime.mockResolvedValue({
+      runtime: {
+        name: "docker",
+        supports: (cap: string) => cap === "containerInfo",
+        getContainerInfo: vi.fn().mockResolvedValue({
+          containerId: "container_1",
+          ip: "172.18.0.5",
+          hostPort: 4000,
+        }),
+        getContainerIp: vi.fn().mockResolvedValue("172.18.0.5"),
+      },
+      routing: { registerRoute: vi.fn() },
+      effectiveTarget: "local",
+    });
+
+    await applyProjectRouting("proj_1");
+
+    expect(reconcileProjectRoutes).toHaveBeenCalledTimes(1);
+    const [, optsArg] = reconcileProjectRoutes.mock.calls[0];
+    expect(optsArg.registers).toHaveLength(1);
+    expect(optsArg.registers[0]).toMatchObject({
+      hostname: "app.example.com",
+      targetUrl: "http://127.0.0.1:4000",
+    });
+  });
+
+  it("falls back to the container IP even when live inspection fails", async () => {
+    resolveDeploymentRuntime.mockResolvedValue({
+      runtime: {
+        name: "docker",
+        supports: () => true,
+        getContainerInfo: vi.fn().mockRejectedValue(new Error("not found")),
+        getContainerIp: vi.fn().mockResolvedValue("172.18.0.5"),
+      },
+      routing: { registerRoute: vi.fn() },
+      effectiveTarget: "local",
+    });
+
+    await applyProjectRouting("proj_1");
+
+    expect(reconcileProjectRoutes).toHaveBeenCalledTimes(1);
+    const [, optsArg] = reconcileProjectRoutes.mock.calls[0];
+    expect(optsArg.registers).toHaveLength(1);
+    expect(optsArg.registers[0]).toMatchObject({
+      hostname: "app.example.com",
+      targetUrl: "http://172.18.0.5:3001",
+    });
+  });
+});

--- a/apps/api/src/modules/domains/routing-apply.service.ts
+++ b/apps/api/src/modules/domains/routing-apply.service.ts
@@ -32,7 +32,11 @@ import {
   buildDomainFanoutRegistrations,
   planCompositeRoute,
 } from "../deployments/compose/composite-route";
-import { buildUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
+import {
+  buildUpstreamUrl,
+  resolveRouteStrategy,
+  resolveUpstreamUrl,
+} from "../../lib/upstream-url";
 
 export async function applyProjectRouting(projectId: string): Promise<void> {
   const project = await repos.project.findById(projectId);
@@ -61,9 +65,42 @@ export async function applyProjectRouting(projectId: string): Promise<void> {
     const rowByService = new Map(liveRows.map((row) => [row.serviceId, row]));
     const routeStrategy = resolveRouteStrategy(project.routeStrategy);
 
-    // One live-upstream resolver, shared by the vercel composite AND the migration
-    // path-fan-out — each service's URL from its service_deployment row.
+    // Resolve live upstreams from the running container, then fall back to the
+    // persisted service_deployment row. This makes migrated/attached containers
+    // that were never published to 127.0.0.1 route via the container IP instead.
+    const upstreamsByServiceId = new Map<string, string | null>();
+    await Promise.all(
+      liveRows.map(async (row) => {
+        if (!row.containerId) return;
+        const def = defs.find((s) => s.id === row.serviceId);
+        const port = def ? resolveServicePort(def, project.port) : null;
+        if (!port) return;
+        try {
+          let liveHostPort: number | undefined;
+          if (routeStrategy === "loopback-port" && runtime.name !== "bare") {
+            liveHostPort =
+              (await runtime.getContainerInfo?.(row.containerId).catch(() => null))?.hostPort ?? undefined;
+          }
+          const url = await resolveUpstreamUrl({
+            strategy: routeStrategy,
+            runtime,
+            containerId: row.containerId,
+            containerPort: port,
+            hostPort: liveHostPort ?? row?.hostPort,
+          });
+          upstreamsByServiceId.set(row.serviceId, url);
+        } catch (err) {
+          console.warn(
+            `[routing-apply] live upstream for ${row.serviceId} failed: ${safeErrorMessage(err)}`,
+          );
+          upstreamsByServiceId.set(row.serviceId, null);
+        }
+      }),
+    );
+
     const resolveTargetUrl = (serviceId: string) => {
+      const cached = upstreamsByServiceId.get(serviceId);
+      if (cached !== undefined) return cached;
       const def = defs.find((s) => s.id === serviceId);
       const row = rowByService.get(serviceId);
       const port = def ? resolveServicePort(def, project.port) : null;

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -10,6 +10,7 @@ import {
   isMultiServiceRuntime,
   type LogEntry,
   type ContainerStatus,
+  type RuntimeAdapter,
 } from "@repo/adapters";
 import { scopedVolumeName, type CommandExecutor } from "@repo/adapters";
 import { encrypt, decrypt } from "../../lib/encryption";
@@ -43,7 +44,11 @@ import {
 import { resolveRuntimeResources } from "../../lib/resources";
 import { assertFreeEndpointsAllowed } from "../../lib/free-domain-guard";
 import { ensurePendingServiceDomain, removeServiceDomain, reuseServerCertForDomain } from "../domains/domain.service";
-import { buildUpstreamUrl, resolveRouteStrategy } from "../../lib/upstream-url";
+import {
+  buildUpstreamUrl,
+  resolveRouteStrategy,
+  resolveUpstreamUrl,
+} from "../../lib/upstream-url";
 import {
   reconcileProjectRoutes,
   type RouteRegister,
@@ -659,6 +664,7 @@ export async function updateService(
   const exposedChanged = touchesRouting && patch.exposed !== svc.exposed;
 
   if (updated && (enabledChanged || exposedChanged || touchesRouting || nameChanged)) {
+    let runtime: RuntimeAdapter | undefined;
     try {
       const runtimeName = platform().runtime.name;
       // `enabled` / `exposed` are non-nullable DB columns - no need to
@@ -677,22 +683,66 @@ export async function updateService(
         .filter((route) => !nextByHost.has(route.hostname.toLowerCase()))
         .map((route) => ({ hostname: route.hostname, isCustomDomain: route.domainType === "custom" }));
 
-      // Self-hosted upstream = loopback host port (published) or the active
-      // deployment's service-row IP; cloud ignores targetUrl. Resolve once.
+      // Self-hosted upstream = loopback host port (read live) or container IP.
+      // For migrated/attached containers that were never published to 127.0.0.1,
+      // live resolution falls back to the container IP so the edge can still reach
+      // the service under the default "loopback-port" strategy.
       let ip: string | undefined;
       let hostPort: number | undefined;
+      let containerId: string | undefined;
+      let dep: Awaited<ReturnType<typeof repos.deployment.findById>> | null = null;
       if (isRoutable && nextRoutes.length > 0 && !project.cloudWorkspaceId && project.activeDeploymentId) {
         const rows = await repos.service.listByDeployment(project.activeDeploymentId);
         const row = rows.find((r) => r.serviceId === serviceId);
         ip = row?.ip ?? undefined;
         hostPort = row?.hostPort ?? undefined;
+        containerId = row?.containerId ?? undefined;
+        dep = await repos.deployment.findById(project.activeDeploymentId);
+        // Only resolve a Docker runtime for live reads; bare workloads already
+        // run on the host and their stored 127.0.0.1:<port> row is authoritative.
+        if (containerId && dep && (dep.meta as { runtimeMode?: string } | null)?.runtimeMode !== "bare") {
+          try {
+            ({ runtime } = await resolveDeploymentRuntimeForRead(dep));
+          } catch (err) {
+            console.warn(
+              `[SERVICE] ${svc.name}: could not resolve runtime for upstream: ${(err as Error).message}`,
+            );
+          }
+        }
       }
       const strategy = resolveRouteStrategy(project.routeStrategy);
-      const registers: RouteRegister[] = nextRoutes.map((route) => ({
+      // Read the container's CURRENT loopback binding once, then fall back to the
+      // stored row when the live read fails. A migrated container with no
+      // 127.0.0.1:<hostPort> publish will return no hostPort and resolve to its
+      // bridge IP via resolveUpstreamUrl.
+      let liveHostPort: number | undefined;
+      if (runtime && containerId && strategy === "loopback-port" && runtime.name !== "bare") {
+        liveHostPort = (await runtime.getContainerInfo?.(containerId).catch(() => null))?.hostPort ?? undefined;
+      }
+      const resolveUrl = async (containerPort: number): Promise<string | undefined> => {
+        if (!runtime || !containerId) {
+          return buildUpstreamUrl({ strategy, ip, hostPort, containerPort }) ?? undefined;
+        }
+        try {
+          const url = await resolveUpstreamUrl({
+            strategy,
+            runtime,
+            containerId,
+            containerPort,
+            hostPort: liveHostPort ?? hostPort,
+          });
+          return url ?? buildUpstreamUrl({ strategy, ip, hostPort, containerPort }) ?? undefined;
+        } catch (err) {
+          console.warn(`[SERVICE] ${svc.name}: live upstream resolution failed: ${(err as Error).message}`);
+          return buildUpstreamUrl({ strategy, ip, hostPort, containerPort }) ?? undefined;
+        }
+      };
+      const targetUrls = await Promise.all(
+        nextRoutes.map((route) => (route.targetPort ? resolveUrl(route.targetPort) : undefined)),
+      );
+      const registers: RouteRegister[] = nextRoutes.map((route, i) => ({
         hostname: route.hostname,
-        targetUrl: route.targetPort
-          ? (buildUpstreamUrl({ strategy, ip, hostPort, containerPort: route.targetPort }) ?? undefined)
-          : undefined,
+        targetUrl: targetUrls[i],
         port: route.targetPort,
         isCustomDomain: route.domainType === "custom",
       }));
@@ -740,13 +790,6 @@ export async function updateService(
         }
       }
 
-      // Single reused path: cloud → page/workspace primitives, self-hosted →
-      // the deployment's own routing (local box or remote server/sandbox).
-      const dep =
-        !project.cloudWorkspaceId && project.activeDeploymentId
-          ? await repos.deployment.findById(project.activeDeploymentId)
-          : null;
-
       // The edge re-register (+ cert reuse) runs over SSH to the serving box.
       // When that box is REMOTE (desktop mode) the write+reload can be slow — and
       // the service row is ALREADY saved above, with routing being best-effort
@@ -770,6 +813,10 @@ export async function updateService(
       ]);
     } catch (err) {
       console.error(`[SERVICE] Failed to update route for ${svc.name}:`, err);
+    } finally {
+      if (runtime?.dispose) {
+        await runtime.dispose().catch(() => {});
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #506.

Same-server migrations that attach the running container in place (reuse) never publish a `127.0.0.1` host port, so the default **Auto → loopback-port** strategy left the app unreachable through its custom domain. The edge had no loopback binding to dial.

## Change

Make the live route-apply paths inspect the container first, then fall back to the container's bridge/host IP when no loopback host port is bound:

- `resolveUpstreamUrl` now falls through from a loopback host port to the container IP when `hostPort` is absent.
- `applyProjectRouting` resolves a live upstream per `service_deployment` row, using `getContainerInfo` for the current host port and `getContainerIp` as the fallback.
- `service.service` `updateService` does the same live resolution when publishing or editing a service route, so migrated domains register with the correct container-IP target instead of a missing loopback port.

## Test plan

- `apps/api/src/lib/upstream-url.test.ts` – unit tests for `buildUpstreamUrl` and `resolveUpstreamUrl`, including the loopback → container-IP fallback.
- `apps/api/src/modules/domains/routing-apply.service.test.ts` – tests that `applyProjectRouting` falls back to the container IP when the migrated container has no loopback host port, uses the live loopback port when present, and still falls back when live inspection fails.
- `bun run lint` (tsc --noEmit) passes.
- Targeted `bun vitest run src/modules/migration` passes.