### PR TITLE
refactor(deployments): one usable-ref predicate, no bare sentinel lit…

### DIFF
--- a/apps/api/src/lib/container-ref.ts
+++ b/apps/api/src/lib/container-ref.ts
@@ -14,7 +14,17 @@
  *  and made a project pause report success having stopped nothing. */
 export const COMPOSE_SENTINEL = "compose";
 
-/** True when a stored reference names something a runtime can actually act on. */
+/** The reference, trimmed, when it names something a runtime can actually act on
+ *  — else null. Trims because these come from stored columns and a whitespace-only
+ *  value is as unusable as an empty one. */
+export function usableRef(ref: string | null | undefined): string | null {
+  const trimmed = ref?.trim();
+  if (!trimmed || trimmed === COMPOSE_SENTINEL) return null;
+  return trimmed;
+}
+
+/** `usableRef` as a type guard, for the call sites that only need the question
+ *  answered and already hold a clean value. */
 export function isRealContainerRef(ref: string | null | undefined): ref is string {
-  return !!ref && ref !== COMPOSE_SENTINEL;
+  return usableRef(ref) !== null;
 }

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -2337,6 +2337,30 @@ export async function deployComposeServices(
   }
   const deployed = results.filter((r) => r.status !== "failed" && !r.carried).length;
 
+  if (prepareFailure) {
+    sessionManager.broadcastInstallPhase(dep.id, { id: "app-setup", status: "failed" });
+    const failedNow = results.filter((r) => r.status === "failed");
+    logger.step("deploy", "failed", prepareFailure);
+    return {
+      status: "failed",
+      summary: {
+        total: ordered.length,
+        successful,
+        deployed,
+        failed: failedNow.length,
+        indeterminate: 0,
+        mutated,
+        failedServices: failedNow.map((r) => r.serviceName),
+      },
+      services: results,
+      // No primary container: this return goes to onFailure, which ignores it —
+      // resolving one would cost a domain query on the failure path for nothing.
+      error: prepareFailure,
+      publicUrl: firstPublicUrl,
+      portChecks,
+    };
+  }
+
   // The container a project-level question resolves to, picked the same way the
   // access URL is — and over `enabled`, NOT `ordered`: `pickPrimaryServiceId`'s
   // last resort is the first element, and `ordered` is topo-sorted, so for a
@@ -2360,29 +2384,6 @@ export async function deployComposeServices(
       withContainer[0].containerId
     );
   })();
-
-  if (prepareFailure) {
-    sessionManager.broadcastInstallPhase(dep.id, { id: "app-setup", status: "failed" });
-    const failedNow = results.filter((r) => r.status === "failed");
-    logger.step("deploy", "failed", prepareFailure);
-    return {
-      status: "failed",
-      summary: {
-        total: ordered.length,
-        successful,
-        deployed,
-        failed: failedNow.length,
-        indeterminate: 0,
-        mutated,
-        failedServices: failedNow.map((r) => r.serviceName),
-      },
-      services: results,
-      primaryContainerId,
-      error: prepareFailure,
-      publicUrl: firstPublicUrl,
-      portChecks,
-    };
-  }
 
   // Final service-mesh convergence pass (cloud only — docker has live DNS and
   // implements no finalize). Now that every service's workspace exists, this

--- a/apps/api/src/modules/deployments/rollback/restore-plan.ts
+++ b/apps/api/src/modules/deployments/rollback/restore-plan.ts
@@ -35,7 +35,9 @@
  * same shape as image-gc's `computeKeepSet`.
  */
 
-import { COMPOSE_SENTINEL } from "../../../lib/container-ref";
+import { COMPOSE_SENTINEL, usableRef } from "../../../lib/container-ref";
+
+export { usableRef };
 
 export const ROLLBACK_ERROR_CODES = {
   NOT_READY: "ROLLBACK_NOT_READY",
@@ -109,13 +111,6 @@ export interface RestorePlanInput {
   imagePresent?: (imageRef: string) => boolean;
   /** Does this release DIRECTORY still exist on the host? Static releases only. */
   pathPresent?: (path: string) => boolean;
-}
-
-/** A real, dial-able artifact reference (not a compose marker, not blank). */
-export function usableRef(ref: string | null | undefined): string | null {
-  const trimmed = ref?.trim();
-  if (!trimmed || trimmed === COMPOSE_SENTINEL) return null;
-  return trimmed;
 }
 
 /**

--- a/apps/api/src/modules/migration/migrate.service.ts
+++ b/apps/api/src/modules/migration/migrate.service.ts
@@ -18,6 +18,7 @@ import { repos, restoreSubgraph, PkCollisionError, type Service } from "@repo/db
 import { slugify, safeErrorMessage, type ComposeAdvanced } from "@repo/core";
 import { buildNetworkAliases, type ContainerStatus } from "@repo/adapters";
 import { serviceAliasExtras } from "../../lib/deployable-service";
+import { COMPOSE_SENTINEL } from "../../lib/container-ref";
 import type { RequestContext } from "../../lib/request-context";
 import { ensureProject, createServicesProjectWithId } from "../projects/project-crud.service";
 import { getFileContent } from "../github/github.service";
@@ -597,7 +598,7 @@ async function reattachRuntime(opts: {
       branch: group.source?.gitBranch ?? "main",
       environment: "production",
       status: deriveDeploymentStatus(placements.map((p) => p.status)),
-      containerId: "compose", // multi-service sentinel (single-app modeled as 1 service)
+      containerId: COMPOSE_SENTINEL, // single-app is modeled as 1 service
       imageRef: chosen.find((c) => c.image)?.image ?? null,
       trigger: "manual",
       // deployTarget:"server" is REQUIRED, not implied by serverId: target
@@ -698,7 +699,7 @@ export async function attachLiveRuntime(opts: {
         branch: "main",
         environment: "production",
         status: deriveDeploymentStatus(placements.map((p) => p.status)),
-        containerId: "compose", // multi-service sentinel
+        containerId: COMPOSE_SENTINEL,
         imageRef: attach.find((c) => c.image)?.image ?? null,
         trigger: "manual",
         // deployTarget:"server" required — see reattachRuntime above; without it a


### PR DESCRIPTION
…erals

Follow-up cleanup, no behaviour change.

`isRealContainerRef` was introduced next to a predicate that already existed: `usableRef` in rollback/restore-plan, with five call sites, testing the same sentinel. They differed only in that one trims and returns the value. Both now live in `lib/container-ref` — `usableRef` returning the trimmed ref, and `isRealContainerRef` defined as `usableRef(...) !== null` — so the sentinel is compared in exactly one place. `restore-plan` re-exports `usableRef` so its existing importers are untouched.

`migrate.service` still wrote the bare `"compose"` literal with a hand comment in two places; both use the constant now.

The primary-container resolve, and the domain query behind it, ran before the prepare-failure return — which hands the result to onFailure, where the container id is ignored. Moved below it, so a failed deploy no longer pays for a value nothing reads.

Note for reviewers: `test/lib/self-server-register.test.ts` and `packages/core/test/audit-taxonomy.test.ts` (`domain.dns_provisioned`) fail on `main` as of 8b2e8e6d, independently of this branch — verified by running both against main's own copy of the files they scan. Neither file is touched here.

<!--
Thanks for contributing to Openship! Please skim CONTRIBUTING.md before opening this PR.
Fill in the sections below and delete any that genuinely don't apply.
-->

## Summary

<!-- What does this PR do, in one or two sentences? -->

## Motivation

<!-- What was broken, or what did the linked issue agree on? Why is this change needed? -->

## Related issue

<!--
New features, behavior changes, new dependencies, new endpoints, and schema/migration changes
need a maintainer to agree on scope *and* approach in an issue **before** the code is written —
link that issue here (for example: Closes #123).

Bug fixes, tests, docs, and small self-contained improvements don't need one. Write "None".
-->

## Changes

<!-- Bullet what changed, grouped by workspace (apps/api, apps/dashboard, packages/db, ...). -->

## Verification

<!--
How you actually verified this: the commands you ran and the before/after behavior.
Paste real output rather than describing what should happen.
-->

```bash

```

## Screenshots

<!-- Before/after for dashboard, web, or desktop changes. Delete this section if not applicable. -->

## Checklist

- [ ] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [ ] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [ ] A test fails without this change and passes with it (or I explained above why there isn't one)
- [ ] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally
- [ ] I understand every line of this diff and can explain it in review
