### PR TITLE
fix(deployments): probe local readiness from host

### DIFF
--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -36,7 +36,6 @@ import {
   isHostChannelUnavailableError,
   runDeployPipeline,
   isMultiServiceRuntime,
-  waitForReady,
   ensureEdge,
 } from "@repo/adapters";
 import { platform } from "../../lib/controller-helpers";
@@ -58,6 +57,8 @@ import {
   type DeployRouting,
 } from "./build-execution-plan";
 import { attachLinkedNetworks } from "./attach-linked-networks";
+import { resolveReadinessTarget } from "./readiness-target";
+import { waitForReadyFromExecutor } from "./forwarded-readiness";
 import { syncProjectToServerManifest } from "../../lib/openship-manifest-sync";
 import { syncManagedEdgeRoutes, edgeUnsyncedWarning } from "../../lib/managed-edge-proxy";
 import { decryptEnvMap } from "../../lib/encryption";
@@ -1590,25 +1591,12 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
         },
         resolveRoute: undefined,
         readiness: async (containerId, cfg) => {
-          let host = "127.0.0.1";
-          // An explicit `readiness.port` overrides; otherwise probe the app port
-          // and let the container-runtime lookup below remap it to the published one.
-          let port = readinessGate.probe.port ?? cfg.port;
-          if (runtime.name !== "bare" && readinessGate.probe.port === undefined) {
-            // Container runtime: prefer the published host port; fall back to the
-            // container's bridge IP:port (reachable on the local daemon).
-            try {
-              const info = await runtime.getContainerInfo(containerId);
-              if (info?.hostPort) {
-                port = info.hostPort;
-              } else if (runtime.supports("containerIp")) {
-                const ip = await runtime.getContainerIp(containerId);
-                if (ip) host = ip;
-              }
-            } catch {
-              /* fall back to 127.0.0.1:cfg.port */
-            }
-          }
+          const { host, port } = await resolveReadinessTarget({
+            runtime,
+            containerId,
+            primaryPort: cfg.port,
+            probePort: readinessGate.probe.port,
+          });
           // Name the address actually dialed. Reporting `cfg.port` here sent
           // operators to look at the app's own port (3000) when the probe had
           // really been talking to the published host port, so a wrong-port or
@@ -1619,11 +1607,25 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
             `Health check: waiting up to ${seconds}s for the app to answer at ${target}` +
               `${readinessGate.probe.path ? "" : " (TCP connect)"}…\n`,
           );
-          const ready = await waitForReady(host, port, {
-            path: readinessGate.probe.path,
-            timeoutMs: readinessGate.probe.timeoutMs,
-            intervalMs: readinessGate.probe.intervalMs,
-          });
+          let ready: boolean;
+          try {
+            // A containerized OpenShip API has its own loopback/network namespace.
+            // Probe from the host through the same pooled SSH channel used for
+            // local host operations; a non-containerized install transparently
+            // falls back to the executor process's direct socket path.
+            ready = await sshManager.withHostExecutor((executor) =>
+              waitForReadyFromExecutor(executor, host, port, {
+                path: readinessGate.probe.path,
+                timeoutMs: readinessGate.probe.timeoutMs,
+                intervalMs: readinessGate.probe.intervalMs,
+              }),
+            );
+          } catch (error) {
+            return (
+              `OpenShip could not probe ${target} from the deployment host: ` +
+              `${safeErrorMessage(error)}. Check the local host-control channel.`
+            );
+          }
           if (!ready) {
             return (
               `The app never answered at ${target} within ${seconds}s` +

--- a/apps/api/src/modules/deployments/forwarded-readiness.ts
+++ b/apps/api/src/modules/deployments/forwarded-readiness.ts
@@ -1,0 +1,145 @@
+import type { Duplex } from "node:stream";
+import { waitForReady, type CommandExecutor } from "@repo/adapters";
+
+interface ReadinessOptions {
+  path?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+  probeTimeoutMs?: number;
+  acceptStatusBelow?: number;
+}
+
+type PortForwarder = (host: string, port: number) => Promise<Duplex>;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function openForward(
+  forward: PortForwarder,
+  host: string,
+  port: number,
+  timeoutMs: number,
+): Promise<Duplex | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      resolve(null);
+    }, timeoutMs);
+    timer.unref?.();
+
+    forward(host, port).then(
+      (stream) => {
+        if (settled) {
+          stream.destroy();
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(stream);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(null);
+      },
+    );
+  });
+}
+
+function probeHttpStream(
+  stream: Duplex,
+  host: string,
+  port: number,
+  path: string,
+  timeoutMs: number,
+  acceptStatusBelow: number,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let received = "";
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stream.destroy();
+      resolve(ok);
+    };
+    const timer = setTimeout(() => done(false), timeoutMs);
+    timer.unref?.();
+
+    stream.on("data", (chunk) => {
+      received += chunk.toString("latin1");
+      const lineEnd = received.indexOf("\r\n");
+      if (lineEnd < 0) {
+        if (received.length > 8_192) done(false);
+        return;
+      }
+      const match = /^HTTP\/\d(?:\.\d)?\s+(\d{3})\b/.exec(received.slice(0, lineEnd));
+      const status = match ? Number(match[1]) : 0;
+      done(status > 0 && status < acceptStatusBelow);
+    });
+    stream.once("error", () => done(false));
+    stream.once("end", () => done(false));
+
+    if (!path.startsWith("/") || /[\r\n]/.test(path)) {
+      done(false);
+      return;
+    }
+    stream.write(`GET ${path} HTTP/1.1\r\nHost: ${host}:${port}\r\nConnection: close\r\n\r\n`);
+  });
+}
+
+/** Poll readiness from the machine represented by an SSH direct-tcpip channel. */
+export async function waitForForwardedReady(
+  forward: PortForwarder,
+  host: string,
+  port: number,
+  opts: ReadinessOptions = {},
+): Promise<boolean> {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const intervalMs = opts.intervalMs ?? 1_000;
+  const probeTimeoutMs = opts.probeTimeoutMs ?? 2_500;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    const stream = await openForward(forward, host, port, Math.min(probeTimeoutMs, remaining));
+    if (stream) {
+      if (!opts.path) {
+        stream.destroy();
+        return true;
+      }
+      if (
+        await probeHttpStream(
+          stream,
+          host,
+          port,
+          opts.path,
+          Math.min(probeTimeoutMs, Math.max(1, deadline - Date.now())),
+          opts.acceptStatusBelow ?? 500,
+        )
+      ) {
+        return true;
+      }
+    }
+    const waitMs = Math.min(intervalMs, deadline - Date.now());
+    if (waitMs <= 0) return false;
+    await delay(waitMs);
+  }
+}
+
+/** Use host forwarding when available, with direct sockets for LocalExecutor. */
+export function waitForReadyFromExecutor(
+  executor: CommandExecutor,
+  host: string,
+  port: number,
+  opts: ReadinessOptions = {},
+): Promise<boolean> {
+  return executor.forwardPort
+    ? waitForForwardedReady(executor.forwardPort.bind(executor), host, port, opts)
+    : waitForReady(host, port, opts);
+}

--- a/apps/api/src/modules/deployments/readiness-target.ts
+++ b/apps/api/src/modules/deployments/readiness-target.ts
@@ -1,0 +1,35 @@
+import type { RuntimeAdapter } from "@repo/adapters";
+
+interface ReadinessTargetOptions {
+  runtime: RuntimeAdapter;
+  containerId: string;
+  primaryPort: number;
+  probePort?: number;
+}
+
+/** Resolve the address the deployment host can actually dial for readiness. */
+export async function resolveReadinessTarget(
+  options: ReadinessTargetOptions,
+): Promise<{ host: string; port: number }> {
+  const containerPort = options.probePort ?? options.primaryPort;
+  if (options.runtime.name === "bare") {
+    return { host: "127.0.0.1", port: containerPort };
+  }
+
+  try {
+    const info = await options.runtime.getContainerInfo(options.containerId);
+    // `readiness.port` names a workload/container port. The primary container
+    // port is published on the host port, even when it was explicitly selected.
+    if (info?.hostPort && containerPort === options.primaryPort) {
+      return { host: "127.0.0.1", port: info.hostPort };
+    }
+    if (options.runtime.supports("containerIp")) {
+      const ip = await options.runtime.getContainerIp(options.containerId);
+      if (ip) return { host: ip, port: containerPort };
+    }
+  } catch {
+    // The readiness gate reports the exact fallback address if this also fails.
+  }
+
+  return { host: "127.0.0.1", port: containerPort };
+}

--- a/apps/api/test/modules/deployments/forwarded-readiness.test.ts
+++ b/apps/api/test/modules/deployments/forwarded-readiness.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { Duplex } from "node:stream";
+import { waitForForwardedReady } from "../../../src/modules/deployments/forwarded-readiness";
+
+function response(status: number): Duplex {
+  let sent = false;
+  return new Duplex({
+    read() {
+      if (sent) return;
+      sent = true;
+      this.push(`HTTP/1.1 ${status} Test\r\nContent-Length: 0\r\n\r\n`);
+      this.push(null);
+    },
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+describe("waitForForwardedReady", () => {
+  it("accepts a forwarded TCP connection", async () => {
+    const calls: Array<[string, number]> = [];
+    const ready = await waitForForwardedReady(
+      async (host, port) => {
+        calls.push([host, port]);
+        return response(200);
+      },
+      "127.0.0.1",
+      20_001,
+      { timeoutMs: 20, probeTimeoutMs: 10 },
+    );
+
+    expect(ready).toBe(true);
+    expect(calls).toEqual([["127.0.0.1", 20_001]]);
+  });
+
+  it("requires a forwarded HTTP response below 500", async () => {
+    let attempts = 0;
+    const ready = await waitForForwardedReady(
+      async () => response(++attempts === 1 ? 503 : 204),
+      "127.0.0.1",
+      20_001,
+      { path: "/healthz", timeoutMs: 100, intervalMs: 1, probeTimeoutMs: 20 },
+    );
+
+    expect(ready).toBe(true);
+    expect(attempts).toBe(2);
+  });
+
+  it("times out when the forwarded target keeps refusing", async () => {
+    let attempts = 0;
+    const ready = await waitForForwardedReady(
+      async () => {
+        attempts += 1;
+        throw new Error("ECONNREFUSED");
+      },
+      "127.0.0.1",
+      20_001,
+      { timeoutMs: 20, intervalMs: 1, probeTimeoutMs: 5 },
+    );
+
+    expect(ready).toBe(false);
+    expect(attempts).toBeGreaterThan(1);
+  });
+
+  it("rejects a path that could inject an HTTP header", async () => {
+    const ready = await waitForForwardedReady(async () => response(200), "127.0.0.1", 20_001, {
+      path: "/healthz\r\nX-Bad: yes",
+      timeoutMs: 5,
+      intervalMs: 1,
+    });
+
+    expect(ready).toBe(false);
+  });
+});

--- a/apps/api/test/modules/deployments/readiness-target.test.ts
+++ b/apps/api/test/modules/deployments/readiness-target.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeAdapter } from "@repo/adapters";
+import { resolveReadinessTarget } from "../../../src/modules/deployments/readiness-target";
+
+function runtime(options: {
+  name?: string;
+  hostPort?: number;
+  containerIp?: string | null;
+}): RuntimeAdapter {
+  return {
+    name: options.name ?? "docker",
+    supports: (capability: string) => capability === "containerIp",
+    getContainerInfo: async () => ({ hostPort: options.hostPort }),
+    getContainerIp: async () => options.containerIp ?? null,
+  } as RuntimeAdapter;
+}
+
+describe("resolveReadinessTarget", () => {
+  it("maps an explicit primary container port to its published host port", async () => {
+    const target = await resolveReadinessTarget({
+      runtime: runtime({ hostPort: 20_001, containerIp: "172.19.0.8" }),
+      containerId: "container-1",
+      primaryPort: 8080,
+      probePort: 8080,
+    });
+
+    expect(target).toEqual({ host: "127.0.0.1", port: 20_001 });
+  });
+
+  it("uses the container address for an alternate container port", async () => {
+    const target = await resolveReadinessTarget({
+      runtime: runtime({ hostPort: 20_001, containerIp: "172.19.0.8" }),
+      containerId: "container-1",
+      primaryPort: 8080,
+      probePort: 9090,
+    });
+
+    expect(target).toEqual({ host: "172.19.0.8", port: 9090 });
+  });
+
+  it("keeps bare workloads on loopback", async () => {
+    let inspected = false;
+    const bare = runtime({ name: "bare", hostPort: 20_001 });
+    bare.getContainerInfo = async () => {
+      inspected = true;
+      throw new Error("bare runtime must not be inspected");
+    };
+
+    const target = await resolveReadinessTarget({
+      runtime: bare,
+      containerId: "process-1",
+      primaryPort: 8080,
+      probePort: 9090,
+    });
+
+    expect(target).toEqual({ host: "127.0.0.1", port: 9090 });
+    expect(inspected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve an explicit primary container readiness port to the published host port
- run local-target readiness through the pooled host executor and SSH direct-TCP forwarding when OpenShip is containerized
- retain direct socket probing for non-containerized LocalExecutor installs
- report host-control failures separately from app readiness failures

## Root cause

For a self-hosted Docker deployment, the workload port is published on the deployment host. The API itself may also run in Docker, so `waitForReady("127.0.0.1", hostPort)` probes the API container's private loopback namespace instead of the host. A healthy app therefore times out and the deployment is marked failed. An explicit `readiness.port` equal to the primary container port also bypassed the published-port mapping.

The existing `CommandExecutor.forwardPort` and pooled host executor already provide the correct network boundary, so this change reuses them without requiring curl or another host dependency.

## Validation

- `bun run --cwd apps/api test -- test/modules/deployments/readiness-target.test.ts test/modules/deployments/forwarded-readiness.test.ts` (7 passed)
- `bun run --cwd apps/api lint`
- reproduced with a containerized self-hosted API: workload healthy on the host-published port while the API-container loopback probe timed out; the forwarded probe passes against the same workload
