### PR TITLE
fix(audit): catalogue uncatalogued audit events, unpin two stale e2e expectations

### DIFF
--- a/apps/api/test/e2e/backup-volume-roundtrip.e2e.test.ts
+++ b/apps/api/test/e2e/backup-volume-roundtrip.e2e.test.ts
@@ -21,10 +21,16 @@
  *     old code stopped unconditionally and always started, which threw here.
  *   - No helper container is left behind (`AutoRemove: false` + `finally` reap).
  *
- * The local destination is a tmpdir, not the default `BACKUP_LOCAL_ROOT`: the
- * root/deny-list rules are create-time gates in destination.service.ts and are
- * covered by test/modules/backups/local-destination-path.test.ts. The adapter
- * itself reads no env — it takes the row's endpoint as its root.
+ * The local destination is a tmpdir INSIDE `env.BACKUP_LOCAL_ROOT` (pointed at a
+ * dedicated tmp root by vitest.e2e.config.ts, since config/env.ts parses the
+ * environment at import). The adapter itself still reads no env — it takes the
+ * row's endpoint as its root — but the gate in front of it does: local
+ * destinations are refused unless the instance opted in AND the endpoint resolves
+ * inside that root, on every path that USES a row, not only the ones that create
+ * one. A seeded row takes no create path, so this test is the one that has to
+ * satisfy the consumer gate. Which paths reject what is covered by
+ * test/modules/backups/local-destination-path.test.ts and
+ * backup-local-destination-gate.test.ts.
  *
  * Skips without a reachable daemon, FAILS under RUN_DOCKER_E2E=1 (what CI sets).
  * See test/helpers/docker-e2e.ts.
@@ -32,11 +38,11 @@
 
 import { it, expect, beforeAll, afterAll } from "vitest";
 import { randomBytes } from "node:crypto";
-import { mkdtemp, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { DockerRuntime, initPlatform, resetPlatform, scopedVolumeName } from "@repo/adapters";
 import { repos, type BackupRestoreStatus } from "@repo/db";
+import { env } from "../../src/config";
 import type { RequestContext } from "../../src/lib/request-context";
 import { resolvePlatformConfig } from "../../src/lib/controller-helpers";
 import { describeDockerE2E, requireDocker } from "../helpers/docker-e2e";
@@ -179,7 +185,10 @@ describeDockerE2E("backup → wipe → restore, real volume", () => {
         `printf %s '${NESTED}' > /mnt/nested/deep.txt`,
     );
 
-    destRoot = await mkdtemp(join(tmpdir(), "openship-backup-e2e-"));
+    // Inside the sandbox root, because the gate re-resolves containment on every
+    // use — a tmpdir next to it reads as an escape and fails the run.
+    await mkdir(env.BACKUP_LOCAL_ROOT, { recursive: true });
+    destRoot = await mkdtemp(join(env.BACKUP_LOCAL_ROOT, "run-"));
     const destination = await seedBackupDestination(organizationId, {
       kind: "local",
       endpoint: destRoot,
@@ -201,7 +210,10 @@ describeDockerE2E("backup → wipe → restore, real volume", () => {
     if (volumeName) {
       await runtime.docker.getVolume(volumeName).remove({ force: true }).catch(() => {});
     }
-    if (destRoot) await rm(destRoot, { recursive: true, force: true }).catch(() => {});
+    // The root, not just this run's subdirectory: the suite created both, the root
+    // is this process's alone, and removing the parent can't leave a child behind
+    // — including when beforeAll threw between the two.
+    await rm(env.BACKUP_LOCAL_ROOT, { recursive: true, force: true }).catch(() => {});
     await runtime?.dispose?.().catch(() => {});
     resetPlatform();
   }, 120_000);

--- a/apps/api/test/e2e/host-profile-distros.e2e.test.ts
+++ b/apps/api/test/e2e/host-profile-distros.e2e.test.ts
@@ -96,7 +96,12 @@ const CASES: readonly Case[] = [
     libc: "glibc",
     versionPrefix: "2",
     installGit: ["yum install -y git"],
-    dockerEngine: ["amazon-linux-extras install -y docker"],
+    // Braced, and tolerating a non-zero exit when the binary is there: AL2's
+    // `amazon-linux-extras` exits 13 AFTER yum has installed dockerd, and
+    // `opScript` joins with `&&`, so a bare command aborted the compose-plugin
+    // steps that follow and provisioned an engine with no `docker compose`.
+    // Pinned as one step on purpose — the braces are what keep it one.
+    dockerEngine: ["{ amazon-linux-extras install -y docker || command -v docker >/dev/null 2>&1; }"],
     composeFrom: "plugin",
   },
   {

--- a/apps/api/vitest.e2e.config.ts
+++ b/apps/api/vitest.e2e.config.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { configDefaults, defineConfig } from "vitest/config";
 import { sharedTestOptions, testAlias } from "./vitest.config";
 
@@ -23,6 +25,19 @@ const HEAVY = "test/e2e/rollback-build-restore.e2e.test.ts";
 const scope = process.env.E2E_SCOPE;
 const include = scope === "heavy" ? [HEAVY] : ["test/e2e/**/*.e2e.test.ts"];
 
+/**
+ * The sandbox `backup-volume-roundtrip` puts its destination inside, read back
+ * from `env.BACKUP_LOCAL_ROOT` by the test rather than recomputed there.
+ *
+ * A dedicated directory, not `tmpdir()` itself: the root is what the deny-list in
+ * local-path.ts screens, and "point it at a dedicated directory" is the advice the
+ * product gives an operator — the suite should be configured the way one would be.
+ *
+ * Per-process, because the suite removes this whole tree when it finishes: a fixed
+ * name would let one run delete the sandbox another was mid-backup in.
+ */
+const BACKUP_ROOT = join(tmpdir(), `openship-e2e-backup-root-${process.pid}`);
+
 export default defineConfig({
   resolve: {
     alias: testAlias,
@@ -30,6 +45,15 @@ export default defineConfig({
   test: {
     ...sharedTestOptions,
     include,
+    env: {
+      ...sharedTestOptions.env,
+      // A `kind: 'local'` destination is gated on EVERY path that uses one, not
+      // just the ones that create one (local-gate.ts), so the suite has to opt in
+      // the way an operator does. It belongs here and not in a hook: config/env.ts
+      // parses process.env eagerly at import, which a `beforeAll` runs after.
+      BACKUP_ALLOW_LOCAL_DESTINATION: "true",
+      BACKUP_LOCAL_ROOT: BACKUP_ROOT,
+    },
     exclude: [...configDefaults.exclude, ...(scope === "fast" ? [HEAVY] : [])],
     // Pulling and building images and streaming volumes all happen in
     // beforeAll. There is no sane default here, which is why every E2E hook

--- a/packages/core/src/audit-taxonomy.ts
+++ b/packages/core/src/audit-taxonomy.ts
@@ -275,11 +275,30 @@ export const AUDIT_EVENTS: Record<string, AuditEventDef> = {
     tone: "warning",
     description: "DNS records for this domain don't point here yet.",
   },
+  // The name the AUDIT row carries — `verify` and `verifyStream` both write it,
+  // while the notification namespace uses `verification_failed` above. Both are
+  // catalogued rather than renamed: the event type is a stored, queryable column,
+  // so a rename would orphan every row already written on an operator's instance.
+  "domain.verify_failed": {
+    category: "domains",
+    action: "failed to verify the domain",
+    label: "Domain verification failed",
+    tone: "warning",
+    description: "DNS records for this domain don't point here yet.",
+  },
   "domain.set_primary": {
     category: "domains",
     action: "made primary the domain",
     label: "Primary domain changed",
     description: "The domain other addresses now redirect to.",
+  },
+  "domain.dns_provisioned": {
+    category: "domains",
+    action: "provisioned DNS for",
+    label: "DNS records provisioned",
+    tone: "info",
+    description:
+      "Openship wrote this domain's records at the connected DNS provider. The counts of applied and failed records are in the details.",
   },
   "domain.cert_uploaded": {
     category: "domains",
@@ -808,6 +827,18 @@ export const AUDIT_EVENTS: Record<string, AuditEventDef> = {
     category: "system",
     action: "failed to back up",
     label: "Backup failed",
+    tone: "danger",
+  },
+  "backup_restore.completed": {
+    category: "system",
+    action: "restored",
+    label: "Restore completed",
+    tone: "success",
+  },
+  "backup_restore.failed": {
+    category: "system",
+    action: "failed to restore",
+    label: "Restore failed",
     tone: "danger",
   },
   "backup.webhook.fired": {

--- a/packages/core/test/audit-taxonomy.test.ts
+++ b/packages/core/test/audit-taxonomy.test.ts
@@ -44,19 +44,36 @@ function apiSourceFiles(dir: string): string[] {
 }
 
 /**
- * Event types emitted as literals: `eventType: "..."` outside a comment.
+ * Event types emitted as literals: every string in the `eventType:` expression.
  *
  * Deliberately over-inclusive — it also catches the notification dispatcher's
  * literals, which are mostly audit types too. A catalog entry for a type that
  * never reaches audit_event costs nothing; a missing one costs a readable row.
+ *
+ * BOTH branches of a ternary, not just a bare literal: `eventType: ok ? "a" : "b"`
+ * is how ~half the pass/fail pairs are written, and a regex anchored on a quote
+ * right after the colon saw neither. That blind spot is what let
+ * `domain.verify_failed` ship uncatalogued while its `domain.verified` twin —
+ * written on the same line — looked covered.
+ *
+ * Scoped twice, so the scan stays over-inclusive about event types without
+ * inventing ones: to the expression (up to the first comma), so the sibling keys
+ * of a single-line `{ eventType: "x", resourceType: "y" }` aren't read as types;
+ * and past the `?`, so the operand of a `status === "succeeded" ? …` condition
+ * isn't either.
  */
 function emittedEventTypes(): Map<string, string> {
   const found = new Map<string, string>();
   for (const file of apiSourceFiles(API_SRC)) {
     for (const line of readFileSync(file, "utf8").split("\n")) {
       if (/^\s*\*/.test(line)) continue; // jsdoc example, not a call site
-      const match = line.match(/eventType:\s*"([^"]+)"/);
-      if (match?.[1] && !found.has(match[1])) found.set(match[1], file);
+      const at = line.indexOf("eventType:");
+      if (at === -1) continue;
+      const expr = line.slice(at + "eventType:".length).split(",")[0]!;
+      const branches = expr.includes("?") ? expr.slice(expr.indexOf("?") + 1) : expr;
+      for (const [, type] of branches.matchAll(/"([^"]+)"/g)) {
+        if (type && !found.has(type)) found.set(type, file);
+      }
     }
   }
   return found;


### PR DESCRIPTION
Fixes the three red CI tests on `main` (v0.6.5). One was a product defect; two were test expectations that had drifted from deliberate fixes.

## `@repo/core` — `domain.dns_provisioned` uncatalogued (real defect)

The row was recorded fine, but with no `AUDIT_EVENTS` entry it rendered as the prettified fallback and landed in the **System** tab — invisible to an operator filtering Audit → Domains.

Hardening the scan to read **both branches of a ternary** (how half the pass/fail pairs are written, and the blind spot that let this class ship) surfaced two more genuine holes, now catalogued too:

- `domain.verify_failed` — the name both verify paths actually write. Kept **beside** `domain.verification_failed` rather than renamed: the event type is a stored, queryable column, so a rename would orphan every row already written on an operator's instance.
- `backup_restore.completed` / `backup_restore.failed`.

The scan is scoped twice — to the expression, and past the `?` — so sibling keys and a `status === "succeeded"` operand aren't mistaken for event types.

## `host-profile-distros` e2e — stale pin (test only)

Pinned `amazon-linux-extras install -y docker`, but AL2 exits 13 *after* dockerd is on disk, so the step is deliberately braced and tolerates that exit; otherwise the `&&`-joined compose-plugin steps abort and the host gets an engine with no `docker compose`. Expectation updated, with the reason recorded so it isn't "simplified" back.

## `backup-volume-roundtrip` e2e — never opted in (test only)

The suite seeds a `kind: local` destination, and the gate now re-asks on every path that **uses** one, not just the ones that create one. The suite now opts in the way an operator does — from `vitest.e2e.config.ts`, because `config/env.ts` parses the environment eagerly at import, with the destination inside the sandbox root (per-process, so concurrent runs can't delete each other's).

## Verification

- `bun run test` — 7/7 turbo tasks, 610 test files, green
- `RUN_DOCKER_E2E=1 … test:e2e` — 9/9 files green against a real daemon, no leaked sandbox
- Hardened scan replayed against this branch's `apps/api/src`: 79 emitted event types, **0** uncatalogued

## Note for release notes (not a bug)

After upgrading, an existing local backup destination keeps working only if `BACKUP_ALLOW_LOCAL_DESTINATION` is still set **and** its endpoint still resolves inside `BACKUP_LOCAL_ROOT`. A row that arrived by org transfer, or one whose root moved, now fails at backup/prune/restore time rather than writing outside the sandbox.