### PR TITLE
fix(deployments): allow commandless Dockerfile projects

### DIFF
--- a/apps/api/src/modules/deployments/preflight.ts
+++ b/apps/api/src/modules/deployments/preflight.ts
@@ -975,14 +975,20 @@ function checkConfig(snapshot: DeploymentConfigSnapshot, opts?: PreflightOptions
   // Mirrors the multi-service branch's dockerfile/build check. #231
   if (snapshot.framework !== "docker" && !snapshot.buildImage) missing.push("build image");
 
-  if (snapshot.hasBuild && !snapshot.installCommand) {
+  // A single-project Dockerfile owns install, build, and process startup. Those
+  // buildpack commands are deliberately empty after repository/folder detection
+  // and are not consumed by the Docker pipeline. The workload-specific checks
+  // below still enforce a port for web apps.
+  const dockerOwnsBuild = snapshot.framework === "docker";
+  if (!dockerOwnsBuild && snapshot.hasBuild && !snapshot.installCommand) {
     missing.push("install command");
   }
 
   const cls = snapshotToClass(snapshot);
   if (cls.workload === "web") {
     // A web app is reached on a port and must declare how it starts and listens.
-    if (!snapshot.startCommand) missing.push("start command");
+    // Dockerfile apps inherit their process command from the image.
+    if (!dockerOwnsBuild && !snapshot.startCommand) missing.push("start command");
     if (!snapshot.port) missing.push("port");
   } else if (cls.workload === "worker") {
     // A worker is a portless long-running container (#538-B): it needs a command

--- a/apps/api/test/modules/deployments/preflight.test.ts
+++ b/apps/api/test/modules/deployments/preflight.test.ts
@@ -187,6 +187,66 @@ describe("runPreflightChecks", () => {
     expect(result.checks.some((check) => check.message?.includes("start command"))).toBe(false);
   });
 
+  it("does not require buildpack commands for a single Dockerfile web project", async () => {
+    const result = await runPreflightChecks(
+      {
+        repoUrl: "",
+        branch: "",
+        sourceStaged: true,
+        framework: "docker",
+        buildImage: "ubuntu:22.04",
+        installCommand: "",
+        buildCommand: "",
+        startCommand: "",
+        port: 8080,
+        hasBuild: true,
+        hasServer: true,
+        deployTarget: "server",
+        organizationId: "org-1",
+      } as any,
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" } as any,
+        buildStrategy: "local",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "config", status: "pass" })]),
+    );
+    expect(result.checks.some((check) => check.message?.includes("install command"))).toBe(false);
+    expect(result.checks.some((check) => check.message?.includes("start command"))).toBe(false);
+  });
+
+  it("still requires a port for a single Dockerfile web project", async () => {
+    const result = await runPreflightChecks(
+      {
+        repoUrl: "",
+        branch: "",
+        sourceStaged: true,
+        framework: "docker",
+        installCommand: "",
+        buildCommand: "",
+        startCommand: "",
+        port: null,
+        hasBuild: true,
+        hasServer: true,
+        deployTarget: "server",
+        organizationId: "org-1",
+      } as any,
+      {
+        ctx: { userId: "user-1", organizationId: "org-1" } as any,
+        buildStrategy: "local",
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    const config = result.checks.find((check) => check.id === "config");
+    expect(config?.message).toContain("port");
+    expect(config?.message).not.toContain("install command");
+    expect(config?.message).not.toContain("start command");
+  });
+
   it("warns instead of failing on a monorepo sub-app that has never been deployed and has no commands", async () => {
     const result = await runPreflightChecks(
       {


### PR DESCRIPTION
## Summary

- skip buildpack install/start-command requirements for single-project Dockerfile builds
- keep the web-port requirement, since routing still needs a concrete target
- cover both the valid commandless Dockerfile path and the missing-port failure

## Why

Repository and folder detection can correctly classify a single Dockerfile project as `framework: "docker"` while leaving install, build, and start commands empty. Those fields are not consumed by the Docker pipeline: the Dockerfile owns the build and the image `CMD` owns startup. Preflight nevertheless rejected the project before the Docker build began.

This aligns the single-project check with the existing multi-service Dockerfile behavior.

## Verification

- `bun run --cwd apps/api test -- test/modules/deployments/preflight.test.ts` (17 tests passed)
- `bun run --cwd apps/api lint`
- reproduced end to end on a self-hosted instance: the unpatched preflight rejected the scanned Dockerfile project; with this change, preflight passed and the Docker image built successfully
