### PR TITLE
fix(auth): resolve the conflict markers left in the verification OTP path

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -415,9 +415,6 @@ export const auth = betterAuth({
         // types are not enabled, so they fall through and send nothing.
         if (type === "email-verification") {
           const tmpl = verifyOtpEmailTemplate(otp, { expiresMinutes: 10 });
-<<<<<<< HEAD
-          await sendMail({ to: email, ...tmpl });
-=======
           if (!(await sendMail({ to: email, ...tmpl }))) {
             throw new APIError("SERVICE_UNAVAILABLE", {
               message:
@@ -425,7 +422,6 @@ export const auth = betterAuth({
                 "email transport. Configure SMTP in Settings → Email.",
             });
           }
->>>>>>> a52e2566 (patch v0.6.6)
           return;
         }
         // Password reset. This replaced the link flow (`sendResetPassword` in the


### PR DESCRIPTION
Fixes #594.

`74ec3f72` ("patch v0.6.6") committed unresolved merge conflict markers into `apps/api/src/lib/auth.ts`, in the `emailOTP` plugin's `sendVerificationOTP`. `main` has not typechecked since.

## Before

```
$ bun run lint
src/lib/auth.ts(418,1): error TS1185: Merge conflict marker encountered.
src/lib/auth.ts(420,1): error TS1185: Merge conflict marker encountered.
src/lib/auth.ts(428,1): error TS1185: Merge conflict marker encountered.
```

esbuild also cannot parse the file, so **48 API test files fail at transform time** — everything that reaches `auth.ts` through `middleware/auth.ts`.

## After

```
$ bun run lint          # apps/api
# clean, exit 0

$ bun run test          # apps/api
Test Files  354 passed | 1 failed (355)
     Tests  4158 passed | 1 failed | 3 skipped (4162)
```

The one remaining failure is `service-exec-isolation.test.ts` hitting the 20s test timeout under full-suite load; it passes in isolation in ~8s and is unrelated to this change. `packages/core` is 608/608.

## Which side this keeps

The fail-loudly one:

```ts
if (!(await sendMail({ to: email, ...tmpl }))) {
  throw new APIError("SERVICE_UNAVAILABLE", { ... });
}
```

That is already what the `forget-password` branch does a few lines below in the same function, and its comment states the reasoning: `sendMail` returns silently when no transport is configured, so without the result check the user is told to check their inbox for a code that was never sent. The discarded `HEAD` side was the older fire-and-forget call that v0.6.6 was in the process of replacing.

Four deleted lines, no behavior change beyond removing the markers. No test asserted the silent behavior.

## Not addressed here

#594 also notes that #586 merged with `Typecheck` and `Test` red. This PR only unbreaks `main`; the branch protection gap that allowed it is left for a separate discussion.
