### PR TITLE
feat(cli): add `openship deployment bisect` to find the first bad deployment

### DIFF
--- a/apps/cli/src/commands/deployment.ts
+++ b/apps/cli/src/commands/deployment.ts
@@ -46,6 +46,25 @@ function shortSha(v: unknown): string {
   return typeof v === "string" ? v.slice(0, 7) : "";
 }
 
+/** Resolve the project scope, clamp paging to the API's 100-row ceiling, and
+ *  return one page of deployments. */
+async function fetchDeployments(opts: {
+  project?: string;
+  env?: string;
+  limit?: string;
+}): Promise<Record<string, unknown>[]> {
+  const projectId: string | undefined = opts.project || readProjectLink()?.projectId;
+  const params = new URLSearchParams();
+  if (projectId) params.set("projectId", projectId);
+  if (opts.env) params.set("environment", opts.env);
+  params.set("perPage", String(Math.min(Number(opts.limit) || 50, 100)));
+  const qs = params.toString();
+  const res = await apiRequest<{ data?: Record<string, unknown>[] }>(
+    `/deployments${qs ? `?${qs}` : ""}`,
+  );
+  return res.data ?? [];
+}
+
 async function confirm(question: string): Promise<boolean> {
   if (!process.stdin.isTTY) return true;
   const rl = createInterface({ input: process.stdin, output: process.stderr });
@@ -61,16 +80,7 @@ const list = new Command("list")
   .option("--limit <n>", "Max rows to fetch", "50")
   .action(
     run(async (opts) => {
-      const projectId: string | undefined = opts.project || readProjectLink()?.projectId;
-      const params = new URLSearchParams();
-      if (projectId) params.set("projectId", projectId);
-      if (opts.env) params.set("environment", opts.env);
-      params.set("perPage", String(Math.min(Number(opts.limit) || 50, 100)));
-      const qs = params.toString();
-      const res = await apiRequest<{ data?: Record<string, unknown>[] }>(
-        `/deployments${qs ? `?${qs}` : ""}`,
-      );
-      const rows = (res.data ?? []).map((d) => ({
+      const rows = (await fetchDeployments(opts)).map((d) => ({
         id: d.id,
         status: d.status,
         env: d.environment,

--- a/apps/cli/src/commands/deployment.ts
+++ b/apps/cli/src/commands/deployment.ts
@@ -9,6 +9,7 @@
  *   usage     GET    /deployments/:id/usage     (container usage)
  *   redeploy  POST   /deployments/:id/redeploy  { useExistingCommit? }
  *   rollback  POST   /deployments/:id/rollback
+ *   bisect    —      binary search over list + rollback, no new route
  *   pin       POST   /deployments/:id/pin       { pinned }
  *   cancel    POST   /deployments/:id/cancel
  *   restart   POST   /deployments/:id/restart
@@ -20,9 +21,12 @@
  */
 import { Command } from "commander";
 import { createInterface } from "node:readline";
+import { isCancel, select } from "@clack/prompts";
 import { apiRequest, ApiError } from "../lib/api-client";
 import { readProjectLink } from "../lib/project-link";
-import { isJsonMode, printJson, printTable, ok, err } from "../lib/output";
+// `info` is aliased — this module already binds that name to the `info` subcommand.
+import { isJsonMode, printJson, printTable, ok, err, info as note } from "../lib/output";
+import { bisectDone, bisectMidpoint, bisectStep } from "../lib/bisect";
 
 /** Wrap a subcommand action so ApiError surfaces cleanly and exits non-zero. */
 function run<A extends unknown[]>(fn: (...args: A) => Promise<void>) {
@@ -46,8 +50,8 @@ function shortSha(v: unknown): string {
   return typeof v === "string" ? v.slice(0, 7) : "";
 }
 
-/** Resolve the project scope, clamp paging to the API's 100-row ceiling, and
- *  return one page of deployments. */
+/** Shared by `list` and `bisect`: resolve the project scope, clamp paging to the
+ *  API's 100-row ceiling, and return one page of deployments. */
 async function fetchDeployments(opts: {
   project?: string;
   env?: string;
@@ -159,6 +163,125 @@ const rollback = new Command("rollback")
     run(async (id: string) => {
       const res = await apiRequest(`/deployments/${id}/rollback`, { method: "POST" });
       report(res, `Rolled back to ${id}`);
+    }),
+  );
+
+interface BisectCandidate {
+  id: string;
+  branch: string;
+  commitSha: string | null;
+  version: number | null;
+  url: string | null;
+  createdAt: string;
+}
+
+function describeCandidate(d: BisectCandidate): string {
+  return `${d.id} (${d.version ? `v${d.version}` : shortSha(d.commitSha)}, ${d.branch}, ${d.createdAt})`;
+}
+
+const bisect = new Command("bisect")
+  .description("Binary-search deployment history to find the first bad deployment")
+  .option("--project <id>", "Scope to a project (defaults to the linked project)")
+  .option("--env <environment>", "Filter by environment: production | preview")
+  .option("--limit <n>", "Max deployments to search through", "50")
+  .option("--good <id>", "Known-good deployment ID (defaults to the oldest fetched)")
+  .option("--bad <id>", "Known-bad deployment ID (defaults to the most recent)")
+  .action(
+    run(async (opts) => {
+      if (!process.stdin.isTTY || isJsonMode()) {
+        err("`deployment bisect` is interactive — it needs a TTY and cannot run under --json.");
+        process.exit(1);
+      }
+
+      // Only ready/partial_failure actually deployed something visitable —
+      // queued/building/failed/cancelled/rejected have nothing to look at.
+      const testable: BisectCandidate[] = (await fetchDeployments(opts))
+        .filter((d) => d.status === "ready" || d.status === "partial_failure")
+        .map((d) => ({
+          id: String(d.id),
+          branch: String(d.branch ?? ""),
+          commitSha: (d.commitSha as string | null) ?? null,
+          version: (d.version as number | null) ?? null,
+          url: (d.url as string | null) ?? null,
+          createdAt: String(d.createdAt ?? ""),
+        }))
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+      if (testable.length < 2) {
+        err(
+          `Need at least two testable deployments (status ready/partial_failure) to bisect; found ${testable.length}. Try --env or raise --limit.`,
+        );
+        process.exit(1);
+      }
+
+      const goodIndex = opts.good ? testable.findIndex((d) => d.id === opts.good) : 0;
+      const badIndex = opts.bad
+        ? testable.findIndex((d) => d.id === opts.bad)
+        : testable.length - 1;
+
+      if (opts.good && goodIndex === -1) {
+        err(
+          `--good ${opts.good} not found among the last ${testable.length} testable deployments. Try --limit.`,
+        );
+        process.exit(1);
+      }
+      if (opts.bad && badIndex === -1) {
+        err(
+          `--bad ${opts.bad} not found among the last ${testable.length} testable deployments. Try --limit.`,
+        );
+        process.exit(1);
+      }
+      if (goodIndex >= badIndex) {
+        err(
+          "--good must be chronologically before --bad (need at least two testable deployments to bisect).",
+        );
+        process.exit(1);
+      }
+
+      let range = testable.slice(goodIndex, badIndex + 1);
+      note(
+        `Bisecting ${range.length} deployments between ${range[0].id} (good) and ${range[range.length - 1].id} (bad).\n`,
+      );
+
+      while (!bisectDone(range)) {
+        const mid = bisectMidpoint(range);
+        const candidate = range[mid];
+        note(`Testing ${describeCandidate(candidate)}`);
+        if (candidate.url) {
+          note(`  ${candidate.url}`);
+          try {
+            const { default: open } = await import("open");
+            await open(candidate.url);
+          } catch {
+            /* best-effort only; the URL above still works */
+          }
+        }
+
+        const answer = await select({
+          message: "Is this deployment good or bad?",
+          options: [
+            { value: "good" as const, label: "Good", hint: "this deployment works" },
+            { value: "bad" as const, label: "Bad", hint: "this deployment is broken" },
+            { value: "skip" as const, label: "Skip", hint: "can't tell — untestable" },
+            { value: "abort" as const, label: "Abort bisect" },
+          ],
+        });
+        if (isCancel(answer) || answer === "abort") {
+          err("Bisect aborted.");
+          process.exit(1);
+        }
+        range = bisectStep(range, mid, answer);
+      }
+
+      const goodDep = range[0];
+      const badDep = range[range.length - 1];
+      ok(`\nFirst bad deployment: ${describeCandidate(badDep)}`);
+      note(`Last known good:      ${describeCandidate(goodDep)}`);
+
+      if (await confirm(`\nRoll back to ${goodDep.id} now?`)) {
+        const rbRes = await apiRequest(`/deployments/${goodDep.id}/rollback`, { method: "POST" });
+        report(rbRes, `Rolled back to ${goodDep.id}`);
+      }
     }),
   );
 
@@ -286,6 +409,7 @@ export const deploymentCommand = new Command("deployment")
   .addCommand(usage)
   .addCommand(redeploy)
   .addCommand(rollback)
+  .addCommand(bisect)
   .addCommand(pin)
   .addCommand(cancel)
   .addCommand(restart)

--- a/apps/cli/src/lib/bisect.ts
+++ b/apps/cli/src/lib/bisect.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure binary-search core for `openship deployment bisect`. No I/O here —
+ * fetching the deployment list, prompting good/bad/skip, and the rollback
+ * call all live in commands/deployment.ts. Kept separate so the actual
+ * search logic is unit-testable without mocking @clack/prompts.
+ *
+ * Contract: `range` is chronological ascending, index 0 = known good,
+ * last index = known bad.
+ */
+
+export type BisectAnswer = "good" | "bad" | "skip";
+
+/** Index of the next candidate to test, or -1 once `range` can't be
+ *  narrowed further (down to just the good/bad boundary pair). */
+export function bisectMidpoint<T>(range: T[]): number {
+  return range.length > 2 ? Math.floor(range.length / 2) : -1;
+}
+
+export function bisectDone<T>(range: T[]): boolean {
+  return bisectMidpoint(range) === -1;
+}
+
+/** Narrow `range` given the answer for `range[mid]`. "good" moves the good
+ *  boundary up to the candidate; "bad" moves the bad boundary down to it;
+ *  "skip" drops the candidate and keeps both boundaries as-is. */
+export function bisectStep<T>(range: T[], mid: number, answer: BisectAnswer): T[] {
+  if (answer === "good") return range.slice(mid);
+  if (answer === "bad") return range.slice(0, mid + 1);
+  return [...range.slice(0, mid), ...range.slice(mid + 1)];
+}

--- a/apps/cli/test/e2e/deployment.test.ts
+++ b/apps/cli/test/e2e/deployment.test.ts
@@ -91,3 +91,156 @@ describe("openship deployment rollback", () => {
     expect(fetchStub.calls[0].url).toBe("http://api.test/api/deployments/dep1/rollback");
   });
 });
+
+// The interactive good/bad/skip loop and the final rollback prompt both read
+// real stdin (@clack/prompts `select`, the local readline `confirm`) once a
+// TTY is present — there's no mock seam for either in this harness (no other
+// command's tests exercise that path either), so only the deterministic
+// branches below are covered here. The binary-search math itself is fully
+// unit-tested in test/unit/bisect.test.ts.
+describe("openship deployment bisect", () => {
+  const realIsTTY = process.stdin.isTTY;
+  afterEach(() => {
+    (process.stdin as { isTTY?: boolean }).isTTY = realIsTTY;
+  });
+
+  it("refuses to run without a TTY — bisect needs a human to judge each candidate", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = false;
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("interactive");
+  });
+
+  it("errors when nothing in range is testable", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          { id: "dep1", status: "building", branch: "main", createdAt: "2024-01-01T00:00:00Z" },
+        ],
+      },
+    }));
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("Need at least two testable deployments");
+  });
+
+  it("errors on a single testable deployment without blaming flags the user never passed", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          { id: "dep-only", status: "ready", branch: "main", createdAt: "2024-01-01T00:00:00Z" },
+        ],
+      },
+    }));
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("Need at least two testable deployments");
+    expect(errOut).not.toContain("--good");
+  });
+
+  it("errors when --good isn't among the fetched deployments", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          { id: "dep-old", status: "ready", branch: "main", createdAt: "2024-01-01T00:00:00Z" },
+          { id: "dep-new", status: "ready", branch: "main", createdAt: "2024-01-02T00:00:00Z" },
+        ],
+      },
+    }));
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+      "--good",
+      "dep-missing",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("dep-missing");
+    expect(errOut).toContain("not found");
+  });
+
+  it("errors when --bad isn't among the fetched deployments", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          { id: "dep-old", status: "ready", branch: "main", createdAt: "2024-01-01T00:00:00Z" },
+          { id: "dep-new", status: "ready", branch: "main", createdAt: "2024-01-02T00:00:00Z" },
+        ],
+      },
+    }));
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+      "--bad",
+      "dep-missing",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("dep-missing");
+    expect(errOut).toContain("not found");
+  });
+
+  it("errors when --good is chronologically at or after --bad", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          { id: "dep-old", status: "ready", branch: "main", createdAt: "2024-01-01T00:00:00Z" },
+          { id: "dep-new", status: "ready", branch: "main", createdAt: "2024-01-02T00:00:00Z" },
+        ],
+      },
+    }));
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+      "--good",
+      "dep-new",
+      "--bad",
+      "dep-old",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("chronologically before");
+  });
+
+  it("excludes queued/building/failed deployments from the testable set", async () => {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          { id: "dep-queued", status: "queued", branch: "main", createdAt: "2024-01-01T00:00:00Z" },
+          { id: "dep-failed", status: "failed", branch: "main", createdAt: "2024-01-02T00:00:00Z" },
+        ],
+      },
+    }));
+    const { err: errOut, code } = await runCommand(deploymentCommand, [
+      "bisect",
+      "--project",
+      "p1",
+      "--env",
+      "production",
+    ]);
+    expect(code).toBe(1);
+    expect(errOut).toContain("found 0");
+    // bisect scopes its fetch exactly like `deployment list` does.
+    expect(fetchStub.calls[0].url).toBe(
+      "http://api.test/api/deployments?projectId=p1&environment=production&perPage=50",
+    );
+  });
+});

--- a/apps/cli/test/e2e/deployment.test.ts
+++ b/apps/cli/test/e2e/deployment.test.ts
@@ -11,6 +11,54 @@ import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
 let fetchStub: FetchStub;
 afterEach(() => fetchStub?.restore());
 
+describe("openship deployment list", () => {
+  it("scopes the query by project and environment, and renders the rows", async () => {
+    fetchStub = stubFetch(() => ({
+      json: {
+        data: [
+          {
+            id: "dep1",
+            status: "ready",
+            environment: "production",
+            branch: "main",
+            commitSha: "abcdef1234567890",
+            isActive: true,
+            createdAt: "2024-01-01T00:00:00Z",
+          },
+        ],
+      },
+    }));
+    const { out, code } = await runCommand(deploymentCommand, [
+      "list",
+      "--project",
+      "p1",
+      "--env",
+      "production",
+      "--limit",
+      "10",
+    ]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].url).toBe(
+      "http://api.test/api/deployments?projectId=p1&environment=production&perPage=10",
+    );
+    expect(out).toContain("dep1");
+    expect(out).toContain("abcdef1"); // commit column is the short sha
+  });
+
+  it("clamps --limit to the API's 100-row ceiling", async () => {
+    fetchStub = stubFetch(() => ({ json: { data: [] } }));
+    const { code } = await runCommand(deploymentCommand, [
+      "list",
+      "--project",
+      "p1",
+      "--limit",
+      "500",
+    ]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].url).toContain("perPage=100");
+  });
+});
+
 describe("openship deployment get", () => {
   it("GETs /deployments/:id and renders it", async () => {
     fetchStub = stubFetch(() => ({

--- a/apps/cli/test/unit/bisect.test.ts
+++ b/apps/cli/test/unit/bisect.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { bisectDone, bisectMidpoint, bisectStep } from "../../src/lib/bisect";
+
+describe("bisectMidpoint / bisectDone", () => {
+  it("has no midpoint left once only the good/bad boundary pair remains", () => {
+    expect(bisectMidpoint([1, 2])).toBe(-1);
+    expect(bisectDone([1, 2])).toBe(true);
+  });
+
+  it("picks the middle index for a larger range", () => {
+    expect(bisectMidpoint([1, 2, 3])).toBe(1);
+    expect(bisectMidpoint([1, 2, 3, 4, 5])).toBe(2);
+    expect(bisectDone([1, 2, 3])).toBe(false);
+  });
+});
+
+describe("bisectStep", () => {
+  const range = [1, 2, 3, 4, 5];
+
+  it("good moves the good boundary up to the candidate", () => {
+    expect(bisectStep(range, 2, "good")).toEqual([3, 4, 5]);
+  });
+
+  it("bad moves the bad boundary down to the candidate", () => {
+    expect(bisectStep(range, 2, "bad")).toEqual([1, 2, 3]);
+  });
+
+  it("skip drops the candidate and keeps both boundaries", () => {
+    expect(bisectStep(range, 2, "skip")).toEqual([1, 2, 4, 5]);
+  });
+});
+
+describe("full binary search converges to the first bad element", () => {
+  it("finds the boundary between good and bad in a monotonic history", () => {
+    // element index 6 (value 6) is the first "bad" one — everything before is good.
+    const history = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const firstBadIndex = 6;
+    let range = history;
+    let steps = 0;
+    while (!bisectDone(range)) {
+      const mid = bisectMidpoint(range);
+      range = bisectStep(range, mid, range[mid] >= firstBadIndex ? "bad" : "good");
+      steps++;
+      expect(steps).toBeLessThan(10); // sanity: must converge, never loop forever
+    }
+    expect(range).toEqual([firstBadIndex - 1, firstBadIndex]);
+  });
+
+  it("skip drops the untestable candidate and still converges, without ever mislabeling the boundary", () => {
+    // A skipped candidate is never determined good or bad, so the final
+    // bracket may be wider than the minimal pair — but it must still be
+    // correct: range[0] genuinely good, range[last] genuinely bad.
+    const history = [0, 1, 2, 3, 4, 5];
+    const firstBadIndex = 4;
+    let range = history;
+    let skippedOnce = false;
+    let steps = 0;
+    while (!bisectDone(range)) {
+      const mid = bisectMidpoint(range);
+      if (!skippedOnce) {
+        range = bisectStep(range, mid, "skip");
+        skippedOnce = true;
+      } else {
+        range = bisectStep(range, mid, range[mid] >= firstBadIndex ? "bad" : "good");
+      }
+      steps++;
+      expect(steps).toBeLessThan(10);
+    }
+    expect(range).toHaveLength(2);
+    expect(range[0]).toBeLessThan(firstBadIndex);
+    expect(range[1]).toBeGreaterThanOrEqual(firstBadIndex);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `openship deployment bisect`, a binary search over deployment history that finds the first bad deployment in roughly log2(n) checks instead of n, then offers a rollback to the last known-good one. No new API route, no schema change, no new dependency.

## Motivation

`deployment list` shows the history and `deployment rollback <id>` reverts to a chosen deployment, but nothing connects them: there is no supported way to find *which* deployment introduced a regression. In practice that means walking the history one deployment at a time — O(n) rollbacks, each one mutating the active deployment just to take a look.

Everything needed was already stored and already served. `deployment.version` is a monotonic per-project counter, `createdAt` orders the history, `url` is the visitable address, and all three already come back on `GET /api/deployments` — `presentDeployments` masks env only, it does not project columns away. Nothing consumed them for this.

On a project with 40 deployments between the last good release and the current broken one, this is 6 questions instead of 40.

## Related issue

Closes #541.

To be straight about the ordering: I opened #541 and this PR together rather than getting scope agreed first, so treat the issue as the proposal, not a settled decision. Happy to cut or reshape anything — the interactive flow, the rollback offer, the flag surface — if the approach isn't what you want.

## Changes

All in `apps/cli`, three commits, each building and passing on its own.

**`2663003c` refactor(cli): extract the shared deployment-list fetch**
- `src/commands/deployment.ts` — `list` built its query inline (project scope from `--project` or the linked project, optional env filter, `perPage` clamped to the API's 100-row ceiling). Pulled into `fetchDeployments()` so a second caller doesn't copy it. No behaviour change.
- `test/e2e/deployment.test.ts` — `deployment list` had **no test coverage at all**. Added two before touching it: one asserting the query built for `--project/--env/--limit` plus the rendered row, one pinning the 100-row clamp. Both pass before *and* after the extraction, which is what makes the refactor safe.

**`911f9875` feat(cli): add the pure binary-search core**
- `src/lib/bisect.ts` (new, 30 lines) — `bisectMidpoint` / `bisectDone` / `bisectStep`. No I/O, so the actual search logic is unit-testable without mocking prompts. `bisectMidpoint` returns -1 once only the boundary pair is left, which doubles as the termination signal; for a range of 3 or more it never lands on a boundary, so an already-known deployment is never re-asked.
- `test/unit/bisect.test.ts` (new) — 7 tests: midpoint/termination boundaries, all three transitions, and two full convergence simulations.

**`9661debd` feat(cli): add `openship deployment bisect`**
- `src/commands/deployment.ts` — the command, plus registration and one row in the module's route table.
- `test/e2e/deployment.test.ts` — 7 tests over the deterministic branches.

Deliberately reused rather than rebuilt: `run()`, `report()`, `confirm()`, `shortSha()`, `readProjectLink()`, the `output` helpers, `fetchDeployments()` from commit 1, `@clack/prompts`, and the `open` package with the same dynamic-import-and-swallow pattern as `openship open`.

**Status filter.** Only `ready` and `partial_failure` are treated as testable — `queued`/`building`/`deploying` haven't finished and `failed`/`cancelled`/`rejected` have nothing to visit. Note for reviewers: the API persists `ready`; `success` is a dashboard-side display mapping (`mapRowToDeployment`) and never appears in an API response, so a filter on `success` would match zero rows. Same distinction #410 is about, and the same eligibility set #414 settles on.

**Skip semantics.** A skipped candidate is never labelled, so the final bracket can be wider than the minimal transition pair. That is intended: the invariant reported on is that the lower bound is genuinely good and the upper bound genuinely bad, not that they are adjacent. There is a test that skips a midpoint and asserts the surviving bracket still straddles the real transition.

**Refuses to run** without a TTY or under `--json`, since neither can answer a prompt. Aborting (menu or Ctrl-C) and declining the final offer both leave the active deployment untouched.

## Verification

Each commit independently, on top of `main` at `30074018`:

```
2663003c refactor(cli): extract the shared deployment-list fetch | tsc:ok | fmt:ok | Tests 418 passed (418)
911f9875 feat(cli): add the pure binary-search core             | tsc:ok | fmt:ok | Tests 425 passed (425)
9661debd feat(cli): add `openship deployment bisect`            | tsc:ok | fmt:ok | Tests 432 passed (432)
```

`bun run test` (full monorepo): `Tasks: 7 successful, 7 total`.

**Against a real instance**, not a mock — API on :4000 with Postgres, `DEPLOY_MODE=docker`, a project deployed 7 times as real Docker containers where v5 onward serves HTTP 500, plus one `failed` deployment in the history:

```
Bisecting 7 deployments between dep_5K3h18vXnlkzvkxH (good) and dep_piaUjKAOqnXLTw17 (bad).
Testing dep_NZ_E7CcgB7AxtkxE (v4, main, 2026-08-11T04:46:59.502Z)   -> good
Testing dep_-8Wgc0FotXd1Lv9V (v6, main, 2026-08-11T04:47:21.410Z)   -> bad
Testing dep_fPCMZxBlHEhNphe_ (v5, main, 2026-08-11T04:47:10.446Z)   -> bad
First bad deployment: dep_fPCMZxBlHEhNphe_ (v5, main, 2026-08-11T04:47:10.446Z)
Last known good:      dep_NZ_E7CcgB7AxtkxE (v4, main, 2026-08-11T04:46:59.502Z)
Rolled back to dep_NZ_E7CcgB7AxtkxE
```

Three questions for seven candidates, correct culprit, and the `failed` deployment excluded by the status filter. The rollback was verified at the application layer, not just by exit code — it created a new deployment and the live container then answered:

```
HTTP 200 v4 OK
```

The interactive loop itself was driven through a real PTY (`expect`), with a `PATH` shim standing in for `open` so the browser calls were captured rather than launched:

```
skip path      -> v4 skipped, v5 bad, v3 good  -> first bad v5, last good v3 (wider bracket, as intended)
--good/--bad   -> range narrowed 7 -> 4, first bad v5, last good v4
abort (menu)   -> "Bisect aborted", exit 1, zero rollback requests
abort (Ctrl-C) -> "Bisect aborted", exit 1, zero rollback requests
decline offer  -> clean exit 0, zero rollback requests
open shim      -> called with the v4/v6/v5 URLs, in order
```

Not covered by automated tests, and stated rather than hidden: the live good/bad/skip loop and the final rollback prompt read real stdin, and this suite has no mock seam for `@clack/prompts` or a TTY — no other interactive command here has one either. That is what the PTY runs above are standing in for. The search logic those branches drive *is* fully unit-tested.

## Checklist

- [x] One change per PR — one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test`, `bun run --cwd apps/cli lint`, and `prettier --check` all pass locally
- [x] I understand every line of this diff and can explain it in review
