### PR TITLE
fix(backups): bound pg_dump exec + reconcile stale runs, without killing honest uploads (#516)

### DIFF
--- a/apps/api/src/modules/backups/backup-stale-sweep.ts
+++ b/apps/api/src/modules/backups/backup-stale-sweep.ts
@@ -1,0 +1,39 @@
+/**
+ * Periodic reconciliation for backup runs stuck in non-terminal states.
+ *
+ * Boot already calls `sweepStaleRuns` for every in-flight row after a crash,
+ * but a wedged `pg_dump` exec (#516) can hang indefinitely without restarting
+ * the API — `lastEventAt` stops moving, queued siblings never get a worker
+ * slot, and the operator only sees relief after a manual restart.
+ *
+ * Thresholds mirror the docker exec defaults: 10 minutes of silence, 6 hours
+ * absolute, plus a separate queued-or-orphan window so a run that never left
+ * `queued` is surfaced even when concurrency is saturated.
+ */
+
+import { repos } from "@repo/db";
+import type { JobSummary } from "../../lib/system-jobs";
+
+/** Matches `DEFAULT_HELPER_IDLE_MS` in the docker backup executor. */
+export const BACKUP_RUN_IDLE_STALE_MS = 10 * 60 * 1000;
+/** Matches `DEFAULT_HELPER_TIMEOUT_MS` in the docker backup executor. */
+export const BACKUP_RUN_CEILING_STALE_MS = 6 * 60 * 60 * 1000;
+/** A queued row should be picked up within one poll cycle + concurrency wait. */
+export const BACKUP_RUN_QUEUED_STALE_MS = 30 * 60 * 1000;
+
+const STALE_REASON =
+  "Backup run made no progress within the configured timeout and was reconciled.";
+
+export async function runBackupStaleSweep(): Promise<JobSummary> {
+  const now = Date.now();
+  const swept = await repos.backupRun.sweepRunsWithStaleHeartbeat({
+    queuedCutoff: new Date(now - BACKUP_RUN_QUEUED_STALE_MS),
+    idleCutoff: new Date(now - BACKUP_RUN_IDLE_STALE_MS),
+    ceilingCutoff: new Date(now - BACKUP_RUN_CEILING_STALE_MS),
+    reason: STALE_REASON,
+  });
+  if (swept > 0) {
+    console.warn(`[backup-stale-sweep] reconciled ${swept} stale backup run(s)`);
+  }
+  return { swept };
+}

--- a/apps/api/src/modules/jobs/job.registry.ts
+++ b/apps/api/src/modules/jobs/job.registry.ts
@@ -19,6 +19,7 @@ import { platform } from "../../lib/controller-helpers";
 import { renewExpiringCerts } from "../../lib/ssl-scheduler";
 import { runOrphanSweep } from "../projects/orphan-gc-schedule";
 import { runRetentionSweep } from "../backups/retention-prune";
+import { runBackupStaleSweep } from "../backups/backup-stale-sweep";
 import { pruneAuditEvents } from "../audit/audit-prune";
 import { runReconcileSweep } from "../deployments/reconcile-schedule";
 import { runImageGcSweep } from "../deployments/image-gc";
@@ -110,6 +111,14 @@ export const SYSTEM_JOB_DEFS: SystemJobDef[] = [
     label: "Backup retention prune",
     defaultCron: "17 3 * * *",
     run: async () => runRetentionSweep(),
+  },
+  {
+    key: "backups:stale-run-sweep",
+    label: "Backup in-flight stale reconciliation",
+    // Every five minutes — short enough to unblock queued siblings when an
+    // uploading run wedged without an API restart (#516).
+    defaultCron: "*/5 * * * *",
+    run: async () => runBackupStaleSweep(),
   },
   {
     key: "audit:retention-prune",

--- a/apps/api/test/modules/backups/backup-stale-sweep.test.ts
+++ b/apps/api/test/modules/backups/backup-stale-sweep.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Selective stale-heartbeat sweep for in-flight backup runs (#516).
+ */
+
+import { describe, expect, it } from "vitest";
+import { createBackupRunRepo } from "../../../../../packages/db/src/repos/backup.repo";
+
+interface PgFake {
+  db: unknown;
+  rows: Array<Record<string, unknown>>;
+  updates: Array<Record<string, unknown>>;
+}
+
+function makePgFake(rows: Array<Record<string, unknown>>): PgFake {
+  const now = Date.now();
+  const state: PgFake = { db: null, rows: rows.map((r) => ({ ...r })), updates: [] };
+  state.db = {
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          state.updates.push(values);
+          const queuedCutoff = now - 30 * 60 * 1000;
+          const idleCutoff = now - 10 * 60 * 1000;
+          const ceilingCutoff = now - 6 * 60 * 60 * 1000;
+          const swept: Array<Record<string, unknown>> = [];
+
+          for (const row of state.rows) {
+            const status = row.status as string;
+            const last = (row.lastEventAt as Date).getTime();
+            const bytes = row.bytesTransferred as number | null | undefined;
+            const terminal = ["succeeded", "failed", "cancelled", "server_error"];
+            if (terminal.includes(status) || row.finishedAt) continue;
+
+            const stale =
+              (status === "queued" && last < queuedCutoff) ||
+              (["preparing", "snapshotting", "verifying"].includes(status) && last < idleCutoff) ||
+              (status === "uploading" && (bytes == null || bytes === 0) && last < idleCutoff) ||
+              last < ceilingCutoff;
+
+            if (stale) {
+              Object.assign(row, values);
+              swept.push(row);
+            }
+          }
+          return {
+            returning: async () => swept,
+          };
+        },
+      }),
+    }),
+  };
+  return state;
+}
+
+describe("backupRun.sweepRunsWithStaleHeartbeat", () => {
+  const now = Date.now();
+
+  it("fails a queued run nobody picked up", async () => {
+    const pg = makePgFake([
+      {
+        id: "bkr_q",
+        status: "queued",
+        lastEventAt: new Date(now - 31 * 60 * 1000),
+        finishedAt: null,
+      },
+    ]);
+    const repo = createBackupRunRepo(pg.db as never);
+    const swept = await repo.sweepRunsWithStaleHeartbeat({
+      queuedCutoff: new Date(now - 30 * 60 * 1000),
+      idleCutoff: new Date(now - 10 * 60 * 1000),
+      ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
+      reason: "stale",
+    });
+    expect(swept).toBe(1);
+    expect(pg.rows[0].status).toBe("server_error");
+  });
+
+  it("fails uploading with null bytes and a stale heartbeat (#516 shape)", async () => {
+    const pg = makePgFake([
+      {
+        id: "bkr_u",
+        status: "uploading",
+        bytesTransferred: null,
+        lastEventAt: new Date(now - 11 * 60 * 1000),
+        finishedAt: null,
+      },
+    ]);
+    const repo = createBackupRunRepo(pg.db as never);
+    const swept = await repo.sweepRunsWithStaleHeartbeat({
+      queuedCutoff: new Date(now - 30 * 60 * 1000),
+      idleCutoff: new Date(now - 10 * 60 * 1000),
+      ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
+      reason: "stale",
+    });
+    expect(swept).toBe(1);
+    expect(pg.rows[0].status).toBe("server_error");
+  });
+
+  it("does not fail uploading when bytes are moving and under the ceiling", async () => {
+    const pg = makePgFake([
+      {
+        id: "bkr_ok",
+        status: "uploading",
+        bytesTransferred: 1_048_576,
+        lastEventAt: new Date(now - 20 * 60 * 1000),
+        finishedAt: null,
+      },
+    ]);
+    const repo = createBackupRunRepo(pg.db as never);
+    const swept = await repo.sweepRunsWithStaleHeartbeat({
+      queuedCutoff: new Date(now - 30 * 60 * 1000),
+      idleCutoff: new Date(now - 10 * 60 * 1000),
+      ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
+      reason: "stale",
+    });
+    expect(swept).toBe(0);
+    expect(pg.rows[0].status).toBe("uploading");
+  });
+});

--- a/apps/api/test/modules/backups/backup-stale-sweep.test.ts
+++ b/apps/api/test/modules/backups/backup-stale-sweep.test.ts
@@ -1,5 +1,9 @@
 /**
  * Selective stale-heartbeat sweep for in-flight backup runs (#516).
+ *
+ * NOTE: `makePgFake` hand-mirrors the WHERE in `sweepRunsWithStaleHeartbeat`
+ * rather than running the real drizzle query, so it only guards intent — keep
+ * the predicate below in sync with the repo when the sweep logic changes.
  */
 
 import { describe, expect, it } from "vitest";
@@ -27,14 +31,16 @@ function makePgFake(rows: Array<Record<string, unknown>>): PgFake {
           for (const row of state.rows) {
             const status = row.status as string;
             const last = (row.lastEventAt as Date).getTime();
-            const bytes = row.bytesTransferred as number | null | undefined;
             const terminal = ["succeeded", "failed", "cancelled", "server_error"];
             if (terminal.includes(status) || row.finishedAt) continue;
 
+            // Mirror of sweepRunsWithStaleHeartbeat's WHERE. `uploading` is NOT
+            // idle-swept — a single-artifact dump holds (uploading, bytes=NULL,
+            // lastEventAt=frozen) for the whole honest upload — so it is bounded
+            // by the ceiling only (the executor watchdog reaps a real wedge).
             const stale =
               (status === "queued" && last < queuedCutoff) ||
               (["preparing", "snapshotting", "verifying"].includes(status) && last < idleCutoff) ||
-              (status === "uploading" && (bytes == null || bytes === 0) && last < idleCutoff) ||
               last < ceilingCutoff;
 
             if (stale) {
@@ -52,6 +58,13 @@ function makePgFake(rows: Array<Record<string, unknown>>): PgFake {
   return state;
 }
 
+const CUTOFFS = (now: number) => ({
+  queuedCutoff: new Date(now - 30 * 60 * 1000),
+  idleCutoff: new Date(now - 10 * 60 * 1000),
+  ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
+  reason: "stale",
+});
+
 describe("backupRun.sweepRunsWithStaleHeartbeat", () => {
   const now = Date.now();
 
@@ -65,35 +78,45 @@ describe("backupRun.sweepRunsWithStaleHeartbeat", () => {
       },
     ]);
     const repo = createBackupRunRepo(pg.db as never);
-    const swept = await repo.sweepRunsWithStaleHeartbeat({
-      queuedCutoff: new Date(now - 30 * 60 * 1000),
-      idleCutoff: new Date(now - 10 * 60 * 1000),
-      ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
-      reason: "stale",
-    });
+    const swept = await repo.sweepRunsWithStaleHeartbeat(CUTOFFS(now));
     expect(swept).toBe(1);
     expect(pg.rows[0].status).toBe("server_error");
   });
 
-  it("fails uploading with null bytes and a stale heartbeat (#516 shape)", async () => {
+  it("fails a preparing run idle past the idle cutoff", async () => {
     const pg = makePgFake([
       {
-        id: "bkr_u",
-        status: "uploading",
-        bytesTransferred: null,
+        id: "bkr_p",
+        status: "preparing",
         lastEventAt: new Date(now - 11 * 60 * 1000),
         finishedAt: null,
       },
     ]);
     const repo = createBackupRunRepo(pg.db as never);
-    const swept = await repo.sweepRunsWithStaleHeartbeat({
-      queuedCutoff: new Date(now - 30 * 60 * 1000),
-      idleCutoff: new Date(now - 10 * 60 * 1000),
-      ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
-      reason: "stale",
-    });
+    const swept = await repo.sweepRunsWithStaleHeartbeat(CUTOFFS(now));
     expect(swept).toBe(1);
     expect(pg.rows[0].status).toBe("server_error");
+  });
+
+  it("does NOT idle-sweep an uploading run with null bytes (honest large dump, #516)", async () => {
+    // A single-artifact pg_dump/mysqldump/mongodump streams the whole payload
+    // through one destination.put; bytesTransferred stays NULL and lastEventAt
+    // is frozen at the transition into `uploading` until the artifact finishes.
+    // Idle-sweeping this would kill the exact backup #516 is about. A genuine
+    // wedge is reaped in-process by the executor's per-stream idle watchdog.
+    const pg = makePgFake([
+      {
+        id: "bkr_u",
+        status: "uploading",
+        bytesTransferred: null,
+        lastEventAt: new Date(now - 25 * 60 * 1000), // well past idle, well under ceiling
+        finishedAt: null,
+      },
+    ]);
+    const repo = createBackupRunRepo(pg.db as never);
+    const swept = await repo.sweepRunsWithStaleHeartbeat(CUTOFFS(now));
+    expect(swept).toBe(0);
+    expect(pg.rows[0].status).toBe("uploading");
   });
 
   it("does not fail uploading when bytes are moving and under the ceiling", async () => {
@@ -107,13 +130,24 @@ describe("backupRun.sweepRunsWithStaleHeartbeat", () => {
       },
     ]);
     const repo = createBackupRunRepo(pg.db as never);
-    const swept = await repo.sweepRunsWithStaleHeartbeat({
-      queuedCutoff: new Date(now - 30 * 60 * 1000),
-      idleCutoff: new Date(now - 10 * 60 * 1000),
-      ceilingCutoff: new Date(now - 6 * 60 * 60 * 1000),
-      reason: "stale",
-    });
+    const swept = await repo.sweepRunsWithStaleHeartbeat(CUTOFFS(now));
     expect(swept).toBe(0);
     expect(pg.rows[0].status).toBe("uploading");
+  });
+
+  it("fails an uploading run once it passes the 6h ceiling", async () => {
+    const pg = makePgFake([
+      {
+        id: "bkr_ceil",
+        status: "uploading",
+        bytesTransferred: null,
+        lastEventAt: new Date(now - 7 * 60 * 60 * 1000),
+        finishedAt: null,
+      },
+    ]);
+    const repo = createBackupRunRepo(pg.db as never);
+    const swept = await repo.sweepRunsWithStaleHeartbeat(CUTOFFS(now));
+    expect(swept).toBe(1);
+    expect(pg.rows[0].status).toBe("server_error");
   });
 });

--- a/packages/adapters/src/backup/executors/docker.ts
+++ b/packages/adapters/src/backup/executors/docker.ts
@@ -141,7 +141,9 @@ function compressionFlag(compression: "zstd" | "gzip" | "none" | undefined): str
 }
 
 /** Parse a compose-syntax volume string into the executor's source shape. */
-function parseVolumeSpec(spec: string): { source: string; target: string; type: BackupSource["type"] } | null {
+function parseVolumeSpec(
+  spec: string,
+): { source: string; target: string; type: BackupSource["type"] } | null {
   // Strip mode suffix (":ro" / ":rw" etc.)
   const noMode = spec.replace(/:(ro|rw|z|Z|nocopy)$/, "");
   const parts = noMode.split(":");
@@ -176,9 +178,7 @@ export class DockerBackupExecutor implements BackupExecutor {
     //     isn't running or doesn't exist yet).
     if (service.containerId) {
       try {
-        const data = await this.dockerode
-          .getContainer(service.containerId)
-          .inspect();
+        const data = await this.dockerode.getContainer(service.containerId).inspect();
         const mounts = (data.Mounts ?? []) as Array<{
           Type?: string;
           Name?: string;
@@ -187,12 +187,14 @@ export class DockerBackupExecutor implements BackupExecutor {
         }>;
         return mounts
           .filter((m) => m.Type === "volume" || m.Type === "bind")
-          .map((m, i): BackupSource => ({
-            id: m.Name ?? m.Source ?? `mount-${i}`,
-            target: m.Destination ?? "",
-            source: m.Name ?? m.Source ?? "",
-            type: (m.Type as BackupSource["type"]) ?? "volume",
-          }));
+          .map(
+            (m, i): BackupSource => ({
+              id: m.Name ?? m.Source ?? `mount-${i}`,
+              target: m.Destination ?? "",
+              source: m.Name ?? m.Source ?? "",
+              type: (m.Type as BackupSource["type"]) ?? "volume",
+            }),
+          );
       } catch {
         // Container gone — fall through to the DB-declared volumes.
       }
@@ -238,9 +240,7 @@ export class DockerBackupExecutor implements BackupExecutor {
       AttachStderr: true,
       User: opts?.user,
       WorkingDir: opts?.cwd,
-      Env: opts?.env
-        ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`)
-        : undefined,
+      Env: opts?.env ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`) : undefined,
     });
     // NO `hijack` — this is the single entry point for EVERY backup producer
     // (pg_dump, mysqldump, mongodump, redis, custom commands, pre/post hooks), and
@@ -251,7 +251,9 @@ export class DockerBackupExecutor implements BackupExecutor {
     // failed before a byte was read. Nothing here writes stdin, so there is no
     // reason to hijack at all; see DockerEdgeExecutor.run() for the same fix.
     const stream = await exec.start({ stdin: false });
-    return this.attachDemuxed(this.dockerode, exec.id, stream, opts?.timeoutMs);
+    return this.attachDemuxed(this.dockerode, exec.id, stream, opts, {
+      label: `exec in service ${service.name}`,
+    });
   }
 
   async streamPath(
@@ -275,10 +277,7 @@ export class DockerBackupExecutor implements BackupExecutor {
     // shellEscape each pattern — these flow from user-facing fields,
     // an unescaped `; rm -rf /` would inject. tar's glob handling is
     // unchanged because the shell strips the quotes before exec.
-    const excludeArgs = (opts?.exclude ?? []).flatMap((p) => [
-      "--exclude",
-      shellEscape(p),
-    ]);
+    const excludeArgs = (opts?.exclude ?? []).flatMap((p) => ["--exclude", shellEscape(p)]);
     const tarFlags = compressionFlag(compression);
     const tarCmd =
       compression === "zstd"
@@ -309,7 +308,11 @@ export class DockerBackupExecutor implements BackupExecutor {
     return this.handOffHelper(
       {
         Image: helperImage,
-        Cmd: ["sh", "-c", compression === "zstd" ? `apk add --no-cache zstd >/dev/null 2>&1; ${tarCmd}` : tarCmd],
+        Cmd: [
+          "sh",
+          "-c",
+          compression === "zstd" ? `apk add --no-cache zstd >/dev/null 2>&1; ${tarCmd}` : tarCmd,
+        ],
         HostConfig: hostConfig,
         AttachStdout: true,
         AttachStderr: true,
@@ -358,9 +361,7 @@ export class DockerBackupExecutor implements BackupExecutor {
     const helperImage = compression === "zstd" ? "alpine:3" : HELPER_IMAGE;
     await this.ensureImage(helperImage);
 
-    const clearCmd = opts?.clearTarget
-      ? `find /mnt -mindepth 1 -delete 2>/dev/null || true; `
-      : "";
+    const clearCmd = opts?.clearTarget ? `find /mnt -mindepth 1 -delete 2>/dev/null || true; ` : "";
     const untarCmd =
       compression === "zstd"
         ? `${clearCmd}zstd -d -c | tar -x -C /mnt`
@@ -570,7 +571,11 @@ export class DockerBackupExecutor implements BackupExecutor {
           continue; // transient daemon hiccup — keep polling
         }
         // "created" also reports Running:false; only an exit carries a code.
-        if (state.Running === false && state.Status !== "created" && typeof state.ExitCode === "number") {
+        if (
+          state.Running === false &&
+          state.Status !== "created" &&
+          typeof state.ExitCode === "number"
+        ) {
           return { StatusCode: state.ExitCode };
         }
       }
@@ -726,9 +731,7 @@ export class DockerBackupExecutor implements BackupExecutor {
       AttachStderr: true,
       User: opts?.user,
       WorkingDir: opts?.cwd,
-      Env: opts?.env
-        ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`)
-        : undefined,
+      Env: opts?.env ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`) : undefined,
     });
     // Hand-rolled upgrade rather than dockerode's `{hijack: true}`: this exec
     // needs stdin (the dump bytes), and under Bun modem's hijack comes back as
@@ -781,7 +784,9 @@ export class DockerBackupExecutor implements BackupExecutor {
         try {
           resolve({
             code: await resolveExecExitCode(exec, exec.id),
-            stderr: Buffer.concat(stderrChunks).toString("utf8").slice(0, 16 * 1024),
+            stderr: Buffer.concat(stderrChunks)
+              .toString("utf8")
+              .slice(0, 16 * 1024),
           });
         } catch (err) {
           reject(err);
@@ -845,8 +850,13 @@ export class DockerBackupExecutor implements BackupExecutor {
     docker: Dockerode,
     execId: string,
     stream: NodeJS.ReadWriteStream,
-    timeoutMs: number | undefined,
+    opts?: ExecuteCommandOpts,
+    meta?: { label?: string },
   ): { stdout: Readable; awaitExit: Promise<ExecExitInfo> } {
+    const label = meta?.label ?? "exec";
+    const idleMs = opts?.idleTimeoutMs ?? DEFAULT_HELPER_IDLE_MS;
+    const timeoutMs = opts?.timeoutMs ?? DEFAULT_HELPER_TIMEOUT_MS;
+
     const stdout = new PassThrough();
     const stderrChunks: Buffer[] = [];
     const stderrSink = new PassThrough();
@@ -856,30 +866,42 @@ export class DockerBackupExecutor implements BackupExecutor {
 
     docker.modem.demuxStream(stream as unknown as NodeJS.ReadableStream, stdout, stderrSink);
 
-    const awaitExit = new Promise<ExecExitInfo>((resolve, reject) => {
-      const timer = timeoutMs
-        ? setTimeout(() => {
-            stdout.destroy(new Error(`exec timed out after ${timeoutMs}ms`));
-            reject(new Error(`exec timed out after ${timeoutMs}ms`));
-          }, timeoutMs)
-        : null;
+    const watchdog = createIdleWatchdog(
+      idleMs,
+      `${label} produced no data for ${Math.round(idleMs / 1000)}s and was abandoned.`,
+    );
+    stream.on("data", () => watchdog.touch());
 
-      stream.on("end", async () => {
-        if (timer) clearTimeout(timer);
-        try {
-          resolve({
-            code: await resolveExecExitCode(docker.getExec(execId), execId),
-            stderr: Buffer.concat(stderrChunks).toString("utf8").slice(0, 16 * 1024),
-          });
-        } catch (err) {
-          reject(err);
-        }
+    const awaitExit = (async (): Promise<ExecExitInfo> => {
+      const onEnd = new Promise<ExecExitInfo>((resolve, reject) => {
+        stream.on("end", async () => {
+          try {
+            resolve({
+              code: await resolveExecExitCode(docker.getExec(execId), execId),
+              stderr: Buffer.concat(stderrChunks)
+                .toString("utf8")
+                .slice(0, 16 * 1024),
+            });
+          } catch (err) {
+            reject(err);
+          }
+        });
+        stream.on("error", (err) => reject(err));
       });
-      stream.on("error", (err) => {
-        if (timer) clearTimeout(timer);
-        reject(err);
-      });
-    });
+
+      try {
+        return await withTimeout(
+          Promise.race([onEnd, watchdog.promise]),
+          timeoutMs,
+          `${label} exceeded its ${Math.round(timeoutMs / 1000)}s ceiling and was abandoned.`,
+        );
+      } catch (err) {
+        stdout.destroy(err as Error);
+        throw err;
+      } finally {
+        watchdog.dispose();
+      }
+    })();
 
     return { stdout, awaitExit };
   }
@@ -956,7 +978,9 @@ export class DockerBackupExecutor implements BackupExecutor {
         reapIfDone();
         return {
           code: res.StatusCode,
-          stderr: Buffer.concat(stderrChunks).toString("utf8").slice(0, 16 * 1024),
+          stderr: Buffer.concat(stderrChunks)
+            .toString("utf8")
+            .slice(0, 16 * 1024),
         };
       } catch (err) {
         // Nothing will drain this helper now, so reap directly rather than

--- a/packages/adapters/src/backup/types.ts
+++ b/packages/adapters/src/backup/types.ts
@@ -80,8 +80,17 @@ export interface ExecuteCommandOpts {
   user?: string;
   /** Working directory inside the service. */
   cwd?: string;
-  /** Kill the exec after this many milliseconds. Null = no timeout
-   *  (use cautiously — long-running dumps are legitimate). */
+  /**
+   * Give up after this long with NO stdout/stderr — not this long overall.
+   * Same reasoning as `StreamPathOpts.idleTimeoutMs`: a large `pg_dump` that is
+   * actively streaming must not be cut off by elapsed time alone, but a wedged
+   * exec that never prints a byte should fail within minutes, not hours.
+   * Executors own their defaults; `undefined` means "the executor's", never
+   * "unbounded".
+   */
+  idleTimeoutMs?: number;
+  /** Absolute ceiling regardless of traffic, behind `idleTimeoutMs`. Docker
+   *  exec default 6 hours, matching capture/restore helpers. */
   timeoutMs?: number;
 }
 
@@ -445,11 +454,7 @@ export interface BackupDestination {
    *  the API host. Only implemented when capabilities include
    *  `presignedGet`. */
   presignGet?(key: string, ttlSec: number): Promise<string>;
-  presignPut?(
-    key: string,
-    ttlSec: number,
-    opts?: { contentType?: string },
-  ): Promise<string>;
+  presignPut?(key: string, ttlSec: number, opts?: { contentType?: string }): Promise<string>;
 }
 
 export type DestinationFactory = (row: BackupDestinationRow) => BackupDestination;

--- a/packages/adapters/test/backup-exec-stream-timeout.test.ts
+++ b/packages/adapters/test/backup-exec-stream-timeout.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The database-dump direction of #516.
+ *
+ * `streamPath` and `receiveStream` got idle watchdogs in #434; `execStream`
+ * (pg_dump, mysqldump, hooks) kept a wall-clock timer only when the caller
+ * passed `timeoutMs`, and no idle bound at all — so a wedged `pg_dump | zstd`
+ * pipe hung forever with `bytesTransferred` still null. These tests pin the
+ * same four properties the capture suite does: silence bounded, traffic not,
+ * ceiling enforced, and stdout destroyed on failure.
+ */
+
+import type { Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ServiceHandle } from "../src/backup/types";
+import { DockerRuntime } from "../src/runtime/docker";
+import { DockerBackupExecutor } from "../src/backup/executors/docker";
+import { drive, FakeAttachStream } from "./helpers/docker-helper-harness";
+
+const SERVICE: ServiceHandle = {
+  id: "svc_1",
+  projectId: "prj_1",
+  name: "db",
+  image: "postgres:16",
+  env: { POSTGRES_DB: "app" },
+  volumes: [],
+  containerId: "ctr_pg",
+  projectSlug: "shop",
+  namespaceVolumes: false,
+};
+
+function execHarness(stream: FakeAttachStream) {
+  const execInspectable = {
+    id: "exec_1",
+    start: vi.fn(async () => stream),
+    inspect: vi.fn(async () => ({ Running: false, ExitCode: 0 })),
+  };
+  const container = {
+    exec: vi.fn(async () => execInspectable),
+  };
+
+  return {
+    execInspectable,
+    async executor() {
+      const runtime = await DockerRuntime.create();
+      (runtime as unknown as { pullImage: () => Promise<void> }).pullImage = async () => {};
+      runtime.docker.getContainer = (() => container) as never;
+      runtime.docker.getExec = (() => execInspectable) as never;
+      runtime.docker.modem = {
+        demuxStream: (src: FakeAttachStream, out: Writable, err: Writable) => {
+          src.on("data", (chunk: Buffer) => out.write(chunk));
+          src.on("data", (chunk: Buffer) => err.write(chunk));
+        },
+      } as never;
+      return new DockerBackupExecutor(runtime);
+    },
+  };
+}
+
+function collect(stdout: NodeJS.ReadableStream) {
+  const chunks: Buffer[] = [];
+  stdout.on("data", (c: Buffer) => chunks.push(c));
+  stdout.on("error", () => {});
+  return () => Buffer.concat(chunks).toString("utf8");
+}
+
+let stream: FakeAttachStream;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  stream = new FakeAttachStream();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("execStream silence is bounded, traffic is not", () => {
+  it("abandons an exec that produces nothing for the idle window", async () => {
+    const h = execHarness(stream);
+    const exec = await h.executor();
+
+    const { stdout, awaitExit } = await exec.execStream(SERVICE, ["pg_dump"], {
+      idleTimeoutMs: 5_000,
+      timeoutMs: 60_000,
+    });
+    collect(stdout);
+
+    await expect(drive(awaitExit, 30_000)).rejects.toThrow(/produced no data for 5s/);
+  });
+
+  it("uses the same 10-minute idle default as capture when the caller sets none", async () => {
+    const h = execHarness(stream);
+    const exec = await h.executor();
+
+    const { stdout, awaitExit } = await exec.execStream(SERVICE, ["pg_dump"]);
+    collect(stdout);
+
+    await expect(drive(awaitExit, 11 * 60_000, 5_000)).rejects.toThrow(/no data for 600s/);
+  });
+
+  it("lets a slow but live exec run far past the idle window", async () => {
+    const h = execHarness(stream);
+    const exec = await h.executor();
+
+    const { stdout, awaitExit } = await exec.execStream(SERVICE, ["pg_dump"], {
+      idleTimeoutMs: 5_000,
+      timeoutMs: 120_000,
+    });
+    const read = collect(stdout);
+    awaitExit.catch(() => {});
+
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(4_000);
+      stream.emitOutput("dump.");
+    }
+    stream.finish();
+
+    await expect(drive(awaitExit, 30_000)).resolves.toMatchObject({ code: 0 });
+    expect(read()).toBe("dump.".repeat(5));
+  });
+
+  it("enforces an absolute ceiling even while bytes keep flowing", async () => {
+    const h = execHarness(stream);
+    const exec = await h.executor();
+
+    const { stdout, awaitExit } = await exec.execStream(SERVICE, ["pg_dump"], {
+      idleTimeoutMs: 60_000,
+      timeoutMs: 10_000,
+    });
+    collect(stdout);
+    awaitExit.catch(() => {});
+
+    for (let i = 0; i < 20; i++) {
+      stream.emitOutput("trickle");
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+
+    await expect(drive(awaitExit, 30_000)).rejects.toThrow(/exceeded its 10s ceiling/);
+  });
+});

--- a/packages/db/src/repos/backup.repo.ts
+++ b/packages/db/src/repos/backup.repo.ts
@@ -599,11 +599,20 @@ export function createBackupRunRepo(db: Database) {
      * `sweepStaleRuns` (boot-only, marks everything in-flight), this is selective:
      *   - queued rows nobody picked up within `queuedCutoff`
      *   - preparing/snapshotting/verifying with no transition within `idleCutoff`
-     *   - uploading with zero bytes and no transition within `idleCutoff` (#516)
+     *     (brief hops between states — a stall there is genuinely stuck)
      *   - any in-flight row past the absolute `ceilingCutoff`
      *
-     * Uploading rows that ARE moving bytes rely on the ceiling only — `lastEventAt`
-     * is not bumped per chunk, so a long honest upload must not be cut at idle.
+     * `uploading` is deliberately NOT idle-swept. A single-artifact dump
+     * (pg_dump/mysqldump/mongodump) streams the whole payload through one
+     * `destination.put`, and the orchestrator writes `bytesTransferred` / bumps
+     * `lastEventAt` only at artifact boundaries — never mid-stream. So for the
+     * entire upload the row sits `(uploading, bytesTransferred=NULL,
+     * lastEventAt=frozen)`, which is indistinguishable by DB state alone from a
+     * wedge. Idle-sweeping it here would kill honest multi-GB uploads that
+     * legitimately run past `idleCutoff` — the exact managed-postgres case #516
+     * is about. A genuinely wedged upload is reaped in-process by the executor's
+     * per-stream idle watchdog (which also frees the worker slot); this sweep
+     * only backstops `uploading` via the 6h `ceilingCutoff`.
      */
     async sweepRunsWithStaleHeartbeat(params: {
       queuedCutoff: Date;
@@ -628,11 +637,6 @@ export function createBackupRunRepo(db: Database) {
               and(eq(backupRun.status, "queued"), lt(backupRun.lastEventAt, queuedCutoff)),
               and(
                 inArray(backupRun.status, ["preparing", "snapshotting", "verifying"]),
-                lt(backupRun.lastEventAt, idleCutoff),
-              ),
-              and(
-                eq(backupRun.status, "uploading"),
-                or(isNull(backupRun.bytesTransferred), eq(backupRun.bytesTransferred, 0)),
                 lt(backupRun.lastEventAt, idleCutoff),
               ),
               lt(backupRun.lastEventAt, ceilingCutoff),

--- a/packages/db/src/repos/backup.repo.ts
+++ b/packages/db/src/repos/backup.repo.ts
@@ -10,12 +10,7 @@
 
 import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import type { Database } from "../client";
-import {
-  backupDestination,
-  backupPolicy,
-  backupRestore,
-  backupRun,
-} from "../schema";
+import { backupDestination, backupPolicy, backupRestore, backupRun } from "../schema";
 import { detailOf } from "./storable-detail";
 
 // ─── Inferred types ──────────────────────────────────────────────────────────
@@ -179,10 +174,7 @@ export function createBackupDestinationRepo(db: Database) {
 
     async findById(id: string): Promise<BackupDestination | undefined> {
       return db.query.backupDestination.findFirst({
-        where: and(
-          eq(backupDestination.id, id),
-          isNull(backupDestination.deletedAt),
-        ),
+        where: and(eq(backupDestination.id, id), isNull(backupDestination.deletedAt)),
       });
     },
 
@@ -206,11 +198,7 @@ export function createBackupDestinationRepo(db: Database) {
       return row;
     },
 
-    async setLastVerified(
-      id: string,
-      ok: boolean,
-      error?: string,
-    ): Promise<void> {
+    async setLastVerified(id: string, ok: boolean, error?: string): Promise<void> {
       await db
         .update(backupDestination)
         .set({
@@ -227,12 +215,7 @@ export function createBackupDestinationRepo(db: Database) {
       const referencingCount = await db
         .select({ count: sql<number>`count(*)::int` })
         .from(backupPolicy)
-        .where(
-          and(
-            eq(backupPolicy.destinationId, id),
-            isNull(backupPolicy.deletedAt),
-          ),
-        )
+        .where(and(eq(backupPolicy.destinationId, id), isNull(backupPolicy.deletedAt)))
         .then((rows) => Number(rows[0]?.count ?? 0));
 
       if (referencingCount > 0) {
@@ -259,10 +242,7 @@ export function createBackupPolicyRepo(db: Database) {
   return {
     async listByProject(projectId: string): Promise<BackupPolicy[]> {
       return db.query.backupPolicy.findMany({
-        where: and(
-          eq(backupPolicy.projectId, projectId),
-          isNull(backupPolicy.deletedAt),
-        ),
+        where: and(eq(backupPolicy.projectId, projectId), isNull(backupPolicy.deletedAt)),
       });
     },
 
@@ -270,10 +250,7 @@ export function createBackupPolicyRepo(db: Database) {
      *  detail page's "used by" view (which projects/services back up here). */
     async listByDestination(destinationId: string): Promise<BackupPolicy[]> {
       return db.query.backupPolicy.findMany({
-        where: and(
-          eq(backupPolicy.destinationId, destinationId),
-          isNull(backupPolicy.deletedAt),
-        ),
+        where: and(eq(backupPolicy.destinationId, destinationId), isNull(backupPolicy.deletedAt)),
       });
     },
 
@@ -324,23 +301,15 @@ export function createBackupPolicyRepo(db: Database) {
     },
 
     /** The single active policy for a mail server (mail_server source). */
-    async findActiveByMailServer(
-      mailServerId: string,
-    ): Promise<BackupPolicy | undefined> {
+    async findActiveByMailServer(mailServerId: string): Promise<BackupPolicy | undefined> {
       return db.query.backupPolicy.findFirst({
-        where: and(
-          eq(backupPolicy.mailServerId, mailServerId),
-          isNull(backupPolicy.deletedAt),
-        ),
+        where: and(eq(backupPolicy.mailServerId, mailServerId), isNull(backupPolicy.deletedAt)),
       });
     },
 
     async findByWebhookToken(token: string): Promise<BackupPolicy | undefined> {
       return db.query.backupPolicy.findFirst({
-        where: and(
-          eq(backupPolicy.webhookToken, token),
-          isNull(backupPolicy.deletedAt),
-        ),
+        where: and(eq(backupPolicy.webhookToken, token), isNull(backupPolicy.deletedAt)),
       });
     },
 
@@ -372,9 +341,7 @@ export function createBackupPolicyRepo(db: Database) {
       });
     },
 
-    async *iterateEnabledScheduled(
-      pageSize = 100,
-    ): AsyncIterableIterator<BackupPolicy> {
+    async *iterateEnabledScheduled(pageSize = 100): AsyncIterableIterator<BackupPolicy> {
       let offset = 0;
       while (true) {
         const page = await db.query.backupPolicy.findMany({
@@ -407,9 +374,7 @@ export function createBackupPolicyRepo(db: Database) {
      *
      * Paginated because the sweep runs against every org on the instance.
      */
-    async *iterateEnabledForRetention(
-      pageSize = 100,
-    ): AsyncIterableIterator<BackupPolicy> {
+    async *iterateEnabledForRetention(pageSize = 100): AsyncIterableIterator<BackupPolicy> {
       let offset = 0;
       while (true) {
         const page = await db.query.backupPolicy.findMany({
@@ -504,8 +469,7 @@ export function createBackupRunRepo(db: Database) {
       ];
       if (opts?.projectId) conditions.push(eq(backupRun.projectId, opts.projectId));
       if (opts?.serviceId) conditions.push(eq(backupRun.serviceId, opts.serviceId));
-      if (opts?.mailServerId)
-        conditions.push(eq(backupRun.mailServerId, opts.mailServerId));
+      if (opts?.mailServerId) conditions.push(eq(backupRun.mailServerId, opts.mailServerId));
       return db.query.backupRun.findMany({
         where: and(...conditions),
         orderBy: (t, { desc }) => [desc(t.startedAt)],
@@ -534,7 +498,14 @@ export function createBackupRunRepo(db: Database) {
      *  time. Powers the Backups page's per-destination size monitoring. */
     async statsByDestination(
       organizationId: string,
-    ): Promise<Array<{ destinationId: string | null; storedBytes: number; runCount: number; lastRunAt: Date | null }>> {
+    ): Promise<
+      Array<{
+        destinationId: string | null;
+        storedBytes: number;
+        runCount: number;
+        lastRunAt: Date | null;
+      }>
+    > {
       const rows = await db
         .select({
           destinationId: backupRun.destinationId,
@@ -590,12 +561,7 @@ export function createBackupRunRepo(db: Database) {
       status: BackupRunStatus,
       patch?: Partial<Omit<NewBackupRun, "id" | "startedAt">>,
     ): Promise<void> {
-      const TERMINAL: BackupRunStatus[] = [
-        "succeeded",
-        "failed",
-        "cancelled",
-        "server_error",
-      ];
+      const TERMINAL: BackupRunStatus[] = ["succeeded", "failed", "cancelled", "server_error"];
       const finishing = TERMINAL.includes(status);
       const now = new Date();
       await persistTransition(
@@ -623,10 +589,54 @@ export function createBackupRunRepo(db: Database) {
           lastEventAt: new Date(),
           errorMessage: reason,
         })
+        .where(and(inArray(backupRun.status, IN_FLIGHT_RUN_STATUSES), isNull(backupRun.finishedAt)))
+        .returning();
+      return result.length;
+    },
+
+    /**
+     * Fail in-flight runs whose `lastEventAt` heartbeat has gone stale. Unlike
+     * `sweepStaleRuns` (boot-only, marks everything in-flight), this is selective:
+     *   - queued rows nobody picked up within `queuedCutoff`
+     *   - preparing/snapshotting/verifying with no transition within `idleCutoff`
+     *   - uploading with zero bytes and no transition within `idleCutoff` (#516)
+     *   - any in-flight row past the absolute `ceilingCutoff`
+     *
+     * Uploading rows that ARE moving bytes rely on the ceiling only — `lastEventAt`
+     * is not bumped per chunk, so a long honest upload must not be cut at idle.
+     */
+    async sweepRunsWithStaleHeartbeat(params: {
+      queuedCutoff: Date;
+      idleCutoff: Date;
+      ceilingCutoff: Date;
+      reason: string;
+    }): Promise<number> {
+      const { queuedCutoff, idleCutoff, ceilingCutoff, reason } = params;
+      const result = await db
+        .update(backupRun)
+        .set({
+          status: "server_error",
+          finishedAt: new Date(),
+          lastEventAt: new Date(),
+          errorMessage: reason,
+        })
         .where(
           and(
             inArray(backupRun.status, IN_FLIGHT_RUN_STATUSES),
             isNull(backupRun.finishedAt),
+            or(
+              and(eq(backupRun.status, "queued"), lt(backupRun.lastEventAt, queuedCutoff)),
+              and(
+                inArray(backupRun.status, ["preparing", "snapshotting", "verifying"]),
+                lt(backupRun.lastEventAt, idleCutoff),
+              ),
+              and(
+                eq(backupRun.status, "uploading"),
+                or(isNull(backupRun.bytesTransferred), eq(backupRun.bytesTransferred, 0)),
+                lt(backupRun.lastEventAt, idleCutoff),
+              ),
+              lt(backupRun.lastEventAt, ceilingCutoff),
+            ),
           ),
         )
         .returning();
@@ -634,10 +644,7 @@ export function createBackupRunRepo(db: Database) {
     },
 
     /** Used by the retention prune job (Chunk 2). */
-    async listSucceededOlderThan(
-      destinationId: string,
-      cutoff: Date,
-    ): Promise<BackupRun[]> {
+    async listSucceededOlderThan(destinationId: string, cutoff: Date): Promise<BackupRun[]> {
       return db.query.backupRun.findMany({
         where: and(
           eq(backupRun.destinationId, destinationId),
@@ -680,10 +687,7 @@ export function createBackupRunRepo(db: Database) {
     },
 
     async softDelete(id: string): Promise<void> {
-      await db
-        .update(backupRun)
-        .set({ deletedAt: new Date() })
-        .where(eq(backupRun.id, id));
+      await db.update(backupRun).set({ deletedAt: new Date() }).where(eq(backupRun.id, id));
     },
 
     /** Toggle the "protect this backup" flag. When set, retention
@@ -737,12 +741,7 @@ export function createBackupRestoreRepo(db: Database) {
       return db.query.backupRestore.findFirst({
         where: and(
           eq(backupRestore.runId, runId),
-          inArray(backupRestore.status, [
-            "queued",
-            "preparing",
-            "prepared",
-            "applying",
-          ]),
+          inArray(backupRestore.status, ["queued", "preparing", "prepared", "applying"]),
         ),
       });
     },
@@ -776,12 +775,7 @@ export function createBackupRestoreRepo(db: Database) {
       status: BackupRestoreStatus,
       patch?: Partial<Omit<NewBackupRestore, "id" | "userId" | "startedAt">>,
     ): Promise<void> {
-      const TERMINAL: BackupRestoreStatus[] = [
-        "succeeded",
-        "failed",
-        "cancelled",
-        "server_error",
-      ];
+      const TERMINAL: BackupRestoreStatus[] = ["succeeded", "failed", "cancelled", "server_error"];
       const finishing = TERMINAL.includes(status);
       const now = new Date();
       await persistTransition(


### PR DESCRIPTION
Lands @santhiprakash's #519 (commit `0a737155`, preserved) plus one follow-up fix.

## What #519 fixes (kept as-is)
The root cause of #516: `pg_dump`'s exec stream was attached with no idle/absolute timeout, so a stalled dump hung forever, wedging the run in `uploading` and holding a worker slot. #519 adds a per-stream idle watchdog + 6h ceiling to `attachDemuxed`, a boot sweep, a periodic stale-run sweep, and the `backups:stale-run-sweep` system job. All correct.

## Follow-up fix in this PR
#519's periodic DB sweep also reaped `uploading` rows with `bytesTransferred IS NULL/0` idle past 10 min. But the orchestrator only writes `bytesTransferred` / bumps `lastEventAt` at **artifact boundaries, never mid-stream** (`backup.orchestrator.ts:360,385-393`). A single-artifact dump therefore sits at `(uploading, bytes=NULL, lastEventAt=frozen)` for the *entire* honest upload — indistinguishable by DB state from a wedge. That branch would kill legitimate multi-GB uploads, i.e. the exact managed-postgres case #516 is about.

This removes the uploading-idle branch. A genuinely wedged upload is reaped in-process by the executor's per-stream idle watchdog (which also frees the worker slot); the DB sweep backstops `uploading` only via the 6h ceiling.

## Tests
- Rewrote `backup-stale-sweep` to guard the regression: an actively-uploading null-bytes run past the idle cutoff is **not** swept; one past the 6h ceiling **is**.
- Backups suites: 121/121. Adapters watchdog suites: 25/25.

Closes #516. Supersedes #519.