### PR TITLE
fix(api): scope the terminal WS upgrade to the ticket's organization

### DIFF
--- a/apps/api/src/modules/terminal/terminal.controller.ts
+++ b/apps/api/src/modules/terminal/terminal.controller.ts
@@ -180,23 +180,24 @@ export const terminalWsHandler = upgradeWebSocket(async (c) => {
   let ticketServerId: string | null = null;
   // Resolve activeOrganizationId here — the WS upgrade route deliberately
   // skips the HTTP authMiddleware (auth happens inside this factory), so
-  // it's not pre-set on the Hono context. We mirror the middleware's
-  // logic: prefer session.activeOrganizationId, fall back to the user's
-  // oldest membership.
-  // not ctx-scoped: WebSocket upgrade path. This route runs OUTSIDE
-  // the normal Hono auth middleware (Bun WS doesn't carry the same
-  // request lifecycle), so it has to re-derive the active org from
-  // scratch. Both branches funnel through resolveActiveOrganizationId
-  // (the canonical resolver from middleware/active-organization.ts) so
-  // the WS path applies the same team-org-preferred + memberships[0]
-  // fallback as every other authed request — no behavior drift.
+  // it's not pre-set on the Hono context. Two paths, mirroring the
+  // sibling service-terminal controller:
+  //   - Ticket path: the ticket carries (userId, orgId, serverId) baked
+  //     in at mint time, when authMiddleware HAD resolved the org. Use
+  //     that org — re-deriving it here would scope the socket to a
+  //     different tenant than the one the mint-time checks passed in.
+  //   - Cookie path: no ticket, so re-derive from the session through
+  //     resolveActiveOrganizationId (the canonical resolver from
+  //     middleware/active-organization.ts), applying the same
+  //     team-org-preferred + memberships[0] fallback as every other
+  //     authed request.
   // Foreground non-WS callers must NOT duplicate this pattern — they
   // read ctx.organizationId, which authMiddleware already populated.
   let activeOrgId: string | null = null;
   if (ticket) {
     userId = ticket.userId;
     ticketServerId = ticket.serverId;
-    activeOrgId = await resolveActiveOrganizationId(userId, null).catch(() => null);
+    activeOrgId = ticket.organizationId;
   } else {
     try {
       const session = await auth.api.getSession({ headers: c.req.raw.headers });

--- a/apps/api/test/modules/terminal/terminal.controller.test.ts
+++ b/apps/api/test/modules/terminal/terminal.controller.test.ts
@@ -47,7 +47,11 @@ const terminalSession = vi.hoisted(() => {
   };
 });
 
-vi.mock("@repo/db", () => ({ repos: { terminalSession } }));
+const server = vi.hoisted(() => ({
+  getInOrganization: vi.fn(async (_serverId: string, _orgId: string) => null),
+}));
+
+vi.mock("@repo/db", () => ({ repos: { terminalSession, server } }));
 vi.mock("../../../src/lib/ws", () => ({
   upgradeWebSocket: (fn: unknown) => fn,
 }));
@@ -57,8 +61,25 @@ vi.mock("../../../src/lib/auth", () => ({
 vi.mock("../../../src/lib/ssh-manager", () => ({
   sshManager: { retain: vi.fn(), release: vi.fn() },
 }));
+vi.mock("../../../src/lib/permission", () => ({
+  permission: { assert: vi.fn() },
+  checkPermission: vi.fn(async () => true),
+}));
+// The user's fallback org — what the WS path used to resolve to, and must
+// no longer, when a ticket minted in a different org is presented.
+vi.mock("../../../src/middleware/active-organization", () => ({
+  resolveActiveOrganizationId: vi.fn(async () => "org_fallback"),
+}));
 
-import { teardown, type ConnState } from "../../../src/modules/terminal/terminal.controller";
+import {
+  teardown,
+  terminalWsHandler,
+  type ConnState,
+} from "../../../src/modules/terminal/terminal.controller";
+import { issueTerminalTicket } from "../../../src/lib/terminal-session-manager";
+import { checkPermission } from "../../../src/lib/permission";
+import { trustedOrigins } from "../../../src/config/env";
+import type { RequestContext } from "../../../src/lib/request-context";
 
 function fakeShell(): ShellSession {
   return {
@@ -169,5 +190,53 @@ describe("terminal.controller teardown", () => {
     // A second call (e.g. onClose after shell exit) must not re-close the row.
     await teardown(state, "client_close", null, false, true);
     expect(terminalSession.close).toHaveBeenCalledOnce();
+  });
+});
+
+/** Minimal Hono-context stand-in for the WS upgrade factory. */
+function fakeUpgradeContext(token: string, serverId: string) {
+  const headers: Record<string, string> = {
+    origin: trustedOrigins[0]!,
+    "sec-websocket-protocol": `openship.terminal.v1+${token}`,
+  };
+  return {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+      param: (name: string) => (name === "serverId" ? serverId : undefined),
+      raw: { headers: new Headers() },
+    },
+    var: { clientIp: null },
+  };
+}
+
+describe("terminal.controller WS upgrade", () => {
+  it("scopes the socket to the ticket's org, not the user's fallback org", async () => {
+    // Ticket minted while the user was acting in org_ticket (the mint
+    // endpoint runs under authMiddleware, so ctx.organizationId is real).
+    const { token } = issueTerminalTicket(
+      { userId: "user_1", organizationId: "org_ticket" } as RequestContext,
+      "server_1",
+    );
+    server.getInOrganization.mockResolvedValue({
+      id: "server_1",
+    } as unknown as null);
+
+    const handler = terminalWsHandler as unknown as (
+      c: unknown,
+    ) => Promise<unknown>;
+    await handler(fakeUpgradeContext(token, "server_1"));
+
+    // Both tenant gates must see the ticket's org. Resolving the org from
+    // the user's memberships instead sends a member of several orgs to
+    // whichever one sorts first, and every server outside it 404s.
+    expect(checkPermission).toHaveBeenCalledWith("user_1", "org_ticket", {
+      resourceType: "server",
+      resourceId: "server_1",
+      action: "admin",
+    });
+    expect(server.getInOrganization).toHaveBeenCalledWith(
+      "server_1",
+      "org_ticket",
+    );
   });
 });


### PR DESCRIPTION
## Summary

The terminal WebSocket upgrade throws away the organization its auth ticket was minted with and re-derives one from the user's memberships. For a user who belongs to more than one organization that lands on the wrong tenant, so opening a shell on any server outside it closes with `4404` / **"Server not found."** — moments after `POST /api/terminal/ticket` returned `200` for that same server.

## Motivation

Opening a server terminal is a two-step handshake:

1. `POST /api/terminal/ticket` runs under `authMiddleware`, so `ctx.organizationId` is the org the user is actually working in. It checks `server:admin` and the org-scoped server lookup, then mints a ticket binding `(userId, organizationId, serverId)`.
2. The WS upgrade consumes that ticket. It runs outside `authMiddleware`, so it resolves the org itself — and in the ticket branch it ignored the ticket's org:

```ts
activeOrgId = await resolveActiveOrganizationId(userId, null).catch(() => null);
```

Passing `null` as `sessionOrgId` skips step 1 of the resolver ("the org on the session") and falls through to *the user's first team org*. So the socket is scoped to whichever org sorts first, not the workspace the user was in. `checkPermission` and `repos.server.getInOrganization` then both run against that org, the lookup misses, and `openInitFailure("server_not_found", …, 4404)` fires.

Consequences:

- A user in N organizations can only ever open a terminal on servers in one of them. The dashboard offers no clue why — the WS closes with the same `server_not_found` shape used for permission denial, so it reads as "this server doesn't exist".
- It is org-count dependent, which is why it isn't caught by single-org setups: with one membership the fallback happens to pick the right org.
- The ticket that *did* pass the mint-time checks is reduced to carrying a `userId`, defeating the point of binding a tenant into it.

`terminal-session-manager.ts` already documents the intended contract on the `Ticket` type:

> Org the user was acting in at mint time. The WS upgrade scopes every downstream check (permission, server existence, audit) to this org — NOT to whatever org the user happens to be in at consume time. Mint and consume share the same tenant.

The sibling service-terminal module implements exactly that (`service-terminal.controller.ts`: `activeOrgId = ticket.organizationId;`). This brings the server-terminal module in line with both.

Reproduced on a self-hosted v0.6.5 instance with two organizations: every server in the older org opens a shell, every server in the newer one fails with "Server not found." — and `terminal_sessions` has never had a row for the second org. The line is unchanged in v0.6.1 → v0.6.6 and on `main`.

## Related issue

None.

## Changes

**apps/api**

- `src/modules/terminal/terminal.controller.ts` — the ticket branch of the WS upgrade now uses `ticket.organizationId` instead of re-resolving from memberships. The cookie-fallback branch is untouched: with no ticket there is no minted org to trust, so it still goes through `resolveActiveOrganizationId` with the session's org. Reworded the comment above the block, which described the old both-branches-re-resolve behavior.
- `test/modules/terminal/terminal.controller.test.ts` — regression test driving the real upgrade factory with a ticket minted in `org_ticket` while `resolveActiveOrganizationId` is stubbed to return a different org, asserting both tenant gates (`checkPermission`, `repos.server.getInOrganization`) receive the ticket's org.

## Verification

Node v26.7.0, Bun 1.3.14.

```bash
# 1. The new test on unmodified main (fix reverted, test kept) — fails:
$ bun run --cwd apps/api test -- test/modules/terminal/terminal.controller.test.ts
 ✓ closes the audit row when a parked session is later force-closed by timeout
 ✓ rejects stale shell.onClose from a previous WebSocket after a resume
 ✓ is idempotent when force-close is triggered twice
 × scopes the socket to the ticket's org, not the user's fallback org
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected "vi.fn()" to be called with arguments: [ 'user_1', 'org_ticket', { …(3) } ]
      Tests  1 failed | 3 passed (4)

# 2. With the fix — passes:
$ bun run --cwd apps/api test -- test/modules/terminal/terminal.controller.test.ts
 ✓ test/modules/terminal/terminal.controller.test.ts (4 tests) 12ms
 Test Files  1 passed (1)
      Tests  4 passed (4)

# 3. Full API suite:
$ bun run --cwd apps/api test
 Test Files  376 passed (376)
      Tests  4480 passed | 3 skipped (4483)

# 4. Typecheck:
$ bun run --cwd apps/api lint        # tsc --noEmit → exit 0
```

Two notes, so nothing is overstated:

- `bun run test` (root) also reports 3 failures in `apps/cli` — `test/e2e/completion.test.ts` asserts an empty stderr, and Node 26 prints `[DEP0205] DeprecationWarning: module.register() is deprecated`. Those reproduce on unmodified `main` with this change stashed; they are unrelated to this PR.
- `bun format` (root) rewrites lines in both touched files that were already drifted on `main`, so I did not run it repo-wide. `prettier --check` is clean on every line this PR adds; the pre-existing drift is left alone to keep the diff scoped.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it (or I explained above why there isn't one)
- [x] `bun run test`, `bun run --cwd <workspace> lint`, and `bun format` all pass locally — with the two caveats noted under Verification
- [x] I understand every line of this diff and can explain it in review
