### PR TITLE
fix(runtime): cancel remote Docker builds

### DIFF
--- a/apps/api/src/modules/deployments/compose/build-cancel.test.ts
+++ b/apps/api/src/modules/deployments/compose/build-cancel.test.ts
@@ -1,0 +1,126 @@
+import { BuildLogger, DEFAULT_RESOURCE_CONFIG } from "@repo/adapters";
+import { describe, expect, it, vi } from "vitest";
+
+// Same stubs as build.service.test.ts: the DB row read and the SSE broadcast are
+// side effects this contract doesn't depend on (and importing the real @repo/db
+// would risk the PGlite single-instance lock).
+const { listByProjectMock } = vi.hoisted(() => ({ listByProjectMock: vi.fn() }));
+vi.mock("@repo/db", () => ({
+  repos: { service: { listByProject: listByProjectMock } },
+}));
+vi.mock("../session-manager", () => ({
+  broadcastServiceStatus: vi.fn(),
+  broadcastInstallPhase: vi.fn(),
+}));
+
+import { buildComposeImages } from "./build.service";
+
+/**
+ * A cancelled service build must NOT be laundered into a build failure. The
+ * compose pipeline branches on the two differently: a failure deploys whatever
+ * did build (and marks the deployment failed), while a cancel has to stop the
+ * pipeline before it flips the row back to "deploying" — so losing the
+ * distinction here is what silently deploys a cancelled deployment.
+ */
+
+const SNAPSHOT = {
+  repoUrl: "https://example.com/repo.git",
+  branch: "main",
+  framework: "docker",
+  buildImage: "",
+  runtimeImage: "",
+  packageManager: "",
+  installCommand: "",
+  buildCommand: "",
+  outputDirectory: "",
+  productionPaths: [] as string[],
+  rootDirectory: "",
+  port: 3000,
+  startCommand: "",
+  hasServer: true,
+  hasBuild: false,
+};
+
+function service(name: string) {
+  return {
+    id: name,
+    name,
+    enabled: true,
+    image: null,
+    build: ".",
+    advanced: null,
+    framework: null,
+    buildCommand: null,
+    startCommand: null,
+    rootDirectory: null,
+    dockerfile: null,
+  };
+}
+
+/** Drive buildComposeImages with a fake batch build that returns `statuses` in order. */
+async function run(statuses: Array<"deploying" | "failed" | "cancelled">) {
+  const services = statuses.map((_, index) => service(`svc-${index}`));
+  listByProjectMock.mockResolvedValue(services);
+
+  const runtime = {
+    name: "docker" as const,
+    build: vi.fn(),
+    buildImages: vi.fn(async (items: Array<Record<string, unknown>>) => {
+      items.forEach((item, index) => {
+        const status = statuses[index]!;
+        (item.onResult as (r: unknown) => void)({
+          sessionId: `sess-svc-${index}`,
+          status,
+          imageRef: status === "deploying" ? `img/svc-${index}` : undefined,
+          errorMessage: status === "failed" ? "boom" : undefined,
+          durationMs: 1,
+        });
+      });
+    }),
+  };
+
+  return buildComposeImages({
+    project: {
+      id: "p1",
+      slug: "app",
+      name: "app",
+      localPath: null,
+      workspacePrepareCommand: null,
+    } as never,
+    dep: { id: "d1", branch: "main", commitSha: null, trigger: "deploy", meta: null } as never,
+    runtime: runtime as never,
+    logger: new BuildLogger(() => {}),
+    snapshot: SNAPSHOT as never,
+    buildSessionId: "sess",
+    buildEnvVars: {},
+    buildResources: DEFAULT_RESOURCE_CONFIG,
+  });
+}
+
+describe("buildComposeImages — cancellation", () => {
+  it("reports a cancelled service as cancelled, not as a build failure", async () => {
+    const result = await run(["cancelled", "cancelled"]);
+
+    expect(result.cancelled).toBe(true);
+    expect(result.buildFailures.size).toBe(0);
+    expect(result.imageRefs.size).toBe(0);
+    expect(result.builtImageRefs.size).toBe(0);
+  });
+
+  it("flags the whole build cancelled even when an earlier service finished", async () => {
+    const result = await run(["deploying", "cancelled"]);
+
+    // svc-0's image exists and is reported so the pipeline can clean it up; the
+    // cancel still has to win over "1 of 2 built, deploy what we have".
+    expect(result.cancelled).toBe(true);
+    expect(result.buildFailures.size).toBe(0);
+    expect([...result.builtImageRefs.values()]).toEqual(["img/svc-0"]);
+  });
+
+  it("leaves ordinary failures untouched", async () => {
+    const result = await run(["deploying", "failed"]);
+
+    expect(result.cancelled).toBe(false);
+    expect(result.buildFailures.size).toBe(1);
+  });
+});

--- a/apps/api/src/modules/deployments/compose/build.service.ts
+++ b/apps/api/src/modules/deployments/compose/build.service.ts
@@ -296,6 +296,12 @@ export interface ComposeBuildImagesResult {
   buildFailures: Map<string, string>;
   /** Count of image-only (external) services included in imageRefs */
   externalCount: number;
+  /**
+   * At least one service build came back "cancelled" (the user cancelled the
+   * deployment). Distinct from buildFailures: the caller must stop WITHOUT
+   * marking the deployment failed.
+   */
+  cancelled: boolean;
   durationMs: number;
 }
 
@@ -330,6 +336,7 @@ export async function buildComposeImages(opts: {
   const imageRefs = new Map<string, string>();
   const builtImageRefs = new Map<string, string>();
   const buildFailures = new Map<string, string>();
+  const cancelledServices = new Set<string>();
   const startedAt = Date.now();
 
   // Buildable = anything that needs a per-service image build.
@@ -590,6 +597,24 @@ export async function buildComposeImages(opts: {
 
     // Record a per-service build result: image refs / failures + status broadcast.
     const applyBuildResult = (service: Service, buildResult: BuildResult) => {
+      // Cancelled ≠ failed: tracked separately so the pipeline can stop without
+      // recording a build failure on the deployment. The per-service SSE status
+      // union has no "cancelled" member, so the tab reports the reason instead of
+      // being left spinning on "building".
+      if (buildResult.status === "cancelled") {
+        cancelledServices.add(service.id);
+        opts.logger.log(`Compose service "${service.name}" build cancelled\n`, "info", {
+          serviceName: service.name,
+        });
+        sessionManager.broadcastServiceStatus(opts.dep.id, {
+          serviceName: service.name,
+          serviceId: service.id,
+          status: "failed",
+          error: "Build cancelled",
+        });
+        return;
+      }
+
       if (buildResult.status === "failed" || !buildResult.imageRef) {
         const failureMessage =
           buildResult.errorMessage ?? `Failed to build service "${service.name}"`;
@@ -665,7 +690,12 @@ export async function buildComposeImages(opts: {
       );
     }
 
-    if (buildable.length > 0) {
+    if (buildable.length > 0 && cancelledServices.size > 0) {
+      // Cancelled: no "failed" step and no phase result — the deployment's own
+      // cancelled status is the outcome the user is waiting on.
+      opts.logger.step("build", "failed", "Image build cancelled");
+      opts.logger.log("Compose image build cancelled. Deployment will not continue.\n", "error");
+    } else if (buildable.length > 0) {
       // Count of images actually BUILT (builtImageRefs is set only on a build) —
       // not imageRefs.size, which also holds external/pull + handed-over images.
       const succeeded = builtImageRefs.size;
@@ -710,6 +740,7 @@ export async function buildComposeImages(opts: {
     builtImageRefs,
     buildFailures,
     externalCount: external.length,
+    cancelled: cancelledServices.size > 0,
     durationMs: Date.now() - startedAt,
   };
 }

--- a/apps/api/src/modules/deployments/compose/pipeline.ts
+++ b/apps/api/src/modules/deployments/compose/pipeline.ts
@@ -28,6 +28,7 @@ import { BuildLogger } from "@repo/adapters";
 import type { BuildConfigSnapshotLike } from "../build-config";
 import {
   cleanupBuildArtifact,
+  onCancelled,
   onFailure,
   onReconciling,
   onSuccess,
@@ -140,6 +141,20 @@ export async function executeComposePipeline(opts: ComposePipelineOpts): Promise
     targetServiceIds,
     refreshServiceIds,
   });
+
+  // Cancelled during the image phase: stop here. setDeploymentStatus below has no
+  // terminal-state guard, so without this the cancelled row would be flipped back
+  // to "deploying" and the services the user cancelled would start anyway.
+  if (composeBuild.cancelled) {
+    for (const [serviceId, imageRef] of composeBuild.builtImageRefs) {
+      await cleanupBuildArtifact(runtime, imageRef).catch((err) => {
+        const detail = safeErrorMessage(err);
+        logger.log(`Warning: failed to clean up built service image ${serviceId}: ${detail}\n`, "warn");
+      });
+    }
+    await onCancelled(ctx, composeBuild.durationMs);
+    return;
+  }
 
   if (composeBuild.buildFailures.size > 0) {
     logger.log(

--- a/packages/adapters/src/runtime/bare.ts
+++ b/packages/adapters/src/runtime/bare.ts
@@ -41,7 +41,15 @@ import type {
   RollbackInput,
   MakeActiveResult,
 } from "./types";
-import { BuildCancelledError, BuildLogger, detectBuildKillHint, runBuildPipeline, sq, type BuildEnvironment } from "./build-pipeline";
+import {
+  BuildCancelledError,
+  BuildLogger,
+  detectBuildKillHint,
+  killProcessesUnderDir,
+  runBuildPipeline,
+  sq,
+  type BuildEnvironment,
+} from "./build-pipeline";
 import { runLocalBuild } from "./local-build";
 import { transferLocalDirectory } from "./transfer";
 import { prepareStackOutput, resolveProjectDir, resolveStaticOutputPath } from "./stack-output";
@@ -588,16 +596,10 @@ export class BareRuntime implements RuntimeAdapter {
       abort.abort();
       this.activeBuilds.delete(sessionId);
     }
-    // Aborting only gates the API BETWEEN commands — the in-flight remote
-    // command (git/npm/vite) keeps running on the target until killed. Kill every
-    // process whose CWD is (under) this build's dir — SIGTERM, then SIGKILL the
-    // survivors. Killing it closes the streamExec channel so the pipeline unwinds
-    // to a cancelled result. Best-effort; a no-op for local builds / non-Linux
-    // targets (nothing runs under this dir there).
-    const dir = sq(this.buildDir(sessionId));
-    const scan = (sig: string) =>
-      `for p in /proc/[0-9]*; do c=$(readlink "$p/cwd" 2>/dev/null); case "$c" in ${dir}|${dir}/*) kill -${sig} "\${p##*/}" 2>/dev/null || true;; esac; done`;
-    await this.executor.exec(`${scan("TERM")}; sleep 2; ${scan("KILL")}`).catch(() => {});
+    // Aborting only gates the API BETWEEN commands — the in-flight remote command
+    // (git/npm/vite) keeps running on the target until killed. Shared with the
+    // docker runtime so both remote-build cancels kill the same way.
+    await killProcessesUnderDir(this.executor, this.buildDir(sessionId));
   }
 
   async getBuildLogs(sessionId: string): Promise<LogEntry[]> {

--- a/packages/adapters/src/runtime/build-pipeline.ts
+++ b/packages/adapters/src/runtime/build-pipeline.ts
@@ -141,6 +141,46 @@ export class BuildCancelledError extends Error {
   }
 }
 
+/**
+ * Kill every process whose CWD is (under) a build's private directory — SIGTERM,
+ * then SIGKILL the survivors.
+ *
+ * Aborting a build only gates our own API BETWEEN commands: the in-flight remote
+ * command (git / npm / `docker build`) keeps running on the target until someone
+ * signals it. Killing it also closes the streamExec channel, so the build unwinds
+ * to a cancelled result instead of finishing work nobody wants.
+ *
+ * The ` (deleted)` patterns are load-bearing. A cancelled build's own `finally`
+ * fires `rm -rf <contextDir>` the moment it unwinds, and Linux then reports the
+ * process's cwd link as "<dir> (deleted)" — which the bare patterns miss, leaving
+ * exactly the orphaned build this sweep exists to kill.
+ *
+ * `includeSuffixed` also matches `<dir>-*`: a compose deploy builds one image per
+ * service under `<buildSessionId>-<serviceId>`, while cancel only knows the parent
+ * session id.
+ *
+ * Best-effort: a no-op for local builds and non-Linux targets (nothing runs under
+ * this dir there) and when the command has already exited.
+ */
+export async function killProcessesUnderDir(
+  executor: { exec(command: string): Promise<string> },
+  dir: string,
+  opts?: { includeSuffixed?: boolean },
+): Promise<void> {
+  const quoted = sq(dir);
+  const roots = opts?.includeSuffixed ? [quoted, `${quoted}-*`] : [quoted];
+  const patterns = roots.flatMap((root) => [
+    root,
+    `${root}/*`,
+    `${root}" (deleted)"`,
+    `${root}/*" (deleted)"`,
+  ]);
+  const scan = (sig: string) =>
+    `for p in /proc/[0-9]*; do c=$(readlink "$p/cwd" 2>/dev/null); ` +
+    `case "$c" in ${patterns.join("|")}) kill -${sig} "\${p##*/}" 2>/dev/null || true;; esac; done`;
+  await executor.exec(`${scan("TERM")}; sleep 2; ${scan("KILL")}`).catch(() => {});
+}
+
 export interface BuildPipelineResult {
   status: "deploying" | "failed" | "cancelled";
   /** Which step failed (undefined if success) */

--- a/packages/adapters/src/runtime/docker-build-cancellation.test.ts
+++ b/packages/adapters/src/runtime/docker-build-cancellation.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { BuildConfig, CommandExecutor } from "../types";
-import { DockerRuntime } from "./docker";
+import { BuildLogger } from "./build-pipeline";
+import { DockerRuntime, packBuildContext } from "./docker";
+
+// The dockerode path clones the repo through this module; the cancellation tests
+// care about what happens AFTER a context exists, so hand them a fake one.
+const fakeBuildContext = vi.hoisted(() => ({
+  current: null as { contextDir: string; cleanup: () => Promise<void> } | null,
+}));
+
+vi.mock("./docker-build-context", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./docker-build-context")>();
+  return {
+    ...actual,
+    createDockerBuildContext: vi.fn(async () => ({
+      contextDir: fakeBuildContext.current!.contextDir,
+      contextEntries: ["Dockerfile"],
+      dockerfileName: "Dockerfile",
+      usesRepositoryDockerfile: true,
+      cleanup: fakeBuildContext.current!.cleanup,
+    })),
+  };
+});
 
 function buildConfig(sessionId: string): BuildConfig {
   return {
@@ -99,5 +123,151 @@ describe("DockerRuntime build cancellation", () => {
     expect(cloneSourceOnRemote).not.toHaveBeenCalled();
     expect(executor.streamExec).not.toHaveBeenCalled();
     expect(verifyImageBuilt).not.toHaveBeenCalled();
+  });
+
+  it("kills orphaned remote processes under the session dir, including deleted cwds", async () => {
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+    } as unknown as CommandExecutor;
+    const { runtime } = runtimeWith(executor);
+
+    await runtime.cancelBuild("session-sweep");
+
+    const sweep = (executor.exec as ReturnType<typeof vi.fn>).mock.calls
+      .map(([command]) => String(command))
+      .find((command) => command.includes("/proc/"))!;
+    expect(sweep).toContain("kill -TERM");
+    expect(sweep).toContain("kill -KILL");
+    // The build's own cleanup rm -rf's the context dir, so by the time the sweep
+    // runs Linux reports the cwd as "<dir> (deleted)" — matching only the plain
+    // dir would find nothing, which is what made the kill a no-op.
+    expect(sweep).toContain(`'/tmp/openship-build-session-sweep'" (deleted)"`);
+    // Compose services build in `<parent>-<serviceId>` dirs off the same cancel.
+    expect(sweep).toContain(`'/tmp/openship-build-session-sweep'-*`);
+  });
+
+  it("cancels every compose service build under the parent session id", async () => {
+    let enteredBuild!: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      enteredBuild = resolve;
+    });
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async (_command, _onLog, opts) => {
+        enteredBuild();
+        await new Promise<void>((resolve) => {
+          opts?.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return { code: 0, output: "" };
+      }),
+    } as unknown as CommandExecutor;
+
+    const { runtime: buildRuntime, verifyImageBuilt } = runtimeWith(executor);
+    const { runtime: cancelRuntime } = runtimeWith(executor);
+
+    const specs = ["svc-a", "svc-b"].map((serviceId) => ({
+      config: buildConfig(`parent-1-${serviceId}`),
+      serviceName: serviceId,
+      logger: new BuildLogger(),
+    }));
+
+    const resultsPromise = buildRuntime.buildImages(specs, new BuildLogger());
+    await buildStarted;
+    // The API cancels with the PARENT build-session id; the services registered
+    // under `<parent>-<serviceId>` have to be covered by it.
+    await cancelRuntime.cancelBuild("parent-1");
+
+    const results = await resultsPromise;
+    expect(results.map((entry) => entry.result.status)).toEqual(["cancelled", "cancelled"]);
+    // svc-b never got its turn — sequential builds, so it must not have started.
+    expect(executor.streamExec).toHaveBeenCalledTimes(1);
+    expect(verifyImageBuilt).not.toHaveBeenCalled();
+  });
+});
+
+describe("DockerRuntime build cancellation — dockerode path", () => {
+  let contextDir: string | null = null;
+
+  afterEach(async () => {
+    if (contextDir) await rm(contextDir, { recursive: true, force: true });
+    contextDir = null;
+    fakeBuildContext.current = null;
+  });
+
+  it("returns cancelled instead of deploying when the daemon build is aborted", async () => {
+    contextDir = await mkdtemp(join(tmpdir(), "openship-cancel-"));
+    await writeFile(join(contextDir, "Dockerfile"), "FROM scratch\n");
+    fakeBuildContext.current = { contextDir, cleanup: async () => {} };
+
+    let enteredBuild!: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      enteredBuild = resolve;
+    });
+
+    const verifyImageBuilt = vi.fn(async () => {});
+    const buildImage = vi.fn(async (_body: unknown, opts: { abortSignal: AbortSignal }) => {
+      enteredBuild();
+      await new Promise<void>((resolve) => {
+        opts.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw new Error("The operation was aborted");
+    });
+
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, {
+      // No executor: local socket / TCP, so build() takes the dockerode path.
+      connectionOptions: {},
+      transport: { kind: "socket", description: "local socket" },
+      systemManager: null,
+      _docker: { buildImage, listContainers: vi.fn(async () => []) },
+      estimateContextSize: vi.fn(async () => 0),
+      verifyImageBuilt,
+    });
+
+    const config = { ...buildConfig("session-dockerode"), cloneOnServer: false };
+    const resultPromise = runtime.build(config);
+    await buildStarted;
+    await runtime.cancelBuild("session-dockerode");
+
+    // The pipeline stops ONLY on "cancelled" and otherwise re-writes the row to
+    // "deploying" — a "failed"/"deploying" result here deploys a cancelled deploy.
+    await expect(resultPromise).resolves.toMatchObject({
+      sessionId: "session-dockerode",
+      status: "cancelled",
+    });
+    expect(verifyImageBuilt).not.toHaveBeenCalled();
+  });
+});
+
+describe("packBuildContext", () => {
+  let contextDir: string | null = null;
+
+  afterEach(async () => {
+    if (contextDir) await rm(contextDir, { recursive: true, force: true });
+    contextDir = null;
+  });
+
+  it("aborts the daemon request when the build's cancel signal fires", async () => {
+    contextDir = await mkdtemp(join(tmpdir(), "openship-pack-"));
+    await writeFile(join(contextDir, "Dockerfile"), "FROM scratch\n");
+
+    const cancel = new AbortController();
+    const packed = packBuildContext(contextDir, ["Dockerfile"], cancel.signal);
+    expect(packed.abortSignal.aborted).toBe(false);
+    cancel.abort();
+    expect(packed.abortSignal.aborted).toBe(true);
+    expect(packed.takeError()).toBeNull();
+    packed.body.resume();
+  });
+
+  it("starts aborted when the build was already cancelled", async () => {
+    contextDir = await mkdtemp(join(tmpdir(), "openship-pack-"));
+    await writeFile(join(contextDir, "Dockerfile"), "FROM scratch\n");
+
+    const packed = packBuildContext(contextDir, ["Dockerfile"], AbortSignal.abort());
+    expect(packed.abortSignal.aborted).toBe(true);
+    packed.body.resume();
   });
 });

--- a/packages/adapters/src/runtime/docker-build-cancellation.test.ts
+++ b/packages/adapters/src/runtime/docker-build-cancellation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BuildConfig, CommandExecutor } from "../types";
+import { DockerRuntime } from "./docker";
+
+function buildConfig(sessionId: string): BuildConfig {
+  return {
+    sessionId,
+    projectId: "project-1",
+    slug: "cancel-test",
+    repoUrl: "https://example.com/repo.git",
+    branch: "main",
+    stack: "docker",
+    buildImage: "",
+    packageManager: "",
+    installCommand: "",
+    buildCommand: "",
+    outputDirectory: "",
+    port: 8080,
+    runtimeImage: "",
+    envVars: {},
+    resources: { cpuCores: 0, memoryMb: 0, diskMb: 0 },
+    cloneOnServer: true,
+  };
+}
+
+describe("DockerRuntime build cancellation", () => {
+  function runtimeWith(executor: CommandExecutor) {
+    const verifyImageBuilt = vi.fn(async () => {});
+    const cloneSourceOnRemote = vi.fn(async () => {});
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, {
+      connectionOptions: { executor },
+      transport: { kind: "ssh", description: "test ssh" },
+      systemManager: null,
+      _docker: {
+        listContainers: vi.fn(async () => []),
+      },
+      cloneSourceOnRemote,
+      resolveRemoteDockerfile: vi.fn(async () => "Dockerfile"),
+      verifyImageBuilt,
+    });
+    return { runtime, verifyImageBuilt, cloneSourceOnRemote };
+  }
+
+  it("aborts the streamed SSH docker build and returns cancelled", async () => {
+    let enteredBuild!: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      enteredBuild = resolve;
+    });
+
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async (_command, _onLog, opts) => {
+        enteredBuild();
+        await new Promise<void>((resolve) => {
+          opts?.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return { code: 0, output: "" };
+      }),
+    } as unknown as CommandExecutor;
+
+    const { runtime: buildRuntime, verifyImageBuilt } = runtimeWith(executor);
+    const { runtime: cancelRuntime } = runtimeWith(executor);
+
+    const resultPromise = buildRuntime.build(buildConfig("session-1"));
+    await buildStarted;
+    await cancelRuntime.cancelBuild("session-1");
+
+    await expect(resultPromise).resolves.toMatchObject({
+      sessionId: "session-1",
+      status: "cancelled",
+    });
+    expect(executor.streamExec).toHaveBeenCalledWith(
+      expect.stringContaining("docker build"),
+      expect.any(Function),
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(executor.exec).toHaveBeenCalledWith(
+      expect.stringContaining("/tmp/openship-build-session-1"),
+    );
+    expect(verifyImageBuilt).not.toHaveBeenCalled();
+  });
+
+  it("remembers cancellation that arrives before build registration", async () => {
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+    } as unknown as CommandExecutor;
+    const { runtime: buildRuntime, cloneSourceOnRemote, verifyImageBuilt } = runtimeWith(executor);
+    const { runtime: cancelRuntime } = runtimeWith(executor);
+
+    await cancelRuntime.cancelBuild("session-queued");
+    await expect(buildRuntime.build(buildConfig("session-queued"))).resolves.toMatchObject({
+      sessionId: "session-queued",
+      status: "cancelled",
+    });
+
+    expect(cloneSourceOnRemote).not.toHaveBeenCalled();
+    expect(executor.streamExec).not.toHaveBeenCalled();
+    expect(verifyImageBuilt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -117,7 +117,14 @@ import type {
   DockerNetworkInfo,
   ContainerLifecycleEvent,
 } from "./types";
-import { BuildCancelledError, BuildLogger, parseLogLevel, sq, assembleGitClone } from "./build-pipeline";
+import {
+  BuildCancelledError,
+  BuildLogger,
+  killProcessesUnderDir,
+  parseLogLevel,
+  sq,
+  assembleGitClone,
+} from "./build-pipeline";
 import { materializeGitSsh, shellGitSshWriter, type GitSshMaterial } from "./git-ssh-material";
 import { githubTarballUrl, downloadTarballOnRemote } from "./source-tarball";
 import { scopeVolumeBinds, isHostPathSource } from "./volume-namespace";
@@ -166,12 +173,64 @@ const DOCKER_BUILD_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * A deployment build and its cancellation request may resolve separate
- * DockerRuntime instances. Build session ids are process-wide, so cancellation
- * state must be process-wide too or the cancelling runtime cannot reach the
- * builder's controller.
+ * DockerRuntime instances — the cancel endpoint takes `platform().runtime`, not
+ * the per-server runtime that ran the build. Build session ids are process-wide
+ * and globally unique, so cancellation state must be process-wide too or the
+ * cancelling runtime cannot reach the builder's controller.
  */
 const activeDockerBuilds = new Map<string, AbortController>();
-const pendingDockerBuildCancellations = new Set<string>();
+const pendingDockerBuildCancellations = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** How long a cancel that landed before its build waits for that build to start. */
+const PENDING_CANCEL_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Cancelling `<parent>` also cancels every `<parent>-<serviceId>` sub-build: a
+ * compose deploy builds one image per service under that derived id, while the
+ * cancel endpoint only ever knows the parent build-session id.
+ */
+function cancelCovers(cancelledId: string, sessionId: string): boolean {
+  return sessionId === cancelledId || sessionId.startsWith(`${cancelledId}-`);
+}
+
+/**
+ * Remember a cancel whose build hasn't registered yet, so the build exits instead
+ * of starting work.
+ *
+ * Entries EXPIRE rather than being consumed on first match: one compose cancel has
+ * to reach every per-service build that hasn't started, so no single build can own
+ * the entry. Nothing else would ever evict it — a build session id is single-use,
+ * so a surviving entry can't cancel an unrelated build, but the map would grow for
+ * the life of the process.
+ */
+function recordPendingCancellation(sessionId: string): void {
+  clearTimeout(pendingDockerBuildCancellations.get(sessionId));
+  const timer = setTimeout(
+    () => pendingDockerBuildCancellations.delete(sessionId),
+    PENDING_CANCEL_TTL_MS,
+  );
+  // Never let a pending cancel hold the process open.
+  (timer as { unref?: () => void }).unref?.();
+  pendingDockerBuildCancellations.set(sessionId, timer);
+}
+
+/** Register a build as active; the controller comes pre-aborted if a cancel beat it here. */
+function registerDockerBuild(sessionId: string): AbortController {
+  const abort = new AbortController();
+  for (const cancelledId of pendingDockerBuildCancellations.keys()) {
+    if (cancelCovers(cancelledId, sessionId)) {
+      abort.abort();
+      break;
+    }
+  }
+  activeDockerBuilds.set(sessionId, abort);
+  return abort;
+}
+
+/** Deregister, but only if this build still owns the slot (never evict a newer one). */
+function releaseDockerBuild(sessionId: string, abort: AbortController): void {
+  if (activeDockerBuilds.get(sessionId) === abort) activeDockerBuilds.delete(sessionId);
+}
 
 /** Last-resort cap for a one-shot in-container exec. Every caller passes its own
  *  (5s probe / 15s prepare step); this only guards a stream that connects and
@@ -468,6 +527,7 @@ export function parsePortBindings(portSpecs: string[]): {
 export function packBuildContext(
   contextDir: string,
   entries: string[],
+  cancelSignal?: AbortSignal,
 ): { body: NodeJS.ReadableStream; abortSignal: AbortSignal; takeError: () => Error | null } {
   const controller = new AbortController();
   const pack = tarFs.pack(contextDir, { entries });
@@ -477,6 +537,13 @@ export function packBuildContext(
     contextError ??= err instanceof Error ? err : new Error(String(err));
     if (!controller.signal.aborted) controller.abort();
   };
+  // A cancelled build has to abort the in-flight buildImage request too: dockerode
+  // forwards `abortSignal` to it, and on this path there is no remote process to
+  // kill — aborting the request is the only thing that stops the daemon's build.
+  if (cancelSignal) {
+    if (cancelSignal.aborted) controller.abort();
+    else cancelSignal.addEventListener("abort", () => controller.abort(), { once: true });
+  }
   // pipe() does NOT forward source errors, so a tar-fs walk failure is only
   // observable on the pack itself — this listener is what keeps it from killing
   // the process. Guard the gzip side too for completeness.
@@ -1419,12 +1486,14 @@ export class DockerRuntime implements RuntimeAdapter {
     buildContext: Awaited<ReturnType<typeof createDockerBuildContext>>,
     tag: string,
     log: BuildLogger,
+    cancelSignal?: AbortSignal,
   ): Promise<void> {
     log.log(`Streaming build context to Docker daemon - image tag: ${tag}`);
 
     const { body, abortSignal, takeError } = packBuildContext(
       buildContext.contextDir,
       buildContext.contextEntries,
+      cancelSignal,
     );
 
     try {
@@ -1573,19 +1642,18 @@ export class DockerRuntime implements RuntimeAdapter {
     const log = logger ?? new BuildLogger();
     const startTime = Date.now();
     const tag = this.imageTag(config.slug, config.sessionId);
-    const abort = new AbortController();
-    if (pendingDockerBuildCancellations.delete(config.sessionId)) abort.abort();
-    activeDockerBuilds.set(config.sessionId, abort);
+    const abort = registerDockerBuild(config.sessionId);
+    const cancelled = (): BuildResult => {
+      log.step("build", "failed", "Docker build cancelled");
+      return {
+        sessionId: config.sessionId,
+        status: "cancelled",
+        durationMs: Date.now() - startTime,
+      };
+    };
 
     try {
-      if (abort.signal.aborted) {
-        log.step("build", "failed", "Docker build cancelled");
-        return {
-          sessionId: config.sessionId,
-          status: "cancelled",
-          durationMs: Date.now() - startTime,
-        };
-      }
+      if (abort.signal.aborted) return cancelled();
       log.log(`Build strategy: docker (${this.transport.description})\n`);
 
       // Ensure the host is provisioned for Docker, but avoid doing a second
@@ -1628,6 +1696,9 @@ export class DockerRuntime implements RuntimeAdapter {
           sshExecutor.exec(`rm -rf ${sq(remoteContextDir)}`).catch(() => { /* best effort */ });
         }
 
+        // Same last gate as the transferred-context path below: a cancel that lands
+        // after the build command finished must not hand back a deployable image.
+        if (abort.signal.aborted) return cancelled();
         await this.verifyImageBuilt(tag);
         log.log(`Image ${tag} is ready.\n`);
         log.step("build", "completed", `Finalizing image ${tag}`);
@@ -1695,8 +1766,16 @@ export class DockerRuntime implements RuntimeAdapter {
         await this.buildViaSshTarPipe(config, buildContext, tag, log, abort.signal);
       } else {
         // ── Dockerode path (local socket, TCP, or SSH without executor) ─
-        await this.buildViaDockerode(config, buildContext, tag, log);
+        await this.buildViaDockerode(config, buildContext, tag, log, abort.signal);
       }
+
+      // Last gate before the image counts as deployable. Cancelling mid-build is
+      // best-effort on every path — an abort that lands after the daemon finished
+      // still leaves a usable image here — so without this check a cancel would
+      // return "deploying", and the pipeline (which stops ONLY on "cancelled" and
+      // re-writes the row to "deploying" without checking for a terminal state)
+      // would deploy the deployment the user just cancelled.
+      if (abort.signal.aborted) return cancelled();
 
       await this.verifyImageBuilt(tag);
 
@@ -1706,21 +1785,12 @@ export class DockerRuntime implements RuntimeAdapter {
       const durationMs = Date.now() - startTime;
       return { sessionId: config.sessionId, status: "deploying", imageRef: tag, durationMs };
     } catch (err) {
-      if (abort.signal.aborted || err instanceof BuildCancelledError) {
-        log.step("build", "failed", "Docker build cancelled");
-        return {
-          sessionId: config.sessionId,
-          status: "cancelled",
-          durationMs: Date.now() - startTime,
-        };
-      }
+      if (abort.signal.aborted || err instanceof BuildCancelledError) return cancelled();
       const msg = safeErrorMessage(err);
       log.step("build", "failed", `Docker build failed: ${msg}`);
       return { sessionId: config.sessionId, status: "failed", durationMs: Date.now() - startTime, errorMessage: `Docker build failed: ${msg}` };
     } finally {
-      if (activeDockerBuilds.get(config.sessionId) === abort) {
-        activeDockerBuilds.delete(config.sessionId);
-      }
+      releaseDockerBuild(config.sessionId, abort);
     }
   }
 
@@ -2075,20 +2145,31 @@ export class DockerRuntime implements RuntimeAdapter {
     const cloneOnServer = isSsh && !!source.cloneOnServer;
     const remoteContextDir = `/tmp/openship-build-${source.sessionId}`;
 
-    // Acquire the shared source ONCE: clone-on-server clones directly on the
-    // remote host (no transfer); otherwise clone on the orchestrator (and
-    // transfer the tree below).
-    let tree: Awaited<ReturnType<typeof prepareSourceTree>> | null = null;
-    if (cloneOnServer) {
-      prepareLogger.step("clone", "running", "Cloning source on the server...");
-      await this.cloneSourceOnRemote(source, remoteContextDir, prepareLogger);
-      prepareLogger.step("clone", "completed", "Source cloned on the server");
-    } else {
-      prepareLogger.step("clone", "running", "Preparing shared build context...");
-      tree = await prepareSourceTree(source, { onLog: prepareLogger.callback });
-    }
+    // Register EVERY service's build up front, before the shared clone/transfer:
+    // a cancel that lands during that shared phase must be seen by all of them,
+    // and cancelBuild() only reaches builds that are already registered.
+    const abortControllers = new Map(
+      specs.map((spec) => [spec.config.sessionId, registerDockerBuild(spec.config.sessionId)]),
+    );
+    const isCancelled = (sessionId: string): boolean =>
+      abortControllers.get(sessionId)?.signal.aborted === true;
+    const anyCancelled = (): boolean =>
+      [...abortControllers.values()].some((c) => c.signal.aborted);
 
+    let tree: Awaited<ReturnType<typeof prepareSourceTree>> | null = null;
     try {
+      // Acquire the shared source ONCE: clone-on-server clones directly on the
+      // remote host (no transfer); otherwise clone on the orchestrator (and
+      // transfer the tree below).
+      if (cloneOnServer) {
+        prepareLogger.step("clone", "running", "Cloning source on the server...");
+        await this.cloneSourceOnRemote(source, remoteContextDir, prepareLogger);
+        prepareLogger.step("clone", "completed", "Source cloned on the server");
+      } else {
+        prepareLogger.step("clone", "running", "Preparing shared build context...");
+        tree = await prepareSourceTree(source, { onLog: prepareLogger.callback });
+      }
+
       // Resolve/generate each service's Dockerfile INTO the shared tree, with a
       // per-service generated name so concurrent builds never clobber each other.
       const resolvedList = await Promise.all(
@@ -2144,7 +2225,8 @@ export class DockerRuntime implements RuntimeAdapter {
         } catch {
           prepareLogger.step("clone", "completed", "Shared build context ready");
         }
-        if (isSsh) {
+        // Don't push megabytes at a host whose build the user already cancelled.
+        if (isSsh && !anyCancelled()) {
           await this.transferBuildContext(tree.contextDir, remoteContextDir, prepareLogger);
         }
       }
@@ -2160,6 +2242,21 @@ export class DockerRuntime implements RuntimeAdapter {
       for (const { spec, dockerfileName, contextEntries, error } of resolvedList) {
         const startedAt = Date.now();
         const tag = this.imageTag(spec.config.slug, spec.config.sessionId);
+        const signal = abortControllers.get(spec.config.sessionId)?.signal;
+
+        // Cancelled before this service's turn came up (builds are sequential, so
+        // most services of a cancelled compose deploy land here). Reported as
+        // "cancelled", never "failed" — the pipeline branches on it.
+        if (isCancelled(spec.config.sessionId)) {
+          const result: BuildResult = {
+            sessionId: spec.config.sessionId,
+            status: "cancelled",
+            durationMs: Date.now() - startedAt,
+          };
+          spec.onResult?.(result);
+          results.push({ serviceName: spec.serviceName, result });
+          continue;
+        }
 
         if (error || !dockerfileName) {
           const result: BuildResult = {
@@ -2184,6 +2281,7 @@ export class DockerRuntime implements RuntimeAdapter {
               dockerfileName,
               tag,
               spec.logger,
+              signal,
             );
           } else {
             // Own the pack (error handler + abort) so a build-context read
@@ -2193,6 +2291,7 @@ export class DockerRuntime implements RuntimeAdapter {
             const { body, abortSignal, takeError } = packBuildContext(
               tree!.contextDir,
               contextEntries ?? [],
+              signal,
             );
             try {
               const stream = await this.docker.buildImage(body, {
@@ -2214,6 +2313,19 @@ export class DockerRuntime implements RuntimeAdapter {
                 ? new Error(`Failed to read Docker build context: ${safeErrorMessage(contextErr)}`, { cause: contextErr })
                 : err;
             }
+          }
+
+          // Same last gate as build(): an image that finished under a cancel must
+          // not come back "deploying", or the compose pipeline deploys it anyway.
+          if (isCancelled(spec.config.sessionId)) {
+            const result: BuildResult = {
+              sessionId: spec.config.sessionId,
+              status: "cancelled",
+              durationMs: Date.now() - startedAt,
+            };
+            spec.onResult?.(result);
+            results.push({ serviceName: spec.serviceName, result });
+            continue;
           }
 
           await this.verifyImageBuilt(tag);
@@ -2250,6 +2362,19 @@ export class DockerRuntime implements RuntimeAdapter {
           spec.onResult?.(result);
           results.push({ serviceName: spec.serviceName, result });
         } catch (err) {
+          // A cancelled build surfaces as an aborted stream or BuildCancelledError;
+          // either way it is not a build failure.
+          if (isCancelled(spec.config.sessionId) || err instanceof BuildCancelledError) {
+            spec.logger.log("Docker build cancelled\n", "error");
+            const result: BuildResult = {
+              sessionId: spec.config.sessionId,
+              status: "cancelled",
+              durationMs: Date.now() - startedAt,
+            };
+            spec.onResult?.(result);
+            results.push({ serviceName: spec.serviceName, result });
+            continue;
+          }
           const msg = safeErrorMessage(err);
           spec.logger.log(`Docker build failed: ${msg}\n`, "error");
           const result: BuildResult = {
@@ -2264,6 +2389,9 @@ export class DockerRuntime implements RuntimeAdapter {
       }
       return results;
     } finally {
+      for (const [sessionId, abort] of abortControllers) {
+        releaseDockerBuild(sessionId, abort);
+      }
       if (isSsh) {
         this.connectionOptions?.executor
           ?.exec(`rm -rf ${sq(remoteContextDir)}`)
@@ -2274,34 +2402,39 @@ export class DockerRuntime implements RuntimeAdapter {
   }
 
   async cancelBuild(sessionId: string): Promise<void> {
-    const abort = activeDockerBuilds.get(sessionId);
-    if (abort) {
-      abort.abort();
-    } else {
-      pendingDockerBuildCancellations.add(sessionId);
+    // A compose deploy registers one build per service under `<sessionId>-<serviceId>`,
+    // so abort every active build this id covers, not just an exact match.
+    for (const [activeId, abort] of activeDockerBuilds) {
+      if (cancelCovers(sessionId, activeId)) abort.abort();
     }
+    // Recorded unconditionally: "something was active" does NOT mean every build
+    // this cancel covers has registered — the later services of a compose deploy
+    // may still be queued behind the one that's running.
+    recordPendingCancellation(sessionId);
 
     // Closing an SSH channel normally sends SIGHUP to its remote shell, but a
     // host-side `docker build` may outlive that channel while the daemon keeps
-    // working. Kill the command whose cwd is this session's private context,
-    // mirroring BareRuntime's remote-build cancellation. This is a no-op for
-    // local/TCP runtimes and when the command has already exited.
+    // working. Kill whatever is running in this session's private context dirs,
+    // sharing BareRuntime's sweep. A no-op for local/TCP runtimes and when the
+    // command has already exited.
     const executor =
       this.transport.kind === "ssh" ? this.connectionOptions?.executor : undefined;
     if (executor) {
-      const dir = sq(`/tmp/openship-build-${sessionId}`);
-      const scan = (signal: string) =>
-        `for p in /proc/[0-9]*; do c=$(readlink "$p/cwd" 2>/dev/null); ` +
-        `case "$c" in ${dir}|${dir}/*) kill -${signal} "\${p##*/}" 2>/dev/null || true;; esac; done`;
-      await executor.exec(`${scan("TERM")}; sleep 2; ${scan("KILL")}`).catch(() => {});
+      await killProcessesUnderDir(executor, `/tmp/openship-build-${sessionId}`, {
+        includeSuffixed: true,
+      });
     }
 
-    // Attempt to find and kill the build container by label
+    // Attempt to find and kill the build container by label. Filtered on the label
+    // KEY, not `key=value`: a compose service's container carries the derived
+    // `<sessionId>-<serviceId>`, which an exact-value filter would never match.
     const containers = await this.docker.listContainers({
       all: true,
-      filters: { label: [`openship.build=${sessionId}`] },
+      filters: { label: ["openship.build"] },
     });
     for (const c of containers) {
+      const buildId = c.Labels?.["openship.build"];
+      if (!buildId || !cancelCovers(sessionId, buildId)) continue;
       try {
         await this.docker.getContainer(c.Id).remove({ force: true });
       } catch { /* already removed */ }

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -117,7 +117,7 @@ import type {
   DockerNetworkInfo,
   ContainerLifecycleEvent,
 } from "./types";
-import { BuildLogger, parseLogLevel, sq, assembleGitClone } from "./build-pipeline";
+import { BuildCancelledError, BuildLogger, parseLogLevel, sq, assembleGitClone } from "./build-pipeline";
 import { materializeGitSsh, shellGitSshWriter, type GitSshMaterial } from "./git-ssh-material";
 import { githubTarballUrl, downloadTarballOnRemote } from "./source-tarball";
 import { scopeVolumeBinds, isHostPathSource } from "./volume-namespace";
@@ -163,6 +163,15 @@ const RESTART_POLICIES: Record<string, { Name: string; MaximumRetryCount: number
 };
 
 const DOCKER_BUILD_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * A deployment build and its cancellation request may resolve separate
+ * DockerRuntime instances. Build session ids are process-wide, so cancellation
+ * state must be process-wide too or the cancelling runtime cannot reach the
+ * builder's controller.
+ */
+const activeDockerBuilds = new Map<string, AbortController>();
+const pendingDockerBuildCancellations = new Set<string>();
 
 /** Last-resort cap for a one-shot in-container exec. Every caller passes its own
  *  (5s probe / 15s prepare step); this only guards a stream that connects and
@@ -831,7 +840,6 @@ export class DockerRuntime implements RuntimeAdapter {
   readonly transport: DockerTransport;
   private readonly systemManager: DockerSystemManager | null;
   private readonly provisionLock?: ProvisionLock;
-
   private constructor(
     opts?: DockerConnectionOptions,
     systemManager?: DockerSystemManager | null,
@@ -1160,6 +1168,7 @@ export class DockerRuntime implements RuntimeAdapter {
     dockerfileName: string,
     tag: string,
     log: BuildLogger,
+    signal?: AbortSignal,
   ): Promise<void> {
     const executor = this.connectionOptions?.executor;
     if (!executor) throw new Error("SSH build path requires an executor on connectionOptions");
@@ -1197,12 +1206,21 @@ export class DockerRuntime implements RuntimeAdapter {
     log.log("─── docker build output ───");
     this.emitDockerStep(log, "install", "running", "Running install inside container (docker build)");
 
-    const { code } = await executor.streamExec(buildCmd, (entry) => {
-      // Pass docker's real output straight through.
-      log.log(entry.message, parseLogLevel(entry.message));
-    });
+    const { code } = await executor.streamExec(
+      buildCmd,
+      (entry) => {
+        // Pass docker's real output straight through.
+        log.log(entry.message, parseLogLevel(entry.message));
+      },
+      { signal },
+    );
 
     log.log("─── end docker build output ───");
+    // SshExecutor intentionally resolves an aborted stream so browser log
+    // teardown is not reported as a transport failure. A deployment cancel is
+    // different: surface it as a cancelled BuildResult instead of continuing
+    // through image verification and deploy.
+    if (signal?.aborted) throw new BuildCancelledError();
     if (code !== 0) throw new Error(`docker build exited with code ${code}`);
     this.emitDockerStep(log, "install", "completed", "Image build finished");
   }
@@ -1364,11 +1382,19 @@ export class DockerRuntime implements RuntimeAdapter {
     buildContext: Awaited<ReturnType<typeof createDockerBuildContext>>,
     tag: string,
     log: BuildLogger,
+    signal?: AbortSignal,
   ): Promise<void> {
     const remoteContextDir = `/tmp/openship-build-${config.sessionId}`;
     try {
       await this.transferBuildContext(buildContext.contextDir, remoteContextDir, log);
-      await this.buildImageOnRemote(config, remoteContextDir, buildContext.dockerfileName, tag, log);
+      await this.buildImageOnRemote(
+        config,
+        remoteContextDir,
+        buildContext.dockerfileName,
+        tag,
+        log,
+        signal,
+      );
     } finally {
       // Always clean up the remote context - even on failure. Don't await - if
       // cleanup fails we still want the build result.
@@ -1547,8 +1573,19 @@ export class DockerRuntime implements RuntimeAdapter {
     const log = logger ?? new BuildLogger();
     const startTime = Date.now();
     const tag = this.imageTag(config.slug, config.sessionId);
+    const abort = new AbortController();
+    if (pendingDockerBuildCancellations.delete(config.sessionId)) abort.abort();
+    activeDockerBuilds.set(config.sessionId, abort);
 
     try {
+      if (abort.signal.aborted) {
+        log.step("build", "failed", "Docker build cancelled");
+        return {
+          sessionId: config.sessionId,
+          status: "cancelled",
+          durationMs: Date.now() - startTime,
+        };
+      }
       log.log(`Build strategy: docker (${this.transport.description})\n`);
 
       // Ensure the host is provisioned for Docker, but avoid doing a second
@@ -1571,6 +1608,7 @@ export class DockerRuntime implements RuntimeAdapter {
         try {
           this.emitDockerStep(log, "clone", "running", "Cloning source on the server...");
           await this.cloneSourceOnRemote(config, remoteContextDir, log);
+          if (abort.signal.aborted) throw new BuildCancelledError();
           this.emitDockerStep(log, "clone", "completed", "Source cloned on the server");
           const dockerfileName = await this.resolveRemoteDockerfile(
             config,
@@ -1578,7 +1616,14 @@ export class DockerRuntime implements RuntimeAdapter {
             "Dockerfile.openship",
             config.stack === "docker",
           );
-          await this.buildImageOnRemote(config, remoteContextDir, dockerfileName, tag, log);
+          await this.buildImageOnRemote(
+            config,
+            remoteContextDir,
+            dockerfileName,
+            tag,
+            log,
+            abort.signal,
+          );
         } finally {
           sshExecutor.exec(`rm -rf ${sq(remoteContextDir)}`).catch(() => { /* best effort */ });
         }
@@ -1595,6 +1640,7 @@ export class DockerRuntime implements RuntimeAdapter {
         requireRepositoryDockerfile: config.stack === "docker",
         onLog: log.callback,
       });
+      if (abort.signal.aborted) throw new BuildCancelledError();
 
       // Report the size of the context so users know what they're paying
       // for over the SSH wire. Failure here is non-fatal - the build can
@@ -1646,7 +1692,7 @@ export class DockerRuntime implements RuntimeAdapter {
         // per-3s `~X% · Y MB sent · Z MB/s` progress), then run native
         // `docker build` on the remote so its real stdout/stderr streams
         // back uninterpreted.
-        await this.buildViaSshTarPipe(config, buildContext, tag, log);
+        await this.buildViaSshTarPipe(config, buildContext, tag, log, abort.signal);
       } else {
         // ── Dockerode path (local socket, TCP, or SSH without executor) ─
         await this.buildViaDockerode(config, buildContext, tag, log);
@@ -1660,9 +1706,21 @@ export class DockerRuntime implements RuntimeAdapter {
       const durationMs = Date.now() - startTime;
       return { sessionId: config.sessionId, status: "deploying", imageRef: tag, durationMs };
     } catch (err) {
+      if (abort.signal.aborted || err instanceof BuildCancelledError) {
+        log.step("build", "failed", "Docker build cancelled");
+        return {
+          sessionId: config.sessionId,
+          status: "cancelled",
+          durationMs: Date.now() - startTime,
+        };
+      }
       const msg = safeErrorMessage(err);
       log.step("build", "failed", `Docker build failed: ${msg}`);
       return { sessionId: config.sessionId, status: "failed", durationMs: Date.now() - startTime, errorMessage: `Docker build failed: ${msg}` };
+    } finally {
+      if (activeDockerBuilds.get(config.sessionId) === abort) {
+        activeDockerBuilds.delete(config.sessionId);
+      }
     }
   }
 
@@ -2216,6 +2274,28 @@ export class DockerRuntime implements RuntimeAdapter {
   }
 
   async cancelBuild(sessionId: string): Promise<void> {
+    const abort = activeDockerBuilds.get(sessionId);
+    if (abort) {
+      abort.abort();
+    } else {
+      pendingDockerBuildCancellations.add(sessionId);
+    }
+
+    // Closing an SSH channel normally sends SIGHUP to its remote shell, but a
+    // host-side `docker build` may outlive that channel while the daemon keeps
+    // working. Kill the command whose cwd is this session's private context,
+    // mirroring BareRuntime's remote-build cancellation. This is a no-op for
+    // local/TCP runtimes and when the command has already exited.
+    const executor =
+      this.transport.kind === "ssh" ? this.connectionOptions?.executor : undefined;
+    if (executor) {
+      const dir = sq(`/tmp/openship-build-${sessionId}`);
+      const scan = (signal: string) =>
+        `for p in /proc/[0-9]*; do c=$(readlink "$p/cwd" 2>/dev/null); ` +
+        `case "$c" in ${dir}|${dir}/*) kill -${signal} "\${p##*/}" 2>/dev/null || true;; esac; done`;
+      await executor.exec(`${scan("TERM")}; sleep 2; ${scan("KILL")}`).catch(() => {});
+    }
+
     // Attempt to find and kill the build container by label
     const containers = await this.docker.listContainers({
       all: true,

--- a/packages/adapters/src/system/system-ssh-executor-abort.test.ts
+++ b/packages/adapters/src/system/system-ssh-executor-abort.test.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * `streamExec`'s signal is how a cancelled deploy stops a remote `docker build`.
+ * SshExecutor (ssh2) honours it; this executor — the one used for agent-auth
+ * servers, where the OS `ssh` binary does the authenticating — used to drop the
+ * option on the floor, so a cancel there let the build run to completion and the
+ * deployment came back "deploying". These tests pin the kill and the exit code.
+ */
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn((_signal?: string) => {
+    // Real ssh dies and the close event carries no exit code.
+    this.emit("close", null);
+    return true;
+  });
+}
+
+const spawned: FakeChild[] = [];
+vi.mock("node:child_process", () => ({
+  // ensureMaster()'s `-fN` handshake, promisified at module load.
+  execFile: (
+    ..._args: [string, string[], object, (err: Error | null, stdout: string, stderr: string) => void]
+  ) => {
+    const cb = _args[_args.length - 1] as (
+      err: Error | null,
+      stdout: string,
+      stderr: string,
+    ) => void;
+    cb(null, "", "");
+  },
+  spawn: () => {
+    const child = new FakeChild();
+    spawned.push(child);
+    return child;
+  },
+}));
+
+import { SystemSshExecutor } from "./system-ssh-executor";
+
+const CONFIG = { host: "h", username: "u", useSystemSsh: true };
+
+describe("SystemSshExecutor.streamExec abort", () => {
+  it("kills the ssh child and resolves with code 0 when the signal fires", async () => {
+    const executor = new SystemSshExecutor(CONFIG);
+    const controller = new AbortController();
+
+    const promise = executor.streamExec("docker build .", () => {}, {
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      if (spawned.length === 0) throw new Error("not spawned yet");
+    });
+
+    controller.abort();
+
+    // code 0, not the killed child's null→1: an abort is the caller's own
+    // decision, so it must not read as a transport failure (matches SshExecutor).
+    await expect(promise).resolves.toEqual({ code: 0, output: "" });
+    expect(spawned.at(-1)!.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("never spawns when the signal is already aborted", async () => {
+    const executor = new SystemSshExecutor(CONFIG);
+    const before = spawned.length;
+
+    await expect(
+      executor.streamExec("docker build .", () => {}, { signal: AbortSignal.abort() }),
+    ).resolves.toEqual({ code: 0, output: "" });
+    expect(spawned.length).toBe(before);
+  });
+});

--- a/packages/adapters/src/system/system-ssh-executor.ts
+++ b/packages/adapters/src/system/system-ssh-executor.ts
@@ -238,14 +238,29 @@ export class SystemSshExecutor implements CommandExecutor {
   async streamExec(
     command: string,
     onLog: (log: LogEntry) => void,
+    opts?: { signal?: AbortSignal },
   ): Promise<{ code: number; output: string }> {
     await this.ensureMaster();
+    const signal = opts?.signal;
+    if (signal?.aborted) return { code: 0, output: "" };
     return new Promise((resolve) => {
       const child = spawn(
         "ssh",
         [...this.baseArgs(), sshTarget(this.config), SystemSshExecutor.ENV_PREFIX + command],
         { env: sshChildEnv(this.config), stdio: ["ignore", "pipe", "pipe"] },
       );
+
+      // Abort = kill the ssh client, which tears the channel down. Resolve with
+      // code 0 like SshExecutor does: an abort is the caller's own decision, not
+      // a transport failure, and callers that care (a cancelled build) re-check
+      // `signal.aborted` themselves. Without this the signal was ignored outright
+      // and a cancelled remote build streamed to completion.
+      let aborted = false;
+      const onAbort = () => {
+        aborted = true;
+        child.kill("SIGKILL");
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
 
       // Raw passthrough (see LocalExecutor.streamExec): forward the untouched
       // byte stream as rawData so the client's xterm renders "\r"/ANSI natively
@@ -262,11 +277,13 @@ export class SystemSshExecutor implements CommandExecutor {
       child.stdout.on("data", (chunk: Buffer) => onChunk(chunk, "info"));
       child.stderr.on("data", (chunk: Buffer) => onChunk(chunk, "warn"));
       child.on("error", (err) => {
+        signal?.removeEventListener("abort", onAbort);
         onLog(logEntry(`Process error: ${err.message}`, "error"));
         resolve({ code: 1, output: err.message });
       });
       child.on("close", (code) => {
-        const c = code ?? 1;
+        signal?.removeEventListener("abort", onAbort);
+        const c = aborted ? 0 : (code ?? 1);
         void this.maybeSignalDisconnect(c).catch(() => {});
         resolve({ code: c, output: chunks.join("") });
       });


### PR DESCRIPTION
> **Corrections (post-merge).** Three claims below were wrong or overstated when this merged. Kept in place with the correction inline rather than silently rewritten. Follow-up: #552
>
> 1. **Scope is self-hosted/desktop, not "every build path".** This covers `DockerRuntime` (all transports) and the `BareRuntime` sweep. `CloudRuntime` is untouched: its `cancelBuild` is instance-local and matches the session id exactly, and it has no `buildImages` override — so cloud/SaaS compose builds are still uncancellable. Pre-existing, not a regression from this PR, and not fixed here.
> 2. **The shared clone was NOT skipped** — only the context transfer was. A cancelled compose batch still paid for a full `git clone` on the host. Fixed in the follow-up.
> 3. **The deleted-cwd claim is a race, not a certainty.** Whether the build's `rm -rf` lands before the sweep reads `/proc/*/cwd` isn't ordered, so the plain-dir patterns were unreliable rather than dead. Matching both forms is still the fix.

## Summary

Build cancellation only ever reached **one** of the ways OpenShip builds on a self-hosted or desktop target — the SSH tar-pipe stream. Every other path there ran to completion and returned `status: "deploying"`, and because `setDeploymentStatus` has no terminal-state guard, the pipeline wrote over the `cancelled` row and deployed anyway.

- **Process-wide registry.** `cancelBuildSession` resolves `platform().runtime`, not the per-server runtime that built, so the abort controllers live at module scope. Cancellation that arrives before a build registers is remembered, and the build exits without starting work.
- **dockerode / local-socket path.** The cancel signal is forwarded into `packBuildContext`, whose `abortSignal` dockerode passes to the in-flight `buildImage` request — previously this path never consulted the signal at all.
- **Compose / multi-service builds.** `buildImages()` bypasses `build()`, so it was entirely uncancellable. It now registers a controller per service under `<buildSessionId>-<serviceId>`, and `cancelBuild()` matches by prefix because the API only ever knows the parent `bld_…` id. Services still queued short-circuit instead of starting; the shared context transfer is skipped once anything is cancelled (see correction 2 — the clone itself was not, and is fixed in the follow-up).
- **Orphan kill actually kills.** The `/proc/*/cwd` sweep is shared with `BareRuntime` and now also matches `"<dir> (deleted)"`. A cancelled build's own `finally` `rm -rf`s the context dir, so on Linux the cwd readlink can come back suffixed and the plain-dir patterns then match nothing (see correction 3 — this is a race, so both forms have to be matched).
- **Agent-auth servers.** `SystemSshExecutor.streamExec` (the spawned OpenSSH binary used when `sshAuthMethod === "agent"`) ignored the signal outright. It now SIGKILLs the child and resolves `{code: 0}`, matching `SshExecutor` so an abort doesn't read as a transport failure.
- **Bounded pending cancellations.** The pending map had no eviction and was consumed on first match; it now carries a 10-minute TTL and entries expire instead of being consumed, so one compose cancel still covers every service that hasn't registered yet.
- **Label cleanup.** Containers are listed by label *key* and matched by prefix — an exact `openship.build=<id>` filter could never hit a compose sub-build.
- **API side.** A cancelled service build is propagated as cancelled rather than laundered into a build failure, and the compose pipeline stops on it (cleaning up whatever images did build) instead of deploying the partial set. The single-app pipeline already returned on `status === "cancelled"`.

Image cleanup after a cancel is already handled by `executeCleanup` in `cancelBuildSession` via the deployment manifest; this PR doesn't change that.

## Root cause

For Docker projects deployed through an SSH-backed runtime, OpenShip runs `docker build` as a streamed remote command. The cancellation path only tried to stop labelled Docker containers, so it did not control that SSH stream. Cancellation and build can also be handled by separate `DockerRuntime` instances, so an instance-local registry cannot coordinate them. The remaining self-hosted build paths (local daemon, compose fan-out, agent-auth SSH) had no cancellation hook at all.

## Known gap at merge time

The static-extract paths gate on cancel *before* `docker create` + `docker cp` of the output tree, not after, so a cancel landing during the extract still returned `"deploying"`. Fixed in the follow-up.

The terminal-state guard this PR's summary names as part of the root cause is also **not** added here — it was left as-is, so a cancel arriving during the *deploy* phase (which has no cancel awareness at all) still let that work reach `onSuccess`, write `ready` over the cancellation, and advance the active release. Fixed in #552 at `repos.deployment.updateStatus`.

## Validation

- Cancellation tests cover: the streamed SSH build, cancel-before-registration, the dockerode/daemon path, the compose parent-id fan-out, the sweep's shape including deleted cwds, `packBuildContext` signal forwarding, `SystemSshExecutor` abort, and the compose cancelled-vs-failed contract.
- Non-vacuity checked: reducing the prefix match to exact equality fails the compose test.
- `packages/adapters`: 129 test files, 2,841 tests passed. `apps/api` suite passed. `tsc --noEmit` clean for both.
