### PR TITLE
fix(auth): resolve the merge conflict markers committed in v0.6.6

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -415,9 +415,6 @@ export const auth = betterAuth({
         // types are not enabled, so they fall through and send nothing.
         if (type === "email-verification") {
           const tmpl = verifyOtpEmailTemplate(otp, { expiresMinutes: 10 });
-<<<<<<< HEAD
-          await sendMail({ to: email, ...tmpl });
-=======
           if (!(await sendMail({ to: email, ...tmpl }))) {
             throw new APIError("SERVICE_UNAVAILABLE", {
               message:
@@ -425,7 +422,6 @@ export const auth = betterAuth({
                 "email transport. Configure SMTP in Settings → Email.",
             });
           }
->>>>>>> a52e2566 (patch v0.6.6)
           return;
         }
         // Password reset. This replaced the link flow (`sendResetPassword` in the


### PR DESCRIPTION
apps/api/src/lib/auth.ts carries unresolved conflict markers from the
v0.6.6 patch, so `tsc --noEmit` fails with TS1185 and the API workspace
does not compile. CI runs that typecheck, so main is red and so is every
pull request opened against it.

Kept the v0.6.6 side, which is the change that patch was making and the
behaviour the sibling forget-password branch a few lines below already
implements: sendMail returns a boolean, and a verification code that was
never delivered has to fail loudly rather than tell the user to check an
inbox that will stay empty.

Verified: bun run --cwd apps/api lint is clean again, and the apps/api
lib suite passes (90 files, 1376 tests).


Noticed while rebasing another branch: the API workspace stopped compiling
on main. CI runs `bun run --cwd apps/api lint` (tsc --noEmit), so this is
currently failing on main and on every open pull request against it.

I kept the v0.6.6 side of the conflict because that is the change the patch
was making, and because the sibling forget-password branch a few lines below
already implements exactly that pattern: sendMail returns a boolean, and a
verification code that was never delivered should fail loudly rather than
tell the user to check an inbox that stays empty.

Happy to flip it to the other side instead if the intent was different.
