### PR TITLE
fix(deployments): correct three defects in the merged compose no-op change (#499 follow-up)

### DIFF
--- a/apps/api/src/lib/deployment-runtime.ts
+++ b/apps/api/src/lib/deployment-runtime.ts
@@ -110,10 +110,6 @@ export interface DeploymentMeta {
    * agree on one path.
    */
   staticServeOutputDir?: string;
-  /** This deploy carried every service forward and shipped nothing, so it never
-   *  became the active release (see `onNoChanges`). Mirrors the row's
-   *  `no_changes` status for clients reading meta rather than status. */
-  noChanges?: boolean;
   /** Compose roll-up. Loosely typed on purpose — the pipeline writes a wider
    *  object than any one reader needs. */
   composeDeployment?: { warningMessage?: string } & Record<string, unknown>;

--- a/apps/api/src/lib/notification-categories.ts
+++ b/apps/api/src/lib/notification-categories.ts
@@ -322,8 +322,6 @@ export const EVENT_HEADLINES: Record<string, { title: string; description: strin
     title: "Server reachable",
     description: "A server's Docker daemon is answering again, with how long it was gone.",
   },
-  // Same reasoning: it subscribes as a success, but "Deploy succeeded" over a body
-  // saying nothing shipped is the exact mismatch this override exists for.
   "deployment.no_changes": {
     title: "No changes to deploy",
     description: "A redeploy found every service already up to date; the live release didn't move.",

--- a/apps/api/src/modules/analytics/analytics.service.ts
+++ b/apps/api/src/modules/analytics/analytics.service.ts
@@ -544,7 +544,12 @@ export async function getDeploymentStats(
   });
 
   const total = deployments.length;
-  const success = deployments.filter((d) => d.status === "ready").length;
+  // `no_changes` counts as success: nothing failed, and the release it declined to
+  // replace is still live. Left out, every unchanged redeploy would lower the rate
+  // AND land in the `pending` residue below, which is `total - success - failed`.
+  const success = deployments.filter(
+    (d) => d.status === "ready" || d.status === "no_changes",
+  ).length;
   const failed = deployments.filter((d) => d.status === "failed").length;
 
   // Average build duration of successful deployments
@@ -643,7 +648,8 @@ export async function getDashboardStats(ctx: RequestContext) {
 
   let totalDeployments = 0;
   for (const count of Object.values(deploymentsByStatus)) totalDeployments += count;
-  const successDeployments = deploymentsByStatus["ready"] ?? 0;
+  const successDeployments =
+    (deploymentsByStatus["ready"] ?? 0) + (deploymentsByStatus["no_changes"] ?? 0);
   const failedDeployments = deploymentsByStatus["failed"] ?? 0;
 
   return {

--- a/apps/api/src/modules/deployments/build-status.service.ts
+++ b/apps/api/src/modules/deployments/build-status.service.ts
@@ -240,10 +240,6 @@ export async function getBuildSessionStatus(deploymentId: string) {
     // the server-backed keep/reject decision so the "Action Required" banner +
     // modal reappear after a refresh, until the user keeps or rejects.
     deploymentStatus: dep.status,
-    // A settled deploy that shipped nothing. Distinct from `ready` for a client
-    // that wants to say so, but still a healthy terminal state — the SSE status
-    // above stays "ready", so the build page renders as finished either way.
-    noChanges: snapshot?.noChanges === true,
     decisionPending: snapshot?.composeDeployment?.decision === "pending",
     partial: snapshot?.composeDeployment
       ? {

--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -251,16 +251,10 @@ export interface DeploymentConfigSnapshot {
   /** STATIC twin: a retained release DIRECTORY on the host to promote again
    *  (static releases have no image). Set by a rollback restore. */
   handoverStaticDir?: string;
-  /** This deploy carried every service forward and shipped nothing, so it never
-   *  became the active release (`onNoChanges`). Mirrors the row's `no_changes`
-   *  status for clients reading the snapshot rather than the status. */
-  noChanges?: boolean;
   /** Summary of a compose deployment fan-out, when applicable. */
   composeDeployment?: {
     totalServices: number;
     successfulServices: number;
-    /** Of those, the ones actually (re)created — the rest were carried forward. */
-    deployedServices?: number;
     failedServices: number;
     failedServiceNames: string[];
     warningMessage?: string;

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -985,9 +985,10 @@ export async function deployComposeServices(
     const prev = previousByServiceId.get(svc.id);
     if (!prev?.containerId) return false; // nothing running to carry
     // Against the image this deploy INTENDS, not the service row's: a pinned ref
-    // (rollback, `--image-version`) arrives via `builtImages` and is first read
-    // past the carry `continue`, so comparing `svc.image` carried a service whose
-    // intended image differed from the running one.
+    // (a rollback replay, a migration cutover's `handoverImages`) arrives via
+    // `builtImages` and is first read PAST the carry `continue`, so comparing
+    // `svc.image` carried a service whose intended image differed from the running
+    // one — comparing the row against itself.
     const intended = opts?.builtImages?.get(svc.id) ?? svc.image;
     if (prev.imageRef && prev.imageRef !== intended) return false;
     return true;
@@ -1244,22 +1245,16 @@ export async function deployComposeServices(
         // that is the row the next deploy reads (`previousByServiceId`), and an
         // all-carried pass never becomes active — so writing it only under `dep.id`
         // discards the fix and the stale binding comes back next time.
+        //
+        // A NARROW write, not an upsert: `upsertServiceDeployment` sets every
+        // column, so omitting `imageDigest` would null the anchor the update
+        // scanner needs to see a moved mutable tag — on the LIVE release's row.
         if (
-          project.activeDeploymentId &&
           project.activeDeploymentId !== dep.id &&
           (carriedIp !== (carried.ip ?? null) || carriedHostPort !== (carried.hostPort ?? null))
         ) {
           await repos.service
-            .upsertServiceDeployment({
-              deploymentId: project.activeDeploymentId,
-              serviceId: svc.id,
-              serviceName: svc.name,
-              containerId: carried.containerId,
-              status: "success",
-              imageRef: carried.imageRef ?? null,
-              hostPort: carriedHostPort,
-              ip: carriedIp,
-            })
+            .updateServiceDeployment(carried.id, { ip: carriedIp, hostPort: carriedHostPort })
             .catch(() => {});
         }
         // Decoupled single-service add on a mesh runtime (cloud): this peer is
@@ -2321,7 +2316,7 @@ export async function deployComposeServices(
             [],
             service.id,
           );
-          mutated = true; // persisted env — this pass is not a no-op
+          mutated = true;
           logger.log(`Prepared ${step.capture} → ${step.persistAs.key}\n`, "info");
         }
       } catch (err) {
@@ -2340,26 +2335,28 @@ export async function deployComposeServices(
       sessionManager.broadcastInstallPhase(dep.id, { id: "app-setup", status: "done" });
     }
   }
-  // Services this pass actually stood up, derived from the results rather than
-  // counted next to `successful` — a future success branch that forgets to
-  // increment would otherwise re-open #498 silently.
   const deployed = results.filter((r) => r.status !== "failed" && !r.carried).length;
 
   // The container a project-level question resolves to, picked the same way the
-  // access URL is. The fallbacks cover a primary with no container of its own (a
-  // static-served app, a failed one): any other exposed service, then the
-  // topo-first row — for a worker-only stack there is no better answer, and a
-  // wrong container still beats the sentinel's guaranteed 404.
+  // access URL is — and over `enabled`, NOT `ordered`: `pickPrimaryServiceId`'s
+  // last resort is the first element, and `ordered` is topo-sorted, so for a
+  // port-only project (nothing `exposed`, no verified domain) that first element
+  // is the dependency — the database — which is the very thing #498 is about. The
+  // read paths pass `listByProject` order, so passing `enabled` also keeps write
+  // and read agreeing on one answer. Narrowed to the services that actually came
+  // up with a container, so a static-served or failed primary defers to a real one.
   const primaryContainerId = await (async () => {
     const withContainer = results.filter((r) => r.containerId);
     if (withContainer.length === 0) return undefined;
     const domainRows = needsDomainMap
       ? [...domainByHostname.values()]
       : await repos.domain.listByProject(project.id).catch(() => []);
-    const primaryId = pickPrimaryServiceId(ordered, domainRows);
+    const candidates = enabled.filter((svc) =>
+      withContainer.some((r) => r.serviceId === svc.id),
+    );
+    const primaryId = pickPrimaryServiceId(candidates, domainRows);
     return (
       withContainer.find((r) => r.serviceId === primaryId)?.containerId ??
-      withContainer.find((r) => ordered.find((s) => s.id === r.serviceId)?.exposed)?.containerId ??
       withContainer[0].containerId
     );
   })();
@@ -2535,7 +2532,7 @@ export async function deployComposeServices(
       if (!previous.containerId || enabledServiceIds.has(previous.serviceId)) continue;
       try {
         await runtime.destroy(previous.containerId);
-        mutated = true; // reaped a container — this pass is not a no-op
+        mutated = true;
         logger.log(`Stopped disabled service container (${previous.containerId.slice(0, 12)}).\n`);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";
@@ -2573,7 +2570,7 @@ export async function deployComposeServices(
     ) {
       try {
         await runtime.destroy(prevContainerId);
-        mutated = true; // reaped a container — this pass is not a no-op
+        mutated = true;
         logger.log(`Stopped previous single-app container (${prevContainerId.slice(0, 12)}).\n`);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";

--- a/apps/api/src/modules/deployments/compose/pipeline.ts
+++ b/apps/api/src/modules/deployments/compose/pipeline.ts
@@ -262,7 +262,6 @@ export async function executeComposePipeline(opts: ComposePipelineOpts): Promise
       composeDeployment: {
         totalServices: composeResult.summary.total,
         successfulServices: composeResult.summary.successful,
-        deployedServices: composeResult.summary.deployed,
         failedServices: composeResult.summary.failed,
         failedServiceNames: composeResult.summary.failedServices,
         warningMessage: composeResult.warning,

--- a/apps/api/src/modules/deployments/deployment-lifecycle.ts
+++ b/apps/api/src/modules/deployments/deployment-lifecycle.ts
@@ -329,13 +329,11 @@ export async function onNoChanges(
     result.warningMessage ??
     "No changes to deploy — every service was already up to date, so the current release stayed live.";
   // Under `composeDeployment.warningMessage` because that is where the build-status
-  // refresh path reads a persisted deploy note from; `noChanges` is the flag
-  // clients branch on. Sanitized like onSuccess's meta — a NUL in the reason must
-  // not fail the write.
+  // refresh path reads a persisted deploy note from. Sanitized like onSuccess's
+  // meta — a NUL in the reason must not fail the write.
   const previousMeta = (dep.meta as DeploymentMeta | null) ?? {};
   const mergedMeta = sanitizeStorableStrings({
     ...previousMeta,
-    noChanges: true,
     composeDeployment: { ...(previousMeta.composeDeployment ?? {}), warningMessage: reason },
   });
   await recordOutcome(dep.id, "no_changes", { errorMessage: null, meta: mergedMeta }, ["meta"]);

--- a/apps/api/src/modules/deployments/rollback/restore-plan.test.ts
+++ b/apps/api/src/modules/deployments/rollback/restore-plan.test.ts
@@ -1,6 +1,6 @@
+import { COMPOSE_SENTINEL } from "../../../lib/container-ref";
 import { describe, it, expect } from "vitest";
 import {
-  COMPOSE_SENTINEL,
   ROLLBACK_ERROR_CODES,
   planNeedsRepository,
   planRestore,

--- a/apps/api/src/modules/deployments/rollback/restore-plan.ts
+++ b/apps/api/src/modules/deployments/rollback/restore-plan.ts
@@ -37,8 +37,6 @@
 
 import { COMPOSE_SENTINEL } from "../../../lib/container-ref";
 
-export { COMPOSE_SENTINEL };
-
 export const ROLLBACK_ERROR_CODES = {
   NOT_READY: "ROLLBACK_NOT_READY",
   ALREADY_ACTIVE: "ROLLBACK_ALREADY_ACTIVE",

--- a/apps/api/src/modules/domains/project-route.service.ts
+++ b/apps/api/src/modules/domains/project-route.service.ts
@@ -453,12 +453,11 @@ export async function reapplyProjectLiveRoutes(
 
     const containerId = deployment.containerId;
     if (!isRealContainerRef(containerId)) {
-      // Compose/multi-service deployments track containers per-service, so the
-      // parent row carries the `"compose"` sentinel or one service's container —
-      // never a single-app upstream to point a project-level route at (per-service
-      // routes are handled in updateService). Testing only for null let a compose
-      // project's project-level domain fall through to the port published by
-      // whichever service the row named, which in dependency order was its database.
+      // The `"compose"` sentinel means the release has no single upstream to point a
+      // project-level route at (per-service routes are handled in updateService). A
+      // REAL primary container is routed below — it is the container the project's
+      // canonical URL resolves to, which is what `primaryContainerId` now guarantees.
+      // Testing only for null sent the sentinel down that path as a container id.
       // Still tear down any dropped hostnames on the correct host.
       console.warn(
         `[project-route] ${project.slug}: deployment ${deployment.id} has no containerId (target=${effectiveTarget}) — skipping single-app route registration`,

--- a/apps/api/src/modules/projects/project-logs-container.test.ts
+++ b/apps/api/src/modules/projects/project-logs-container.test.ts
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
   containerId: "cid-db" as string | null,
+  activeDeploymentId: "dep_1" as string,
   services: [] as Array<{ id: string; name: string; enabled: boolean; exposed: boolean }>,
   serviceRows: [] as Array<{ id: string; serviceId: string; containerId: string | null }>,
   live: [] as Array<{ id: string; names: string[]; state: string; labels: Record<string, string> }>,
@@ -34,7 +35,7 @@ vi.mock("@repo/db", () => ({
         id: "proj_1",
         slug: "stack",
         organizationId: "org_1",
-        activeDeploymentId: "dep_1",
+        activeDeploymentId: h.activeDeploymentId,
       }),
     },
     deployment: {
@@ -105,6 +106,7 @@ const container = (serviceName: string, id: string) => ({
 
 beforeEach(() => {
   h.containerId = "cid-db";
+  h.activeDeploymentId = "dep_1";
   h.services = [];
   h.serviceRows = [];
   h.live = [];
@@ -142,16 +144,31 @@ describe("project logs target the primary service, not the recorded database", (
     expect(h.healed).toEqual([{ rowId: "row_app", containerId: "cid-new" }]);
   });
 
-  it("uses the recorded id for a single-app deployment and never reads service rows", async () => {
+  it("uses the recorded id for a single-app deployment and stops after one query", async () => {
     h.containerId = "cid-single";
 
     await getRuntimeLogs("proj_1", "org_1");
 
     expect(h.logTargets).toEqual(["cid-single"]);
-    // One project-services read to establish there are none, and nothing further:
-    // opening logs must not fan out per call.
-    expect(h.listByProjectCalls).toBe(1);
-    expect(h.listByDeploymentCalls).toBe(0);
+    // The deployment's own rows answer "was this a service deploy", and there are
+    // none — so nothing further is read. Opening logs must not fan out per call.
+    expect(h.listByDeploymentCalls).toBe(1);
+    expect(h.listByProjectCalls).toBe(0);
+  });
+
+  it("answers a HISTORICAL deployment from its own row and never rewrites it", async () => {
+    // The live matcher keys on the project+service label, so it reports whatever
+    // runs NOW. For an older release that is the wrong container, and healing from
+    // it would rewrite history from a GET — these endpoints take any deployment id.
+    h.activeDeploymentId = "dep_7";
+    h.services = [{ id: "svc_app", name: "app", enabled: true, exposed: true }];
+    h.serviceRows = [{ id: "row_app", serviceId: "svc_app", containerId: "cid-v3" }];
+    h.live = [container("app", "cid-v7")];
+
+    await getRuntimeLogs("proj_1", "org_1");
+
+    expect(h.logTargets).toEqual(["cid-v3"]);
+    expect(h.healed).toEqual([]);
   });
 
   it("refuses the compose sentinel rather than dialling a container named 'compose'", async () => {

--- a/apps/api/src/modules/projects/project.controller.ts
+++ b/apps/api/src/modules/projects/project.controller.ts
@@ -1795,10 +1795,8 @@ async function reRegisterDomainRoute(
     // Find the service deployment to get the container target. Prefer a row with
     // a container to inspect — a stored ip alone is just the last-known value.
     //
-    // Which service is "primary" comes from the same picker the access URL uses:
-    // `service_deployment` rows come back in insertion (dependency) order, so
-    // taking the first one with a container pointed the webhook vhost at whatever
-    // an exposed app depends on — its database (#498).
+    // Via the same picker the access URL uses: these rows come back in insertion
+    // (dependency) order, so the first one with a container was the database (#498).
     const svcDeps = await repos.service.listByDeployment(project.activeDeploymentId);
     const [projectServices, domainRows] = await Promise.all([
       repos.service.listByProject(project.id).catch(() => []),

--- a/apps/api/src/modules/services/service-container.ts
+++ b/apps/api/src/modules/services/service-container.ts
@@ -119,52 +119,62 @@ export async function liveContainerIdWithRuntime(
 
 /**
  * The container a PROJECT-level question means — "its logs", "its container info",
- * "its resource usage" — resolved live, using a runtime the caller already holds.
+ * "its resource usage" — for the deployment `dep`.
  *
- * `deployment.containerId` cannot answer it for a multi-service project: it holds
- * ONE service's container, and because the deploy loop walks services in
- * dependency order that service was the database an app `dependsOn` — so project
- * logs answered for postgres while the app served traffic (#498). It can also hold
- * the `"compose"` sentinel, which is no container at all.
+ * `dep.containerId` cannot answer it for a multi-service release: it holds ONE
+ * service's container, chosen without reference to which service the project's URL
+ * points at, so it named the database an app `dependsOn` (#498). It can also hold
+ * the `"compose"` sentinel, which is no container at all. So the primary service is
+ * picked the way the access URL is picked, and its container read from `dep`'s own
+ * rows.
  *
- * So: pick the primary service the same way the access URL does, then resolve ITS
- * container against the host and heal the record, exactly as the per-service path
- * does. Single-app deployments (no service rows) short-circuit to the recorded id
- * and issue no extra queries.
+ * Resolved LIVE against the host, and the row healed, for the ACTIVE release only.
+ * The live matcher keys on identity (project+service label) rather than deployment,
+ * so it answers with whatever runs NOW — right for the current release, wrong for a
+ * historical one, whose recorded container is the point of asking. These endpoints
+ * accept any deployment id, so healing unconditionally would rewrite history from a
+ * GET.
  *
- * Null means the primary service's container is genuinely gone — callers should
- * surface "not deployed" rather than hand a dead id to docker.
+ * Null means the primary service's container is genuinely gone.
  */
 export async function livePrimaryContainerId(
   runtime: HostContainerLister | null | undefined,
   dep: { id: string; projectId: string; containerId: string | null },
 ): Promise<string | null> {
   const recorded = isRealContainerRef(dep.containerId) ? dep.containerId : null;
-  const services = (await repos.service.listByProject(dep.projectId).catch(() => [])).filter(
-    (svc) => svc.enabled,
-  );
-  if (services.length === 0) return recorded;
-
-  const [project, domainRows, rows] = await Promise.all([
+  const [project, rows] = await Promise.all([
     repos.project.findById(dep.projectId).catch(() => null),
-    repos.domain.listByProject(dep.projectId).catch(() => []),
     repos.service.listByDeployment(dep.id).catch(() => []),
   ]);
-  const primaryId = pickPrimaryServiceId(services, domainRows);
-  const svc = services.find((s) => s.id === primaryId);
-  if (!svc || !project) return recorded;
+  // THIS release's own rows decide whether it was a service deploy. The project's
+  // current service list would misread a single-app release that later gained a
+  // sidecar, and answer for the sidecar.
+  if (!project || rows.length === 0) return recorded;
 
-  const row = rows.find((r) => r.serviceId === svc.id);
+  const [services, domainRows] = await Promise.all([
+    repos.service.listByProject(dep.projectId).catch(() => []),
+    repos.domain.listByProject(dep.projectId).catch(() => []),
+  ]);
+  const candidates = services.filter(
+    (svc) => svc.enabled && rows.some((r) => r.serviceId === svc.id && r.containerId),
+  );
+  const primaryId = pickPrimaryServiceId(candidates, domainRows);
+  const svc = candidates.find((s) => s.id === primaryId);
+  const row = svc ? rows.find((r) => r.serviceId === svc.id) : undefined;
+  if (!svc || !row?.containerId) return recorded;
+
+  if (project.activeDeploymentId !== dep.id) return row.containerId;
+
   const live = await liveContainerIdWithRuntime(runtime, {
     service: { id: svc.id, name: svc.name },
     projectId: dep.projectId,
     slug: project.slug,
-    tracked: row?.containerId ?? null,
+    tracked: row.containerId,
   });
-  if (row && live && row.containerId !== live) {
+  if (live && live !== row.containerId) {
     await repos.service.updateServiceDeployment(row.id, { containerId: live }).catch(() => {});
   }
-  return live ?? recorded;
+  return live;
 }
 
 /**

--- a/apps/api/test/modules/deployments/compose-noop-settle.test.ts
+++ b/apps/api/test/modules/deployments/compose-noop-settle.test.ts
@@ -163,7 +163,6 @@ describe("executeComposePipeline — an all-carried redeploy must not take over"
     expect(h.activePointer).toEqual([]);
     const settle = h.statusWrites.find((w) => w.status === "no_changes");
     expect(settle, "a no-op must record a no_changes row").toBeTruthy();
-    expect((settle!.extra?.meta as { noChanges?: boolean } | undefined)?.noChanges).toBe(true);
     expect(h.containerIdWrites).toEqual([]);
     expect(h.notifications).toEqual(["deployment.no_changes"]);
     expect(h.audits).toEqual(["deployment.no_changes"]);

--- a/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
@@ -675,7 +675,10 @@ export default function AppInstallPage() {
             status,
           )
         ) {
-          await resolveTerminal({ ok: status === "ready", message: s.failureMessage });
+          await resolveTerminal({
+            ok: status === "ready" || status === "no_changes",
+            message: s.failureMessage,
+          });
           return;
         }
       } catch {

--- a/apps/dashboard/src/app/(dashboard)/deployments/utils.ts
+++ b/apps/dashboard/src/app/(dashboard)/deployments/utils.ts
@@ -246,7 +246,12 @@ export const filterDeployments = (
 export const calculateDeploymentStats = (deployments: Deployment[]) => {
   return {
     total: deployments.length,
-    success: deployments.filter((d) => d.status === "success").length,
+    // `no_changes` is a success that shipped nothing — counted here for the same
+    // reason `action_required` is counted as failed below: it is in `total`, so
+    // leaving it in no bucket would quietly deflate the success rate, and an
+    // unchanged redeploy of an image-only stack is routine.
+    success: deployments.filter((d) => d.status === "success" || d.status === "no_changes")
+      .length,
     // Blocked deploys count as failed here for the same reason they show under
     // the Failed filter — they didn't ship. Keeping them out would quietly
     // inflate the success rate.

--- a/packages/db/src/schema/deployment.ts
+++ b/packages/db/src/schema/deployment.ts
@@ -59,8 +59,8 @@ export const deployment = pgTable("deployment", {
    * Build status.
    *
    * Values: `queued | building | deploying | ready | failed | cancelled |
-   * partial_failure | action_required | rejected` (plus `reconciling`, written
-   * by onReconciling).
+   * partial_failure | action_required | rejected | no_changes` (plus
+   * `reconciling`, written by onReconciling).
    * `rejected` is terminal: the operator declined a finished (ready /
    * partial_failure) deploy; its runtime is torn down but the row + logs are
    * kept for history (see rejectDeployment).
@@ -74,6 +74,10 @@ export const deployment = pgTable("deployment", {
    * reads "Action Required" instead of a dead end. Like `partial_failure` it is
    * a DB-ONLY status: the SSE session still reports `failed`, so the build
    * stream closes normally.
+   * `no_changes` is a terminal SUCCESS that shipped nothing: a compose redeploy
+   * carried every service forward, so it owns no container and no image and is
+   * deliberately NOT promoted to the active release (see onNoChanges). DB-only
+   * too — the SSE session reports `ready`.
    * Free-text column (no DB check constraint) so callers can extend
    * without a migration; keep values lowercase + snake_case.
    *


### PR DESCRIPTION
Follow-up to #499, which merged before this review landed. Three real defects in that commit, plus its dead weight.

## Must-fix (all introduced by #499)

**1. The `#506` mirror write nulls the live release's `image_digest`.** `repos.service.upsertServiceDeployment` is a FULL-row writer — its conflict clause sets `imageDigest`, `reason` and `reasonSkipped` from the payload (`packages/db/src/repos/service.repo.ts:765-779`). The mirror passed none of the three, so it nulled them on `project.activeDeploymentId`'s row. `image_digest` is the anchor the update scanner needs to notice a moved mutable tag, and it reads the **active** deployment's rows (`project-crud.service.ts:1899`) — so a carried `n8nio/n8n:latest` service would report "no update available" forever, because the tag string never changes. The row id was already in hand; use the narrow `updateServiceDeployment`.

**2. The write path still recorded the database.** `pickPrimaryServiceId` falls back to the first element when nothing is `exposed` and no domain is verified, and #499 passed it the **topo-sorted** list — whose first element is a dependency. That shape is exactly a port-only app install (`materializeAppServiceRow` sets `exposed` from `publicEndpoints.length > 0`), so #498 was unfixed for it, and the write path disagreed with the read paths (which pass `listByProject` order). Now picks over `enabled`, narrowed to the services that actually produced a container.

**3. `livePrimaryContainerId` was deployment-agnostic and rewrote history from a GET.** The live matcher's first tier is the `openship.project`+`openship.service` label, so it answers with whatever runs **now** — right for the active release, wrong for a historical one, whose recorded container is the whole point of asking. And `GET /deployments/:id/{logs,info,usage}` accept any deployment id — `getContainerUsage`'s own docblock says *"reachable for a non-active deployment"* — so the heal wrote the current container onto an old release's row on a read. Now: this deployment's own rows decide whether it was a service deploy (the project's current list would misread a single-app release that later gained a sidecar), and live resolution + healing run only for the active release. Dropping the `?? recorded` mask restores the documented null contract. Regression test added.

## Dead weight removed

- The `noChanges` meta flag had **no consumer at four levels** (meta → `DeploymentMeta` → snapshot type → build-status response) while `status === "no_changes"` already carried it, on the same endpoint.
- `composeDeployment.deployedServices` was write-only.
- The `getStatusConfig` case added to `apps/dashboard/src/utils/deployment.ts` fed a module with **no importers** (everything uses the `(dashboard)/deployments/utils.ts` copy).
- The `COMPOSE_SENTINEL` re-export from `restore-plan.ts` had one consumer, now pointed at the source module.
- Comments that restated the code, and the #498 narrative retold five times, reduced to the canonical statement on the picker that owns the rule.

## Two comments were factually wrong

- `--image-version` is `openship up`'s own compose image tag, **not** a producer of `builtImages`. The real second producer is a **migration cutover**'s `handoverImages` (`migration.orchestrator.ts:694` → `pinnedImageForService` → `compose/build.service.ts:413`) — which means the image-comparison fix in #499 also matters for a cutover, not just a rollback.
- The `project-route.service.ts` comment claimed the guard refuses to route a compose release. It only catches the sentinel; a real primary container **is** routed below — which is now correct behaviour rather than accidental, so the comment was fixed, not the code.

## Metrics

`no_changes` now counts as success in the deployment stats, server and dashboard. Left out it sat in no bucket while still counting in `total`, deflating the success rate — and server-side `pending` is `total - success - failed`, so a settled no-op would have been reported **pending forever** (both MCP-exposed).

Also records `no_changes` in the `deployment.status` column docblock, which #499 cited as its authority for needing no migration but didn't update.

## Verification

`tsc --noEmit` clean in `apps/api` + `apps/dashboard`. Full suites: api 322 files / 3817 passed, dashboard 714, core 575, adapters 2832, db 89, cli 416.

Refs #498, #499
