### PR TITLE
fix(backups): close exec-stream sinks on EOF so finished dumps don't hang forever

### DIFF
--- a/packages/adapters/src/backup/destinations/sftp.ts
+++ b/packages/adapters/src/backup/destinations/sftp.ts
@@ -212,15 +212,52 @@ class SftpDestinationImpl implements BackupDestination {
 
       await new Promise<void>((resolve, reject) => {
         const ws = sftp.createWriteStream(tmp);
-        ws.on("error", reject);
-        ws.on("close", () => resolve());
+        let lastProgressAt = Date.now();
+        let settled = false;
+
+        // #openship-sftp-stall: ssh2's SFTP write stream has a known
+        // backpressure/drain bug where pipe() can wait forever for a
+        // 'drain' event that never fires once its internal request queue
+        // saturates — the upload silently freezes mid-transfer with no
+        // error and no close. Observed in production: a `.uploading-*`
+        // temp file stuck at a fixed byte size indefinitely. Bound the
+        // whole operation with an idle watchdog (mirrors the idle/ceiling
+        // pattern already used for docker exec streams, see #516) so a
+        // stall surfaces as a clear, retryable error instead of hanging
+        // the run (and the worker slot behind it) forever.
+        const STALL_TIMEOUT_MS = 2 * 60 * 1000;
+        const watchdog = setInterval(() => {
+          if (!settled && Date.now() - lastProgressAt > STALL_TIMEOUT_MS) {
+            finish(
+              new Error(
+                `SFTP upload stalled: no write progress for ${STALL_TIMEOUT_MS / 1000}s ` +
+                  `(wrote ${bytesWritten} bytes so far). The destination's SFTP write stream ` +
+                  `stopped draining — retry, or check the destination server's SFTP subsystem.`,
+              ),
+            );
+          }
+        }, 10_000);
+
+        const finish = (err?: Error) => {
+          if (settled) return;
+          settled = true;
+          clearInterval(watchdog);
+          if (err) {
+            ws.destroy();
+            body.destroy();
+            reject(err);
+          } else {
+            resolve();
+          }
+        };
+
+        ws.on("error", (err) => finish(err));
+        ws.on("close", () => finish());
         body.on("data", (chunk: Buffer) => {
           bytesWritten += chunk.byteLength;
+          lastProgressAt = Date.now();
         });
-        body.on("error", (err) => {
-          ws.destroy();
-          reject(err);
-        });
+        body.on("error", (err) => finish(err));
         body.pipe(ws);
       });
 

--- a/packages/adapters/src/backup/destinations/sftp.ts
+++ b/packages/adapters/src/backup/destinations/sftp.ts
@@ -44,6 +44,21 @@ const CAPS: ReadonlySet<DestinationCapability> = new Set<DestinationCapability>(
   "streamingGet",
 ]);
 
+/**
+ * Idle ceiling for one artifact upload — silence, not wall clock, for the same
+ * reason capture and restore bound on idle: an honest multi-hour artifact must
+ * not be strangled, and a wedged one must not be forever.
+ *
+ * Must never be TIGHTER than the producer's own idle allowance (execStream's
+ * 10-minute default). `put`'s body is the dump stream itself, so from here a
+ * source that has gone quiet — pg_dump waiting on a lock, a cold-cache table
+ * scan, a user's custom command — is indistinguishable from a dead destination.
+ * A shorter bound here would silently override that budget and fail healthy
+ * backups of large databases.
+ */
+const UPLOAD_STALL_TIMEOUT_MS = 10 * 60 * 1000;
+const UPLOAD_STALL_PROBE_MS = 30 * 1000;
+
 interface ConnectionConfig {
   host: string;
   port: number;
@@ -215,33 +230,12 @@ class SftpDestinationImpl implements BackupDestination {
         let lastProgressAt = Date.now();
         let settled = false;
 
-        // #openship-sftp-stall: ssh2's SFTP write stream has a known
-        // backpressure/drain bug where pipe() can wait forever for a
-        // 'drain' event that never fires once its internal request queue
-        // saturates — the upload silently freezes mid-transfer with no
-        // error and no close. Observed in production: a `.uploading-*`
-        // temp file stuck at a fixed byte size indefinitely. Bound the
-        // whole operation with an idle watchdog (mirrors the idle/ceiling
-        // pattern already used for docker exec streams, see #516) so a
-        // stall surfaces as a clear, retryable error instead of hanging
-        // the run (and the worker slot behind it) forever.
-        const STALL_TIMEOUT_MS = 2 * 60 * 1000;
-        const watchdog = setInterval(() => {
-          if (!settled && Date.now() - lastProgressAt > STALL_TIMEOUT_MS) {
-            finish(
-              new Error(
-                `SFTP upload stalled: no write progress for ${STALL_TIMEOUT_MS / 1000}s ` +
-                  `(wrote ${bytesWritten} bytes so far). The destination's SFTP write stream ` +
-                  `stopped draining — retry, or check the destination server's SFTP subsystem.`,
-              ),
-            );
-          }
-        }, 10_000);
+        let watchdog: ReturnType<typeof setInterval> | undefined;
 
         const finish = (err?: Error) => {
           if (settled) return;
           settled = true;
-          clearInterval(watchdog);
+          if (watchdog) clearInterval(watchdog);
           if (err) {
             ws.destroy();
             body.destroy();
@@ -251,7 +245,23 @@ class SftpDestinationImpl implements BackupDestination {
           }
         };
 
-        ws.on("error", (err) => finish(err));
+        // A wedged upload used to hang the run — and the worker slot behind it —
+        // with no error and no close, leaving a `.uploading-*` temp file frozen at
+        // a fixed size (#516). This bound is deliberately cause-agnostic: it says
+        // nothing about WHY the bytes stopped, only that they did.
+        watchdog = setInterval(() => {
+          if (settled || Date.now() - lastProgressAt <= UPLOAD_STALL_TIMEOUT_MS) return;
+          finish(
+            new Error(
+              `SFTP upload stalled: no write progress for ${UPLOAD_STALL_TIMEOUT_MS / 1000}s ` +
+                `(wrote ${bytesWritten} bytes so far). Retry; if it recurs, check both ends — ` +
+                `whether the source is still producing bytes, and the destination's SFTP subsystem.`,
+            ),
+          );
+        }, UPLOAD_STALL_PROBE_MS);
+        (watchdog as { unref?: () => void }).unref?.();
+
+        ws.on("error", (err: Error) => finish(err));
         ws.on("close", () => finish());
         body.on("data", (chunk: Buffer) => {
           bytesWritten += chunk.byteLength;

--- a/packages/adapters/src/backup/executors/docker.ts
+++ b/packages/adapters/src/backup/executors/docker.ts
@@ -866,17 +866,18 @@ export class DockerBackupExecutor implements BackupExecutor {
 
     docker.modem.demuxStream(stream as unknown as NodeJS.ReadableStream, stdout, stderrSink);
 
-    // #openship-exec-stream-eof: docker-modem's demuxStream only forwards
-    // 'data' events — it never calls .end() on the destination streams
-    // when the source attach stream ends. demuxContainerStream (used for
-    // volume/tar backups, below) already works around this; this
-    // exec-based path (pg_dump, mysqldump, mongodump, custom commands)
-    // never got the same fix. Observed in production: a finished pg_dump
-    // (fully written, correct byte count) left the SFTP destination's
-    // .pipe() waiting forever for an EOF that never arrives — the temp
-    // file looked "stuck uploading" when in fact 100% of the data had
-    // already been sent and the process had already exited. Mirror the
-    // same endSinks() fix used below.
+    // demuxStream only forwards 'data' — it never ends the destinations when the
+    // source attach stream ends. Without this, a consumer piping stdout (pg_dump,
+    // mysqldump, mongodump, custom commands → the destination writer) waits on an
+    // EOF that never comes: the dump is fully written, the exec has exited, and
+    // the run still sits in `uploading` forever (#516). demuxContainerStream
+    // below carries the same fix for the volume/tar path.
+    //
+    // Safe to end here, and ONLY here: this path learns the exit code from the
+    // attach stream's own 'end' (see awaitExit below), so by the time it fires
+    // every byte has already been demuxed. Do not move this to a daemon-side exit
+    // signal — an exec can exit with bytes still in flight, and ending early
+    // truncates the artifact (the trap demuxContainerStream documents).
     let sinksEnded = false;
     const endSinks = () => {
       if (sinksEnded) return;
@@ -911,18 +912,11 @@ export class DockerBackupExecutor implements BackupExecutor {
       });
 
       try {
-        const result = await withTimeout(
+        return await withTimeout(
           Promise.race([onEnd, watchdog.promise]),
           timeoutMs,
           `${label} exceeded its ${Math.round(timeoutMs / 1000)}s ceiling and was abandoned.`,
         );
-        // Backstop: over an SSH-tunneled Docker connection (e.g. a remote
-        // server managed over SSH) the attach stream's 'end'/'close' is
-        // not always delivered promptly even though the exec has already
-        // exited and pushed all its output. The exit code is known now —
-        // force the sinks closed so a downstream .pipe() consumer sees EOF.
-        endSinks();
-        return result;
       } catch (err) {
         stdout.destroy(err as Error);
         throw err;

--- a/packages/adapters/src/backup/executors/docker.ts
+++ b/packages/adapters/src/backup/executors/docker.ts
@@ -866,6 +866,27 @@ export class DockerBackupExecutor implements BackupExecutor {
 
     docker.modem.demuxStream(stream as unknown as NodeJS.ReadableStream, stdout, stderrSink);
 
+    // #openship-exec-stream-eof: docker-modem's demuxStream only forwards
+    // 'data' events — it never calls .end() on the destination streams
+    // when the source attach stream ends. demuxContainerStream (used for
+    // volume/tar backups, below) already works around this; this
+    // exec-based path (pg_dump, mysqldump, mongodump, custom commands)
+    // never got the same fix. Observed in production: a finished pg_dump
+    // (fully written, correct byte count) left the SFTP destination's
+    // .pipe() waiting forever for an EOF that never arrives — the temp
+    // file looked "stuck uploading" when in fact 100% of the data had
+    // already been sent and the process had already exited. Mirror the
+    // same endSinks() fix used below.
+    let sinksEnded = false;
+    const endSinks = () => {
+      if (sinksEnded) return;
+      sinksEnded = true;
+      stdout.end();
+      stderrSink.end();
+    };
+    stream.on("end", endSinks);
+    stream.on("close", endSinks);
+
     const watchdog = createIdleWatchdog(
       idleMs,
       `${label} produced no data for ${Math.round(idleMs / 1000)}s and was abandoned.`,
@@ -890,11 +911,18 @@ export class DockerBackupExecutor implements BackupExecutor {
       });
 
       try {
-        return await withTimeout(
+        const result = await withTimeout(
           Promise.race([onEnd, watchdog.promise]),
           timeoutMs,
           `${label} exceeded its ${Math.round(timeoutMs / 1000)}s ceiling and was abandoned.`,
         );
+        // Backstop: over an SSH-tunneled Docker connection (e.g. a remote
+        // server managed over SSH) the attach stream's 'end'/'close' is
+        // not always delivered promptly even though the exec has already
+        // exited and pushed all its output. The exit code is known now —
+        // force the sinks closed so a downstream .pipe() consumer sees EOF.
+        endSinks();
+        return result;
       } catch (err) {
         stdout.destroy(err as Error);
         throw err;

--- a/packages/adapters/test/backup-exec-stream-timeout.test.ts
+++ b/packages/adapters/test/backup-exec-stream-timeout.test.ts
@@ -139,3 +139,31 @@ describe("execStream silence is bounded, traffic is not", () => {
     await expect(drive(awaitExit, 30_000)).rejects.toThrow(/exceeded its 10s ceiling/);
   });
 });
+
+describe("execStream stdout reaches EOF (not just awaitExit)", () => {
+  it("ends stdout when the attach stream finishes, so a piped consumer isn't left waiting forever", async () => {
+    const h = execHarness(stream);
+    const exec = await h.executor();
+
+    const { stdout, awaitExit } = await exec.execStream(SERVICE, ["pg_dump"], {
+      idleTimeoutMs: 60_000,
+      timeoutMs: 60_000,
+    });
+    const read = collect(stdout);
+    awaitExit.catch(() => {});
+
+    const stdoutEnded = new Promise<void>((resolve) => stdout.on("end", resolve));
+
+    stream.emitOutput("dump-bytes");
+    stream.finish();
+
+    // docker-modem's demuxStream only forwards 'data' — it never closes the
+    // destination streams itself. A consumer piping stdout downstream (the
+    // SFTP/S3 destination writer) waits on this 'end' event to know the
+    // artifact is complete. Before the fix, this never fires and the
+    // downstream write stream hangs forever despite every byte already
+    // having arrived.
+    await drive(stdoutEnded, 5_000);
+    expect(read()).toBe("dump-bytes");
+  });
+});

--- a/packages/adapters/test/backup-sftp-upload-stall.test.ts
+++ b/packages/adapters/test/backup-sftp-upload-stall.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The destination end of #516.
+ *
+ * `attachDemuxed` leaving stdout un-ended is the root cause of the "stuck in
+ * uploading" run (see backup-exec-stream-timeout.test.ts), but the destination
+ * had no bound of its own: whatever the reason bytes stopped, `put` waited on a
+ * write stream that would never close and never error, holding the run and the
+ * worker slot forever. These tests pin both halves of the bound — that a wedged
+ * upload fails, and that the bound is not tight enough to kill a live one.
+ */
+
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { drive } from "./helpers/docker-helper-harness";
+
+/** The SFTP write stream, scriptable as "accepts bytes" or "wedged". */
+class FakeWriteStream extends EventEmitter {
+  written = 0;
+  destroyedWith = false;
+  /** When false, write() applies backpressure and 'drain' never comes. */
+  accepting = true;
+
+  write(chunk: Buffer): boolean {
+    if (!this.accepting) return false;
+    this.written += chunk.byteLength;
+    return true;
+  }
+  end() {
+    queueMicrotask(() => this.emit("close"));
+  }
+  destroy() {
+    this.destroyedWith = true;
+    return this;
+  }
+}
+
+let ws: FakeWriteStream;
+
+vi.mock("ssh2", () => {
+  const { EventEmitter: EE } = require("node:events") as typeof import("node:events");
+  class FakeClient extends EE {
+    connect() {
+      queueMicrotask(() => this.emit("ready"));
+      return this;
+    }
+    sftp(cb: (err: Error | null, sftp: unknown) => void) {
+      cb(null, {
+        createWriteStream: () => ws,
+        mkdir: (_p: string, done: (e: Error | null) => void) => queueMicrotask(() => done(null)),
+        stat: (_p: string, done: (e: Error | null) => void) => queueMicrotask(() => done(null)),
+        rename: (_a: string, _b: string, done: (e: Error | null) => void) =>
+          queueMicrotask(() => done(null)),
+      });
+      return this;
+    }
+    end() {
+      this.emit("close");
+    }
+  }
+  return { Client: FakeClient };
+});
+
+// Imported after the mock so the destination's `new Client()` is the fake.
+const { resolveDestination } = await import("../src/backup/registry");
+await import("../src/backup/destinations/sftp");
+
+function destination() {
+  return resolveDestination({
+    id: "dst_1",
+    name: "backups",
+    kind: "sftp",
+    sshHost: "backup.example.com",
+    sshPort: 22,
+    sshUser: "openship",
+    // Values without the `enc1:` envelope decrypt verbatim, so no key needed.
+    sftpPasswordEnc: "pw",
+    pathPrefix: "/srv/backups",
+  } as Parameters<typeof resolveDestination>[0]);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  ws = new FakeWriteStream();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("SFTP upload silence is bounded, slowness is not", () => {
+  it("fails a wedged upload instead of waiting on a write stream that never closes", async () => {
+    const body = new PassThrough();
+    // Bytes land, then the stream stops accepting and never drains — the shape of
+    // the production stall, whatever its cause.
+    body.write(Buffer.alloc(1024, 1));
+    ws.accepting = false;
+    body.write(Buffer.alloc(4096, 1));
+
+    const put = destination().put("shop/db/run_1/pg-dump.zst", body, {});
+    const failure = expect(drive(put, 12 * 60_000, 5_000)).rejects;
+
+    await failure.toThrow(/SFTP upload stalled: no write progress for 600s/);
+    expect(ws.destroyedWith).toBe(true);
+  });
+
+  it("lets an upload whose source goes quiet inside execStream's idle budget finish", async () => {
+    const body = new PassThrough();
+    const put = destination().put("shop/db/run_1/pg-dump.zst", body, {});
+
+    // 9 minutes of silence: a pg_dump on a lock wait or a cold table scan is
+    // still healthy here — execStream allows it 10 minutes before abandoning it,
+    // and this destination must not be the one to give up first.
+    body.write(Buffer.alloc(512, 1));
+    await vi.advanceTimersByTimeAsync(9 * 60_000);
+    body.write(Buffer.alloc(512, 1));
+    body.end();
+
+    await expect(drive(put, 60_000)).resolves.toMatchObject({ bytesWritten: 1024 });
+    expect(ws.written).toBe(1024);
+    expect(ws.destroyedWith).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Command-based Docker backups (`pg_dump`, `mysqldump`, `mongodump`, custom hooks) could finish writing 100% of their bytes and then hang forever in `uploading`, because the exec attach stream's EOF never reached the destination writer.

## Related issue

None. Self-contained bug fix, no filed issue.

## Problem

An SFTP-destination backup run for a small (~1.7MB) Postgres database sat in `uploading` indefinitely. The `.uploading-*` temp file on the destination stopped growing at a fixed, fully-correct byte count and never got renamed to its final name. No error, no progress, no completion.

## Triage / Root cause

Instrumented the SFTP write stream during a live stuck run to log the raw `ssh2` SFTP channel state (outgoing window, buffered payloads) every 5s. At the moment of the stall the channel window was >2MB free and nothing was buffered, so the SSH/SFTP layer was completely idle. That ruled out a network or `ssh2` backpressure issue.

Reproduced the same `pg_dump | zstd` command directly via the `docker exec` CLI, bypassing Openship entirely: it completed in under half a second, producing a file the same size as where the "stall" happened. So the dump itself was never stalling mid-transfer. It was already fully done, and something downstream just never found out.

`DockerBackupExecutor.execStream` calls `attachDemuxed`, which pipes the exec attach stream through `docker.modem.demuxStream`. `demuxStream` only forwards `data` events; it never calls `.end()` on the destination sinks when the source stream ends. `attachDemuxed` never worked around this, so `stdout` (which becomes the backup artifact stream, piped straight into the destination writer) never received an `end` event once the exec process exited. The destination writer had nothing left to wait for and no signal to stop waiting.

The sibling function a bit lower in the same file, `demuxContainerStream` (used for volume/tar backups), already has this exact fix, with a comment explaining why it's needed. It just never got applied to the exec-based path.

## Fix

- `attachDemuxed`: end `stdout`/`stderrSink` when the source attach stream emits `end` or `close`, mirroring `demuxContainerStream`. Added a backstop that force-closes the sinks once the exec exit code is known, for connections (e.g. Docker reached over an SSH tunnel, as with a remotely-managed server) where `end`/`close` isn't always delivered promptly even though the process has already exited.
- `sftp.ts`: added a 2-minute idle watchdog around the SFTP write itself, so any other future cause of a stall (unrelated to this bug) surfaces as a clear, retryable error instead of hanging the run, and the worker slot behind it, forever.

## Verification

Reproduced against a live SFTP destination before and after the fix, same ~1.7MB Postgres dump:

```
Before: backup run status stuck in "uploading", errorMessage after the new
        watchdog's 2-minute timeout:
        "SFTP upload stalled: no write progress for 120s (wrote 1699620
        bytes so far)."

After:  backup run status "succeeded"
        startedAt  2026-08-09T10:39:05.439Z
        finishedAt 2026-08-09T10:39:08.733Z
        bytesTransferred: 1699619
```

Added a regression test in `backup-exec-stream-timeout.test.ts` asserting `stdout` emits `end` once the fake attach stream finishes (the mock's `demuxStream` reproduces the real bug: it only forwards `data`, same as `docker-modem`). Confirmed this test fails on the pre-fix code and passes with the fix, by toggling `packages/adapters/src/backup/executors/docker.ts` with `git stash` and re-running:

```
$ bun run test -- backup-exec-stream-timeout
 ✓ test/backup-exec-stream-timeout.test.ts (5 tests) 79ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full `packages/adapters` suite:

```
$ bun run test
 Test Files  106 passed | 1 failed (107)
      Tests  1046 passed | 1 failed (1047)
```

The one remaining failure (`remote-journal.test.ts`) is pre-existing and unrelated: reproduced identically on a clean `upstream/main` checkout with none of this PR's changes applied.

Note: on this machine, `bun run test` only collects correctly after a local, uncommitted `ssr.noExternal: ["zod"]` tweak to `packages/adapters/vitest.config.ts`. Without it, `import { z } from "zod"` resolves to a build missing the `z` export under Vite's SSR transform, unrelated to this PR (reproduced with a trivial standalone test and with this PR's changes fully reverted). Not included in this diff since it's a separate, unrelated environment issue; happy to open it as its own PR if useful.

## Notes / Risks

- Scoped to the exec-based backup path (`attachDemuxed`). The volume/tar path (`demuxContainerStream`) already had this fix and is untouched.
- The idle watchdog in `sftp.ts` is a defense-in-depth addition, not the root-cause fix. It would have converted the original hang into a clear error, but the actual fix is the `attachDemuxed` change above.

## Checklist

- [x] One change per PR: this PR is the exec-stream EOF fix only; an unrelated dashboard i18n fix found during the same investigation is #525
- [x] The diff is scoped: no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test` passes (1046 of 1047; the one unrelated pre-existing failure is noted above)
- [x] I understand every line of this diff and can explain it in review

