### PR TITLE
fix(adapters): harden ensureOwnedDir, and make the #514 regression test reach the write

### DIFF
--- a/packages/adapters/src/runtime/bare-remote-promote.test.ts
+++ b/packages/adapters/src/runtime/bare-remote-promote.test.ts
@@ -6,14 +6,18 @@ import type { CommandExecutor } from "../types";
  * Regression for issue #514 — a static site deployed to a REMOTE SSH server
  * whose deploy user is not root.
  *
- * Two things went wrong on that box, and both are exercised here through
+ * Two things went wrong on that box. Both are exercised here through
  * `deployStatic`, the last step of the deploy:
  *
- *   1. `/opt/openship/static` is root-owned (Docker created it for the edge's
- *      bind mount), so the promote's `mkdir releases` failed outright.
- *   2. the promote is journaled, and the journal was hardcoded to
- *      `/root/.openship` — unwritable for this user, so the `mv` was never even
- *      issued and `releases/` stayed empty while `.builds/<id>` was cleaned up.
+ *   1. nothing under `/opt/openship` was writable by the deploy user, and no
+ *      preflight provisioned it, so the promote's `mkdir releases` failed. (The
+ *      reporter's box was a first-ever deploy that died earlier still, in the
+ *      build's doc-root extract — same missing-provisioning cause, different
+ *      call site.)
+ *   2. the promote is journaled, and the journal base was hardcoded to
+ *      `/root/.openship` — unreadable for this user, so `ensureRemoteJournal`
+ *      died SFTP-writing `bin/opsh-run` and the `mv` was never issued.
+ *      `releases/` stayed empty while `.builds/<id>` was reaped by cleanup.
  *
  * Both surfaced as the same opaque "Deploy failed: Permission denied".
  */
@@ -55,7 +59,11 @@ function remoteNonRootServer() {
       // The journal wrapper: only reachable under a directory we own.
       if (command.includes("/.openship")) {
         if (!isOurs(HOME)) throw denied();
-        if (command.includes("--version")) return "1";
+        // A box that has never journaled: no wrapper, so `ensureRemoteJournal`
+        // takes the deploy branch and SFTP-writes bin/opsh-run — which IS the
+        // operation that failed. Answering the live version here instead would
+        // skip the write and model the one state where the bug cannot happen.
+        if (command.includes("--version")) return "0";
         if (command.includes("--gc")) return "";
         return "OPSH1 0  ";
       }
@@ -111,5 +119,12 @@ describe("issue #514 — static deploy to a remote SSH server as a non-root user
     // …and the promote journaled into the USER's home, never /root.
     expect(commands.some((c) => c.includes(`${HOME}/.openship`))).toBe(true);
     expect(commands.some((c) => c.includes("/root/.openship"))).toBe(false);
+    // The wrapper write is the operation that used to throw. Assert it actually
+    // happened, so this stays a test about the mechanism and not just the path
+    // string: with the base unfixed, this SFTP write is where the deploy died.
+    expect(executor.writeFile).toHaveBeenCalledWith(
+      `${HOME}/.openship/bin/opsh-run.tmp`,
+      expect.stringContaining("OPSH"),
+    );
   });
 });

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -100,7 +100,7 @@ function clampShellWindow(
 }
 import type { Feature, SystemLog } from "../system/types";
 import { isRuntimeNotFoundError } from "../system/errors";
-import { ensureOwnedDir } from "../system/elevated-executor";
+import { dirOf, ensureOwnedDir } from "../system/elevated-executor";
 
 import type {
   RuntimeAdapter,
@@ -1745,7 +1745,12 @@ export class DockerRuntime implements RuntimeAdapter {
   ): Promise<void> {
     const cid = (await sshExecutor.exec(`docker create ${sq(tag)}`)).trim();
     try {
-      await ensureOwnedDir(sshExecutor, hostOutDir);
+      // The PARENT, not `hostOutDir` itself: promote renames this dir into
+      // releases/, and rename(2) needs write permission on the source's parent.
+      // Ensuring `.builds` covers the dir it will create here too, so the leaf
+      // comes out user-owned from a plain mkdir.
+      await ensureOwnedDir(sshExecutor, dirOf(hostOutDir));
+      await sshExecutor.exec(`mkdir -p ${sq(hostOutDir)}`);
       // `/.` → contents, so no strip step (see the contract above).
       await sshExecutor.exec(`docker cp ${sq(`${cid}:${docRoot}/.`)} ${sq(hostOutDir)}`);
       // `docker cp` of an empty dir exits 0, so the contract is checked here.

--- a/packages/adapters/src/system/elevated-executor.test.ts
+++ b/packages/adapters/src/system/elevated-executor.test.ts
@@ -144,12 +144,13 @@ describe("ensureOwnedDir", () => {
   const PATH = "/opt/openship/static";
 
   /** A target that denies unelevated writes unless the tree is already ours. */
-  function target(opts: { canSudo: boolean; alreadyWritable?: boolean }) {
+  function target(opts: { canSudo: boolean; alreadyWritable?: boolean; loginUser?: string }) {
     const commands: string[] = [];
     const executor = {
       exec: vi.fn(async (command: string) => {
         commands.push(command);
         if (command === "id -u") return "1000";
+        if (command === "id -un") return `${opts.loginUser ?? "deploy"}\n`;
         if (command.startsWith("sudo -n true")) return opts.canSudo ? "yes" : "no";
         if (command.startsWith("sudo -n ")) return "";
         if (command.includes("mkdir -p") && !opts.alreadyWritable) {
@@ -168,10 +169,30 @@ describe("ensureOwnedDir", () => {
 
     // Unwrap the one level of quoting elevateCommand added.
     const inner = commands.find((c) => c.startsWith("sudo -n sh -c "))!.replace(/'\\''/g, "'");
-    expect(inner).toContain(`mkdir -p '${PATH}'`);
-    // $top, not the leaf: an `mv` needs write permission on the PARENT.
-    expect(inner).toContain(`while [ ! -d "$d" ]; do top="$d"; d=$(dirname "$d"); done`);
-    expect(inner).toContain(`chown -R "$SUDO_USER" "$top"`);
+    expect(inner).toContain(`p='${PATH}'`);
+    // Without it, a failed mkdir falls through and the chown's exit status is
+    // what the caller sees.
+    expect(inner).toContain("set -e");
+    // Walks up to the TOPMOST dir it had to create: an `mv` needs write
+    // permission on the PARENT, so a leaf-only chown would still fail.
+    expect(inner).toMatch(/top=\$d/);
+    expect(inner).toContain("dirname");
+    // The owner comes from the UNELEVATED `id -un`, not from `$SUDO_USER`, which a
+    // sudoers env_delete can strip.
+    expect(inner).toContain(`chown -R 'deploy' "\${top:-$p}"`);
+    expect(inner).not.toContain("SUDO_USER");
+  });
+
+  it("falls back to $SUDO_USER when the login probe says nothing", async () => {
+    const { executor, commands } = target({ canSudo: true, loginUser: "" });
+
+    await ensureOwnedDir(executor, PATH);
+
+    const inner = commands.find((c) => c.startsWith("sudo -n sh -c "))!.replace(/'\\''/g, "'");
+    // Left unexpanded on purpose: an empty owner must fail loudly at chown rather
+    // than default to root, which would hand the tree back to a user who still
+    // cannot write it.
+    expect(inner).toContain('chown -R "$SUDO_USER" "${top:-$p}"');
   });
 
   it("stays unelevated when the directory is already writable", async () => {

--- a/packages/adapters/src/system/elevated-executor.ts
+++ b/packages/adapters/src/system/elevated-executor.ts
@@ -14,8 +14,9 @@ export function elevateCommand(command: string): string {
   return `sudo -n sh -c ${sq(`export ${INSTALL_ENV}; ${command}`)}`;
 }
 
-/** Parent directory of an absolute path (for `mkdir -p` before a move). */
-function dirOf(path: string): string {
+/** Parent directory of an absolute path (for `mkdir -p` before a move). POSIX-only
+ *  by contract — these are remote host paths, never native-joined. */
+export function dirOf(path: string): string {
   const idx = path.lastIndexOf("/");
   if (idx < 0) return ".";
   return idx === 0 ? "/" : path.slice(0, idx);
@@ -87,13 +88,11 @@ export function elevatedExecutor(inner: CommandExecutor): CommandExecutor {
  *
  * The chown targets the TOPMOST directory that had to be created, not `path`:
  * renaming an entry needs write permission on its parent, so a leaf-only chown
- * would still leave a later `mv` failing. `$SUDO_USER` is set by sudo itself, so
- * the owner needs no extra probe.
+ * would still leave a later `mv` failing. When nothing had to be created — `path`
+ * exists but isn't ours — the leaf is the best available target; a caller that
+ * will RENAME `path` must therefore ensure `dirOf(path)`, not `path`.
  */
-export async function ensureOwnedDir(
-  executor: CommandExecutor,
-  path: string,
-): Promise<void> {
+export async function ensureOwnedDir(executor: CommandExecutor, path: string): Promise<void> {
   const quoted = sq(path);
   try {
     await executor.exec(`mkdir -p ${quoted} && [ -w ${quoted} ]`);
@@ -115,15 +114,34 @@ export async function ensureOwnedDir(
         `  sudo chown -R "$(id -un)" ${path}`,
     );
   }
+  // Who to hand the tree to. `$SUDO_USER` is sudo's own answer, but a sudoers
+  // `env_delete` can strip it, and there is no safe in-shell default: root would
+  // leave the deploy user still unable to write — the fast path above would then
+  // re-elevate on every deploy and the real write would fail anyway — while an
+  // empty expansion makes `chown -R "" …` the thing that errors. So ask the
+  // UNELEVATED executor, which is the login we actually need, and keep
+  // `$SUDO_USER` only as a last resort so an empty owner still fails loudly.
+  const loginUser = await executor
+    .exec("id -un")
+    .then((out) => out.trim())
+    .catch(() => "");
+  const owner = loginUser ? sq(loginUser) : '"$SUDO_USER"';
+
   await executor.exec(
     elevateCommand(
       [
-        `d=${quoted}`,
-        `top=`,
-        `while [ ! -d "$d" ]; do top="$d"; d=$(dirname "$d"); done`,
-        `mkdir -p ${quoted}`,
-        `[ -z "$top" ] && top=${quoted}`,
-        `chown -R "$SUDO_USER" "$top"`,
+        // Without it the `;`-joined steps fall through a failed mkdir, and the
+        // chown's exit status — not the mkdir's — is what the caller sees. That
+        // reported a permission failure as success.
+        "set -e",
+        `p=${quoted}`,
+        "d=$p",
+        "top=",
+        'while [ ! -d "$d" ]; do top=$d; d=$(dirname "$d"); done',
+        'mkdir -p "$p"',
+        // Expansion, not `[ -z "$top" ] && top=…`: that AND-list returns 1 whenever
+        // $top is already set, which under `set -e` would exit before the chown.
+        `chown -R ${owner} "\${top:-$p}"`,
       ].join("; "),
     ),
   );


### PR DESCRIPTION
Follow-up to #515, which is already merged. Three things the review turned up, none of which change that PR's diagnosis — it was right, including that the issue's own "Docker SSH allows one connection at a time" theory was not the cause.

## 1 — the elevated body reported a failed mkdir as success

The steps were `;`-joined with no `set -e`, so a failed `mkdir -p` fell through to the chown and **the chown's exit status became the command's**. Verified against a real `sh`, with the parent path occupied by a file:

```
# before
mkdir: /tmp/.../c3o/opt: Not a directory
exit=0   chown ran: -R deploy /tmp/.../c3o/opt      <- recursively chowned a FILE

# after
mkdir: /tmp/.../c3/opt: Not a directory
exit=1
```

Exit 0 meant `ensureOwnedDir` returned success and the caller went on to `docker cp` into a directory that does not exist — the clear permission error became a confusing downstream one.

`[ -z "$top" ] && top=…` had to go with it: as the last command of an AND-list it returns 1 whenever `$top` is already set, which under `set -e` exits before the chown. The leaf fallback is now a `${top:-$p}` expansion.

## 2 — the chown owner came from `$SUDO_USER`

sudo sets it, but a sudoers `env_delete` can strip it, and then the chown ran with an empty user:

```
exit=0   chown ran: -R  /tmp/.../c4o/opt/openship    <- empty owner
```

There is no safe in-shell default. Falling back to root would hand the tree to an account the deploy user still cannot write, so the fast path would re-elevate on every deploy and the real write would fail anyway — a silent no-progress loop instead of an error. So the owner now comes from `id -un` on the **unelevated** executor, which is the login we actually need, and `$SUDO_USER` stays unexpanded as a last resort so an empty owner still fails loudly at the chown.

`EnvironmentProfile` has no login-user field, hence the direct probe; it only runs on the failure path.

## 3 — `.builds` was not provisioned, only the build dir under it

`extractDocRootOverSsh` ensured `hostOutDir` itself. That covers a fresh server — the walk up from the missing leaf reaches `/opt` and chowns the whole created chain — but not a box where `.builds` already exists root-owned, from earlier deploys that ran as root before the sshUser was switched. There the walk stops at the leaf, `.builds` keeps its owner, and the promote's `mv <build> releases/<id>` fails: **rename(2) needs write permission on the source's parent**, not on the directory being renamed. Ensuring the parent covers the leaf too.

## 4 — the regression test never reached the write it was about

Measured on #515 as merged: `writeFile` calls = **0**. The fake answered the wrapper's `--version` probe with the live version, so `ensureRemoteJournal` took the up-to-date branch and skipped the SFTP write at `remote-journal.ts:181-188` — the one server state in which the bug cannot occur, while the docblock claimed the write failure was covered. It now reports a box that has never journaled, and asserts the wrapper write landed under the login user's home.

Both halves of the fix are independently load-bearing against the reworked test:

```
revert resolveJournalBase   -> × promise rejected "Error: Permission denied" instead of resolving
revert promote ensureOwnedDir -> × promise rejected "Error: Permission denied" instead of resolving
restore both                -> ✓
```

Also corrects two docblock claims: the reporter's box was a first-ever deploy that died in the build's doc-root extract, not in a promote whose `mkdir releases` "failed outright" (after their manual chown it would have succeeded), and the root-owned directory was missing provisioning rather than something Docker created for the edge's bind mount. Renamed off the issue number, which no other test file in the repo uses.

## Verification

- `packages/adapters`: 107 files, 1046 tests passing
- `bun run test` (full monorepo): 7/7 tasks successful
- `tsc --noEmit -p packages/adapters/tsconfig.json`: clean
- `prettier --check` on every line this PR adds: clean. The six files it touches are already unformatted on `main` (verified against `origin/main` in a separate worktree) and those pre-existing lines are left alone.

## Known follow-ups, not in scope here

- `NginxProvider` writes root-owned host paths through an unelevated executor, and the edge/routing block is wrapped in a warn-only catch — so on a non-root remote target routing still fails **silently** after this (green deploy, no working vhost).
- `ssh-manager.ts` passes `baseDir: OPENSHIP_DIR` explicitly, so the control-plane migration call sites keep journaling to `/root/.openship` regardless of `resolveJournalBase`.