### PR TITLE
fix(deployments): protect carried-forward containers on compose deploy failure

### DIFF
--- a/apps/api/src/modules/deployments/deployment-lifecycle.ts
+++ b/apps/api/src/modules/deployments/deployment-lifecycle.ts
@@ -27,6 +27,11 @@ import { failureStatusFor } from "./blocking-errors";
 import { sanitizeStorableStrings, sliceWithoutSplittingPair } from "./build-log-sanitize";
 import { detectAndStoreFavicon } from "../../lib/favicon-detector";
 import { onWebmailDeployed } from "../mail/webmail/webmail-install.service";
+import {
+  collectDeploymentManifest,
+  executeCleanup,
+  type CleanupManifest,
+} from "../projects/project-cleanup.service";
 
 /**
  * The "your domains didn't route" line for a deploy that otherwise succeeded.
@@ -432,19 +437,17 @@ export async function onFailure(
     }
   }
 
-  if (runtime) {
-    const serviceDeps = await repos.service.listByDeployment(dep.id).catch(() => []);
-    for (const serviceDep of serviceDeps) {
-      if (!serviceDep.containerId) continue;
-      try {
-        await runtime.destroy(serviceDep.containerId);
-      } catch (destroyErr) {
-        console.error(
-          `[DEPLOY] Failed to destroy service container ${serviceDep.containerId} on failure:`,
-          destroyErr,
-        );
-      }
-    }
+  // protectRetained: a failed compose redeploy carries the LIVE release's
+  // containerId/imageRef onto its own service rows for every service it hadn't
+  // replaced yet — same seam as reject/delete/cancel. activeDeploymentId never
+  // advances on failure, so the keep set sees the live release without a hint.
+  const manifest = await collectDeploymentManifest(dep, project, {
+    protectRetained: true,
+  }).catch((): CleanupManifest => ({ projectId: dep.projectId, resources: [] }));
+  if (manifest.resources.length > 0) {
+    await executeCleanup(manifest).catch((err) => {
+      console.error(`[DEPLOY] Cleanup crashed for ${dep.id} on failure:`, err);
+    });
   }
 
   // INVARIANT: failure writes the DEPLOYMENT row only — NEVER the project row.

--- a/apps/api/test/modules/deployments/on-failure-keep-set.test.ts
+++ b/apps/api/test/modules/deployments/on-failure-keep-set.test.ts
@@ -1,0 +1,116 @@
+/**
+ * D3 follow-on: a failed compose redeploy destroyed carried-forward containers.
+ *
+ * `onFailure` tears down a failed release's runtime — but a compose service that
+ * didn't change carries its `containerId` and `imageRef` verbatim onto the failed
+ * release's row (the `carried` seam in compose/deploy.service.ts). The old path
+ * called `runtime.destroy` on every service row, so a deploy that carried `db`
+ * forward and then failed on `web` took down the live `db` container while
+ * `activeDeploymentId` still named the previous release.
+ *
+ * The fix mirrors reject/delete/cancel: consult `collectDeploymentManifest` with
+ * `protectRetained: true` so the live release's artifacts survive.
+ */
+
+import { repos } from "@repo/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/lib/deployment-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/lib/deployment-runtime")>();
+  const { DockerRuntime } = await import("@repo/adapters");
+  return {
+    ...actual,
+    resolveDeploymentRuntime: async () => ({
+      runtime: Object.create(DockerRuntime.prototype) as never,
+    }),
+  };
+});
+
+const { collectDeploymentManifest } = await import(
+  "../../../src/modules/projects/project-cleanup.service"
+);
+
+const {
+  seedDeployment,
+  seedOrg,
+  seedProject,
+  seedService,
+  seedServiceDeployment,
+  setActive,
+} = await import("../../helpers/seed");
+
+const CARRIED_CONTAINER = "carried-db-container";
+const CARRIED_IMAGE = "openship/app-db:bld_live";
+const OWN_CONTAINER = "failed-web-container";
+const OWN_IMAGE = "openship/app-web:bld_failed";
+
+describe("a failed deploy's cleanup manifest", () => {
+  let project: Awaited<ReturnType<typeof seedProject>>;
+  let live: Awaited<ReturnType<typeof seedDeployment>>;
+  let failed: Awaited<ReturnType<typeof seedDeployment>>;
+
+  beforeEach(async () => {
+    const org = await seedOrg();
+    project = await seedProject(org.organizationId, {
+      framework: "docker-compose",
+      rollbackWindow: 1,
+    });
+    const db = await seedService(project.id, { name: "db", image: "postgres:16" });
+    const web = await seedService(project.id, { name: "web", build: "." });
+
+    live = await seedDeployment(project, { containerId: "compose", status: "ready" });
+    await seedServiceDeployment(live.id, db, {
+      containerId: CARRIED_CONTAINER,
+      imageRef: CARRIED_IMAGE,
+    });
+    await seedServiceDeployment(live.id, web, {
+      containerId: "live-web-container",
+      imageRef: "openship/app-web:bld_live",
+    });
+
+    failed = await seedDeployment(project, { containerId: "compose", status: "deploying" });
+    await seedServiceDeployment(failed.id, db, {
+      containerId: CARRIED_CONTAINER,
+      imageRef: CARRIED_IMAGE,
+    });
+    await seedServiceDeployment(failed.id, web, {
+      containerId: OWN_CONTAINER,
+      imageRef: OWN_IMAGE,
+    });
+
+    // onFailure never advances the pointer — the live release stays active.
+    await setActive(project.id, live.id);
+    project = (await repos.project.findById(project.id))!;
+  });
+
+  it("excludes the carried container and the shared image", async () => {
+    const manifest = await collectDeploymentManifest(failed, project, {
+      protectRetained: true,
+    });
+    const refs = manifest.resources.map((r) => r.ref);
+
+    expect(refs).not.toContain(CARRIED_CONTAINER);
+    expect(refs).not.toContain(CARRIED_IMAGE);
+    expect(refs).toContain(OWN_CONTAINER);
+    expect(refs).toContain(OWN_IMAGE);
+  });
+
+  it("would have destroyed them without the flag", async () => {
+    const manifest = await collectDeploymentManifest(failed, project, {
+      protectRetained: false,
+    });
+    const refs = manifest.resources.map((r) => r.ref);
+    expect(refs).toContain(CARRIED_CONTAINER);
+    expect(refs).toContain(CARRIED_IMAGE);
+  });
+
+  it("never lists the compose sentinel as a container", async () => {
+    const manifest = await collectDeploymentManifest(failed, project, {
+      protectRetained: true,
+    });
+    expect(manifest.resources.filter((r) => r.type === "container").map((r) => r.ref)).not.toContain(
+      "compose",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #500 — `onFailure` no longer destroys containers carried verbatim from the still-live previous release when a multi-service compose deploy fails partway through.

## Problem

On a compose project, a redeploy that carries unchanged services forward and then fails on a later step runs `onFailure`, which iterated every service row on the failed deployment and called `runtime.destroy` on each `containerId`. Carried-forward rows name the **same** container as the active release, so a failed redeploy took the live app down while `activeDeploymentId` still pointed at the previous release.

## Triage / Root cause

`onFailure` in `deployment-lifecycle.ts` used a naive destroy loop over `repos.service.listByDeployment(dep.id)`. Reject, delete, and build-cancel teardown paths already consult `collectDeploymentManifest(..., { protectRetained: true })` to skip artifacts a live or retained release still references; the failure path was the lone outlier.

## Fix

- Replace the per-row `runtime.destroy` loop with `collectDeploymentManifest` + `executeCleanup` using `protectRetained: true`, matching cancel/reject/delete.
- Add `on-failure-keep-set.test.ts` regression coverage modeled on `reject-keep-set.test.ts`.

## Verification

```bash
cd apps/api && bun run test test/modules/deployments/on-failure-keep-set.test.ts test/modules/deployments/reject-keep-set.test.ts
```

Result: 9 tests passed.

## Notes / Risks

- Scope is limited to the failure teardown path; `onCancelled` still uses the old destroy loop (separate issue if needed).
- `provisioned.imageRef` cleanup at the top of `onFailure` is unchanged; compose pipeline already cleans built service images before calling `onFailure`.