### PR TITLE
fix(auth): scope nested lists to their parent

### DIFF
--- a/apps/api/src/lib/route-permission.ts
+++ b/apps/api/src/lib/route-permission.ts
@@ -572,14 +572,38 @@ export function requirePermission(spec: PermissionSpec): MiddlewareHandler {
       // record below is byte-identical to the collection branch's.
       leafId = "*";
     } else if (parsed.isList) {
-      // List scope — org from request (X-Organization-Id header or
-      // session default). No specific resource id.
-      await permission.assert(getRequestContext(c), {
-        resourceType: parsed.leaf,
-        resourceId: "*",
-        action: "read",
-        scope: "list",
-      });
+      if (parsed.root !== parsed.leaf) {
+        // A nested collection belongs to the concrete parent named in the URL.
+        // Authorizing `{service,"*"}` here made project-scoped tokens unable to
+        // list that project's services or deployments even though they could
+        // read every concrete child. The parent grant is the collection scope.
+        const parentParamName =
+          idsMap[parsed.root] ?? DEFAULT_ID_PARAMS[parsed.root] ?? "id";
+        const parentId = c.req.param(parentParamName);
+        if (!parentId) {
+          return c.json(
+            {
+              error: `Missing route param :${parentParamName} required by tag "${spec.tag}"`,
+            },
+            400,
+          );
+        }
+        await permission.assert(getRequestContext(c), {
+          resourceType: parsed.root,
+          resourceId: parentId,
+          action: "read",
+        });
+        leafId = "*";
+      } else {
+        // Top-level list scope — org from request (X-Organization-Id header or
+        // session default). No specific resource id.
+        await permission.assert(getRequestContext(c), {
+          resourceType: parsed.leaf,
+          resourceId: "*",
+          action: "read",
+          scope: "list",
+        });
+      }
     } else if (ORG_SINGLETON_RESOURCES.has(parsed.leaf as string)) {
       // Org-singleton resources (billing, settings, analytics, etc.) —
       // no resource id in the URL. Pass "*" so the permission resolver

--- a/apps/api/test/lib/permission-nested-list-parent.test.ts
+++ b/apps/api/test/lib/permission-nested-list-parent.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assertPermission = vi.fn(async () => {});
+
+vi.mock("../../src/lib/permission", () => ({
+  permission: { assert: assertPermission },
+  ORG_SINGLETON_RESOURCES: new Set<string>(),
+}));
+vi.mock("@repo/db", () => ({ repos: {} }));
+vi.mock("../../src/lib/audit", () => ({
+  audit: vi.fn(async () => {}),
+  auditContextFrom: vi.fn(() => ({})),
+}));
+vi.mock("../../src/modules/github/github-access", () => ({
+  canUseGitHubRepo: vi.fn(async () => false),
+  checkSourceTier: vi.fn(async () => ({ ok: false, readPaths: [] })),
+}));
+
+const { requirePermission } = await import("../../src/lib/route-permission");
+
+function context(params: Record<string, string | undefined>) {
+  const values = new Map<string, unknown>([["ctx", { userId: "user-1" }]]);
+  return {
+    req: {
+      param: vi.fn((name: string) => params[name]),
+      query: vi.fn(() => undefined),
+    },
+    get: vi.fn((name: string) => values.get(name)),
+    set: vi.fn((name: string, value: unknown) => values.set(name, value)),
+    json: vi.fn((body: unknown, status: number) => ({ body, status })),
+    res: { status: 200 },
+  };
+}
+
+describe("nested list permission scope", () => {
+  beforeEach(() => assertPermission.mockClear());
+
+  it.each(["project:service:list", "project:deployment:list"])(
+    "authorizes %s against the concrete parent project",
+    async (tag) => {
+      const c = context({ id: "project-1" });
+      const next = vi.fn(async () => {});
+
+      await requirePermission({ tag })(c as never, next);
+
+      expect(assertPermission).toHaveBeenCalledWith(
+        expect.anything(),
+        { resourceType: "project", resourceId: "project-1", action: "read" },
+      );
+      expect(next).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps a top-level list on its org-scoped wildcard", async () => {
+    const c = context({});
+    const next = vi.fn(async () => {});
+
+    await requirePermission({ tag: "project:list" })(c as never, next);
+
+    expect(assertPermission).toHaveBeenCalledWith(
+      expect.anything(),
+      { resourceType: "project", resourceId: "*", action: "read", scope: "list" },
+    );
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when a nested list has no parent id", async () => {
+    const c = context({});
+    const next = vi.fn(async () => {});
+
+    const response = await requirePermission({ tag: "project:service:list" })(c as never, next);
+
+    expect(response).toEqual(expect.objectContaining({ status: 400 }));
+    expect(assertPermission).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- authorize nested list routes against the concrete parent resource named in the URL
- keep top-level collection authorization on the existing org-scoped wildcard path
- fail closed when a nested collection route is missing its parent parameter

## Root cause

`project:service:list` and `project:deployment:list` were handled by the generic list branch as `{resourceType: child, resourceId: "*"}`. A restricted token granted the concrete project could read individual children, but collection requests failed as `service '*' not found` / `deployment '*' not found`. The parent project grant is the correct scope for its child collection.

This blocked least-privilege automation from listing a project's services (including selecting a database for backup) and deployments.

## Validation

- added four regression tests covering services, deployments, top-level lists, and missing-parent fail-closed behavior
- API TypeScript check passed
- complete API suite passed: 321 files, 3,813 tests passed, 3 skipped
