### PR TITLE
fix(cli): convert --import loader path to file URL in smoke e2e test

### DIFF
--- a/apps/cli/test/e2e/smoke.test.ts
+++ b/apps/cli/test/e2e/smoke.test.ts
@@ -8,7 +8,7 @@
  * --help / --version / bad-args paths, which resolve before any action runs.
  */
 import { execFile } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -21,7 +21,7 @@ function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code:
   return new Promise((resolve) => {
     execFile(
       process.execPath,
-      ["--import", "tsx", "--import", inject, entry, ...args],
+      ["--import", "tsx", "--import", pathToFileURL(inject).href, entry, ...args],
       { cwd: cliRoot, env: { ...process.env } },
       (error, stdout, stderr) => {
         const code = error && typeof (error as { code?: number }).code === "number"


### PR DESCRIPTION
<!--
Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
Fill in the sections below and delete any that genuinely don't apply.
-->

## Summary

Convert the `inject` module path passed to Node's `--import` loader in `apps/cli/test/e2e/smoke.test.ts` from a raw filesystem path to a `file://` URL.

## Motivation

`apps/cli/test/e2e/smoke.test.ts` spawns the CLI with Node's ESM loader hooks:

```ts
execFile(
  process.execPath,
  ["--import", "tsx", "--import", inject, entry, ...args],
)
```

`inject` is built with `path.join(...)`, so on Windows it resolves to `D:\...`. Node's ESM loader treats the leading `D:` as a URL scheme and throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` before the CLI can start. The adjacent `completion.test.ts` already fixes the same pattern by wrapping `inject` with `pathToFileURL(...).href`, so this just mirrors that approach.

## Related issue

Fixes #384

## Changes

- `apps/cli/test/e2e/smoke.test.ts`:
  - Import `pathToFileURL` from `node:url`.
  - Pass `pathToFileURL(inject).href` instead of `inject` to `--import`.

## Verification

```bash
$ bun run --cwd apps/cli lint
$ bun run test
```

- `bun run --cwd apps/cli lint` passes (`tsc --noEmit`).
- `bun run test` under `apps/cli` passes: 27 test files, 225 tests (including `test/e2e/smoke.test.ts` and `test/e2e/completion.test.ts`).

Note: I did not run `bun format` on this file because the repo-wide Prettier pass would reformat pre-existing drift in the `const code = ...` block. The two lines I changed are Prettier-clean and the diff is otherwise unchanged.

## Screenshots

<!-- Before/after for dashboard, web, or desktop changes. Delete this section if not applicable. -->

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review

_Leaving the `bun format` checkbox unchecked because the file contains pre-existing Prettier drift that I did not change; the touched lines are Prettier-clean._
