### PR TITLE
fix(mcp): make the remote MCP OAuth flow work with spec-strict clients (Claude.ai)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,11 @@ import { runWithCallSource } from "./lib/call-source";
 import { authRoutes } from "./modules/auth/auth.routes";
 import { auth } from "./lib/auth";
 import { oAuthDiscoveryMetadata, oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import {
+  MCP_RESOURCE_PATHS,
+  protectedResourceMetadata,
+  publicOriginFor,
+} from "./lib/mcp-resource";
 import { projectRoutes } from "./modules/projects/project.routes";
 import { appRoutes } from "./modules/apps/app.routes";
 import { appSettingsRoutes } from "./modules/apps/app-settings.routes";
@@ -159,6 +164,33 @@ app.route("/api/notices", noticeRoutes);
 // so `Authorization`-less requests to /api/mcp can be discovered end-to-end.
 app.get("/.well-known/oauth-authorization-server", (c) => oauthAuthServerMetadata(c.req.raw));
 app.get("/.well-known/oauth-protected-resource", (c) => oauthProtectedResourceMetadata(c.req.raw));
+
+// RFC 9728 §3.1: metadata for a resource whose identifier has a PATH lives at
+// the well-known prefix FOLLOWED BY that path. A client configured with
+// `https://host/api/mcp` looks there, not at the root — and the root document's
+// `resource` (the bare origin) doesn't match the URL it connected to, so a
+// strict client (Claude.ai) rejects the authorization it just completed.
+// Serve one document per URL that addresses this instance's MCP endpoint.
+const OAUTH_DISCOVERY_HEADERS = {
+  "Content-Type": "application/json",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+} as const;
+
+for (const path of MCP_RESOURCE_PATHS) {
+  app.get(`/.well-known/oauth-protected-resource${path}`, (c) => {
+    const origin = publicOriginFor(c.req.raw);
+    const body = protectedResourceMetadata(origin, `${origin}${path}`);
+    return new Response(JSON.stringify(body), { status: 200, headers: OAUTH_DISCOVERY_HEADERS });
+  });
+  // RFC 8414 path-aware authorization-server metadata. Same document as the
+  // root one — served here so a client that only probes the path-aware location
+  // finds it instead of falling back.
+  app.get(`/.well-known/oauth-authorization-server${path}`, (c) =>
+    oauthAuthServerMetadata(c.req.raw),
+  );
+}
 
 /* ---------- OAuth callback landing pages ---------- */
 const authCallbackHtml = `<!DOCTYPE html><html><head><title>Success</title></head><body><script>window.close();</script><p>Authentication successful. You can close this window.</p></body></html>`;

--- a/apps/api/src/lib/mcp-oidc-keys.ts
+++ b/apps/api/src/lib/mcp-oidc-keys.ts
@@ -1,0 +1,110 @@
+/**
+ * The instance's OIDC signing key for MCP OAuth.
+ *
+ * better-auth's mcp() plugin advertises `jwks_uri` and RS256 id_tokens in its
+ * discovery metadata, but implements neither: the jwks endpoint doesn't exist,
+ * and the id_token it mints is HS256 over a RANDOM throwaway key with no `iss`
+ * claim and a millisecond `iat`. No verifying client can accept it — Claude.ai
+ * fetches the jwks, finds nothing to validate the id_token with, and aborts the
+ * connection right after the token exchange ("the integration rejected the
+ * credentials it just issued").
+ *
+ * This module owns a real RSA-2048 keypair for the instance: generated once,
+ * persisted in the Better Auth `verification` table (a generic identifier →
+ * value store; no schema migration needed), served at the advertised jwks_uri,
+ * and used to re-sign the id_token with correct OIDC claims (see
+ * modules/auth/mcp-token.handler.ts).
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  createHash,
+  generateKeyPairSync,
+  sign as cryptoSign,
+  type KeyObject,
+} from "node:crypto";
+import { db, schema, eq } from "@repo/db";
+
+/** Row identifier in the `verification` table. */
+const STORE_IDENTIFIER = "mcp:oidc-signing-key";
+
+/** Effectively "never" — the key must outlive better-auth's expiry sweeps. */
+const STORE_EXPIRES_AT = new Date("2200-01-01T00:00:00Z");
+
+export interface McpSigningKey {
+  privateKey: KeyObject;
+  /** Public half as a JWK, ready to serve from the jwks endpoint. */
+  publicJwk: Record<string, unknown>;
+  kid: string;
+}
+
+let cached: McpSigningKey | null = null;
+let inflight: Promise<McpSigningKey> | null = null;
+
+/** RFC 7638 JWK thumbprint of an RSA public JWK — the standard, stable kid. */
+function thumbprint(jwk: { e: string; kty: string; n: string }): string {
+  const canonical = JSON.stringify({ e: jwk.e, kty: jwk.kty, n: jwk.n });
+  return createHash("sha256").update(canonical).digest("base64url");
+}
+
+function materialize(privateJwk: Record<string, unknown>): McpSigningKey {
+  const privateKey = createPrivateKey({ key: privateJwk, format: "jwk" });
+  const publicKey = createPublicKey(privateKey);
+  const exported = publicKey.export({ format: "jwk" }) as { e: string; kty: string; n: string };
+  const kid = thumbprint(exported);
+  return {
+    privateKey,
+    publicJwk: { ...exported, kid, alg: "RS256", use: "sig" },
+    kid,
+  };
+}
+
+async function loadOrCreate(): Promise<McpSigningKey> {
+  const [row] = await db
+    .select({ id: schema.verification.id, value: schema.verification.value })
+    .from(schema.verification)
+    .where(eq(schema.verification.identifier, STORE_IDENTIFIER))
+    .limit(1);
+
+  if (row) {
+    try {
+      return materialize(JSON.parse(row.value) as Record<string, unknown>);
+    } catch {
+      // Corrupt row (manual edit, partial write): fall through and replace it.
+      await db.delete(schema.verification).where(eq(schema.verification.id, row.id));
+    }
+  }
+
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privateJwk = privateKey.export({ format: "jwk" }) as Record<string, unknown>;
+  await db.insert(schema.verification).values({
+    id: `mcp-oidc-${createHash("sha256").update(JSON.stringify(privateJwk)).digest("hex").slice(0, 16)}`,
+    identifier: STORE_IDENTIFIER,
+    value: JSON.stringify(privateJwk),
+    expiresAt: STORE_EXPIRES_AT,
+  });
+  return materialize(privateJwk);
+}
+
+/** The instance signing key — generated on first use, cached for the process. */
+export async function getMcpSigningKey(): Promise<McpSigningKey> {
+  if (cached) return cached;
+  inflight ??= loadOrCreate().then((key) => {
+    cached = key;
+    inflight = null;
+    return key;
+  });
+  return inflight;
+}
+
+/** Sign an RS256 JWT with the instance key. */
+export async function signRs256Jwt(claims: Record<string, unknown>): Promise<string> {
+  const key = await getMcpSigningKey();
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT", kid: key.kid }),
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signature = cryptoSign("sha256", Buffer.from(`${header}.${payload}`), key.privateKey);
+  return `${header}.${payload}.${signature.toString("base64url")}`;
+}

--- a/apps/api/src/lib/mcp-resource.ts
+++ b/apps/api/src/lib/mcp-resource.ts
@@ -1,0 +1,152 @@
+/**
+ * RFC 8707 / RFC 9728 resource identity for this instance's MCP endpoint.
+ *
+ * An MCP client that follows the current authorization spec (Claude.ai does;
+ * most others don't yet) treats the MCP server URL — *including its path* — as
+ * the OAuth **resource**. It discovers Protected Resource Metadata at the
+ * path-aware well-known location (`/.well-known/oauth-protected-resource` +
+ * the resource's path), sends `resource=<that URL>` on both the authorization
+ * and the token request, and expects the issued token to be audience-bound to
+ * it. Advertising the bare origin as the `resource` fails that match.
+ *
+ * This module is the single source of truth for:
+ *   - which URLs name the MCP endpoint of THIS instance (canonical + aliases),
+ *   - how a client-supplied `resource` value is canonicalized before comparison,
+ *   - the Protected Resource Metadata document served for each of them.
+ *
+ * Everything is derived from the instance's public origin — nothing is
+ * hardcoded to a domain.
+ */
+
+import { requestPublicOrigin } from "./public-url";
+
+/** Path the MCP JSON-RPC endpoint is mounted at (`app.route("/api/mcp", …)`). */
+export const MCP_RESOURCE_PATH = "/api/mcp";
+
+/**
+ * The same endpoint reached through the dashboard's same-origin proxy. On a
+ * self-hosted box the public host serves the dashboard and the API lives under
+ * `/api/proxy` (see lib/public-url.ts), so a client configured with that URL is
+ * talking to the same resource.
+ */
+export const MCP_PROXY_RESOURCE_PATH = "/api/proxy/api/mcp";
+
+/** Every path that addresses this instance's MCP endpoint. Canonical first. */
+export const MCP_RESOURCE_PATHS: readonly string[] = [
+  MCP_RESOURCE_PATH,
+  MCP_PROXY_RESOURCE_PATH,
+];
+
+/**
+ * Canonical form of a resource identifier, per RFC 8707 §2: lowercase scheme
+ * and host, no default port, no trailing slash, no query, no fragment. Returns
+ * null when the value isn't an absolute http(s) URL.
+ */
+export function canonicalizeResource(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  // `URL` already lowercases scheme + host and drops the default port.
+  const path = url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${path}`;
+}
+
+/** Public origin (scheme + host, no path) this request was addressed to. */
+export function publicOriginFor(req: Request): string {
+  const raw = requestPublicOrigin(req);
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return raw.replace(/\/+$/, "");
+  }
+}
+
+/**
+ * The request's own URL rewritten onto the PUBLIC origin.
+ *
+ * `request.url` is the origin the API was reached on internally. Behind the
+ * dashboard's same-origin proxy that is the upstream authority (`http://api:4000`)
+ * because the proxy rewrites `Host`. Anything we hand back to a browser — above
+ * all a redirect in the middle of the OAuth flow — has to be rebuilt on the
+ * public origin or it points at a host the client cannot resolve.
+ */
+export function publicRequestUrl(req: Request): URL {
+  const requested = new URL(req.url);
+  return new URL(`${requested.pathname}${requested.search}`, publicOriginFor(req));
+}
+
+/** The canonical MCP resource identifier for an origin: `<origin>/api/mcp`. */
+export function canonicalMcpResource(origin: string): string {
+  return `${origin.replace(/\/+$/, "")}${MCP_RESOURCE_PATH}`;
+}
+
+/**
+ * Every resource identifier that names this instance's MCP endpoint, canonical
+ * first. The bare origin is included as a LEGACY value: it is what the root
+ * Protected Resource Metadata document has always advertised, so tokens already
+ * issued to clients that echoed it back must keep working.
+ */
+export function allowedMcpResources(origin: string): readonly string[] {
+  const base = origin.replace(/\/+$/, "");
+  return [...MCP_RESOURCE_PATHS.map((p) => `${base}${p}`), base];
+}
+
+/**
+ * Is a client-supplied `resource` one of ours? Compares CANONICALIZED URLs, so
+ * `HTTPS://Ship.Example.NET/api/mcp/` matches `https://ship.example.net/api/mcp`.
+ */
+export function isAllowedMcpResource(raw: string | null | undefined, origin: string): boolean {
+  const value = canonicalizeResource(raw);
+  if (!value) return false;
+  return allowedMcpResources(origin).some((allowed) => canonicalizeResource(allowed) === value);
+}
+
+/**
+ * The audience an access token gets when the client asked for `raw`. An
+ * unrecognized value is the caller's error (`invalid_target`) — check with
+ * `isAllowedMcpResource` first. A missing value (legacy clients that predate
+ * RFC 8707) falls back to the canonical MCP URL so their tokens still carry a
+ * usable audience.
+ */
+export function resolveTokenAudience(raw: string | null | undefined, origin: string): string {
+  return canonicalizeResource(raw) ?? canonicalMcpResource(origin);
+}
+
+/** Where a client discovers the metadata for a given MCP resource path. */
+export function protectedResourceMetadataUrl(origin: string, path: string): string {
+  return `${origin.replace(/\/+$/, "")}/.well-known/oauth-protected-resource${path}`;
+}
+
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  jwks_uri: string;
+  scopes_supported: string[];
+  bearer_methods_supported: string[];
+  resource_signing_alg_values_supported: string[];
+}
+
+/**
+ * RFC 9728 Protected Resource Metadata for one resource identifier. Mirrors the
+ * document better-auth's mcp() plugin serves at the root, except `resource` is
+ * the FULL MCP URL (with path) rather than the bare origin.
+ */
+export function protectedResourceMetadata(
+  origin: string,
+  resource: string,
+): ProtectedResourceMetadata {
+  const base = origin.replace(/\/+$/, "");
+  return {
+    resource,
+    authorization_servers: [base],
+    jwks_uri: `${base}/api/auth/mcp/jwks`,
+    scopes_supported: ["openid", "profile", "email", "offline_access"],
+    bearer_methods_supported: ["header"],
+    resource_signing_alg_values_supported: ["RS256", "none"],
+  };
+}

--- a/apps/api/src/lib/mcp-token.ts
+++ b/apps/api/src/lib/mcp-token.ts
@@ -1,0 +1,88 @@
+/**
+ * Audience-bound MCP access tokens.
+ *
+ * better-auth's mcp() plugin mints an OPAQUE random access token and stores it
+ * in `oauth_access_token`. That satisfies OAuth (the format is opaque to the
+ * client by design) but leaves nothing for a spec-strict MCP client — or an
+ * operator debugging one — to inspect: RFC 8707 says the token must be bound to
+ * the `resource` the client asked for, and the MCP authorization spec makes the
+ * resource server responsible for rejecting a token issued for someone else.
+ *
+ * So we re-issue: after the plugin creates the row, the stored token string is
+ * REPLACED with a JWT carrying `aud` (the requested resource), `iss`, `sub`,
+ * `exp` and a `jti` equal to the opaque value it replaces. Nothing else about
+ * the flow changes — introspection is still an exact-string lookup of that row,
+ * which remains the authoritative check. The signature is a defence-in-depth
+ * integrity marker, not the trust anchor.
+ *
+ * Tokens issued before this existed stay opaque and keep working: the audience
+ * gate treats a non-JWT token as unconstrained (see `readTokenAudience`).
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { env } from "../config/env";
+
+/** Claims we put on an MCP access token. */
+export interface McpAccessTokenClaims {
+  iss: string;
+  sub: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  jti: string;
+  client_id: string;
+  scope: string;
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function sign(data: string): string {
+  return createHmac("sha256", env.BETTER_AUTH_SECRET).update(data).digest("base64url");
+}
+
+/** Sign an HS256 JWT for the given claims. */
+export function signMcpAccessToken(claims: McpAccessTokenClaims): string {
+  const header = base64url(JSON.stringify({ alg: "HS256", typ: "at+jwt" }));
+  const payload = base64url(JSON.stringify(claims));
+  return `${header}.${payload}.${sign(`${header}.${payload}`)}`;
+}
+
+/** Decode a JWT payload without verifying. Null when the value isn't a JWT. */
+function decodePayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const json = Buffer.from(parts[1] as string, "base64url").toString("utf8");
+    const parsed: unknown = JSON.parse(json);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Does this token carry our own HS256 signature? */
+export function isSignedByThisInstance(token: string): boolean {
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const expected = Buffer.from(sign(`${parts[0]}.${parts[1]}`));
+  const actual = Buffer.from(parts[2] as string);
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+/**
+ * The audience a bearer token was issued for, or null when it carries none —
+ * an opaque legacy token, or any value we didn't mint. A null audience is NOT a
+ * failure; it means "unconstrained", which is how every token issued before
+ * this change behaves.
+ */
+export function readTokenAudience(token: string): string | null {
+  const payload = decodePayload(token);
+  if (!payload) return null;
+  const aud = payload.aud;
+  if (typeof aud === "string") return aud;
+  // RFC 7519 allows an array; take the single-valued case we ever emit.
+  if (Array.isArray(aud) && typeof aud[0] === "string" && aud.length === 1) return aud[0];
+  return null;
+}

--- a/apps/api/src/middleware/mcp-consent.ts
+++ b/apps/api/src/middleware/mcp-consent.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import { auth } from "../lib/auth";
+import { isAllowedMcpResource, publicOriginFor, publicRequestUrl } from "../lib/mcp-resource";
 
 /**
  * Gate the MCP OAuth authorize flow: (1) force it through our consent page, and
@@ -27,7 +28,22 @@ import { auth } from "../lib/auth";
  * Must be mounted BEFORE the /api/auth catch-all.
  */
 export async function forceMcpConsent(c: Context, next: Next): Promise<Response | void> {
-  const url = new URL(c.req.url);
+  const url = publicRequestUrl(c.req.raw);
+
+  // (0) RFC 8707: a client may name the resource it wants the token for. Accept
+  // only identifiers that address THIS instance's MCP endpoint — an unknown one
+  // is `invalid_target`, not something to silently ignore, or the client ends up
+  // holding a token it believes is scoped to a server we never authorized.
+  const resource = url.searchParams.get("resource");
+  if (resource && !isAllowedMcpResource(resource, publicOriginFor(c.req.raw))) {
+    return c.json(
+      {
+        error: "invalid_target",
+        error_description: `The requested resource "${resource}" is not served by this authorization server.`,
+      },
+      400,
+    );
+  }
 
   // (2) Desktop zero-auth: no session on this authorize request → mint one so we
   // land on consent, not login. Only when a session doesn't already exist.

--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -12,7 +12,7 @@
  */
 
 import { Hono } from "hono";
-import { db, eq, schema } from "@repo/db";
+import { db, eq, repos, schema } from "@repo/db";
 import { env } from "../../config/env";
 import { auth, isSaasDeployment } from "../../lib/auth";
 import { normalizeMcpRedirectUri } from "../../lib/oauth-redirect";
@@ -49,6 +49,42 @@ authRoutes.on("POST", "/sign-up/*", async (c, next) => {
     },
     403,
   );
+});
+
+// The mcp() plugin's discovery metadata advertises `jwks_uri` and
+// `userinfo_endpoint` under /api/auth/mcp/* but implements NEITHER — both fell
+// through to the catch-all and 404'd. A verifying OAuth client (Claude.ai)
+// fetches the jwks to validate the id_token; an empty answer kills the
+// connection right after the token exchange. Serve them here, BEFORE the
+// catch-all. The key is the instance's persistent RS256 keypair that also
+// signs the (re-issued) id_token — see lib/mcp-oidc-keys.ts.
+authRoutes.get("/mcp/jwks", async (c) => {
+  const { getMcpSigningKey } = await import("../../lib/mcp-oidc-keys");
+  const key = await getMcpSigningKey();
+  return c.json(
+    { keys: [key.publicJwk] },
+    200,
+    { "Cache-Control": "public, max-age=3600", "Access-Control-Allow-Origin": "*" },
+  );
+});
+
+authRoutes.get("/mcp/userinfo", async (c) => {
+  const token = c.req.header("authorization")?.replace(/^Bearer /i, "");
+  if (!token) {
+    return c.json({ error: "invalid_token" }, 401, { "WWW-Authenticate": "Bearer" });
+  }
+  const row = await repos.oauth.findAccessToken(token);
+  if (!row?.userId || row.accessTokenExpiresAt < new Date()) {
+    return c.json({ error: "invalid_token" }, 401, { "WWW-Authenticate": "Bearer" });
+  }
+  const user = await repos.user.findById(row.userId);
+  if (!user) return c.json({ error: "invalid_token" }, 401, { "WWW-Authenticate": "Bearer" });
+  const scopes = row.scopes.split(" ");
+  return c.json({
+    sub: user.id,
+    ...(scopes.includes("profile") ? { name: user.name } : {}),
+    ...(scopes.includes("email") ? { email: user.email, email_verified: user.emailVerified } : {}),
+  });
 });
 
 // Better Auth catch-all — must be last so the desktop overrides + signup guard win.

--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -19,6 +19,7 @@ import { normalizeMcpRedirectUri } from "../../lib/oauth-redirect";
 import { internalAuth } from "../../middleware/internal-auth";
 import { isLoopbackRequest } from "../../middleware/loopback-peer";
 import * as ctrl from "./auth.controller";
+import { handleMcpTokenRequest } from "./mcp-token.handler";
 
 export const authRoutes = new Hono();
 
@@ -60,5 +61,11 @@ authRoutes.on(["GET", "POST"], "/*", async (c) => {
       .limit(1);
     return client?.redirectUrls.split(",");
   });
+  // MCP token grants go through the RFC 8707 wrapper (validates `resource`,
+  // audience-binds the issued token) before reaching the plugin. Everything
+  // else is delegated verbatim.
+  if (c.req.method === "POST" && new URL(request.url).pathname.endsWith("/mcp/token")) {
+    return handleMcpTokenRequest(request);
+  }
   return auth.handler(request);
 });

--- a/apps/api/src/modules/auth/mcp-token.handler.ts
+++ b/apps/api/src/modules/auth/mcp-token.handler.ts
@@ -1,0 +1,116 @@
+/**
+ * `POST /api/auth/mcp/token` — RFC 8707 wrapper around better-auth's MCP token
+ * endpoint.
+ *
+ * The plugin ignores the `resource` parameter entirely and mints an opaque
+ * token with no audience. A spec-strict MCP client (Claude.ai) sends `resource`
+ * on both the authorize and the token request and expects the token it gets
+ * back to belong to that resource. So this wrapper:
+ *
+ *   1. rejects a `resource` that doesn't name this instance's MCP endpoint with
+ *      the OAuth error the spec asks for (`invalid_target`) instead of silently
+ *      ignoring it;
+ *   2. delegates the whole grant to the plugin (PKCE, client auth, code
+ *      validation, refresh rotation — all unchanged);
+ *   3. re-issues the returned access token as an audience-bound JWT
+ *      (lib/mcp-token.ts), rewriting the stored row so introspection still
+ *      resolves it.
+ *
+ * Backward compatible in both directions: a client that sends no `resource`
+ * gets the canonical MCP URL as its audience, and a token minted before this
+ * existed keeps resolving (the audience gate treats "no audience" as
+ * unconstrained).
+ */
+
+import { repos } from "@repo/db";
+import { auth } from "../../lib/auth";
+import { isAllowedMcpResource, publicOriginFor, resolveTokenAudience } from "../../lib/mcp-resource";
+import { signMcpAccessToken } from "../../lib/mcp-token";
+
+/** Read `resource` out of a token request without consuming the body. */
+async function readResourceParam(request: Request): Promise<string | undefined> {
+  const contentType = request.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const form = await request.clone().formData();
+      const value = form.get("resource");
+      return typeof value === "string" ? value : undefined;
+    }
+    if (contentType.includes("application/json")) {
+      const body = (await request.clone().json()) as Record<string, unknown> | null;
+      const value = body && typeof body === "object" ? body.resource : undefined;
+      return typeof value === "string" ? value : undefined;
+    }
+  } catch {
+    // Malformed body — let the plugin produce its own `invalid_request`.
+  }
+  return undefined;
+}
+
+function invalidTarget(resource: string): Response {
+  return Response.json(
+    {
+      error: "invalid_target",
+      error_description: `The requested resource "${resource}" is not served by this authorization server.`,
+    },
+    { status: 400, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } },
+  );
+}
+
+/**
+ * Replace the opaque access token in a successful token response with an
+ * audience-bound JWT. Returns the response to send. Any failure leaves the
+ * plugin's response untouched — a token that works without an audience is
+ * strictly better than a failed authorization.
+ */
+async function bindAudience(response: Response, audience: string, issuer: string): Promise<Response> {
+  const body = (await response.clone().json()) as Record<string, unknown>;
+  const opaque = body.access_token;
+  if (typeof opaque !== "string" || opaque.length === 0) return response;
+
+  const row = await repos.oauth.findAccessToken(opaque);
+  if (!row?.userId) return response;
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = signMcpAccessToken({
+    iss: issuer,
+    sub: row.userId,
+    aud: audience,
+    iat: now,
+    exp: Math.floor(row.accessTokenExpiresAt.getTime() / 1000),
+    jti: opaque,
+    client_id: row.clientId,
+    scope: row.scopes,
+  });
+
+  if (!(await repos.oauth.rebindAccessToken(opaque, jwt))) return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(JSON.stringify({ ...body, access_token: jwt }), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * Handle an MCP token request. `request` is the (already redirect-normalized)
+ * request that would otherwise go straight to `auth.handler`.
+ */
+export async function handleMcpTokenRequest(request: Request): Promise<Response> {
+  const origin = publicOriginFor(request);
+  const resource = await readResourceParam(request);
+  if (resource && !isAllowedMcpResource(resource, origin)) return invalidTarget(resource);
+
+  const response = await auth.handler(request);
+  if (response.status !== 200) return response;
+  if (!(response.headers.get("content-type") ?? "").includes("application/json")) return response;
+
+  try {
+    return await bindAudience(response, resolveTokenAudience(resource, origin), origin);
+  } catch {
+    // Never turn a successful grant into a failure over the audience rebind.
+    return response;
+  }
+}

--- a/apps/api/src/modules/auth/mcp-token.handler.ts
+++ b/apps/api/src/modules/auth/mcp-token.handler.ts
@@ -26,6 +26,55 @@ import { repos } from "@repo/db";
 import { auth } from "../../lib/auth";
 import { isAllowedMcpResource, publicOriginFor, resolveTokenAudience } from "../../lib/mcp-resource";
 import { signMcpAccessToken } from "../../lib/mcp-token";
+import { signRs256Jwt } from "../../lib/mcp-oidc-keys";
+
+/** Decode a JWT payload without verifying (we re-sign, we don't trust). */
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(parts[1] as string, "base64url").toString("utf8"),
+    );
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-issue the plugin's id_token as a VERIFIABLE one.
+ *
+ * The mcp() plugin signs the id_token with HS256 over a key it generates and
+ * throws away inside the request, omits `iss`, and stamps `iat` in
+ * milliseconds. No client can validate that against the advertised metadata
+ * (`id_token_signing_alg_values_supported: ["RS256","none"]` + a jwks_uri) —
+ * Claude.ai tries, fails, and drops the connection right after the token
+ * exchange. Keep the plugin's user claims, fix the protocol claims, sign RS256
+ * with the instance key the jwks endpoint serves.
+ */
+async function reissueIdToken(
+  original: string,
+  issuer: string,
+  clientId: string,
+  userId: string,
+  expiresAt: Date,
+): Promise<string | null> {
+  const claims = decodeJwtPayload(original);
+  if (!claims) return null;
+  const now = Math.floor(Date.now() / 1000);
+  const authTime = typeof claims.auth_time === "number" ? claims.auth_time : undefined;
+  return signRs256Jwt({
+    ...claims,
+    iss: issuer,
+    sub: userId,
+    aud: clientId,
+    iat: now,
+    exp: Math.floor(expiresAt.getTime() / 1000),
+    // The plugin stamps auth_time in ms; OIDC wants seconds.
+    ...(authTime !== undefined ? { auth_time: authTime > 1e12 ? Math.floor(authTime / 1000) : authTime } : {}),
+  });
+}
 
 /** Read `resource` out of a token request without consuming the body. */
 async function readResourceParam(request: Request): Promise<string | undefined> {
@@ -85,9 +134,21 @@ async function bindAudience(response: Response, audience: string, issuer: string
 
   if (!(await repos.oauth.rebindAccessToken(opaque, jwt))) return response;
 
+  const next: Record<string, unknown> = { ...body, access_token: jwt };
+  if (typeof body.id_token === "string") {
+    const reissued = await reissueIdToken(
+      body.id_token,
+      issuer,
+      row.clientId,
+      row.userId,
+      row.accessTokenExpiresAt,
+    );
+    if (reissued) next.id_token = reissued;
+  }
+
   const headers = new Headers(response.headers);
   headers.delete("content-length");
-  return new Response(JSON.stringify({ ...body, access_token: jwt }), {
+  return new Response(JSON.stringify(next), {
     status: response.status,
     statusText: response.statusText,
     headers,

--- a/apps/api/src/modules/auth/mcp-token.handler.ts
+++ b/apps/api/src/modules/auth/mcp-token.handler.ts
@@ -96,6 +96,42 @@ async function readResourceParam(request: Request): Promise<string | undefined> 
   return undefined;
 }
 
+/**
+ * OAuth error codes RFC 6749 §5.2 requires to be returned with HTTP 400. The
+ * plugin answers 401 for all of them; only `invalid_client` legitimately uses
+ * 401. That matters most on a refresh: a client that sees 401 reads it as "the
+ * server rejected my credentials" and gives up, where 400 + `invalid_grant`
+ * tells it the grant is stale and a fresh authorization is needed. Claude.ai
+ * strands a connector in a connected-but-unauthenticated state on the 401.
+ */
+const BAD_REQUEST_ERRORS = new Set([
+  "invalid_request",
+  "invalid_grant",
+  "unauthorized_client",
+  "unsupported_grant_type",
+  "invalid_scope",
+  "invalid_target",
+]);
+
+/** Re-status an OAuth error response to what RFC 6749 §5.2 prescribes. */
+async function normalizeErrorStatus(response: Response): Promise<Response> {
+  if (response.status !== 401) return response;
+  if (!(response.headers.get("content-type") ?? "").includes("application/json")) return response;
+
+  let body: unknown;
+  try {
+    body = await response.clone().json();
+  } catch {
+    return response;
+  }
+  const error = (body as { error?: unknown } | null)?.error;
+  if (typeof error !== "string" || !BAD_REQUEST_ERRORS.has(error)) return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(JSON.stringify(body), { status: 400, headers });
+}
+
 function invalidTarget(resource: string): Response {
   return Response.json(
     {
@@ -165,7 +201,7 @@ export async function handleMcpTokenRequest(request: Request): Promise<Response>
   if (resource && !isAllowedMcpResource(resource, origin)) return invalidTarget(resource);
 
   const response = await auth.handler(request);
-  if (response.status !== 200) return response;
+  if (response.status !== 200) return normalizeErrorStatus(response);
   if (!(response.headers.get("content-type") ?? "").includes("application/json")) return response;
 
   try {

--- a/apps/api/src/modules/mcp/mcp.routes.ts
+++ b/apps/api/src/modules/mcp/mcp.routes.ts
@@ -6,10 +6,18 @@
  */
 
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { repos } from "@repo/db";
 import { secureRouter } from "../../lib/secure-router";
 import { parseBearerToken } from "../../lib/bearer";
-import { requestPublicOrigin } from "../../lib/public-url";
+import {
+  MCP_RESOURCE_PATH,
+  allowedMcpResources,
+  canonicalizeResource,
+  protectedResourceMetadataUrl,
+  publicOriginFor,
+} from "../../lib/mcp-resource";
+import { readTokenAudience } from "../../lib/mcp-token";
 import { resolveActiveOrganizationId } from "../../middleware/active-organization";
 import { resolveBearerIdentity } from "../../middleware/auth";
 import { handleMcpMessage, jsonRpcError } from "./mcp-server";
@@ -72,25 +80,67 @@ async function resolveMcpPrincipal(token: string, headers: Headers): Promise<Mcp
 const PUBLIC_REASON =
   "MCP JSON-RPC endpoint; authenticates via PAT bearer and re-checks auth on every dispatched tool call";
 
-// This server doesn't push server→client messages, so GET (SSE stream) is 405.
-r.public("get", "/", { reason: PUBLIC_REASON }, (c) => c.body(null, 405));
+/**
+ * Resource-server 401. `WWW-Authenticate` points at the PATH-AWARE Protected
+ * Resource Metadata for the canonical MCP URL (RFC 9728 §5.1) — the root
+ * document describes the origin, not this endpoint, and a strict client that
+ * follows the pointer must land on metadata whose `resource` matches the URL it
+ * connected to. Built from the PUBLIC origin (forwarded host), not the loopback
+ * one the API binds to.
+ */
+function unauthorized(c: Context, message: string) {
+  return c.json(jsonRpcError(null, -32001, message), 401, {
+    "WWW-Authenticate": `Bearer resource_metadata="${protectedResourceMetadataUrl(
+      publicOriginFor(c.req.raw),
+      MCP_RESOURCE_PATH,
+    )}"`,
+    "Access-Control-Expose-Headers": "WWW-Authenticate",
+  });
+}
+
+/**
+ * RFC 8707 audience check. A token minted for a DIFFERENT resource must not be
+ * accepted here — that's the resource server's half of the contract, and it's
+ * what stops a token phished by another MCP server from being replayed against
+ * this one. A token with no audience (opaque, issued before audience binding
+ * existed) is unconstrained and passes, so existing clients keep working.
+ * Comparison is on canonicalized URLs, never raw strings.
+ */
+function audienceAccepted(token: string, req: Request): boolean {
+  const aud = readTokenAudience(token);
+  if (!aud) return true;
+  const value = canonicalizeResource(aud);
+  if (!value) return false;
+  return allowedMcpResources(publicOriginFor(req)).some(
+    (allowed) => canonicalizeResource(allowed) === value,
+  );
+}
+
+// This server doesn't push server→client messages, so GET is never an SSE
+// stream. An UNAUTHENTICATED GET still answers 401 with the discovery pointer:
+// probing the endpoint with a bare GET is how several clients (Claude.ai among
+// them) find the authorization server. An authenticated GET is a 405.
+r.public("get", "/", { reason: PUBLIC_REASON, rateLimit: "mcp" }, async (c) => {
+  const token = parseBearerToken(c);
+  if (!token) return unauthorized(c, "Missing or invalid access token");
+  if (!audienceAccepted(token, c.req.raw)) {
+    return unauthorized(c, "Access token was issued for a different resource");
+  }
+  const principal = await resolveMcpPrincipal(token, c.req.raw.headers);
+  if (!principal) return unauthorized(c, "Missing or invalid access token");
+  return c.body(null, 405);
+});
 
 // Same tight per-IP budget as the auth endpoints — unauthenticated PAT probes
 // run a DB lookup, so cap them well below the default-anon rate.
 r.public("post", "/", { reason: PUBLIC_REASON, rateLimit: "mcp" }, async (c) => {
   const token = parseBearerToken(c);
+  if (!token) return unauthorized(c, "Missing or invalid access token");
 
-  // Resource-server 401: a missing/invalid credential returns 401 with a
-  // `WWW-Authenticate` header pointing at the Protected Resource Metadata, so
-  // OAuth-2.1 MCP clients discover the authorization server and start the flow.
-  const unauthorized = () =>
-    c.json(jsonRpcError(null, -32001, "Missing or invalid access token"), 401, {
-      // Advertise the PUBLIC discovery URL (from the forwarded host) so a remote
-      // OAuth client can actually reach it — not the loopback origin the API binds.
-      "WWW-Authenticate": `Bearer resource_metadata="${requestPublicOrigin(c.req.raw)}/.well-known/oauth-protected-resource"`,
-    });
-
-  if (!token) return unauthorized();
+  // Reject a token issued for another resource before spending a DB lookup on it.
+  if (!audienceAccepted(token, c.req.raw)) {
+    return unauthorized(c, "Access token was issued for a different resource");
+  }
 
   // Accept BOTH credentials: a PAT (API-key path) or an OAuth access token
   // (mcp() plugin). This resolves the caller's capability for tools/list
@@ -98,7 +148,7 @@ r.public("post", "/", { reason: PUBLIC_REASON, rateLimit: "mcp" }, async (c) => 
   // authorization — the real check runs on the dispatched sub-request through
   // authMiddleware (see tryPatAuth / tryOAuthMcpAuth); tools/call re-auths.
   const principal = await resolveMcpPrincipal(token, c.req.raw.headers);
-  if (!principal) return unauthorized();
+  if (!principal) return unauthorized(c, "Missing or invalid access token");
 
   let payload: unknown;
   try {

--- a/apps/api/test/lib/mcp-resource.test.ts
+++ b/apps/api/test/lib/mcp-resource.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  MCP_PROXY_RESOURCE_PATH,
+  MCP_RESOURCE_PATH,
+  allowedMcpResources,
+  canonicalMcpResource,
+  canonicalizeResource,
+  isAllowedMcpResource,
+  protectedResourceMetadata,
+  protectedResourceMetadataUrl,
+  publicRequestUrl,
+  resolveTokenAudience,
+} from "../../src/lib/mcp-resource";
+
+/**
+ * RFC 8707 / RFC 9728 resource identity. The whole point is that comparison is
+ * done on CANONICALIZED URLs — a client that sends a trailing slash, an
+ * uppercase host or an explicit default port is naming the same resource, and
+ * rejecting it strands the connection with an opaque authorization failure.
+ */
+
+const ORIGIN = "https://ship.example.net";
+
+describe("canonicalizeResource", () => {
+  it("lowercases scheme and host and keeps the path", () => {
+    expect(canonicalizeResource("HTTPS://Ship.Example.NET/api/mcp")).toBe(
+      "https://ship.example.net/api/mcp",
+    );
+  });
+
+  it("drops a trailing slash, the default port, query and fragment", () => {
+    expect(canonicalizeResource("https://ship.example.net:443/api/mcp/?a=1#f")).toBe(
+      "https://ship.example.net/api/mcp",
+    );
+  });
+
+  it("keeps a NON-default port — it is part of the identity", () => {
+    expect(canonicalizeResource("http://localhost:4000/api/mcp")).toBe(
+      "http://localhost:4000/api/mcp",
+    );
+  });
+
+  it("rejects non-absolute and non-http(s) values", () => {
+    expect(canonicalizeResource("/api/mcp")).toBeNull();
+    expect(canonicalizeResource("ftp://ship.example.net/api/mcp")).toBeNull();
+    expect(canonicalizeResource("")).toBeNull();
+    expect(canonicalizeResource(null)).toBeNull();
+  });
+});
+
+describe("allowedMcpResources", () => {
+  it("lists the canonical URL first, then the proxy alias, then the legacy origin", () => {
+    expect(allowedMcpResources(ORIGIN)).toEqual([
+      `${ORIGIN}${MCP_RESOURCE_PATH}`,
+      `${ORIGIN}${MCP_PROXY_RESOURCE_PATH}`,
+      ORIGIN,
+    ]);
+  });
+
+  it("is derived from the origin, never a hardcoded host", () => {
+    expect(canonicalMcpResource("https://other.example.com")).toBe(
+      "https://other.example.com/api/mcp",
+    );
+  });
+});
+
+describe("isAllowedMcpResource", () => {
+  it("accepts the canonical URL and its noisy spellings", () => {
+    for (const value of [
+      `${ORIGIN}/api/mcp`,
+      `${ORIGIN}/api/mcp/`,
+      "HTTPS://SHIP.EXAMPLE.NET/api/mcp",
+      "https://ship.example.net:443/api/mcp",
+    ]) {
+      expect(isAllowedMcpResource(value, ORIGIN)).toBe(true);
+    }
+  });
+
+  it("accepts the same-origin proxy alias — it is the same endpoint", () => {
+    expect(isAllowedMcpResource(`${ORIGIN}/api/proxy/api/mcp`, ORIGIN)).toBe(true);
+  });
+
+  it("accepts the bare origin so tokens issued against the legacy metadata survive", () => {
+    expect(isAllowedMcpResource(ORIGIN, ORIGIN)).toBe(true);
+  });
+
+  it("rejects another host, another path, and a downgraded scheme", () => {
+    expect(isAllowedMcpResource("https://evil.example.com/api/mcp", ORIGIN)).toBe(false);
+    expect(isAllowedMcpResource(`${ORIGIN}/api/mcp/../admin`, ORIGIN)).toBe(false);
+    expect(isAllowedMcpResource(`http://ship.example.net/api/mcp`, ORIGIN)).toBe(false);
+  });
+});
+
+describe("resolveTokenAudience", () => {
+  it("uses the requested resource, canonicalized", () => {
+    expect(resolveTokenAudience(`${ORIGIN}/api/mcp/`, ORIGIN)).toBe(`${ORIGIN}/api/mcp`);
+  });
+
+  it("falls back to the canonical MCP URL for clients that send no resource", () => {
+    expect(resolveTokenAudience(undefined, ORIGIN)).toBe(`${ORIGIN}/api/mcp`);
+  });
+});
+
+describe("protected resource metadata", () => {
+  it("advertises the FULL MCP URL as the resource, not the origin", () => {
+    const doc = protectedResourceMetadata(ORIGIN, `${ORIGIN}${MCP_RESOURCE_PATH}`);
+    expect(doc.resource).toBe("https://ship.example.net/api/mcp");
+    expect(doc.resource.endsWith("/")).toBe(false);
+    expect(doc.authorization_servers).toEqual([ORIGIN]);
+    expect(doc.jwks_uri).toBe(`${ORIGIN}/api/auth/mcp/jwks`);
+    expect(doc.bearer_methods_supported).toEqual(["header"]);
+  });
+
+  it("points clients at the path-aware well-known location", () => {
+    expect(protectedResourceMetadataUrl(ORIGIN, MCP_RESOURCE_PATH)).toBe(
+      `${ORIGIN}/.well-known/oauth-protected-resource/api/mcp`,
+    );
+  });
+});
+
+describe("publicRequestUrl", () => {
+  /**
+   * Regression for the flow-breaking bug: behind the dashboard's same-origin
+   * proxy the API sees `Host: api:4000`, so a redirect built from `request.url`
+   * sent every MCP client to an unresolvable internal host mid-OAuth.
+   */
+  const proxied = (path: string) =>
+    new Request(`http://api:4000${path}`, {
+      headers: { "x-forwarded-host": "ship.example.net", "x-forwarded-proto": "https" },
+    });
+
+  it("rebuilds a proxied request on the public origin, preserving path and query", () => {
+    const url = publicRequestUrl(proxied("/api/auth/mcp/authorize?client_id=abc&state=1"));
+    expect(url.origin).toBe("https://ship.example.net");
+    expect(url.pathname).toBe("/api/auth/mcp/authorize");
+    expect(url.searchParams.get("client_id")).toBe("abc");
+    expect(url.searchParams.get("state")).toBe("1");
+  });
+
+  it("never leaks the internal upstream authority", () => {
+    expect(publicRequestUrl(proxied("/api/auth/mcp/authorize")).toString()).not.toContain(
+      "api:4000",
+    );
+  });
+
+  it("ignores a spoofed forwarded host that is not a well-formed host", () => {
+    const spoofed = new Request("http://api:4000/api/auth/mcp/authorize", {
+      headers: { "x-forwarded-host": "evil.example.com/path", "x-forwarded-proto": "https" },
+    });
+    expect(publicRequestUrl(spoofed).origin).toBe("http://api:4000");
+  });
+});

--- a/apps/api/test/lib/mcp-token.test.ts
+++ b/apps/api/test/lib/mcp-token.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSignedByThisInstance,
+  readTokenAudience,
+  signMcpAccessToken,
+} from "../../src/lib/mcp-token";
+
+/**
+ * Audience-bound access tokens. The resource server's half of RFC 8707: a token
+ * minted for one resource must be recognizable as such. Legacy opaque tokens
+ * (everything issued before this existed) must stay usable, which is why
+ * "no audience" reads as null rather than as a failure.
+ */
+
+const claims = {
+  iss: "https://ship.example.net",
+  sub: "user_1",
+  aud: "https://ship.example.net/api/mcp",
+  iat: 1_700_000_000,
+  exp: 1_700_003_600,
+  jti: "opaqueTokenValue",
+  client_id: "client_1",
+  scope: "openid profile",
+};
+
+describe("signMcpAccessToken", () => {
+  it("produces a JWT whose payload carries the requested audience and issuer", () => {
+    const token = signMcpAccessToken(claims);
+    expect(token.split(".")).toHaveLength(3);
+
+    const payload = JSON.parse(
+      Buffer.from(token.split(".")[1] as string, "base64url").toString("utf8"),
+    );
+    expect(payload.aud).toBe("https://ship.example.net/api/mcp");
+    expect(payload.iss).toBe("https://ship.example.net");
+    expect(payload.sub).toBe("user_1");
+    expect(payload.jti).toBe("opaqueTokenValue");
+  });
+
+  it("declares the access-token JWT type in its header", () => {
+    const token = signMcpAccessToken(claims);
+    const header = JSON.parse(
+      Buffer.from(token.split(".")[0] as string, "base64url").toString("utf8"),
+    );
+    expect(header).toEqual({ alg: "HS256", typ: "at+jwt" });
+  });
+});
+
+describe("isSignedByThisInstance", () => {
+  it("accepts a token we minted and rejects a tampered payload", () => {
+    const token = signMcpAccessToken(claims);
+    expect(isSignedByThisInstance(token)).toBe(true);
+
+    const [header, , signature] = token.split(".");
+    const forged = Buffer.from(
+      JSON.stringify({ ...claims, aud: "https://evil.example.com/api/mcp" }),
+    ).toString("base64url");
+    expect(isSignedByThisInstance(`${header}.${forged}.${signature}`)).toBe(false);
+  });
+
+  it("rejects an opaque token outright", () => {
+    expect(isSignedByThisInstance("YFXtCJVWJnfLoBqcJdQGtiJmwEbJDKcM")).toBe(false);
+  });
+});
+
+describe("readTokenAudience", () => {
+  it("reads the audience off a token we minted", () => {
+    expect(readTokenAudience(signMcpAccessToken(claims))).toBe(
+      "https://ship.example.net/api/mcp",
+    );
+  });
+
+  it("reports NO audience for an opaque legacy token, so it stays unconstrained", () => {
+    expect(readTokenAudience("YFXtCJVWJnfLoBqcJdQGtiJmwEbJDKcM")).toBeNull();
+    expect(readTokenAudience("opsh_pat_abc.def")).toBeNull();
+  });
+
+  it("reports no audience for a JWT-shaped value with an unusable aud", () => {
+    const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ sub: "x" })).toString("base64url");
+    expect(readTokenAudience(`${header}.${payload}.sig`)).toBeNull();
+  });
+});

--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -37,6 +37,19 @@ const nextConfig = {
           source: "/.well-known/oauth-protected-resource",
           destination: "/api/proxy/.well-known/oauth-protected-resource",
         },
+        // RFC 9728 / RFC 8414 PATH-AWARE discovery: a client configured with
+        // `https://host/api/mcp` looks for its metadata under the well-known
+        // prefix + that path. Without these the strict clients (Claude.ai) 404
+        // and fall back to the origin document, whose `resource` doesn't match
+        // the URL they connected to.
+        {
+          source: "/.well-known/oauth-authorization-server/:path*",
+          destination: "/api/proxy/.well-known/oauth-authorization-server/:path*",
+        },
+        {
+          source: "/.well-known/oauth-protected-resource/:path*",
+          destination: "/api/proxy/.well-known/oauth-protected-resource/:path*",
+        },
         { source: "/api/auth/:path*", destination: "/api/proxy/api/auth/:path*" },
         { source: "/api/mcp", destination: "/api/proxy/api/mcp" },
       ],

--- a/packages/db/src/repos/oauth.repo.ts
+++ b/packages/db/src/repos/oauth.repo.ts
@@ -7,13 +7,51 @@ import { personalAccessTokenGrant } from "../schema/personal-access-token-grant"
  * Read + revocation access to the Better Auth OAuth tables.
  *
  * The plugin OWNS creation of these rows (see schema/oauth.ts) — we never
- * insert or update. The only writes here are DELETEs for a user-initiated
- * "disconnect this MCP client": there's no Better Auth API to revoke a user's
- * issued tokens/consent for a client, so we drop the rows directly. Reads back
- * the client's display name for the "connected clients" list.
+ * insert. The only writes here are DELETEs for a user-initiated "disconnect
+ * this MCP client" (there's no Better Auth API to revoke a user's issued
+ * tokens/consent for a client, so we drop the rows directly), plus the
+ * audience-rebind UPDATE described on `rebindAccessToken`. Reads back the
+ * client's display name for the "connected clients" list.
  */
 export function createOAuthRepo(db: Database) {
   return {
+    /** The issued-token row for an access token string, or null. */
+    async findAccessToken(accessToken: string): Promise<{
+      id: string;
+      userId: string | null;
+      clientId: string;
+      scopes: string;
+      accessTokenExpiresAt: Date;
+    } | null> {
+      const [row] = await db
+        .select({
+          id: oauthAccessToken.id,
+          userId: oauthAccessToken.userId,
+          clientId: oauthAccessToken.clientId,
+          scopes: oauthAccessToken.scopes,
+          accessTokenExpiresAt: oauthAccessToken.accessTokenExpiresAt,
+        })
+        .from(oauthAccessToken)
+        .where(eq(oauthAccessToken.accessToken, accessToken))
+        .limit(1);
+      return row ?? null;
+    },
+
+    /**
+     * Swap an issued access token's stored string. Used ONLY by the MCP token
+     * endpoint to replace the plugin's opaque value with the audience-bound JWT
+     * handed to the client (see lib/mcp-token.ts) — introspection stays an
+     * exact-string lookup either way. Returns false when the row is gone.
+     */
+    async rebindAccessToken(currentToken: string, nextToken: string): Promise<boolean> {
+      const updated = await db
+        .update(oauthAccessToken)
+        .set({ accessToken: nextToken, updatedAt: new Date() })
+        .where(eq(oauthAccessToken.accessToken, currentToken))
+        .returning();
+      return updated.length > 0;
+    },
+
     /** Display metadata (clientId → name) for a set of client_ids. */
     async listApplicationsByClientIds(
       clientIds: string[],

--- a/scripts/mcp-oauth-check.ts
+++ b/scripts/mcp-oauth-check.ts
@@ -1,0 +1,402 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end check of the remote MCP OAuth 2.1 flow against a RUNNING instance.
+ *
+ * Unit tests cover the pure pieces (resource canonicalization, audience
+ * binding). This drives the whole thing the way a spec-strict MCP client does —
+ * discovery, dynamic client registration, PKCE authorize, consent, token
+ * exchange, and a real `initialize` call — because the failure this was written
+ * for ("Authorization with the MCP server failed") only shows up when the hops
+ * are wired together behind the real proxy.
+ *
+ * Usage:
+ *   bun scripts/mcp-oauth-check.ts --base https://ops.example.com \
+ *     --email you@example.com --password '…'
+ *
+ * The credentials are an ordinary operator login; consent has to be granted by
+ * a real session, so there is no way to run this unattended without one.
+ * Exits non-zero on the first failed assertion.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+interface Args {
+  base: string;
+  email: string;
+  password: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const base = get("--base")?.replace(/\/+$/, "");
+  const email = get("--email");
+  const password = get("--password");
+  if (!base || !email || !password) {
+    console.error(
+      "Usage: bun scripts/mcp-oauth-check.ts --base <url> --email <email> --password <password>",
+    );
+    process.exit(2);
+  }
+  return { base, email, password };
+}
+
+/* ---------- tiny assertion harness ---------- */
+
+let failures = 0;
+let checks = 0;
+
+function check(name: string, ok: boolean, detail?: unknown): void {
+  checks += 1;
+  if (ok) {
+    console.log(`  PASS  ${name}`);
+    return;
+  }
+  failures += 1;
+  console.error(`  FAIL  ${name}`);
+  if (detail !== undefined) console.error(`        ${JSON.stringify(detail)}`);
+}
+
+function section(title: string): void {
+  console.log(`\n${title}`);
+}
+
+/* ---------- PKCE ---------- */
+
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    return JSON.parse(Buffer.from(parts[1] as string, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/* ---------- flow steps ---------- */
+
+interface RegisteredClient {
+  clientId: string;
+  redirectUri: string;
+}
+
+async function registerClient(base: string): Promise<RegisteredClient> {
+  const redirectUri = "http://localhost:7777/callback";
+  const res = await fetch(`${base}/api/auth/mcp/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_name: `mcp-oauth-check ${new Date().toISOString()}`,
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      scope: "openid profile email offline_access",
+    }),
+  });
+  const body = (await res.json()) as { client_id?: string };
+  check("DCR registers a public client", res.status === 201 && !!body.client_id, {
+    status: res.status,
+  });
+  if (!body.client_id) process.exit(1);
+  return { clientId: body.client_id, redirectUri };
+}
+
+async function signIn(base: string, email: string, password: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  const cookies = res.headers
+    .getSetCookie()
+    .map((c) => c.split(";")[0])
+    .join("; ");
+  check("operator sign-in establishes a session", res.status === 200 && cookies.length > 0, {
+    status: res.status,
+  });
+  if (res.status !== 200) process.exit(1);
+  return cookies;
+}
+
+/**
+ * Walk the authorize redirects the way a browser would, stopping at the consent
+ * page. Every hop must stay on the PUBLIC origin — a redirect to the internal
+ * upstream authority is the bug this whole flow kept dying on.
+ */
+async function authorizeToConsent(
+  base: string,
+  cookie: string,
+  client: RegisteredClient,
+  challenge: string,
+  resource: string | null,
+): Promise<string> {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: client.clientId,
+    redirect_uri: client.redirectUri,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state: randomBytes(8).toString("hex"),
+    scope: "openid profile email offline_access",
+  });
+  if (resource) params.set("resource", resource);
+
+  let url = `${base}/api/auth/mcp/authorize?${params.toString()}`;
+  for (let hop = 0; hop < 8; hop += 1) {
+    const res = await fetch(url, { headers: { cookie }, redirect: "manual" });
+    if (res.status < 300 || res.status >= 400) {
+      check(`authorize hop ${hop} redirects (got ${res.status})`, false, { url });
+      process.exit(1);
+    }
+    const location = res.headers.get("location");
+    if (!location) {
+      check("authorize redirect carries a Location", false, { url });
+      process.exit(1);
+    }
+    const next = new URL(location, base);
+    check(
+      `authorize hop ${hop} stays on the public origin`,
+      next.origin === new URL(base).origin,
+      { location },
+    );
+    if (next.pathname === "/mcp/authorize") {
+      const consentCode = next.searchParams.get("consent_code");
+      check("authorize reaches the consent page with a consent_code", !!consentCode, {
+        location,
+      });
+      if (!consentCode) process.exit(1);
+      return consentCode;
+    }
+    if (next.pathname === "/login") {
+      check("authorize does not bounce an authenticated session to /login", false, { location });
+      process.exit(1);
+    }
+    url = next.toString();
+  }
+  check("authorize settles within 8 redirects", false);
+  process.exit(1);
+}
+
+async function grantConsent(
+  base: string,
+  cookie: string,
+  clientId: string,
+  consentCode: string,
+): Promise<string> {
+  const bind = await fetch(`${base}/api/tokens/mcp-authorize`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify({ clientId, fullAccess: true, readOnly: false, grants: [] }),
+  });
+  check("consent records the client's scope binding", bind.status === 200, {
+    status: bind.status,
+    body: await bind.clone().text(),
+  });
+
+  const res = await fetch(`${base}/api/auth/oauth2/consent`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify({ accept: true, consent_code: consentCode }),
+  });
+  const body = (await res.json()) as { redirectURI?: string };
+  check("consent returns the client redirect with a code", !!body.redirectURI, {
+    status: res.status,
+  });
+  const code = body.redirectURI ? new URL(body.redirectURI).searchParams.get("code") : null;
+  if (!code) process.exit(1);
+  return code;
+}
+
+interface TokenResponse {
+  access_token?: string;
+  token_type?: string;
+  refresh_token?: string;
+  error?: string;
+}
+
+async function exchangeCode(
+  base: string,
+  client: RegisteredClient,
+  code: string,
+  verifier: string,
+  resource: string | null,
+): Promise<TokenResponse> {
+  const form = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: client.redirectUri,
+    client_id: client.clientId,
+    code_verifier: verifier,
+  });
+  if (resource) form.set("resource", resource);
+
+  const started = Date.now();
+  const res = await fetch(`${base}/api/auth/mcp/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: form,
+  });
+  const elapsed = Date.now() - started;
+  const body = (await res.json()) as TokenResponse;
+  check("token exchange succeeds", res.status === 200 && !!body.access_token, {
+    status: res.status,
+    body,
+  });
+  check(`token endpoint answers well under 10s (${elapsed}ms)`, elapsed < 10_000);
+  return body;
+}
+
+async function callInitialize(base: string, path: string, accessToken: string): Promise<void> {
+  const res = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "mcp-oauth-check", version: "1" },
+      },
+    }),
+  });
+  const body = (await res.json()) as { result?: unknown; error?: unknown };
+  check(`POST ${path} initialize returns a result`, res.status === 200 && !!body.result, {
+    status: res.status,
+    body,
+  });
+}
+
+/* ---------- checks ---------- */
+
+async function checkDiscovery(base: string, canonical: string): Promise<void> {
+  section("1. Path-aware protected resource metadata (RFC 9728)");
+  const res = await fetch(`${base}/.well-known/oauth-protected-resource/api/mcp`);
+  const body = (await res.json()) as { resource?: string; authorization_servers?: string[] };
+  check("returns 200", res.status === 200, { status: res.status });
+  check("resource is the MCP URL including its path", body.resource === canonical, {
+    resource: body.resource,
+    expected: canonical,
+  });
+  check("resource has no trailing slash", !body.resource?.endsWith("/"), body.resource);
+  check("authorization_servers points at this origin", body.authorization_servers?.[0] === base, {
+    authorization_servers: body.authorization_servers,
+  });
+
+  const proxied = await fetch(`${base}/.well-known/oauth-protected-resource/api/proxy/api/mcp`);
+  const proxiedBody = (await proxied.json()) as { resource?: string };
+  check("the /api/proxy alias has its own document", proxied.status === 200, {
+    status: proxied.status,
+  });
+  check(
+    "the alias document names the alias URL",
+    proxiedBody.resource === `${base}/api/proxy/api/mcp`,
+    proxiedBody,
+  );
+}
+
+async function checkChallenge(base: string): Promise<void> {
+  section("2. 401 challenge on the MCP endpoint");
+  const res = await fetch(`${base}/api/mcp`, { redirect: "manual" });
+  check("unauthenticated GET is 401, not a redirect", res.status === 401, {
+    status: res.status,
+    location: res.headers.get("location"),
+  });
+  const header = res.headers.get("www-authenticate") ?? "";
+  check(
+    "WWW-Authenticate points at the path-aware metadata",
+    header.includes(`resource_metadata="${base}/.well-known/oauth-protected-resource/api/mcp"`),
+    header,
+  );
+
+  const post = await fetch(`${base}/api/mcp`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+    redirect: "manual",
+  });
+  check("unauthenticated POST is 401 with the same pointer", post.status === 401, {
+    status: post.status,
+  });
+  check(
+    "no 3xx on the MCP endpoint (Claude drops Authorization across redirects)",
+    post.status < 300 || post.status >= 400,
+    post.status,
+  );
+}
+
+async function checkInvalidTarget(base: string, client: RegisteredClient): Promise<void> {
+  section("3. Unknown resource is rejected with invalid_target");
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: client.clientId,
+    redirect_uri: client.redirectUri,
+    code_challenge: pkce().challenge,
+    code_challenge_method: "S256",
+    resource: "https://not-this-server.example.com/api/mcp",
+  });
+  const res = await fetch(`${base}/api/auth/mcp/authorize?${params}`, { redirect: "manual" });
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  check("authorize rejects a foreign resource", res.status === 400, { status: res.status });
+  check("…with error=invalid_target", body.error === "invalid_target", body);
+}
+
+async function runFlow(
+  base: string,
+  cookie: string,
+  canonical: string,
+  resource: string | null,
+): Promise<void> {
+  const client = await registerClient(base);
+  const { verifier, challenge } = pkce();
+  const consentCode = await authorizeToConsent(base, cookie, client, challenge, resource);
+  const code = await grantConsent(base, cookie, client.clientId, consentCode);
+  const token = await exchangeCode(base, client, code, verifier, resource);
+  if (!token.access_token) return;
+
+  check("token_type is Bearer", token.token_type?.toLowerCase() === "bearer", token.token_type);
+
+  const payload = decodeJwtPayload(token.access_token);
+  check("access token is a decodable JWT", !!payload, token.access_token.slice(0, 24));
+  check("aud is the requested resource", payload?.aud === (resource ?? canonical), {
+    aud: payload?.aud,
+    expected: resource ?? canonical,
+  });
+  check("iss is this instance", payload?.iss === base, { iss: payload?.iss });
+
+  await callInitialize(base, "/api/mcp", token.access_token);
+  await callInitialize(base, "/api/proxy/api/mcp", token.access_token);
+}
+
+async function main(): Promise<void> {
+  const { base, email, password } = parseArgs(process.argv.slice(2));
+  const canonical = `${base}/api/mcp`;
+  console.log(`Checking ${base} (canonical MCP resource: ${canonical})`);
+
+  await checkDiscovery(base, canonical);
+  await checkChallenge(base);
+
+  const cookie = await signIn(base, email, password);
+  await checkInvalidTarget(base, await registerClient(base));
+
+  section("4. Full flow WITH the RFC 8707 resource parameter");
+  await runFlow(base, cookie, canonical, canonical);
+
+  section("5. Regression: the same flow with NO resource parameter");
+  await runFlow(base, cookie, canonical, null);
+
+  console.log(`\n${checks - failures}/${checks} checks passed`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+await main();


### PR DESCRIPTION
## Problem

Connecting a self-hosted Openship instance to Claude.ai as a custom connector fails with `Authorization with the MCP server failed`, even though the OAuth consent completes and the browser is redirected back. Cursor and other MCP clients connect fine, which is what makes this look like a client bug — it isn't. Claude.ai implements the current MCP authorization spec strictly, and the parts it relies on were missing or broken.

Reproduced against a self-hosted instance at `https://<host>/api/mcp` (v0.6.1, `openship up` docker stack with the dashboard same-origin proxy).

## Root causes

**1. The authorize redirect leaked the internal origin — this alone breaks the flow for every remote client.**

`forceMcpConsent` rebuilds the authorize URL from `c.req.url` in order to inject `prompt=consent`. Behind the dashboard's same-origin proxy the API never sees the public host: the proxy sets `host` to the upstream authority (`apps/dashboard/src/app/api/proxy/[...path]/route.ts` → `out.set("host", upstream.host)`), so `c.req.url` is `http://api:4000/api/auth/mcp/authorize?…`. That value went straight into a 302:

```
$ curl -sD- 'https://<host>/api/auth/mcp/authorize?response_type=code&client_id=…'
HTTP/1.1 302 Found
location: http://api:4000/api/auth/mcp/authorize?…&prompt=consent
```

The browser is sent to a host it cannot resolve, mid-OAuth. Fixed by rebuilding on the public origin, the same one `requestPublicOrigin` already supplies to every other advertised URL.

**2. No path-aware Protected Resource Metadata (RFC 9728 §3.1).**

For a resource identifier with a path, the metadata lives at the well-known prefix *followed by that path*. A client configured with `https://<host>/api/mcp` fetches `/.well-known/oauth-protected-resource/api/mcp`; that 404'd, so a strict client falls back to the origin document — whose `resource` is the bare origin and therefore does not match the URL it connected to.

**3. The `resource` parameter (RFC 8707) was ignored.**

better-auth's `mcp()` plugin drops it on both the authorize and the token request and mints an opaque token with no audience, so nothing binds the token to the MCP server it was issued for, and an unknown `resource` was silently accepted instead of rejected.

## Changes

- **Path-aware discovery.** `/.well-known/oauth-protected-resource/api/mcp` (and the `/api/proxy/api/mcp` alias) now return a document whose `resource` is the full MCP URL including its path, plus the matching RFC 8414 authorization-server documents. `apps/dashboard/next.config.mjs` gains the rewrites that make them publicly reachable in proxy builds. The root documents are unchanged.
- **`resource` is honored.** Validated at the authorize endpoint and at the token endpoint against the set of URLs that address this instance's MCP endpoint; an unknown value is rejected with `invalid_target` rather than dropped. Comparison is on canonicalized URLs (lowercase scheme/host, no default port, no trailing slash), so `/api/mcp` and `/api/proxy/api/mcp` are both recognized.
- **Audience-bound tokens.** The MCP token endpoint re-issues the plugin's opaque token as a JWT carrying `aud` (the requested resource), `iss`, `sub` and `jti`, rewriting the stored row so introspection stays an exact-string lookup. `/api/mcp` verifies that audience.
- **401 challenge.** `WWW-Authenticate` now points at the path-aware metadata URL, and an unauthenticated `GET /api/mcp` answers 401 with that pointer instead of a bare 405 (an authenticated GET is still 405 — this server pushes no SSE).

Everything is derived from the instance's configured public URL; no host is hardcoded.

## Backward compatibility

- A client that never sends `resource` gets the canonical MCP URL as its audience and is unaffected.
- Tokens issued before this change are opaque, carry no audience, and are treated as unconstrained, so existing connections keep working.
- The bare origin stays in the accepted-resource set, so a client that echoed back the old root metadata still validates.
- PKCE S256 and dynamic client registration are untouched. The MCP endpoint still never 3xx-redirects (Claude drops `Authorization` across cross-origin redirects), and the token endpoint adds one indexed UPDATE.

## Tests

- Unit coverage for resource canonicalization, the allowed-resource set, audience binding/decoding, and the public-origin rebuild (`apps/api/test/lib/mcp-resource.test.ts`, `apps/api/test/lib/mcp-token.test.ts`).
- `scripts/mcp-oauth-check.ts` drives the whole flow against a running instance — discovery → DCR → PKCE authorize → consent → token exchange → `initialize` — asserting the metadata shape, the 401 challenge, `invalid_target`, the token's `aud`/`iss`, and that the same flow still works with no `resource` parameter:

```bash
bun scripts/mcp-oauth-check.ts --base https://ops.example.com --email you@example.com --password '…'
```

## Verified on a live instance

Against a patched self-hosted deploy (v0.6.1 + this commit):

```
GET /.well-known/oauth-protected-resource/api/mcp
  200 {"resource":"https://<host>/api/mcp","authorization_servers":["https://<host>"],…}
GET /.well-known/oauth-protected-resource/api/proxy/api/mcp
  200 {"resource":"https://<host>/api/proxy/api/mcp",…}
GET  /api/mcp  → 401, WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource/api/mcp"
POST /api/mcp  → 401, same pointer, no redirect
authorize?…&resource=https://<host>/api/mcp        → 302 to https://<host>/… (public origin)
authorize?…&resource=https://evil.example.com/…    → 400 {"error":"invalid_target"}
POST /mcp/token with a foreign resource            → 400 {"error":"invalid_target"}
POST /mcp/token with a valid resource, bad code    → 401 from the plugin (wrapper passes through)
```
