### PR TITLE
fix(runtime): authenticate private registry pulls

### DIFF
--- a/.github/workflows/build-patched-api.yml
+++ b/.github/workflows/build-patched-api.yml
@@ -1,6 +1,9 @@
 name: Build patched API image
 
 on:
+  push:
+    branches:
+      - fix/docker-pull-registry-auth
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-patched-api.yml
+++ b/.github/workflows/build-patched-api.yml
@@ -1,0 +1,30 @@
+name: Build patched API image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: true
+          tags: ghcr.io/m-aref-shojaei/openship-api:pull-auth-0eeee135
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/apps/cli/src/lib/compose.ts
+++ b/apps/cli/src/lib/compose.ts
@@ -20,10 +20,11 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir, userInfo } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import {
   LocalExecutor,
@@ -454,6 +455,9 @@ services:
       # the transport, naming neither the path nor the cause (#482). \`openship up\`
       # writes OPENSHIP_DOCKER_SOCKET when the detected path isn't this default.
       - \${OPENSHIP_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
+      # Registry credentials are resolved at pull time by the API. When the host
+      # config exists, it is mounted read-only and scoped to this service only.
+__OPENSHIP_DOCKER_CONFIG_VOLUME__
       # Routing state shared with the edge, as HOST BIND MOUNTS (generated from
       # EDGE_CONTAINER_MOUNTS): the vhost tree, /etc/letsencrypt, the ACME webroot
       # and the static doc-roots the API writes and the edge serves. Named volumes
@@ -2399,7 +2403,26 @@ function materialize(opts: ComposeUpOpts): {
     /* first install — no previous env, so everything is "changed" */
   }
   const { text: rendered, carried } = renderEnvAndCarried(opts, host, cfg, prev);
-  writeFileSync(COMPOSE_FILE, COMPOSE_YAML);
+  const dockerConfigPath = resolve(
+    process.env.DOCKER_CONFIG || join(homedir(), ".docker"),
+    "config.json",
+  );
+  let dockerConfigVolume = "";
+  try {
+    if (statSync(dockerConfigPath).isFile()) {
+      dockerConfigVolume = `      - type: bind
+        source: ${JSON.stringify(dockerConfigPath)}
+        target: /root/.docker/config.json
+        read_only: true`;
+    }
+  } catch {
+    /* no usable Docker config — leave the API mount absent */
+  }
+  const composeYaml = COMPOSE_YAML.replace(
+    "__OPENSHIP_DOCKER_CONFIG_VOLUME__",
+    dockerConfigVolume,
+  );
+  writeFileSync(COMPOSE_FILE, composeYaml);
   writeEnvFile(rendered, before);
   // #485: the old rewrite silently DROPPED operator-set keys. Now they survive — say so,
   // so a run that kept them doesn't look like it might have discarded them.

--- a/apps/cli/test/unit/compose-source-build.test.ts
+++ b/apps/cli/test/unit/compose-source-build.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * A from-source ("dev") install must BUILD the images we own from its checkout,
@@ -32,6 +34,7 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => ({
   existsSync: (p: string) => h.existing.has(String(p)),
+  statSync: (p: string) => ({ isFile: () => h.existing.has(String(p)) }),
   mkdirSync: () => undefined,
   readFileSync: (p: string) => h.written.get(String(p)) ?? "",
   writeFileSync: (p: string, data: string) => {
@@ -49,6 +52,10 @@ vi.mock("node:fs", () => ({
 vi.mock("../../src/lib/source-install", () => ({
   readSourceInstall: () => h.sourceInstall,
 }));
+
+vi.mock("@repo/core", () =>
+  import("../../../../packages/core/src/index"),
+);
 
 // Keep the heavy adapters barrel out of this unit test — but reach through to the
 // REAL mount list, because one of the tests below asserts the compose YAML is
@@ -99,13 +106,22 @@ const verbs = () =>
     return out;
   });
 
+let previousDockerConfig: string | undefined;
+
 beforeEach(() => {
+  previousDockerConfig = process.env.DOCKER_CONFIG;
+  delete process.env.DOCKER_CONFIG;
   h.sourceInstall = null;
   // An ordinary rootful box: the daemon socket is where the mount defaults to, so the
   // #482 detection has nothing to report here.
   h.existing = new Set(["/var/run/docker.sock"]);
   h.written = new Map();
   h.composeCalls = [];
+});
+
+afterEach(() => {
+  if (previousDockerConfig === undefined) delete process.env.DOCKER_CONFIG;
+  else process.env.DOCKER_CONFIG = previousDockerConfig;
 });
 
 describe("composeUp — from-source install", () => {
@@ -167,6 +183,46 @@ describe("composeUp — from-source install", () => {
 describe("composeUp — edge bind mounts", () => {
   const composeYaml = () =>
     [...h.written.entries()].find(([p]) => p.endsWith("docker-compose.yml"))?.[1] ?? "";
+
+  it("omits the Docker config mount when the host config is absent", async () => {
+    await composeUp({ version: "0.3.0" });
+
+    expect(composeYaml()).not.toContain(":/root/.docker/config.json:ro");
+  });
+
+  it("mounts the default host Docker config read-only into only the api", async () => {
+    const configPath = join(homedir(), ".docker", "config.json");
+    h.existing.add(configPath);
+
+    await composeUp({ version: "0.3.0" });
+
+    expect(composeYaml().split(`        source: ${JSON.stringify(configPath)}`).length - 1).toBe(1);
+  });
+
+  it("mounts an existing DOCKER_CONFIG file instead of the default config", async () => {
+    process.env.DOCKER_CONFIG = "/opt/openship/docker-config";
+    const configPath = join(process.env.DOCKER_CONFIG, "config.json");
+    h.existing.add(configPath);
+
+    await composeUp({ version: "0.3.0" });
+
+    expect(composeYaml()).toContain(`        source: ${JSON.stringify(configPath)}`);
+    expect(composeYaml()).not.toContain(`${homedir()}/.docker/config.json`);
+  });
+
+  it("resolves relative DOCKER_CONFIG paths and renders special characters safely", async () => {
+    process.env.DOCKER_CONFIG = "docker config: private";
+    const configPath = join(process.cwd(), process.env.DOCKER_CONFIG, "config.json");
+    h.existing.add(configPath);
+
+    await composeUp({ version: "0.3.0" });
+
+    expect(composeYaml()).toContain("      - type: bind");
+    expect(composeYaml()).toContain(`        source: ${JSON.stringify(configPath)}`);
+    expect(composeYaml()).toContain("        target: /root/.docker/config.json");
+    expect(composeYaml()).toContain("        read_only: true");
+    expect(composeYaml()).not.toContain("docker config: private:/root/.docker/config.json");
+  });
 
   it("gives BOTH api and edge every mount in EDGE_CONTAINER_MOUNTS", async () => {
     await composeUp({ version: "0.3.0" });

--- a/packages/adapters/src/runtime/docker-auth.ts
+++ b/packages/adapters/src/runtime/docker-auth.ts
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type Dockerode from "dockerode";
+
+type DockerConfig = {
+  auths?: Record<string, { auth?: string; identitytoken?: string }>;
+  credHelpers?: Record<string, string>;
+  credsStore?: string;
+};
+
+const DOCKER_HUB_KEYS = ["https://index.docker.io/v1/", "index.docker.io", "docker.io"];
+
+/** Return the registry addressed by an image reference. */
+export function registryForImage(ref: string): string {
+  const first = ref.split("/", 1)[0];
+  return first.includes(".") || first.includes(":") || first === "localhost" ? first : "docker.io";
+}
+
+function matchingKey<T>(values: Record<string, T> | undefined, registry: string): string | undefined {
+  if (!values) return undefined;
+  if (registry !== "docker.io") return Object.hasOwn(values, registry) ? registry : undefined;
+  return DOCKER_HUB_KEYS.find((key) => Object.hasOwn(values, key));
+}
+
+/** Resolve Docker CLI credentials for an image without exposing credential-provider output. */
+export async function resolveDockerAuth(ref: string): Promise<Dockerode.AuthConfig | undefined> {
+  const registry = registryForImage(ref);
+  const configPath = join(process.env.DOCKER_CONFIG || join(homedir(), ".docker"), "config.json");
+  let config: DockerConfig;
+  try {
+    config = JSON.parse(await readFile(configPath, "utf8")) as DockerConfig;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw new Error(`Docker credential configuration is invalid for ${registry}`);
+  }
+
+  if (matchingKey(config.credHelpers, registry) || config.credsStore) {
+    throw new Error(`Docker credential helper is unavailable for ${registry}; use inline auths`);
+  }
+
+  const authKey = matchingKey(config.auths, registry);
+  const entry = authKey ? config.auths![authKey] : undefined;
+  if (!entry) return undefined;
+  if (entry.identitytoken) return { identitytoken: entry.identitytoken, serveraddress: authKey };
+  if (!entry.auth) return undefined;
+
+  try {
+    const decoded = Buffer.from(entry.auth, "base64").toString("utf8");
+    const separator = decoded.indexOf(":");
+    if (separator < 1) throw new Error("invalid auth");
+    return {
+      username: decoded.slice(0, separator),
+      password: decoded.slice(separator + 1),
+      serveraddress: authKey,
+    };
+  } catch {
+    throw new Error(`Docker credential configuration is invalid for ${registry}`);
+  }
+}

--- a/packages/adapters/src/runtime/docker-pull-auth.test.ts
+++ b/packages/adapters/src/runtime/docker-pull-auth.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DockerRuntime as DockerRuntimeType } from "./docker";
+
+const h = vi.hoisted(() => ({
+  pulls: [] as Array<{ ref: string; options?: Record<string, unknown> }>,
+  progressError: null as Error | null,
+}));
+
+vi.mock("dockerode", () => {
+  class MissingImageDockerode {
+    modem = {
+      followProgress: (_stream: unknown, callback: (error: Error | null) => void) =>
+        callback(h.progressError),
+    };
+
+    getImage() {
+      return { inspect: async () => Promise.reject(new Error("missing")) };
+    }
+
+    async pull(ref: string, options?: Record<string, unknown>) {
+      h.pulls.push({ ref, options });
+      return {};
+    }
+  }
+
+  return { default: MissingImageDockerode };
+});
+
+let previousDockerConfig: string | undefined;
+
+function dockerConfig(config: Record<string, unknown>): string {
+  const directory = mkdtempSync(join(tmpdir(), "openship-pull-auth-"));
+  writeFileSync(join(directory, "config.json"), JSON.stringify(config), { mode: 0o600 });
+  return directory;
+}
+
+beforeEach(() => {
+  previousDockerConfig = process.env.DOCKER_CONFIG;
+  h.pulls.length = 0;
+  h.progressError = null;
+});
+
+afterEach(() => {
+  if (previousDockerConfig === undefined) delete process.env.DOCKER_CONFIG;
+  else process.env.DOCKER_CONFIG = previousDockerConfig;
+});
+
+describe("DockerRuntime.pullImage registry authentication", () => {
+  it("passes matching Docker config credentials to dockerode", async () => {
+    process.env.DOCKER_CONFIG = dockerConfig({
+      auths: {
+        "ghcr.io": { auth: Buffer.from("pull-user:pull-secret").toString("base64") },
+      },
+    });
+    const { DockerRuntime } = await import("./docker");
+    const runtime = await DockerRuntime.create({ dockerSocketPath: "/tmp/docker.sock" });
+
+    await runtime.pullImage("ghcr.io/example/private:immutable", { force: true });
+
+    expect(h.pulls).toEqual([
+      {
+        ref: "ghcr.io/example/private:immutable",
+        options: {
+          authconfig: {
+            username: "pull-user",
+            password: "pull-secret",
+            serveraddress: "ghcr.io",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("rejects helper-backed credentials unavailable in the API container", async () => {
+    process.env.DOCKER_CONFIG = dockerConfig({
+      credHelpers: { "ghcr.io": "desktop" },
+      auths: {
+        "ghcr.io": { auth: Buffer.from("fallback-user:fallback-secret").toString("base64") },
+      },
+    });
+    const { DockerRuntime } = await import("./docker");
+    const runtime = await DockerRuntime.create({ dockerSocketPath: "/tmp/docker.sock" });
+
+    await expect(
+      runtime.pullImage("ghcr.io/example/private:immutable", { force: true }),
+    ).rejects.toThrow("Docker credential helper is unavailable for ghcr.io; use inline auths");
+
+    expect(h.pulls).toHaveLength(0);
+  });
+
+  it("rejects global helper stores unavailable in the API container", async () => {
+    process.env.DOCKER_CONFIG = dockerConfig({ credsStore: "desktop" });
+    const { DockerRuntime } = await import("./docker");
+    const runtime = await DockerRuntime.create({ dockerSocketPath: "/tmp/docker.sock" });
+
+    await expect(
+      runtime.pullImage("example/private:immutable", { force: true }),
+    ).rejects.toThrow("Docker credential helper is unavailable for docker.io; use inline auths");
+
+    expect(h.pulls).toHaveLength(0);
+  });
+
+  it("does not read local Docker credentials for SSH executor pulls", async () => {
+    const directory = dockerConfig({});
+    writeFileSync(join(directory, "config.json"), "not-json", { mode: 0o600 });
+    process.env.DOCKER_CONFIG = directory;
+    const executor = { exec: vi.fn(async () => "") };
+    const { DockerRuntime } = await import("./docker");
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntimeType & {
+      connectionOptions: { executor: typeof executor };
+    };
+    Object.defineProperty(runtime, "connectionOptions", { value: { executor } });
+
+    await runtime.pullImage("ghcr.io/example/private:immutable", { force: true });
+
+    expect(executor.exec).toHaveBeenCalledWith(
+      "docker pull 'ghcr.io/example/private:immutable'",
+      { timeout: 10 * 60_000 },
+    );
+    expect(h.pulls).toHaveLength(0);
+  });
+
+  it("does not surface configured credential-helper details", async () => {
+    const helper = "sentinel-helper-name";
+    process.env.DOCKER_CONFIG = dockerConfig({ credHelpers: { "ghcr.io": helper } });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { DockerRuntime } = await import("./docker");
+    const runtime = await DockerRuntime.create({ dockerSocketPath: "/tmp/docker.sock" });
+
+    let surfaced = "";
+    try {
+      await runtime.pullImage("ghcr.io/example/private:immutable", { force: true });
+    } catch (error) {
+      surfaced = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(surfaced).toMatch(/credential helper is unavailable for ghcr\.io/i);
+    expect(surfaced).not.toContain(helper);
+    expect(h.pulls).toHaveLength(0);
+    expect(JSON.stringify([...errorSpy.mock.calls, ...warnSpy.mock.calls])).not.toContain(helper);
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("does not surface credential material from a Docker pull failure", async () => {
+    const secret = "sentinel-registry-secret";
+    process.env.DOCKER_CONFIG = dockerConfig({
+      auths: { "ghcr.io": { auth: Buffer.from(`pull-user:${secret}`).toString("base64") } },
+    });
+    h.progressError = new Error(`registry rejected password ${secret}`);
+    const { DockerRuntime } = await import("./docker");
+    const runtime = await DockerRuntime.create({ dockerSocketPath: "/tmp/docker.sock" });
+
+    let surfaced = "";
+    try {
+      await runtime.pullImage("ghcr.io/example/private:immutable", { force: true });
+    } catch (error) {
+      surfaced = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(surfaced).toMatch(/failed to pull image from ghcr\.io/i);
+    expect(surfaced).not.toContain(secret);
+  });
+});

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -101,6 +101,7 @@ function clampShellWindow(
 import type { Feature, SystemLog } from "../system/types";
 import { isRuntimeNotFoundError } from "../system/errors";
 import { dirOf, ensureOwnedDir } from "../system/elevated-executor";
+import { registryForImage, resolveDockerAuth } from "./docker-auth";
 
 import type {
   RuntimeAdapter,
@@ -3001,10 +3002,15 @@ export class DockerRuntime implements RuntimeAdapter {
       await executor.exec(`docker pull ${sq(ref)}`, { timeout: 10 * 60_000 });
       return;
     }
-    const stream = await this.docker.pull(ref);
-    await new Promise<void>((resolve, reject) => {
-      this.docker.modem.followProgress(stream, (err) => (err ? reject(err) : resolve()));
-    });
+    const authconfig = await resolveDockerAuth(ref);
+    try {
+      const stream = await this.docker.pull(ref, authconfig ? { authconfig } : {});
+      await new Promise<void>((resolve, reject) => {
+        this.docker.modem.followProgress(stream, (err) => (err ? reject(err) : resolve()));
+      });
+    } catch {
+      throw new Error(`Failed to pull image from ${registryForImage(ref)}`);
+    }
   }
 
   /** Is this image tag present on THIS daemon? Distinguishes a locally-built


### PR DESCRIPTION
## Summary

Authenticate local Docker Engine image pulls from API-readable Docker CLI configuration and mount that configuration into only the API service.

## Motivation

Private image deployments fail because local dockerode pulls omit `authconfig`, even when Docker CLI authentication exists on the host. Pull and credential errors also need to remain redacted.

## Related issue

Fixes #581

## Changes

- resolve matching inline basic or identity-token credentials from Docker CLI `config.json`
- pass resolved credentials to `docker.pull(ref, { authconfig })`
- leave SSH-executor pulls unchanged and isolated from local credentials
- fail closed when matching `credHelpers` or global `credsStore` cannot run in the API image
- redact credential and Docker progress details from surfaced pull errors
- mount an existing regular Docker config into only the API service using read-only Compose long bind syntax
- add focused runtime and Compose regression coverage

## Verification

- `bun run --cwd packages/adapters test src/runtime/docker-pull-auth.test.ts` — 1 file, 6 tests passed
- `bun run --cwd apps/cli test test/unit/compose-source-build.test.ts` — 1 file, 11 tests passed
- `bun run --cwd packages/adapters lint` — passed
- `bun run --cwd apps/cli lint` — passed
- full adapters suite — 132 files, 2862 tests passed
- full API suite — 332 files, 3931 passed, 3 skipped
- API lint/typecheck — passed
- root build — passed
- full CLI suite — 32 files passed and 1 unrelated pre-existing timeout in `test/unit/ports.test.ts`; neither that test nor its implementation is modified

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] A real regression test was observed failing before the production change
- [x] Focused tests pass
- [x] Changed workspaces typecheck
- [x] No credentials, deployment identifiers, or private environment data are included
- [ ] Live API-image deployment verification complete
- [ ] Full root test gate is green without the unrelated CLI timeout