### PR TITLE
fix(adapters): static deploy to a remote SSH server fails for a non-root deploy user

### DIFF
--- a/packages/adapters/src/runtime/bare.ts
+++ b/packages/adapters/src/runtime/bare.ts
@@ -30,6 +30,7 @@ import type {
 } from "../types";
 
 import { LocalExecutor, wrapLocalBuildCommand } from "../system/executor";
+import { ensureOwnedDir } from "../system/elevated-executor";
 import { execReliable } from "../system/remote-journal";
 import { STACKS, appVolumeTargets, buildOutputTransferExcludes, safeErrorMessage, missingOutputDirectoryMessage, packageManagerEnsureCommand, type StackId, type StackDefinition } from "@repo/core";
 import { checkToolchainForStack, installTools } from "../toolchain";
@@ -267,7 +268,7 @@ export class BareRuntime implements RuntimeAdapter {
     const releaseDir = this.releaseDir(deploymentId);
     if (artifactPath === releaseDir) return releaseDir;
 
-    await this.executor.mkdir(`${this.workDir}/releases`);
+    await ensureOwnedDir(this.executor, `${this.workDir}/releases`);
     await this.executor.rm(releaseDir);
 
     // Capistrano-style hard-link dedup: when we know the previous

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -100,6 +100,7 @@ function clampShellWindow(
 }
 import type { Feature, SystemLog } from "../system/types";
 import { isRuntimeNotFoundError } from "../system/errors";
+import { ensureOwnedDir } from "../system/elevated-executor";
 
 import type {
   RuntimeAdapter,
@@ -1744,7 +1745,7 @@ export class DockerRuntime implements RuntimeAdapter {
   ): Promise<void> {
     const cid = (await sshExecutor.exec(`docker create ${sq(tag)}`)).trim();
     try {
-      await sshExecutor.exec(`mkdir -p ${sq(hostOutDir)}`);
+      await ensureOwnedDir(sshExecutor, hostOutDir);
       // `/.` → contents, so no strip step (see the contract above).
       await sshExecutor.exec(`docker cp ${sq(`${cid}:${docRoot}/.`)} ${sq(hostOutDir)}`);
       // `docker cp` of an empty dir exits 0, so the contract is checked here.

--- a/packages/adapters/src/runtime/issue-514-remote-static-deploy.test.ts
+++ b/packages/adapters/src/runtime/issue-514-remote-static-deploy.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { BareRuntime, STATIC_RELEASE_BASE } from "./bare";
+import type { CommandExecutor } from "../types";
+
+/**
+ * Regression for issue #514 — a static site deployed to a REMOTE SSH server
+ * whose deploy user is not root.
+ *
+ * Two things went wrong on that box, and both are exercised here through
+ * `deployStatic`, the last step of the deploy:
+ *
+ *   1. `/opt/openship/static` is root-owned (Docker created it for the edge's
+ *      bind mount), so the promote's `mkdir releases` failed outright.
+ *   2. the promote is journaled, and the journal was hardcoded to
+ *      `/root/.openship` — unwritable for this user, so the `mv` was never even
+ *      issued and `releases/` stayed empty while `.builds/<id>` was cleaned up.
+ *
+ * Both surfaced as the same opaque "Deploy failed: Permission denied".
+ */
+
+const BUILD_DIR = `${STATIC_RELEASE_BASE}/.builds/build_1`;
+const RELEASE_DIR = `${STATIC_RELEASE_BASE}/releases/dep_1`;
+const HOME = "/home/deploy";
+
+/**
+ * A remote box exactly like the reporter's: login user `deploy` (uid 1000) with
+ * passwordless sudo, `/root` unreadable, and `/opt/openship/static` root-owned.
+ * Anything the user can't write fails until an elevated command chowns it.
+ */
+function remoteNonRootServer() {
+  const commands: string[] = [];
+  const owned = new Set<string>([HOME, `${STATIC_RELEASE_BASE}/.builds`]);
+  const denied = () => new Error("Permission denied");
+  const isOurs = (p: string) => [...owned].some((o) => p === o || p.startsWith(`${o}/`));
+
+  const executor = {
+    exec: vi.fn(async (command: string) => {
+      commands.push(command);
+      if (command.includes("$HOME")) return `${HOME}\n`;
+      if (command === "id -u") return "1000";
+      if (command === "id -un" || command === "id -gn") return "deploy\n";
+      if (command.startsWith("sudo -n true")) return "yes";
+      if (command.startsWith("sudo -n ")) {
+        // Root can create anything, and hands it to the login user.
+        const target = command.match(/mkdir -p '\\''([^']+)'\\''/)?.[1];
+        if (target) owned.add(target);
+        return "";
+      }
+      if (/^(mkdir -p|rm -rf|mv) /.test(command) || command.includes("&& [ -w ")) {
+        const target = command.match(/'([^']+)'/)?.[1] ?? "";
+        if (!isOurs(target)) throw denied();
+        if (command.startsWith("mkdir -p")) owned.add(target);
+        return "";
+      }
+      // The journal wrapper: only reachable under a directory we own.
+      if (command.includes("/.openship")) {
+        if (!isOurs(HOME)) throw denied();
+        if (command.includes("--version")) return "1";
+        if (command.includes("--gc")) return "";
+        return "OPSH1 0  ";
+      }
+      // isEmptyDir's doc-root probe — the extracted files are there.
+      if (command.startsWith("if [ -d ")) return "DIR\nindex.html\n";
+      return "";
+    }),
+    streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+    writeFile: vi.fn(async (path: string) => {
+      if (!isOurs(path)) throw denied();
+    }),
+    readFile: vi.fn(async () => ""),
+    exists: vi.fn(async (p: string) => p === BUILD_DIR || p === RELEASE_DIR),
+    // SshExecutor.mkdir is `exec("mkdir -p …")` — unelevated, so it is bound by
+    // the same ownership as everything else.
+    mkdir: vi.fn(async (p: string) => {
+      if (!isOurs(p)) throw denied();
+      owned.add(p);
+    }),
+    rm: vi.fn(async () => {}),
+    transferIn: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
+  } as unknown as CommandExecutor;
+
+  return { executor, commands };
+}
+
+function staticDeployConfig() {
+  return {
+    projectId: "proj_1",
+    deploymentId: "dep_1",
+    imageRef: BUILD_DIR,
+    outputDirectory: "",
+  } as unknown as Parameters<BareRuntime["deployStatic"]>[0];
+}
+
+describe("issue #514 — static deploy to a remote SSH server as a non-root user", () => {
+  it("promotes the build into releases/ instead of failing with 'Permission denied'", async () => {
+    const { executor, commands } = remoteNonRootServer();
+    const rt = new BareRuntime({ workDir: STATIC_RELEASE_BASE, executor });
+
+    await expect(rt.deployStatic(staticDeployConfig())).resolves.toMatchObject({
+      status: "running",
+      containerId: RELEASE_DIR,
+    });
+
+    // The release base was provisioned under sudo and handed to the deploy user…
+    expect(
+      commands.some(
+        (c) => c.startsWith("sudo -n ") && c.includes(`${STATIC_RELEASE_BASE}/releases`),
+      ),
+    ).toBe(true);
+    // …and the promote journaled into the USER's home, never /root.
+    expect(commands.some((c) => c.includes(`${HOME}/.openship`))).toBe(true);
+    expect(commands.some((c) => c.includes("/root/.openship"))).toBe(false);
+  });
+});

--- a/packages/adapters/src/system/elevated-executor.test.ts
+++ b/packages/adapters/src/system/elevated-executor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { execFileSync } from "node:child_process";
-import { elevatedExecutor, elevateCommand } from "./elevated-executor";
+import { elevatedExecutor, elevateCommand, ensureOwnedDir } from "./elevated-executor";
 import { sq } from "./local-shell";
 import type { CommandExecutor, LogEntry } from "../types";
 
@@ -132,5 +132,61 @@ describe("elevatedExecutor", () => {
     const el = elevatedExecutor(inner) as unknown as { rawExec: (c: string) => Promise<unknown> };
     await el.rawExec("docker ps");
     expect(rawExec).toHaveBeenCalledWith("docker ps");
+  });
+});
+
+/**
+ * The two shapes that broke a remote non-root deploy (issue #514): the directory
+ * is absent under a `/opt` the user can't create in, or present and root-owned
+ * because Docker created it for the edge's bind mount.
+ */
+describe("ensureOwnedDir", () => {
+  const PATH = "/opt/openship/static";
+
+  /** A target that denies unelevated writes unless the tree is already ours. */
+  function target(opts: { canSudo: boolean; alreadyWritable?: boolean }) {
+    const commands: string[] = [];
+    const executor = {
+      exec: vi.fn(async (command: string) => {
+        commands.push(command);
+        if (command === "id -u") return "1000";
+        if (command.startsWith("sudo -n true")) return opts.canSudo ? "yes" : "no";
+        if (command.startsWith("sudo -n ")) return "";
+        if (command.includes("mkdir -p") && !opts.alreadyWritable) {
+          throw new Error("mkdir: cannot create directory '/opt/openship': Permission denied");
+        }
+        return "";
+      }),
+    } as unknown as CommandExecutor;
+    return { executor, commands };
+  }
+
+  it("creates the directory and hands it to the login user when sudo is available", async () => {
+    const { executor, commands } = target({ canSudo: true });
+
+    await ensureOwnedDir(executor, PATH);
+
+    // Unwrap the one level of quoting elevateCommand added.
+    const inner = commands.find((c) => c.startsWith("sudo -n sh -c "))!.replace(/'\\''/g, "'");
+    expect(inner).toContain(`mkdir -p '${PATH}'`);
+    // $top, not the leaf: an `mv` needs write permission on the PARENT.
+    expect(inner).toContain(`while [ ! -d "$d" ]; do top="$d"; d=$(dirname "$d"); done`);
+    expect(inner).toContain(`chown -R "$SUDO_USER" "$top"`);
+  });
+
+  it("stays unelevated when the directory is already writable", async () => {
+    const { executor, commands } = target({ canSudo: true, alreadyWritable: true });
+
+    await ensureOwnedDir(executor, PATH);
+
+    expect(commands).toEqual([`mkdir -p '${PATH}' && [ -w '${PATH}' ]`]);
+  });
+
+  it("names the commands an operator must run when there is no sudo", async () => {
+    const { executor } = target({ canSudo: false });
+
+    await expect(ensureOwnedDir(executor, PATH)).rejects.toThrow(
+      /sudo mkdir -p \/opt\/openship\/static/,
+    );
   });
 });

--- a/packages/adapters/src/system/elevated-executor.ts
+++ b/packages/adapters/src/system/elevated-executor.ts
@@ -1,4 +1,5 @@
 import type { CommandExecutor, LogEntry } from "../types";
+import { resolveEnvironment } from "./environment";
 import { sq } from "./local-shell";
 
 // apt/dpkg non-interactive env, re-set INSIDE the sudo'd root shell. sudo
@@ -74,4 +75,56 @@ export function elevatedExecutor(inner: CommandExecutor): CommandExecutor {
       return typeof value === "function" ? (value as (...a: unknown[]) => unknown).bind(target) : value;
     },
   });
+}
+
+/**
+ * Ensure `path` exists and the login user can write into it.
+ *
+ * Openship's host directories sit under `/opt`, which no non-root user may
+ * create in, and the ones Docker materialises for a bind mount are created by
+ * the daemon and so are root-owned. A plain `mkdir -p` fails on both, which is
+ * why this elevates and then hands the result over rather than only creating it.
+ *
+ * The chown targets the TOPMOST directory that had to be created, not `path`:
+ * renaming an entry needs write permission on its parent, so a leaf-only chown
+ * would still leave a later `mv` failing. `$SUDO_USER` is set by sudo itself, so
+ * the owner needs no extra probe.
+ */
+export async function ensureOwnedDir(
+  executor: CommandExecutor,
+  path: string,
+): Promise<void> {
+  const quoted = sq(path);
+  try {
+    await executor.exec(`mkdir -p ${quoted} && [ -w ${quoted} ]`);
+    return;
+  } catch {
+    // Absent and uncreatable, or present and not ours — both need root.
+  }
+
+  const { isRoot, canSudo } = await resolveEnvironment(executor);
+  if (isRoot) {
+    await executor.exec(`mkdir -p ${quoted}`);
+    return;
+  }
+  if (!canSudo) {
+    throw new Error(
+      `Cannot create ${path} on the target server: the deploy user cannot write there and has no ` +
+        `passwordless sudo. Run these once on the server, then redeploy:\n` +
+        `  sudo mkdir -p ${path}\n` +
+        `  sudo chown -R "$(id -un)" ${path}`,
+    );
+  }
+  await executor.exec(
+    elevateCommand(
+      [
+        `d=${quoted}`,
+        `top=`,
+        `while [ ! -d "$d" ]; do top="$d"; d=$(dirname "$d"); done`,
+        `mkdir -p ${quoted}`,
+        `[ -z "$top" ] && top=${quoted}`,
+        `chown -R "$SUDO_USER" "$top"`,
+      ].join("; "),
+    ),
+  );
 }

--- a/packages/adapters/src/system/remote-journal.test.ts
+++ b/packages/adapters/src/system/remote-journal.test.ts
@@ -1,10 +1,17 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { LocalExecutor } from "./local-executor";
-import { ensureRemoteJournal, parseFrame, runJournaled } from "./remote-journal";
+import {
+  DEFAULT_JOURNAL_BASE,
+  ensureRemoteJournal,
+  parseFrame,
+  resolveJournalBase,
+  runJournaled,
+} from "./remote-journal";
+import type { CommandExecutor } from "../types";
 
 /**
  * Exercises the opsh-run wrapper end-to-end against the LOCAL machine via
@@ -88,5 +95,45 @@ describe("remote-journal", () => {
     expect(parseFrame("OPSH-DEAD").status).toBe("dead");
     expect(parseFrame("OPSH-COLLISION").status).toBe("collision");
     expect(parseFrame("OPSH-EIO disk full").status).toBe("eio");
+  });
+});
+
+/**
+ * The base is the SSH user's OWN home. Hardcoding /root/.openship meant every
+ * journaled op on a server whose deploy user isn't root died on the wrapper
+ * write with a bare "Permission denied" (issue #514).
+ */
+describe("resolveJournalBase", () => {
+  /** Records the probes and answers `$HOME` with `home`. */
+  function homeExecutor(home: string | null) {
+    const commands: string[] = [];
+    const executor = {
+      exec: vi.fn(async (command: string) => {
+        commands.push(command);
+        if (command.includes("$HOME")) {
+          if (home === null) throw new Error("Permission denied");
+          return `${home}\n`;
+        }
+        return "";
+      }),
+    } as unknown as CommandExecutor;
+    return { executor, commands };
+  }
+
+  it("uses the login user's home", async () => {
+    const { executor } = homeExecutor("/home/deploy");
+    await expect(resolveJournalBase(executor)).resolves.toBe("/home/deploy/.openship");
+  });
+
+  it("keeps /root/.openship for a root login — unchanged for every server that worked", async () => {
+    const { executor } = homeExecutor("/root");
+    await expect(resolveJournalBase(executor)).resolves.toBe(DEFAULT_JOURNAL_BASE);
+  });
+
+  it("falls back when $HOME is unusable, and probes only once per executor", async () => {
+    const { executor, commands } = homeExecutor(null);
+    await expect(resolveJournalBase(executor)).resolves.toBe(DEFAULT_JOURNAL_BASE);
+    await expect(resolveJournalBase(executor)).resolves.toBe(DEFAULT_JOURNAL_BASE);
+    expect(commands).toHaveLength(1);
   });
 });

--- a/packages/adapters/src/system/remote-journal.ts
+++ b/packages/adapters/src/system/remote-journal.ts
@@ -31,10 +31,37 @@ import { isRetryableRemoteConnectionError } from "./errors";
 /** Bump when the wrapper script changes — forces a redeploy on the next ensure. */
 export const OPSH_RUN_VERSION = 1;
 
-/** Default remote base dir owning bin/ + ops/. Mirrors apps/api's OPENSHIP_DIR
+/** Fallback remote base dir owning bin/ + ops/. Mirrors apps/api's OPENSHIP_DIR
  *  (openship-server-store.ts) so adapter-layer callers don't cross the layer
- *  boundary to journal. Keep the two in sync. */
+ *  boundary to journal. Keep the two in sync. Used only when the target's own
+ *  home directory can't be resolved — see {@link resolveJournalBase}. */
 export const DEFAULT_JOURNAL_BASE = "/root/.openship";
+
+const journalBaseCache = new WeakMap<CommandExecutor, Promise<string>>();
+
+/**
+ * The journal base for a target: `<the SSH user's home>/.openship` — for a root
+ * login that IS `/root/.openship`, so nothing moves on a server that worked.
+ *
+ * The journal holds per-op scratch state (`bin/opsh-run`, `ops/<opId>/`), not
+ * server-of-record state, so it belongs to whoever runs the ops rather than to a
+ * directory only root can write. Resolved once per executor: `$HOME` doesn't
+ * move mid-session.
+ */
+export async function resolveJournalBase(exec: CommandExecutor): Promise<string> {
+  let pending = journalBaseCache.get(exec);
+  if (!pending) {
+    pending = exec
+      .exec(`printf %s "$HOME"`)
+      .then((home) => {
+        const trimmed = home.trim();
+        return trimmed.startsWith("/") ? `${trimmed}/.openship` : DEFAULT_JOURNAL_BASE;
+      })
+      .catch(() => DEFAULT_JOURNAL_BASE);
+    journalBaseCache.set(exec, pending);
+  }
+  return pending;
+}
 
 /**
  * Same non-interactive env both executors prepend to plain `exec()`, applied to
@@ -277,7 +304,8 @@ export interface ReliableRunResult {
 }
 
 export interface RunReliableOptions {
-  /** Remote base dir owning bin/ + ops/. Defaults to DEFAULT_JOURNAL_BASE. */
+  /** Remote base dir owning bin/ + ops/. Defaults to the target's own
+   *  `<home>/.openship` (see resolveJournalBase). */
   baseDir?: string;
   /** Overall deadline across reconnects (default 15 min). */
   timeoutMs?: number;
@@ -325,7 +353,6 @@ export async function runReliable(
   command: string,
   opts: RunReliableOptions,
 ): Promise<ReliableRunResult> {
-  const baseDir = opts.baseDir ?? DEFAULT_JOURNAL_BASE;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_RELIABLE_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
   const minMs = opts.reconnectMinMs ?? DEFAULT_RECONNECT_MIN_MS;
@@ -350,6 +377,9 @@ export async function runReliable(
     }
 
     try {
+      // Per iteration: a reconnect can hand back a different executor, and the
+      // base belongs to whichever login that one holds.
+      const baseDir = opts.baseDir ?? (await resolveJournalBase(executor));
       if (!opts.ensured || !opts.ensured.has(executor)) {
         await ensureRemoteJournal(executor, baseDir);
         opts.ensured?.add(executor);


### PR DESCRIPTION
## Summary

Deploying to a remote SSH server whose deploy user is not root failed twice: the static build died at `Static extract failed: mkdir: Permission denied`, and once the directories were created by hand the deploy died at `Deploy failed: Permission denied` with `releases/` still empty. Openship now provisions the directories it needs on the target and journals its remote ops in the deploy user's own home instead of `/root`.

## Motivation

Two independent root causes, both of which assume the SSH login is root.

**1 — nothing creates the host directories.** `extractDocRootOverSsh` opens with `mkdir -p /opt/openship/static/.builds/<id>` (`runtime/docker.ts`), and `promoteBuildArtifact` with `mkdir /opt/openship/static/releases` (`runtime/bare.ts`). Both are the first write Openship ever makes there. No preflight creates `/opt/openship` — `ensure-container-edge.ts` does `mkdir -p` over `EDGE_CONTAINER_MOUNTS`, but unelevated and inside `.catch(() => {})`, and it runs during deploy, after the build has already failed.

Worth stating because it changes the fix: adding a plain `mkdir -p` to a preflight step is **not** enough. When the edge container starts, dockerd creates the missing bind sources itself, so `/opt/openship/static` comes back as `root:root` and an unelevated `mkdir` fails all the same. The ownership has to be fixed, not just the existence.

**2 — the remote journal lives in `/root`.** `promoteBuildArtifact` runs the release `mv` through `execReliable`, and `DEFAULT_JOURNAL_BASE` was hardcoded to `/root/.openship`. `ensureRemoteJournal` therefore SFTP-writes `bin/opsh-run` into a directory the deploy user cannot read, and ssh2 surfaces that as a bare `Permission denied`. That throws **before** the `mv` is issued, which is why the reporter's `releases/` stayed empty across every attempt while `.builds/<id>` was cleaned up by `cleanupBuildArtifact`. The `only one connection allowed` lines in the daemon log are BuildKit session noise from the build phase — the promote opens no Docker connection at all.

Both surfaced as the same opaque `Permission denied`, which is what made this hard to place.

## Related issue

Fixes #514

## Changes

- `packages/adapters/src/system/elevated-executor.ts` — add `ensureOwnedDir(executor, path)`. Fast path is `mkdir -p && [ -w ]`; on failure it resolves the environment and creates the directory under `sudo -n`, chowning to `$SUDO_USER`. The chown targets the **topmost** directory it had to create, not the leaf: renaming an entry needs write permission on its *parent*, so a leaf-only chown still leaves the promote's `mv` failing. Root just runs `mkdir -p`; a non-root user with no passwordless sudo gets an error naming the two commands to run once instead of `Permission denied`.
- `packages/adapters/src/runtime/docker.ts` — the SSH doc-root extract provisions `hostOutDir` instead of assuming it.
- `packages/adapters/src/runtime/bare.ts` — `promoteBuildArtifact` provisions `<workDir>/releases` instead of a plain `mkdir`.
- `packages/adapters/src/system/remote-journal.ts` — add `resolveJournalBase(exec)`: `<the target's $HOME>/.openship`, memoised per executor, `/root/.openship` as fallback. `runReliable` resolves it per iteration (a reconnect can hand back a different executor). A root login still resolves to `/root/.openship`, so nothing moves on a server that already worked; callers passing an explicit `baseDir` keep it.
- `elevated-executor.test.ts`, `remote-journal.test.ts` — unit coverage for both.
- `runtime/issue-514-remote-static-deploy.test.ts` — new; drives `deployStatic` against a simulated non-root target end to end.

## Verification

Reproduced end to end against a real remote server before writing anything: an sshd container with a non-root `deploy` user (uid 1000, password auth, passwordless sudo, in the docker group via the mounted socket), driven by the real `SshExecutor`, `DockerRuntime.extractDocRootOverSsh` and `BareRuntime.deployStatic`. No mocks in that harness.

**main, fresh server** — the reported stage 1:

```
FAIL  stage 1: static extract  — mkdir: cannot create directory '/opt/openship': Permission denied
FAIL  stage 2: promote into releases/  — mkdir: cannot create directory '/opt/openship': Permission denied
```

**main, after the reporter's manual workaround** (`sudo mkdir -p /opt/openship/static && sudo chown -R deploy`) — the reported stage 2:

```
PASS  stage 1: static extract  — index.html
FAIL  stage 2: promote into releases/  — Permission denied
FAIL  journal written to the deploy user's home  — none
```

**This branch**, fresh server, and again with `/opt/openship/static` pre-created `root:root` (the state dockerd leaves behind for the edge bind mount):

```
PASS  stage 1: static extract  — index.html
PASS  stage 2: promote into releases/  — <h1>openship 514</h1>
PASS  journal written to the deploy user's home  — /home/deploy/.openship/bin/opsh-run
```

Resulting ownership on the target:

```
drwxr-xr-x 3 deploy root   /opt/openship
drwxr-xr-x 4 deploy root   /opt/openship/static
drwxr-xr-x 3 deploy deploy /opt/openship/static/releases
drwxr-sr-x 4 deploy deploy /home/deploy/.openship
-rw-r--r-- 1 deploy deploy /opt/openship/static/releases/dep_e2e_1/index.html
```

A non-root user with no sudo now fails with the remedy instead of the symptom:

```
Cannot create /opt/openship/static/.builds/… on the target server: the deploy user
cannot write there and has no passwordless sudo. Run these once on the server, then redeploy:
  sudo mkdir -p /opt/openship/static/.builds/…
  sudo chown -R "$(id -un)" /opt/openship/static/.builds/…
```

The regression test fails with only the source files reverted:

```bash
$ npx vitest run src/runtime/issue-514-remote-static-deploy.test.ts   # fix reverted, test kept
 × promotes the build into releases/ instead of failing with 'Permission denied'
AssertionError: promise rejected "Error: Permission denied" instead of resolving

$ npx vitest run src/runtime/issue-514-remote-static-deploy.test.ts   # fix restored
      Tests  1 passed (1)
```

Suites, run twice each and green both times:

```bash
$ bun run test
 Tasks:    7 successful, 7 total          # packages/adapters 1041 passed, @repo/core 420 passed
$ cd packages/adapters && npx tsc --noEmit -p tsconfig.json    # clean
$ cd apps/api && npx tsc --noEmit                              # clean
```

Every commit on the branch was checked individually (1037 → 1040 → 1040 → 1040 → 1041 passing, none red).

Two pre-existing failures on `main` that this branch does not touch and does not fix: `@repo/dashboard#lint` (stale `.next` generated types against the installed Next version — fails identically on a clean `main`), and `prettier --check` on the five files I edited, all five of which are already unformatted on `main`. Running `bun format` would rewrite unrelated lines in them, so I left them alone; the one new file is prettier-clean.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — `bun run test` passes; `@repo/dashboard#lint` and `bun format` are pre-existing failures on `main`, see Verification
- [x] I understand every line of this diff and can explain it in review
