### PR TITLE
feat(apps): add Umami app template

### DIFF
--- a/apps/dashboard/src/components/AppLogo.tsx
+++ b/apps/dashboard/src/components/AppLogo.tsx
@@ -38,6 +38,7 @@ export const APP_LOGO: Record<
   freshrss: { slug: "freshrss" },
   excalidraw: { slug: "excalidraw" },
   qdrant: { slug: "qdrant" },
+  umami: { slug: "umami" },
   // Kafka's catalog id is "kafka"; its simpleicons brand slug is "apachekafka".
   // The mark is near-black (brand color #231F20), so it vanishes on the dark/dim
   // tiles — darkInvert flips it to near-white there (dark on light themes as-is).

--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -1829,6 +1829,92 @@
           }
         ]
       }
+    },
+    {
+      "available": true,
+      "verified": true,
+      "id": "umami",
+      "name": "Umami",
+      "description": "Lightweight, privacy-focused website analytics without cookies or personal data collection.",
+      "kind": "template",
+      "logo": "umami",
+      "category": "analytics",
+      "tags": [
+        "analytics",
+        "privacy",
+        "web"
+      ],
+      "framework": "docker-compose",
+      "services": [
+        {
+          "name": "umami-db",
+          "image": "postgres:15-alpine",
+          "environment": {
+            "POSTGRES_DB": "umami",
+            "POSTGRES_USER": "umami"
+          },
+          "secretEnv": [
+            "POSTGRES_PASSWORD"
+          ],
+          "volumes": [
+            "umami_db_data:/var/lib/postgresql/data"
+          ],
+          "restart": "unless-stopped"
+        },
+        {
+          "name": "umami",
+          "image": "ghcr.io/umami-software/umami:postgresql-latest",
+          "ports": [
+            "3009:3000"
+          ],
+          "exposedPort": 3000,
+          "exposed": true,
+          "dependsOn": [
+            "umami-db"
+          ],
+          "environment": {
+            "DATABASE_URL": "postgresql://umami:{{config:POSTGRES_PASSWORD}}@umami-db:5432/umami"
+          },
+          "secretEnv": [
+            "APP_SECRET"
+          ],
+          "restart": "unless-stopped"
+        }
+      ],
+      "configFields": [
+        {
+          "key": "POSTGRES_PASSWORD",
+          "service": "umami-db",
+          "label": "Database password",
+          "help": "Auto-generated. Shared with the umami service's DATABASE_URL.",
+          "generate": "secret",
+          "secret": true
+        },
+        {
+          "key": "APP_SECRET",
+          "service": "umami",
+          "label": "App secret",
+          "help": "Auto-generated. Signs sessions.",
+          "generate": "secret",
+          "secret": true
+        }
+      ],
+      "connection": {
+        "title": "Open Umami",
+        "outputs": [
+          {
+            "id": "url",
+            "label": "URL",
+            "source": "publicUrl:umami",
+            "kind": "url"
+          }
+        ],
+        "firstLogin": {
+          "username": "admin",
+          "password": "umami",
+          "note": "Change the admin password right after your first login."
+        }
+      }
     }
   ]
 }

--- a/packages/core/src/apps/catalog/umami.json
+++ b/packages/core/src/apps/catalog/umami.json
@@ -1,0 +1,65 @@
+{
+  "available": true,
+  "verified": true,
+  "id": "umami",
+  "name": "Umami",
+  "description": "Lightweight, privacy-focused website analytics without cookies or personal data collection.",
+  "kind": "template",
+  "logo": "umami",
+  "category": "analytics",
+  "tags": ["analytics", "privacy", "web"],
+  "framework": "docker-compose",
+  "services": [
+    {
+      "name": "umami-db",
+      "image": "postgres:15-alpine",
+      "environment": {
+        "POSTGRES_DB": "umami",
+        "POSTGRES_USER": "umami"
+      },
+      "secretEnv": ["POSTGRES_PASSWORD"],
+      "volumes": ["umami_db_data:/var/lib/postgresql/data"],
+      "restart": "unless-stopped"
+    },
+    {
+      "name": "umami",
+      "image": "ghcr.io/umami-software/umami:postgresql-latest",
+      "ports": ["3009:3000"],
+      "exposedPort": 3000,
+      "exposed": true,
+      "dependsOn": ["umami-db"],
+      "environment": {
+        "DATABASE_URL": "postgresql://umami:{{config:POSTGRES_PASSWORD}}@umami-db:5432/umami"
+      },
+      "secretEnv": ["APP_SECRET"],
+      "restart": "unless-stopped"
+    }
+  ],
+  "configFields": [
+    {
+      "key": "POSTGRES_PASSWORD",
+      "service": "umami-db",
+      "label": "Database password",
+      "help": "Auto-generated. Shared with the umami service's DATABASE_URL.",
+      "generate": "secret",
+      "secret": true
+    },
+    {
+      "key": "APP_SECRET",
+      "service": "umami",
+      "label": "App secret",
+      "help": "Auto-generated. Signs sessions.",
+      "generate": "secret",
+      "secret": true
+    }
+  ],
+  "connection": {
+    "title": "Open Umami",
+    "outputs": [{ "id": "url", "label": "URL", "source": "publicUrl:umami", "kind": "url" }],
+    "firstLogin": {
+      "username": "admin",
+      "password": "umami",
+      "note": "Change the admin password right after your first login."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Umami (lightweight, privacy-focused, cookie-free website analytics) as an installable app in the catalog.

## Motivation

Requested in #532: users want a self-hostable analytics option that doesn't require cookie consent banners.

## Related issue

Closes #532

## Changes

- `packages/core/src/apps/catalog/umami.json`: new catalog entry — two-service docker-compose (Postgres + `ghcr.io/umami-software/umami:postgresql-latest`), auto-generated `POSTGRES_PASSWORD` shared into `DATABASE_URL` via `{{config:...}}` templating, auto-generated `APP_SECRET`. Host port pinned to `3009:3000` (not the image's default `3000:3000`) to avoid colliding with other catalog apps that already claim host port 3000.
- `packages/core/src/apps/catalog.json`: regenerated via `bun scripts/gen-catalog.ts`.
- `apps/dashboard/src/components/AppLogo.tsx`: added `umami: { slug: "umami" }` so the dashboard renders Umami's real brand mark instead of the generic fallback icon.

## Verification

```bash
$ bun run test src/apps/catalog.test.ts
 ✓ src/apps/catalog.test.ts (20 tests) 11ms
 Test Files  1 passed (1)
      Tests  20 passed (20)

$ bun run --cwd packages/core lint
$ tsc --noEmit
$ bun run --cwd apps/dashboard lint
$ tsc --noEmit
```

Also deployed live via `docker-compose` on a self-hosted Openship instance: both services (`umami-db`, `umami`) started healthy, ran their Prisma migrations, and the app served `HTTP 200` on the pinned host port with no port collisions.

## Screenshots

N/A (catalog/backend change; app UI is Umami's own, unmodified).

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one) — the existing `catalog.test.ts` schema-validation and sync tests cover any new bundled app automatically
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review