### PR TITLE
feat(catalog): add Louez

### DIFF
--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -2923,6 +2923,159 @@
           ]
         }
       ]
+    },
+    {
+      "$schema": "https://openship.io/app.schema.json",
+      "available": false,
+      "id": "louez",
+      "name": "Louez",
+      "description": "Equipment rental platform: a booking storefront with live availability, and a back office for reservations, customers and PDF contracts.",
+      "kind": "template",
+      "logo": "louez",
+      "category": "other",
+      "tags": [
+        "rental",
+        "booking",
+        "reservations",
+        "inventory",
+        "ecommerce"
+      ],
+      "framework": "docker-compose",
+      "repository": "https://github.com/Synapsr/Louez",
+      "services": [
+        {
+          "name": "louez-db",
+          "image": "mysql:8.4",
+          "environment": {
+            "MYSQL_DATABASE": "louez",
+            "MYSQL_USER": "louez"
+          },
+          "secretEnv": [
+            "MYSQL_PASSWORD",
+            "MYSQL_ROOT_PASSWORD"
+          ],
+          "volumes": [
+            "louez_db:/var/lib/mysql"
+          ],
+          "healthcheck": {
+            "test": "mysqladmin ping -h 127.0.0.1",
+            "interval": "5s",
+            "retries": 20
+          },
+          "restart": "unless-stopped"
+        },
+        {
+          "name": "louez-storage",
+          "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+          "command": "server /data",
+          "environment": {
+            "MINIO_ROOT_USER": "louez"
+          },
+          "secretEnv": [
+            "MINIO_ROOT_PASSWORD"
+          ],
+          "volumes": [
+            "louez_storage:/data"
+          ],
+          "healthcheck": {
+            "test": "curl -sf http://127.0.0.1:9000/minio/health/live",
+            "interval": "5s",
+            "retries": 20
+          },
+          "restart": "unless-stopped"
+        },
+        {
+          "name": "louez",
+          "image": "synapsr/louez:2.1.0",
+          "ports": [
+            "3000:3000"
+          ],
+          "exposedPort": 3000,
+          "exposed": true,
+          "dependsOn": [
+            "louez-db",
+            "louez-storage"
+          ],
+          "environment": {
+            "LOUEZ_MODE": "standalone",
+            "AUTH_URL": "{{publicUrl:louez}}",
+            "NEXT_PUBLIC_APP_URL": "{{publicUrl:louez}}",
+            "AUTH_TRUST_HOST": "true",
+            "DATABASE_URL": "mysql://louez:{{config:MYSQL_PASSWORD}}@louez-db:3306/louez",
+            "S3_ENDPOINT": "http://louez-storage:9000",
+            "S3_REGION": "us-east-1",
+            "S3_BUCKET": "louez",
+            "S3_ACCESS_KEY_ID": "louez",
+            "S3_SECRET_ACCESS_KEY": "{{config:MINIO_ROOT_PASSWORD}}",
+            "S3_PUBLIC_URL": "/files"
+          },
+          "secretEnv": [
+            "DATABASE_URL",
+            "S3_SECRET_ACCESS_KEY",
+            "AUTH_SECRET"
+          ],
+          "volumes": [
+            "louez_data:/app/data"
+          ],
+          "restart": "unless-stopped"
+        }
+      ],
+      "endpoints": [
+        {
+          "service": "louez",
+          "port": 3000,
+          "label": "Storefront and dashboard",
+          "kind": "http"
+        }
+      ],
+      "prepare": [
+        {
+          "service": "louez-storage",
+          "phase": "post-ready",
+          "readiness": {
+            "test": "mc alias set local http://127.0.0.1:9000 \"$MINIO_ROOT_USER\" \"$MINIO_ROOT_PASSWORD\"",
+            "interval": 2000,
+            "retries": 30
+          },
+          "command": "mc alias set local http://127.0.0.1:9000 \"$MINIO_ROOT_USER\" \"$MINIO_ROOT_PASSWORD\" && mc mb --ignore-existing local/louez",
+          "capture": "bucket",
+          "mustSucceed": true,
+          "title": "Creating the product image bucket",
+          "description": "Louez stores product photos in MinIO and streams them back through the app, so the bucket stays private."
+        }
+      ],
+      "configFields": [
+        {
+          "key": "MYSQL_PASSWORD",
+          "service": "louez-db",
+          "label": "Database password",
+          "generate": "secret",
+          "secret": true
+        },
+        {
+          "key": "MYSQL_ROOT_PASSWORD",
+          "service": "louez-db",
+          "label": "Database root password",
+          "generate": "secret",
+          "secret": true
+        },
+        {
+          "key": "MINIO_ROOT_PASSWORD",
+          "service": "louez-storage",
+          "label": "Image store password",
+          "help": "Credentials Louez uses to read and write product photos.",
+          "generate": "secret",
+          "secret": true
+        },
+        {
+          "key": "AUTH_SECRET",
+          "service": "louez",
+          "label": "Auth secret",
+          "help": "Signs sessions. Auto-generated.",
+          "generate": "secret",
+          "secret": true
+        }
+      ]
     }
   ]
 }

--- a/packages/core/src/apps/catalog/louez.json
+++ b/packages/core/src/apps/catalog/louez.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://openship.io/app.schema.json",
+  "available": false,
+  "id": "louez",
+  "name": "Louez",
+  "description": "Equipment rental platform: a booking storefront with live availability, and a back office for reservations, customers and PDF contracts.",
+  "kind": "template",
+  "logo": "louez",
+  "category": "other",
+  "tags": [
+    "rental",
+    "booking",
+    "reservations",
+    "inventory",
+    "ecommerce"
+  ],
+  "framework": "docker-compose",
+  "repository": "https://github.com/Synapsr/Louez",
+  "services": [
+    {
+      "name": "louez-db",
+      "image": "mysql:8.4",
+      "environment": {
+        "MYSQL_DATABASE": "louez",
+        "MYSQL_USER": "louez"
+      },
+      "secretEnv": [
+        "MYSQL_PASSWORD",
+        "MYSQL_ROOT_PASSWORD"
+      ],
+      "volumes": [
+        "louez_db:/var/lib/mysql"
+      ],
+      "healthcheck": {
+        "test": "mysqladmin ping -h 127.0.0.1",
+        "interval": "5s",
+        "retries": 20
+      },
+      "restart": "unless-stopped"
+    },
+    {
+      "name": "louez-storage",
+      "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+      "command": "server /data",
+      "environment": {
+        "MINIO_ROOT_USER": "louez"
+      },
+      "secretEnv": [
+        "MINIO_ROOT_PASSWORD"
+      ],
+      "volumes": [
+        "louez_storage:/data"
+      ],
+      "healthcheck": {
+        "test": "curl -sf http://127.0.0.1:9000/minio/health/live",
+        "interval": "5s",
+        "retries": 20
+      },
+      "restart": "unless-stopped"
+    },
+    {
+      "name": "louez",
+      "image": "synapsr/louez:2.1.0",
+      "ports": [
+        "3000:3000"
+      ],
+      "exposedPort": 3000,
+      "exposed": true,
+      "dependsOn": [
+        "louez-db",
+        "louez-storage"
+      ],
+      "environment": {
+        "LOUEZ_MODE": "standalone",
+        "AUTH_URL": "{{publicUrl:louez}}",
+        "NEXT_PUBLIC_APP_URL": "{{publicUrl:louez}}",
+        "AUTH_TRUST_HOST": "true",
+        "DATABASE_URL": "mysql://louez:{{config:MYSQL_PASSWORD}}@louez-db:3306/louez",
+        "S3_ENDPOINT": "http://louez-storage:9000",
+        "S3_REGION": "us-east-1",
+        "S3_BUCKET": "louez",
+        "S3_ACCESS_KEY_ID": "louez",
+        "S3_SECRET_ACCESS_KEY": "{{config:MINIO_ROOT_PASSWORD}}",
+        "S3_PUBLIC_URL": "/files"
+      },
+      "secretEnv": [
+        "DATABASE_URL",
+        "S3_SECRET_ACCESS_KEY",
+        "AUTH_SECRET"
+      ],
+      "volumes": [
+        "louez_data:/app/data"
+      ],
+      "restart": "unless-stopped"
+    }
+  ],
+  "endpoints": [
+    {
+      "service": "louez",
+      "port": 3000,
+      "label": "Storefront and dashboard",
+      "kind": "http"
+    }
+  ],
+  "prepare": [
+    {
+      "service": "louez-storage",
+      "phase": "post-ready",
+      "readiness": {
+        "test": "mc alias set local http://127.0.0.1:9000 \"$MINIO_ROOT_USER\" \"$MINIO_ROOT_PASSWORD\"",
+        "interval": 2000,
+        "retries": 30
+      },
+      "command": "mc alias set local http://127.0.0.1:9000 \"$MINIO_ROOT_USER\" \"$MINIO_ROOT_PASSWORD\" && mc mb --ignore-existing local/louez",
+      "capture": "bucket",
+      "mustSucceed": true,
+      "title": "Creating the product image bucket",
+      "description": "Louez stores product photos in MinIO and streams them back through the app, so the bucket stays private."
+    }
+  ],
+  "configFields": [
+    {
+      "key": "MYSQL_PASSWORD",
+      "service": "louez-db",
+      "label": "Database password",
+      "generate": "secret",
+      "secret": true
+    },
+    {
+      "key": "MYSQL_ROOT_PASSWORD",
+      "service": "louez-db",
+      "label": "Database root password",
+      "generate": "secret",
+      "secret": true
+    },
+    {
+      "key": "MINIO_ROOT_PASSWORD",
+      "service": "louez-storage",
+      "label": "Image store password",
+      "help": "Credentials Louez uses to read and write product photos.",
+      "generate": "secret",
+      "secret": true
+    },
+    {
+      "key": "AUTH_SECRET",
+      "service": "louez",
+      "label": "Auth secret",
+      "help": "Signs sessions. Auto-generated.",
+      "generate": "secret",
+      "secret": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds [Louez](https://github.com/Synapsr/Louez) to the one-click catalog — an AGPL-3.0 equipment rental platform: a booking storefront with live availability for customers, and a back office for reservations, pickups and returns, customers, PDF contracts and revenue statistics. It fills a gap in the catalog: rental of physical goods, which none of the current 28 apps cover.

## The template

Three services, following `guides/add-an-app`:

| Service | Image | Role |
|---|---|---|
| `louez` | `synapsr/louez:2.1.0` | Storefront + dashboard + API, port 3000. Creates its own database schema on first boot |
| `louez-db` | `mysql:8.4` | Database, with a `mysqladmin ping` healthcheck |
| `louez-storage` | `minio/minio:RELEASE.2025-09-07T16-13-09Z` | Product photos |

Every credential is generated: the MySQL password flows into the app's `DATABASE_URL` through `{{config:MYSQL_PASSWORD}}`, the MinIO password into `S3_SECRET_ACCESS_KEY`, and `AUTH_SECRET` is its own generated field. `AUTH_URL` and `NEXT_PUBLIC_APP_URL` come from `{{publicUrl:louez}}` — the app binds sign-in to that origin.

The bucket is created by a `prepare` step rather than a fourth container: `mc mb --ignore-existing local/louez`, `phase: post-ready` with a readiness poll on `mc alias set`, so it is re-run safe. The bucket stays private — Louez streams images same-origin under `/files` with its own credentials, which is why the storage service is not exposed.

## What was verified

- `bun scripts/gen-catalog.ts` regenerated `catalog.json` (the diff is a pure addition, no drift).
- Your own validator, run against the built catalog: `isValidAppTemplate(louez)` → `true`, `parseAppTemplate` → ok, and all 29 apps still validate.
- `louez.json` validates against `https://openship.io/app.schema.json`.
- The same three-service topology (identical images, wiring and bucket step) was deployed and exercised end to end under plain Docker Compose: services healthy, schema installed automatically, account created, a product image uploaded through the app into the MinIO bucket and served back byte-identical.

`available` is left `false` as CONTRIBUTING asks, since I have not yet run it on a real Openship instance — happy to flip it once someone does, or to adjust anything that does not match house style.

One detail: `logo: "louez"` is not a simpleicons slug, so it will fall back to the role glyph. Tell me where vendored SVGs live and I will add the mark.
