### PR TITLE
fix(deployments): finish build cancellation — static extract + make a cancel terminal

### DIFF
--- a/apps/api/src/modules/deployments/cancel-is-final.test.ts
+++ b/apps/api/src/modules/deployments/cancel-is-final.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  updateStatus: vi.fn(),
+  setActiveDeployment: vi.fn(async () => {}),
+  supersedePendingDecisions: vi.fn(async () => {}),
+  sseUpdateStatus: vi.fn(),
+}));
+
+// The lifecycle module transitively pulls in auth/notification wiring that reads
+// `schema` at import time; only the shape matters here, never the contents.
+vi.mock("@repo/db", () => ({
+  schema: { user: {}, organization: {}, member: {} },
+  repos: {
+    deployment: {
+      updateStatus: mocks.updateStatus,
+      supersedePendingDecisions: mocks.supersedePendingDecisions,
+      setContainerId: vi.fn(async () => {}),
+      findReadyVersionByCommit: vi.fn(async () => null),
+      getNextReadyVersion: vi.fn(async () => 1),
+      findBuildSessionById: vi.fn(async () => null),
+      appendBuildLog: vi.fn(async () => {}),
+      finishBuildSession: vi.fn(async () => {}),
+    },
+    project: { setActiveDeployment: mocks.setActiveDeployment },
+    service: { listByDeployment: vi.fn(async () => []) },
+  },
+}));
+// Terminal-event side channels, each of which drags in auth/github/mail wiring.
+vi.mock("../../lib/notification-dispatcher", () => ({ notification: { emit: vi.fn() } }));
+vi.mock("../../lib/audit", () => ({ audit: { recordAsync: vi.fn(), record: vi.fn() } }));
+vi.mock("../../lib/favicon-detector", () => ({ detectAndStoreFavicon: vi.fn(async () => {}) }));
+vi.mock("../mail/webmail/webmail-install.service", () => ({
+  onWebmailDeployed: vi.fn(async () => {}),
+}));
+vi.mock("./session-manager", () => ({
+  updateStatus: mocks.sseUpdateStatus,
+  broadcastServiceStatus: vi.fn(),
+  broadcastInstallPhase: vi.fn(),
+  getSession: vi.fn(() => null),
+  endSession: vi.fn(),
+}));
+
+import { onSuccess, setDeploymentStatus } from "./deployment-lifecycle";
+
+/**
+ * A cancel is the user's last word, but cancellation is COOPERATIVE and the deploy
+ * phase doesn't check for it at all — so the work a cancel interrupts keeps running
+ * and reaches its own success hook. `repos.deployment.updateStatus` refuses to move
+ * a row off `cancelled`; these pin that every consumer of that refusal declines to
+ * publish a success on top of it. The failure this prevents is silent: the deploy
+ * the user stopped goes green and becomes the live release.
+ */
+
+const ctx = {
+  project: { id: "p1", name: "app", slug: "app" },
+  dep: {
+    id: "d1",
+    projectId: "p1",
+    organizationId: "org1",
+    branch: "main",
+    commitSha: null,
+    meta: null,
+  },
+  buildSessionId: "bld_x",
+  provisioned: {},
+  persistLogs: async () => {},
+  runtime: null,
+  logs: [],
+} as never;
+
+describe("a cancelled deployment is final", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("onSuccess does not advance the active release when the row refuses the write", async () => {
+    mocks.updateStatus.mockResolvedValue(false);
+
+    await onSuccess(ctx, { containerId: "c1", durationMs: 10 });
+
+    // The pointer is the whole game: advance it and the cancelled build becomes
+    // the project's live release.
+    expect(mocks.setActiveDeployment).not.toHaveBeenCalled();
+    expect(mocks.supersedePendingDecisions).not.toHaveBeenCalled();
+    expect(mocks.sseUpdateStatus).not.toHaveBeenCalledWith("d1", "ready", expect.anything());
+  });
+
+  it("onSuccess publishes the release normally when the write applied", async () => {
+    mocks.updateStatus.mockResolvedValue(true);
+
+    await onSuccess(ctx, { containerId: "c1", durationMs: 10 });
+
+    expect(mocks.setActiveDeployment).toHaveBeenCalledWith("p1", "d1");
+  });
+
+  it("setDeploymentStatus does not broadcast a status the DB refused", async () => {
+    mocks.updateStatus.mockResolvedValue(false);
+
+    await setDeploymentStatus("d1", "deploying");
+
+    expect(mocks.sseUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("setDeploymentStatus broadcasts when the write applied", async () => {
+    mocks.updateStatus.mockResolvedValue(true);
+
+    await setDeploymentStatus("d1", "deploying");
+
+    expect(mocks.sseUpdateStatus).toHaveBeenCalledWith("d1", "deploying", undefined);
+  });
+});

--- a/apps/api/src/modules/deployments/compose/build.service.ts
+++ b/apps/api/src/modules/deployments/compose/build.service.ts
@@ -690,9 +690,12 @@ export async function buildComposeImages(opts: {
       );
     }
 
-    if (buildable.length > 0 && cancelledServices.size > 0) {
-      // Cancelled: no "failed" step and no phase result — the deployment's own
-      // cancelled status is the outcome the user is waiting on.
+    // Non-empty only for services derived from `buildable`, so it implies there was
+    // something to build.
+    if (cancelledServices.size > 0) {
+      // "failed" is the closest step state there is — BuildLogger has no cancelled
+      // one — but no install phase is marked done: the deployment's own cancelled
+      // status is the outcome the user is waiting on.
       opts.logger.step("build", "failed", "Image build cancelled");
       opts.logger.log("Compose image build cancelled. Deployment will not continue.\n", "error");
     } else if (buildable.length > 0) {

--- a/apps/api/src/modules/deployments/compose/pipeline-cancel.test.ts
+++ b/apps/api/src/modules/deployments/compose/pipeline-cancel.test.ts
@@ -1,0 +1,151 @@
+import { BuildLogger, DEFAULT_RESOURCE_CONFIG } from "@repo/adapters";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The pipeline is only wired here, not exercised: every collaborator is a side
+// effect on the DB, the SSH host, or the SSE stream. Stubbing them leaves exactly
+// one thing under test — which branch the cancel flag takes.
+const mocks = vi.hoisted(() => ({
+  buildComposeImages: vi.fn(),
+  deployComposeServices: vi.fn(),
+  cleanupBuildArtifact: vi.fn(async () => {}),
+  onCancelled: vi.fn(async () => {}),
+  onFailure: vi.fn(async () => {}),
+  onReconciling: vi.fn(async () => {}),
+  onSuccess: vi.fn(async () => {}),
+  setDeploymentStatus: vi.fn(async () => {}),
+}));
+
+vi.mock("@repo/db", () => ({ repos: {} }));
+vi.mock("./build.service", () => ({ buildComposeImages: mocks.buildComposeImages }));
+vi.mock("./deploy.service", () => ({ deployComposeServices: mocks.deployComposeServices }));
+vi.mock("../deployment-lifecycle", () => ({
+  cleanupBuildArtifact: mocks.cleanupBuildArtifact,
+  onCancelled: mocks.onCancelled,
+  onFailure: mocks.onFailure,
+  onReconciling: mocks.onReconciling,
+  onSuccess: mocks.onSuccess,
+  setDeploymentStatus: mocks.setDeploymentStatus,
+  routeIssuesWarning: (issues: string[]) => issues.join(", "),
+}));
+vi.mock("../session-manager", () => ({
+  broadcastServiceStatus: vi.fn(),
+  broadcastInstallPhase: vi.fn(),
+}));
+
+import { executeComposePipeline } from "./pipeline";
+
+/**
+ * `setDeploymentStatus` has NO terminal-state guard, so the cancel branch is the
+ * only thing standing between a cancelled deployment and a live one: fall through
+ * and the "cancelled" row is flipped back to "deploying" and the containers the
+ * user cancelled start anyway. Pinned here because the failure is silent — the
+ * deploy succeeds, which is exactly what it must not do.
+ */
+
+const SNAPSHOT = {
+  repoUrl: "https://example.com/repo.git",
+  branch: "main",
+  framework: "docker",
+  buildImage: "",
+  runtimeImage: "",
+  packageManager: "",
+  installCommand: "",
+  buildCommand: "",
+  outputDirectory: "",
+  productionPaths: [] as string[],
+  rootDirectory: "",
+  port: 3000,
+  startCommand: "",
+  hasServer: true,
+  hasBuild: false,
+};
+
+/** Thrown BY the deploy step, so "did we get there" needs nothing downstream of it. */
+const REACHED_DEPLOY = new Error("reached the deploy step");
+
+async function run(composeBuild: Record<string, unknown>) {
+  mocks.buildComposeImages.mockResolvedValue(composeBuild);
+  // Deploying for real would drag in every collaborator past this point (and pin
+  // this test to whatever the happy path grows next). All that matters here is
+  // whether control reaches it at all.
+  mocks.deployComposeServices.mockRejectedValue(REACHED_DEPLOY);
+
+  await executeComposePipeline({
+    project: { id: "p1", slug: "app", name: "app", webhookDomain: null } as never,
+    dep: { id: "d1", branch: "main", commitSha: null, trigger: "deploy", meta: null } as never,
+    runtime: { name: "docker" } as never,
+    routing: {} as never,
+    ssl: {} as never,
+    system: null,
+    executor: null,
+    usesManagedRouting: false,
+    logger: new BuildLogger(() => {}),
+    ctx: { dep: { id: "d1" }, provisioned: {} } as never,
+    snapshot: SNAPSHOT as never,
+    buildSessionId: "bld_x",
+    buildEnvVars: {},
+    buildResources: DEFAULT_RESOURCE_CONFIG,
+    runtimeResources: DEFAULT_RESOURCE_CONFIG,
+  });
+}
+
+describe("executeComposePipeline — cancellation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stops before the deploy phase and never re-flips the status", async () => {
+    await run({
+      cancelled: true,
+      buildFailures: new Map(),
+      imageRefs: new Map(),
+      builtImageRefs: new Map([["svc-0", "img/svc-0"]]),
+      durationMs: 5,
+    });
+
+    expect(mocks.deployComposeServices).not.toHaveBeenCalled();
+    expect(mocks.setDeploymentStatus).not.toHaveBeenCalled();
+    expect(mocks.onCancelled).toHaveBeenCalledWith(expect.anything(), 5);
+    // Whatever finished building before the cancel landed is garbage — nothing
+    // references it and no deploy will.
+    expect(mocks.cleanupBuildArtifact).toHaveBeenCalledWith(expect.anything(), "img/svc-0");
+  });
+
+  it("still cleans up when a built image refuses to delete", async () => {
+    mocks.cleanupBuildArtifact.mockRejectedValueOnce(new Error("image in use"));
+
+    await run({
+      cancelled: true,
+      buildFailures: new Map(),
+      imageRefs: new Map(),
+      builtImageRefs: new Map([
+        ["svc-0", "img/svc-0"],
+        ["svc-1", "img/svc-1"],
+      ]),
+      durationMs: 5,
+    });
+
+    // A stuck image must not abort the cancel: the second cleanup still runs and
+    // the deployment still lands on `cancelled`.
+    expect(mocks.cleanupBuildArtifact).toHaveBeenCalledTimes(2);
+    expect(mocks.onCancelled).toHaveBeenCalledTimes(1);
+    expect(mocks.deployComposeServices).not.toHaveBeenCalled();
+  });
+
+  // Negative control: without it, a branch that always returned early would pass
+  // both tests above.
+  it("proceeds to deploy when the build was not cancelled", async () => {
+    await expect(
+      run({
+        cancelled: false,
+        buildFailures: new Map(),
+        imageRefs: new Map([["svc-0", "img/svc-0"]]),
+        builtImageRefs: new Map([["svc-0", "img/svc-0"]]),
+        durationMs: 5,
+      }),
+    ).rejects.toBe(REACHED_DEPLOY);
+
+    expect(mocks.onCancelled).not.toHaveBeenCalled();
+    expect(mocks.setDeploymentStatus).toHaveBeenCalledWith("d1", "deploying", expect.anything());
+  });
+});

--- a/apps/api/src/modules/deployments/deployment-lifecycle.ts
+++ b/apps/api/src/modules/deployments/deployment-lifecycle.ts
@@ -180,7 +180,7 @@ async function recordOutcome(
   status: string,
   extra: Partial<NewDeployment>,
   sheddable: ReadonlyArray<keyof NewDeployment> = [],
-): Promise<string | null> {
+): Promise<{ state: "applied" | "refused" | "failed"; error: string | null }> {
   const attempts: Array<{ label: string; extra: Partial<NewDeployment> }> = [
     { label: "", extra },
   ];
@@ -194,14 +194,18 @@ async function recordOutcome(
   let lastError = "";
   for (const [index, attempt] of attempts.entries()) {
     try {
-      await repos.deployment.updateStatus(depId, status, attempt.extra);
+      const applied = await repos.deployment.updateStatus(depId, status, attempt.extra);
       if (index > 0) {
         console.error(
           `[deployment-lifecycle] ${depId}: recorded "${status}" ${attempt.label} — ` +
             `the rejected payload was dropped: ${lastError}`,
         );
       }
-      return null;
+      // ONLY an explicit `false` is a refusal (the row is already cancelled).
+      // Inferring one from any falsy return would turn a successful deploy into a
+      // cancelled one the moment a caller's stub — or a future impl — returns
+      // nothing. "refused" suppresses the success; "failed" must not.
+      return { state: applied === false ? "refused" : "applied", error: null };
     } catch (err) {
       lastError = safeErrorMessage(err);
     }
@@ -209,7 +213,9 @@ async function recordOutcome(
   console.error(
     `[deployment-lifecycle] ${depId}: could not record outcome "${status}": ${lastError}`,
   );
-  return lastError;
+  // The write failed outright. The deploy still SUCCEEDED, so the caller reports
+  // ready with an explanation rather than inverting a working deploy.
+  return { state: "failed", error: lastError };
 }
 
 export async function cleanupBuildArtifact(
@@ -263,7 +269,11 @@ export async function setDeploymentStatus(
     };
   },
 ): Promise<void> {
-  await repos.deployment.updateStatus(deploymentId, dbStatus, opts?.extra);
+  const applied = await repos.deployment.updateStatus(deploymentId, dbStatus, opts?.extra);
+  // An explicit `false` means the row is already cancelled and stayed that way.
+  // Broadcasting anyway would tell the UI the deploy the user stopped is still
+  // moving. Any other return counts as applied — see recordOutcome.
+  if (applied === false) return;
   sessionManager.updateStatus(
     deploymentId,
     opts?.sse?.status ?? (dbStatus as BuildSessionState["status"]),
@@ -628,12 +638,30 @@ export async function onSuccess(
   // deploy that worked.
   const version = await readReleaseVersion(project.id, dep.commitSha);
 
-  const outcomeError = await recordOutcome(
+  const outcome = await recordOutcome(
     dep.id,
     "ready",
     { errorMessage: null, meta: mergedMeta, version },
     ["meta"],
   );
+  const outcomeError = outcome.error;
+
+  // The row refused the write because it is already cancelled: the user stopped
+  // this deploy while it was in the deploy phase, which is not cancellable, so it
+  // ran to completion anyway. Everything below publishes a SUCCESS — the active
+  // release pointer above all — and none of it may happen for a deployment that
+  // was cancelled. cancelBuildSession already tore down what it provisioned and
+  // already broadcast `cancelled`, so this returns silently rather than emitting
+  // a second terminal event.
+  if (outcome.state === "refused") {
+    console.warn(
+      `[deployment-lifecycle] ${dep.id}: deploy finished after the user cancelled it; ` +
+        `leaving the row cancelled and NOT advancing the active release`,
+    );
+    ctx.settled = "cancelled";
+    await finishSession(buildSessionId, "cancelled", result.durationMs, collectLogs(ctx));
+    return;
+  }
 
   // From here the deployment ROW says ready: the outcome is recorded, so
   // nothing below may be allowed to turn it into a failure.

--- a/packages/adapters/src/runtime/docker-build-cancellation.test.ts
+++ b/packages/adapters/src/runtime/docker-build-cancellation.test.ts
@@ -47,8 +47,13 @@ function buildConfig(sessionId: string): BuildConfig {
   };
 }
 
+// Every test uses a DISTINCT session id on purpose: the cancellation registry and
+// the pending-cancel map are module-level (cancelBuildSession resolves a different
+// runtime instance than the one that built, so they have to be), and a pending
+// entry outlives the test that recorded it. Reusing an id across tests would let
+// one test's cancel pre-abort another's build.
 describe("DockerRuntime build cancellation", () => {
-  function runtimeWith(executor: CommandExecutor) {
+  function runtimeWith(executor: CommandExecutor, extra?: Record<string, unknown>) {
     const verifyImageBuilt = vi.fn(async () => {});
     const cloneSourceOnRemote = vi.fn(async () => {});
     const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
@@ -63,6 +68,7 @@ describe("DockerRuntime build cancellation", () => {
       cloneSourceOnRemote,
       resolveRemoteDockerfile: vi.fn(async () => "Dockerfile"),
       verifyImageBuilt,
+      ...extra,
     });
     return { runtime, verifyImageBuilt, cloneSourceOnRemote };
   }
@@ -184,6 +190,98 @@ describe("DockerRuntime build cancellation", () => {
     expect(executor.streamExec).toHaveBeenCalledTimes(1);
     expect(verifyImageBuilt).not.toHaveBeenCalled();
   });
+
+  it("skips the shared clone entirely when the cancel beat the batch", async () => {
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+    } as unknown as CommandExecutor;
+    const { runtime: buildRuntime, cloneSourceOnRemote } = runtimeWith(executor);
+    const { runtime: cancelRuntime } = runtimeWith(executor);
+
+    const specs = ["svc-a", "svc-b"].map((serviceId) => ({
+      config: buildConfig(`parent-clone-${serviceId}`),
+      serviceName: serviceId,
+      logger: new BuildLogger(),
+    }));
+
+    await cancelRuntime.cancelBuild("parent-clone");
+    const results = await buildRuntime.buildImages(specs, new BuildLogger());
+
+    expect(results.map((entry) => entry.result.status)).toEqual(["cancelled", "cancelled"]);
+    // The clone is the most expensive thing the batch does on the host; a build
+    // nobody is waiting for must not pay for it.
+    expect(cloneSourceOnRemote).not.toHaveBeenCalled();
+    expect(executor.streamExec).not.toHaveBeenCalled();
+  });
+
+  it("returns cancelled when the cancel lands during a static service's extract", async () => {
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+    } as unknown as CommandExecutor;
+
+    // The image builds fine; the cancel arrives while the output tree is being
+    // copied off the builder. The pre-verify gate has already been passed, so only
+    // the post-extract gate can stop this from coming back "deploying".
+    const moveStaticBuildToHost = vi.fn(async () => {
+      await cancelRuntime.cancelBuild("parent-static");
+    });
+    const { runtime: buildRuntime } = runtimeWith(executor, { moveStaticBuildToHost });
+    const { runtime: cancelRuntime } = runtimeWith(executor);
+
+    const results = await buildRuntime.buildImages(
+      [
+        {
+          config: {
+            ...buildConfig("parent-static-svc-a"),
+            staticExtractOnly: true,
+            staticOutDir: "/var/lib/openship/static/.builds/parent-static-svc-a",
+          },
+          serviceName: "svc-a",
+          logger: new BuildLogger(),
+        },
+      ],
+      new BuildLogger(),
+    );
+
+    expect(moveStaticBuildToHost).toHaveBeenCalledTimes(1);
+    expect(results[0]!.result).toMatchObject({ status: "cancelled" });
+    // No imageRef: the host dir must not be handed to the deploy phase.
+    expect(results[0]!.result.imageRef).toBeUndefined();
+  });
+
+  it("returns cancelled when the cancel lands during buildStaticToHost's extract", async () => {
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(async () => ({ code: 0, output: "" })),
+    } as unknown as CommandExecutor;
+
+    // build() releases its controller before returning, so the extract that runs
+    // after it is only cancellable because buildStaticToHost re-registers.
+    const moveStaticBuildToHost = vi.fn(async () => {
+      await cancelRuntime.cancelBuild("session-static-solo");
+    });
+    const { runtime: buildRuntime } = runtimeWith(executor, {
+      moveStaticBuildToHost,
+      build: vi.fn(async () => ({
+        sessionId: "session-static-solo",
+        status: "deploying" as const,
+        imageRef: "openship/static:session-static-solo",
+        durationMs: 1,
+      })),
+    });
+    const { runtime: cancelRuntime } = runtimeWith(executor);
+
+    const result = await buildRuntime.buildStaticToHost(
+      buildConfig("session-static-solo"),
+      "/var/lib/openship/static/session-static-solo",
+    );
+
+    expect(moveStaticBuildToHost).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ sessionId: "session-static-solo", status: "cancelled" });
+    expect(result.imageRef).toBeUndefined();
+  });
 });
 
 describe("DockerRuntime build cancellation — dockerode path", () => {
@@ -235,6 +333,45 @@ describe("DockerRuntime build cancellation — dockerode path", () => {
     // "deploying" — a "failed"/"deploying" result here deploys a cancelled deploy.
     await expect(resultPromise).resolves.toMatchObject({
       sessionId: "session-dockerode",
+      status: "cancelled",
+    });
+    expect(verifyImageBuilt).not.toHaveBeenCalled();
+  });
+
+  it("returns cancelled when the abort lands after the daemon already finished", async () => {
+    contextDir = await mkdtemp(join(tmpdir(), "openship-cancel-"));
+    await writeFile(join(contextDir, "Dockerfile"), "FROM scratch\n");
+    fakeBuildContext.current = { contextDir, cleanup: async () => {} };
+
+    const verifyImageBuilt = vi.fn(async () => {});
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, {
+      connectionOptions: {},
+      transport: { kind: "socket", description: "local socket" },
+      systemManager: null,
+      _docker: {
+        buildImage: vi.fn(async (body: { resume?: () => void }) => {
+          body.resume?.();
+          return {};
+        }),
+        listContainers: vi.fn(async () => []),
+      },
+      estimateContextSize: vi.fn(async () => 0),
+      verifyImageBuilt,
+      // Nothing throws: the daemon accepted the build and its output drained
+      // cleanly, and the cancel lands during that drain. So the ONLY thing that can
+      // stop a usable image from being reported "deploying" is build()'s last gate —
+      // the branch that keeps a cancelled deployment from being deployed.
+      streamDockerodeBuild: vi.fn(async () => {
+        await (runtime as DockerRuntime).cancelBuild("session-late-abort");
+      }),
+    });
+
+    const config = { ...buildConfig("session-late-abort"), cloneOnServer: false };
+
+    await expect(runtime.build(config)).resolves.toMatchObject({
+      sessionId: "session-late-abort",
       status: "cancelled",
     });
     expect(verifyImageBuilt).not.toHaveBeenCalled();

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -1876,23 +1876,42 @@ export class DockerRuntime implements RuntimeAdapter {
 
     const tag = buildResult.imageRef;
     const extractStart = Date.now();
+    // `build()` released its controller before returning, so nothing was watching
+    // the extract — a `docker create` + `docker cp` of the whole output tree, long
+    // enough to cancel through. Re-register to stay cancellable across it;
+    // registerDockerBuild pre-aborts from the pending map, so a cancel that landed
+    // inside that gap is not lost.
+    const abort = registerDockerBuild(config.sessionId);
+    // The caller sees ONE build, so the reported duration covers image + extract.
+    const elapsed = () => (buildResult.durationMs ?? 0) + (Date.now() - extractStart);
+    const cancelled = (): BuildResult => {
+      log.step("build", "failed", "Static extract cancelled");
+      return { sessionId: config.sessionId, status: "cancelled", durationMs: elapsed() };
+    };
     try {
       await this.moveStaticBuildToHost(tag, config, hostOutDir, log);
+      if (abort.signal.aborted) return cancelled();
       return {
         sessionId: config.sessionId,
         status: "deploying",
         imageRef: hostOutDir,
-        durationMs: (buildResult.durationMs ?? 0) + (Date.now() - extractStart),
+        durationMs: elapsed(),
       };
     } catch (err) {
+      // cancelBuild force-removes containers carrying this build's label, which is
+      // how the extract container dies mid-`cp`. That throw is the cancel, not a
+      // static-build failure.
+      if (abort.signal.aborted || err instanceof BuildCancelledError) return cancelled();
       const msg = safeErrorMessage(err);
       log.step("build", "failed", `Static extract failed: ${msg}`);
       return {
         sessionId: config.sessionId,
         status: "failed",
-        durationMs: (buildResult.durationMs ?? 0) + (Date.now() - extractStart),
+        durationMs: elapsed(),
         errorMessage: `Static extract failed: ${msg}`,
       };
+    } finally {
+      releaseDockerBuild(config.sessionId, abort);
     }
   }
 
@@ -2153,11 +2172,33 @@ export class DockerRuntime implements RuntimeAdapter {
     );
     const isCancelled = (sessionId: string): boolean =>
       abortControllers.get(sessionId)?.signal.aborted === true;
-    const anyCancelled = (): boolean =>
-      [...abortControllers.values()].some((c) => c.signal.aborted);
+    // `every`, not `some`: the shared phases below are shared, so they may only be
+    // skipped when there is no surviving service left to need them. Today a cancel
+    // covers a whole compose deploy at once (cancelCovers matches every
+    // `<parent>-<serviceId>`), but `some` would silently starve the survivors of
+    // their context the day per-service cancellation exists.
+    const allCancelled = (): boolean =>
+      [...abortControllers.values()].every((c) => c.signal.aborted);
+    const cancelledResult = (sessionId: string, startedAt: number): BuildResult => ({
+      sessionId,
+      status: "cancelled",
+      durationMs: Date.now() - startedAt,
+    });
 
     let tree: Awaited<ReturnType<typeof prepareSourceTree>> | null = null;
     try {
+      // Cancelled while these controllers were being registered. Bail BEFORE the
+      // clone: it is the most expensive thing this method does on the host, and a
+      // build nobody is waiting for should not pay for a full `git clone`.
+      if (allCancelled()) {
+        const startedAt = Date.now();
+        return specs.map((spec) => {
+          const result = cancelledResult(spec.config.sessionId, startedAt);
+          spec.onResult?.(result);
+          return { serviceName: spec.serviceName, result };
+        });
+      }
+
       // Acquire the shared source ONCE: clone-on-server clones directly on the
       // remote host (no transfer); otherwise clone on the orchestrator (and
       // transfer the tree below).
@@ -2226,7 +2267,7 @@ export class DockerRuntime implements RuntimeAdapter {
           prepareLogger.step("clone", "completed", "Shared build context ready");
         }
         // Don't push megabytes at a host whose build the user already cancelled.
-        if (isSsh && !anyCancelled()) {
+        if (isSsh && !allCancelled()) {
           await this.transferBuildContext(tree.contextDir, remoteContextDir, prepareLogger);
         }
       }
@@ -2248,11 +2289,7 @@ export class DockerRuntime implements RuntimeAdapter {
         // most services of a cancelled compose deploy land here). Reported as
         // "cancelled", never "failed" — the pipeline branches on it.
         if (isCancelled(spec.config.sessionId)) {
-          const result: BuildResult = {
-            sessionId: spec.config.sessionId,
-            status: "cancelled",
-            durationMs: Date.now() - startedAt,
-          };
+          const result = cancelledResult(spec.config.sessionId, startedAt);
           spec.onResult?.(result);
           results.push({ serviceName: spec.serviceName, result });
           continue;
@@ -2318,11 +2355,7 @@ export class DockerRuntime implements RuntimeAdapter {
           // Same last gate as build(): an image that finished under a cancel must
           // not come back "deploying", or the compose pipeline deploys it anyway.
           if (isCancelled(spec.config.sessionId)) {
-            const result: BuildResult = {
-              sessionId: spec.config.sessionId,
-              status: "cancelled",
-              durationMs: Date.now() - startedAt,
-            };
+            const result = cancelledResult(spec.config.sessionId, startedAt);
             spec.onResult?.(result);
             results.push({ serviceName: spec.serviceName, result });
             continue;
@@ -2341,12 +2374,18 @@ export class DockerRuntime implements RuntimeAdapter {
               spec.config.staticOutDir,
               spec.logger,
             );
-            const result: BuildResult = {
-              sessionId: spec.config.sessionId,
-              status: "deploying",
-              imageRef: spec.config.staticOutDir,
-              durationMs: Date.now() - startedAt,
-            };
+            // The extract is a `docker create` + `docker cp` of the whole output
+            // tree over SSH — long enough to cancel through. Re-gate: the check
+            // above ran before it, and a "deploying" here deploys the deployment
+            // the user cancelled. The half-copied dir is per-build and unreferenced.
+            const result = isCancelled(spec.config.sessionId)
+              ? cancelledResult(spec.config.sessionId, startedAt)
+              : {
+                  sessionId: spec.config.sessionId,
+                  status: "deploying" as const,
+                  imageRef: spec.config.staticOutDir,
+                  durationMs: Date.now() - startedAt,
+                };
             spec.onResult?.(result);
             results.push({ serviceName: spec.serviceName, result });
             continue;
@@ -2366,11 +2405,7 @@ export class DockerRuntime implements RuntimeAdapter {
           // either way it is not a build failure.
           if (isCancelled(spec.config.sessionId) || err instanceof BuildCancelledError) {
             spec.logger.log("Docker build cancelled\n", "error");
-            const result: BuildResult = {
-              sessionId: spec.config.sessionId,
-              status: "cancelled",
-              durationMs: Date.now() - startedAt,
-            };
+            const result = cancelledResult(spec.config.sessionId, startedAt);
             spec.onResult?.(result);
             results.push({ serviceName: spec.serviceName, result });
             continue;

--- a/packages/db/src/repos/deployment-cancel-final.repo.test.ts
+++ b/packages/db/src/repos/deployment-cancel-final.repo.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import { eq } from "drizzle-orm";
+import * as schema from "../schema";
+import { deployment } from "../schema";
+import { createDeploymentRepo } from "./deployment.repo";
+
+const MIGRATIONS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
+
+/**
+ * Real (in-memory PGlite) test for the one guard that makes a cancel stick.
+ *
+ * Cancellation is cooperative and the deploy phase doesn't check for it, so the
+ * work a cancel interrupts keeps running and reaches its own success hook. This
+ * predicate is what stops that hook from writing `ready` over the cancellation —
+ * and it has to be enforced in SQL, because the racing writer is a different
+ * async task with a stale read of the row.
+ */
+async function freshRepo() {
+  const client = new PGlite("memory://");
+  const db = drizzle(client, { schema });
+  await migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  await client.exec("SET session_replication_role = replica;"); // skip FK seeding
+  const repo = createDeploymentRepo(db);
+  await db.insert(deployment).values({
+    id: "d1",
+    projectId: "p1",
+    organizationId: "org1",
+    status: "building",
+    branch: "main",
+  });
+  return { db, repo };
+}
+
+const statusOf = async (db: Awaited<ReturnType<typeof freshRepo>>["db"]) =>
+  (await db.query.deployment.findFirst({ where: eq(deployment.id, "d1") }))?.status;
+
+describe("updateStatus — a cancelled row is final", () => {
+  it("refuses to move a cancelled deployment to ready", async () => {
+    const { db, repo } = await freshRepo();
+
+    expect(await repo.updateStatus("d1", "cancelled")).toBe(true);
+    expect(await repo.updateStatus("d1", "ready")).toBe(false);
+    expect(await statusOf(db)).toBe("cancelled");
+  });
+
+  it("drops the extras of a refused write instead of applying them partially", async () => {
+    const { db, repo } = await freshRepo();
+    await repo.updateStatus("d1", "cancelled");
+
+    // A success hook carries the release payload alongside the status. Landing
+    // the payload while refusing the status would publish a cancelled build as a
+    // numbered release.
+    expect(await repo.updateStatus("d1", "ready", { releaseVersion: "7" })).toBe(false);
+
+    const row = await db.query.deployment.findFirst({ where: eq(deployment.id, "d1") });
+    expect(row?.status).toBe("cancelled");
+    expect(row?.releaseVersion).toBeNull();
+  });
+
+  it("still allows every other transition", async () => {
+    const { db, repo } = await freshRepo();
+
+    expect(await repo.updateStatus("d1", "deploying")).toBe(true);
+    expect(await repo.updateStatus("d1", "ready")).toBe(true);
+    expect(await statusOf(db)).toBe("ready");
+  });
+
+  it("reports false for a row that does not exist", async () => {
+    const { repo } = await freshRepo();
+
+    expect(await repo.updateStatus("nope", "ready")).toBe(false);
+  });
+});

--- a/packages/db/src/repos/deployment.repo.ts
+++ b/packages/db/src/repos/deployment.repo.ts
@@ -226,11 +226,33 @@ export function createDeploymentRepo(db: Database) {
       });
     },
 
-    async updateStatus(id: string, status: string, extra?: Partial<NewDeployment>) {
-      await db
+    /**
+     * Returns false when the row was left alone because it is already
+     * `cancelled`.
+     *
+     * A cancel is the user's last word on a deployment, but the build/deploy work
+     * it interrupted keeps running for a while — cancellation is cooperative, and
+     * the deploy phase doesn't check for it at all. Without this guard that
+     * in-flight work reaches its own lifecycle hook and writes `ready` (or a
+     * failure) over the cancellation, so the deploy the user stopped goes green.
+     * Guarded HERE because every status write funnels through this one method:
+     * a caller cannot forget it, and a new caller inherits it.
+     *
+     * `cancelled` is the only terminal state pinned this way. The others are
+     * legitimately re-written (`reconciling` settles later; a partial failure is
+     * superseded), and those paths don't route through here.
+     */
+    async updateStatus(
+      id: string,
+      status: string,
+      extra?: Partial<NewDeployment>,
+    ): Promise<boolean> {
+      const rows = await db
         .update(deployment)
         .set({ status, ...extra, updatedAt: new Date() })
-        .where(eq(deployment.id, id));
+        .where(and(eq(deployment.id, id), ne(deployment.status, "cancelled")))
+        .returning();
+      return rows.length > 0;
     },
 
     /**


### PR DESCRIPTION
Follow-up to #548. Closes the gap that PR left open, and makes a cancel actually stick.

#548 made the *image build* cancellable. Two things it did not cover:

### 1. The static extract (`fa82334`)

`moveStaticBuildToHost` is a `docker create` + `docker cp` of the whole output tree over SSH — easily long enough to cancel through. Both static paths checked for a cancel *before* it and never again, so a cancel landing during the copy still reported `deploying` and deployed the build the user stopped.

- `buildImages` re-gates after the extract (the per-service static branch).
- `buildStaticToHost` registers an abort controller across the extract, so `cancelBuild` force-removing the extract container is read as a cancel rather than a static-build failure.
- The shared clone is now skipped entirely when the cancel beat the batch — previously the batch cloned the repo before checking.

The half-copied output dir is per-build and unreferenced, so there is nothing to clean up.

### 2. A cancel was not terminal (`14d60bd`)

The real hole. Cancellation is **cooperative**, and the deploy phase has no cancel awareness at all — `cancelBuildSession` only calls `runtime.cancelBuild` while `status === "building"`. So a cancel during the deploy phase let that work run to completion and reach `onSuccess`, which wrote `ready` over the cancellation **and advanced the project's active release**. The deploy the user stopped went green and became the live release.

Guarded in SQL at `repos.deployment.updateStatus` — the one method every status write funnels through, so a caller cannot forget it and a new caller inherits it:

```ts
.where(and(eq(deployment.id, id), ne(deployment.status, "cancelled")))
.returning()
```

It has to be in SQL: the racing writer is a different async task with a stale read of the row. Consumers of the refusal:

- `setDeploymentStatus` skips the SSE broadcast, so the stream can't show a cancelled deploy as still moving.
- `onSuccess` leaves the row cancelled, does not advance the active release, and returns without emitting a second terminal event (`cancelBuildSession` already broadcast `cancelled`).

The refusal is an explicit `false` **only**. Inferring one from any falsy return would invert a working deploy the moment a total write failure returned nothing, so `recordOutcome` reports a tri-state — a failed write still settles `ready` with an explanation. The existing suite caught exactly this while I was writing it (`deploy-outcome-vs-logs`, `compose-noop-settle`).

`cancelled` is the only state pinned this way. `reconciling` settles later and a partial failure is legitimately superseded; those paths are unaffected.

### Also

- `compose/build.service.ts`: the cancel branch's comment contradicted itself, and a dead conjunct on the guard is removed.

## Tests

Each guard was verified by mutation — revert it and exactly one test goes red — rather than by asserting coverage.

- `docker-build-cancellation.test.ts` → 11 tests: pre-clone bail, both post-extract gates, and `build()`'s last gate (the abort landing *after* the daemon finished cleanly, where nothing throws).
- `pipeline-cancel.test.ts` (new): the compose pipeline's cancel branch, with a negative control that throws a sentinel from the deploy step so it doesn't depend on the happy path.
- `cancel-is-final.test.ts` (new): every consumer of the refusal declines to publish a success.
- `deployment-cancel-final.repo.test.ts` (new): the SQL predicate itself, against real in-memory PGlite.

Observed: `packages/adapters` 130 files / 2848 tests pass · `packages/db` 17 files pass · `apps/api` 3920 tests, 1 failed. That one failure is `test/lib/self-server-register.test.ts`, **pre-existing on `main`** (red since the DNS merge at `0ee805d8`; `#548`'s own commit `a0e07c4f` was green) and in files this branch does not touch.

## Still open, deliberately not in this PR

- `CloudRuntime.cancelBuild` is instance-local and exact-match, with no `buildImages` override — cloud/SaaS compose builds remain uncancellable.
- `execOnHost` reports an aborted stream as `exitCode: 0, timedOut: false`.
