### PR TITLE
feat(apps): enable Uptime Kuma app template

### DIFF
--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -1267,7 +1267,8 @@
       ]
     },
     {
-      "available": false,
+      "available": true,
+      "verified": true,
       "id": "uptime-kuma",
       "name": "Uptime Kuma",
       "description": "Self-hosted uptime monitoring with status pages and alerts.",
@@ -1283,7 +1284,7 @@
       "services": [
         {
           "name": "uptime-kuma",
-          "image": "louislam/uptime-kuma:1",
+          "image": "louislam/uptime-kuma:2",
           "ports": [
             "3001:3001"
           ],
@@ -1294,7 +1295,21 @@
           ],
           "restart": "unless-stopped"
         }
-      ]
+      ],
+      "connection": {
+        "title": "Open Uptime Kuma",
+        "outputs": [
+          {
+            "id": "url",
+            "label": "URL",
+            "source": "publicUrl:uptime-kuma",
+            "kind": "url"
+          }
+        ],
+        "firstLogin": {
+          "note": "First run asks you to pick a database. Choose \"embedded\": this template only provisions Uptime Kuma's own SQLite volume, not an external MariaDB. Then create the admin user. There is no default account."
+        }
+      }
     },
     {
       "available": false,

--- a/packages/core/src/apps/catalog.test.ts
+++ b/packages/core/src/apps/catalog.test.ts
@@ -25,6 +25,13 @@ describe("app catalog (JSON)", () => {
     expect(isValidAppTemplate(null)).toBe(false);
     expect(isValidAppTemplate({ id: "x", name: "X", description: "d", kind: "template", logo: "x", category: "bogus" })).toBe(false);
   });
+
+  it("uptime-kuma is enabled on the current major image", () => {
+    const app = APP_TEMPLATES.find((a) => a.id === "uptime-kuma");
+    expect(app?.available).toBe(true);
+    expect(app?.services?.[0]?.image).toBe("louislam/uptime-kuma:2");
+    expect(app?.connection?.outputs.some((o) => o.source === "publicUrl:uptime-kuma")).toBe(true);
+  });
 });
 
 // A minimal valid template used to probe the stricter, version-aware gate.

--- a/packages/core/src/apps/catalog/uptime-kuma.json
+++ b/packages/core/src/apps/catalog/uptime-kuma.json
@@ -1,5 +1,6 @@
 {
-  "available": false,
+  "available": true,
+  "verified": true,
   "id": "uptime-kuma",
   "name": "Uptime Kuma",
   "description": "Self-hosted uptime monitoring with status pages and alerts.",
@@ -15,7 +16,7 @@
   "services": [
     {
       "name": "uptime-kuma",
-      "image": "louislam/uptime-kuma:1",
+      "image": "louislam/uptime-kuma:2",
       "ports": [
         "3001:3001"
       ],
@@ -26,5 +27,19 @@
       ],
       "restart": "unless-stopped"
     }
-  ]
+  ],
+  "connection": {
+    "title": "Open Uptime Kuma",
+    "outputs": [
+      {
+        "id": "url",
+        "label": "URL",
+        "source": "publicUrl:uptime-kuma",
+        "kind": "url"
+      }
+    ],
+    "firstLogin": {
+      "note": "First run asks you to pick a database. Choose \"embedded\": this template only provisions Uptime Kuma's own SQLite volume, not an external MariaDB. Then create the admin user. There is no default account."
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Enable the Uptime Kuma app template so it installs from the dashboard's Apps tab, and bump it to the current major image.

## Motivation

Uptime Kuma has come up as a requested app on Discord (alongside code-server and Metabase). The catalog entry already exists but is marked `available: false` and pinned to `louislam/uptime-kuma:1`, frozen since October 2025.

## Related issue

Closes #530

## Changes

- `packages/core/src/apps/catalog/uptime-kuma.json`: `available: true`, `verified: true`, image bumped to `louislam/uptime-kuma:2`, added a `connection` block (URL output plus a `firstLogin` note covering the 2.x database-choice step and the lack of default credentials).
- `packages/core/src/apps/catalog.json`: regenerated with `bun scripts/gen-catalog.ts`.
- `packages/core/src/apps/catalog.test.ts`: added a regression test asserting the uptime-kuma entry is `available` on the `:2` image.

## Verification

Deployed both `:1` and `:2` for real on a self-hosted server through the existing server-deploy flow.

```
$ docker ps --filter name=uptime-kuma --format '{{.Names}}\t{{.Status}}\t{{.Ports}}'
openship-uptime-kuma-prueba-catlogo-uptime-kuma   Up 17 seconds (healthy)   127.0.0.1:3055->3001/tcp

$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3055/
302
```

Repeated with `:2` on a separate container, confirmed healthy, and completed the full first-run wizard (database choice, then admin account creation) end to end through a browser.

```
$ bun x vitest run src/apps/catalog.test.ts   # packages/core
 ✓ src/apps/catalog.test.ts (21 tests) 13ms

$ bun run test                                 # repo root, all workspaces
 Tasks: 7 successful, 7 total

$ bun run --cwd packages/core lint
$ bun run --cwd apps/api lint
$ tsc --noEmit                                 # both clean
```

Confirmed the new test actually catches a revert: flipped `available` back to `false` locally, the new test failed on that exact line, restored it, test passed again.

## Screenshots

Not applicable, dashboard-side rendering is the same generic single-service install wizard already used by other simple apps (for example Excalidraw).

## Checklist

- [x] One change per PR, one agreed feature, nothing unrelated bundled in
- [x] The diff is scoped to the two catalog files, no reformatting
- [x] A test fails without this change and passes with it. Added a test asserting the uptime-kuma entry is `available` on the `:2` image. Confirmed it fails when `available` is reverted to `false` and passes once restored (see Verification)
- [x] `bun run test` and lint pass locally. `bun format` was not run directly since it reformats unrelated pre-existing Prettier drift across the repo; used `bunx prettier --write` on the touched files instead, then reverted it since it collapsed unrelated array formatting inconsistent with every other catalog entry (for example `grafana.json`)
- [x] I understand every line of this diff and can explain it in review
