### PR TITLE
fix(dashboard): stop swallowing build-page load errors as 'not found'

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/(deployment)/build/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(deployment)/build/[id]/page.tsx
@@ -10,8 +10,9 @@ import ComposeDeploymentProcessing from "@/components/import-project/ComposeDepl
 import BuildSkeleton from "@/components/import-project/BuildSkeleton";
 import { useAuth } from "@/context/AuthContext";
 import { useI18n } from "@/components/i18n-provider";
+import { BUILD_SESSION_ERROR_FALLBACK } from "@/context/deployment/load-session";
 import { ResourceNotFound } from "@/components/resource-not-found";
-import { Rocket, Home, PackageX } from "lucide-react";
+import { Rocket, Home, PackageX, RotateCcw, TriangleAlert } from "lucide-react";
 
 const BuildPage: React.FC = () => {
   const params = useParams();
@@ -23,6 +24,13 @@ const BuildPage: React.FC = () => {
   const { t } = useI18n();
   const initializedDeploymentRef = useRef<string | null>(null);
   const [notFound, setNotFound] = useState(false);
+  /** Load failure that is NOT a missing deployment — a hydration exception,
+   *  5xx, or network error while the deployment usually exists (#604). Rendered
+   *  as an error state with a retry, never as "not found". */
+  const [loadError, setLoadError] = useState<string | null>(null);
+  /** Bumped by the error state's retry so the init effect re-runs for the same
+   *  deployment id (the `initializedDeploymentRef` guard alone would ignore it). */
+  const [loadRetryNonce, setLoadRetryNonce] = useState(0);
   /** Ref tracking which (deploymentId × errorCode) tuple already opened
    *  the modal — prevents reopening on every re-render. */
   const shownModalRef = useRef<string | null>(null);
@@ -60,7 +68,15 @@ const BuildPage: React.FC = () => {
       }
       const result = await loadBuildSession(deploymentId);
       if (!result.success) {
-        setNotFound(true);
+        // Only the server saying "this doesn't exist" (soft-failed status or
+        // HTTP 404) renders the not-found screen. Anything else — a throw while
+        // hydrating a successful response, a 5xx, a network blip — keeps the
+        // deployment one retry away instead of presenting it as deleted (#604).
+        if (result.notFound) {
+          setNotFound(true);
+        } else {
+          setLoadError(result.error || BUILD_SESSION_ERROR_FALLBACK);
+        }
       }
     };
 
@@ -75,7 +91,16 @@ const BuildPage: React.FC = () => {
     loadBuildSession,
     router,
     searchParams,
+    loadRetryNonce,
   ]);
+
+  // Retry a failed (non-not-found) load: clear the error, release the init
+  // guard, and re-run the effect via the nonce.
+  const retryLoadSession = useCallback(() => {
+    setLoadError(null);
+    initializedDeploymentRef.current = null;
+    setLoadRetryNonce((n) => n + 1);
+  }, []);
 
   // Handle redeploy with URL update.
   //
@@ -131,6 +156,42 @@ const BuildPage: React.FC = () => {
     });
     if (opened) shownModalRef.current = key;
   }, [state.deploymentFailed, state.errorCode, deploymentId, maybeOpenCredentialModal, handleRedeploy]);
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background p-6">
+        <ResourceNotFound
+          icon={<TriangleAlert className="size-7" />}
+          title={t.chrome.error.title}
+          description={
+            <>
+              {t.chrome.error.description}
+              <span className="mt-1 block break-all font-mono text-xs opacity-80">{loadError}</span>
+            </>
+          }
+          detail={deploymentId}
+          detailCopyLabel={t.chrome.notFound.copyId}
+          actions={[
+            {
+              label: t.chrome.error.tryAgain,
+              icon: <RotateCcw className="size-4" />,
+              onClick: retryLoadSession,
+            },
+            {
+              href: "/deployments",
+              label: t.misc.buildPage.viewDeployments,
+              icon: <Rocket className="size-4" />,
+            },
+            {
+              href: "/",
+              label: t.misc.buildPage.goHome,
+              variant: "secondary",
+            },
+          ]}
+        />
+      </div>
+    );
+  }
 
   if (notFound) {
     return (

--- a/apps/dashboard/src/context/deployment/load-session.test.ts
+++ b/apps/dashboard/src/context/deployment/load-session.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/api/client";
+import {
+  BUILD_SESSION_ERROR_FALLBACK,
+  classifyBuildSessionFailure,
+  hydrateSnapshotServices,
+} from "./load-session";
+import { normalizeComposeService, type ComposeServiceInfo } from "./types";
+
+/**
+ * The build page must not render "not found" for a deployment that exists
+ * (#604). These pin the two halves of that fix:
+ *
+ * 1. only the server saying "404" classifies as not-found — a hydration
+ *    exception, a 5xx, or a network failure is a load error with a retry;
+ * 2. an empty `composeServices` snapshot no longer blanks a populated
+ *    service list.
+ */
+
+const svc = (name: string, serviceId?: string): ComposeServiceInfo =>
+  normalizeComposeService({ name, ...(serviceId ? { id: serviceId } : {}) });
+
+describe("classifyBuildSessionFailure", () => {
+  it("marks an HTTP 404 from the API as not-found", () => {
+    const out = classifyBuildSessionFailure(
+      new ApiError(404, "Not Found", { message: "Deployment not found" }),
+    );
+    expect(out.notFound).toBe(true);
+    expect(out.error).toBe("Deployment not found");
+  });
+
+  it("treats a 5xx as a load failure, not a missing deployment", () => {
+    // The backend maps internal failures to 500 precisely so they don't read
+    // as "not found"; the client must not undo that at the last step.
+    const out = classifyBuildSessionFailure(
+      new ApiError(500, "Internal Server Error", { message: "boom" }),
+    );
+    expect(out.notFound).toBe(false);
+  });
+
+  it("treats a client-side hydration exception as a load failure", () => {
+    // A throw while restoring config into state (the reported case: any
+    // exception inside the try) is never evidence the resource is gone.
+    const out = classifyBuildSessionFailure(new TypeError("cannot read properties of undefined"));
+    expect(out.notFound).toBe(false);
+    expect(out.error).toBe("cannot read properties of undefined");
+  });
+
+  it("treats a network-level failure as a load failure", () => {
+    const out = classifyBuildSessionFailure(new TypeError("fetch failed"));
+    expect(out.notFound).toBe(false);
+  });
+
+  it("falls back to the standard message for unrecognized throws", () => {
+    const out = classifyBuildSessionFailure("stray string");
+    expect(out.notFound).toBe(false);
+    expect(out.error).toBe(BUILD_SESSION_ERROR_FALLBACK);
+  });
+});
+
+describe("hydrateSnapshotServices", () => {
+  const loaded = [svc("app", "s_app"), svc("postgres", "s_pg")];
+
+  it("keeps the loaded list when the snapshot ships an empty composeServices array", () => {
+    // #604: a `services`-type deploy reports `composeServices: []` while its
+    // real services live elsewhere in the payload — `[]` is an Array, so the
+    // old guard blanked the list instead of falling back.
+    expect(hydrateSnapshotServices([], loaded)).toBe(loaded);
+  });
+
+  it("keeps the loaded list when the snapshot carries no composeServices at all", () => {
+    expect(hydrateSnapshotServices(undefined, loaded)).toBe(loaded);
+    expect(hydrateSnapshotServices(null, loaded)).toBe(loaded);
+  });
+
+  it("normalizes a populated snapshot and carries ids from the loaded rows", () => {
+    const out = hydrateSnapshotServices([{ name: "app", image: "ghcr.io/app" } as never], loaded);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("app");
+    expect(out[0].image).toBe("ghcr.io/app");
+    // The snapshot carries no service-row ids; the loaded rows' ids survive.
+    expect(out[0].serviceId).toBe("s_app");
+  });
+
+  it("returns an empty list when there is nothing to fall back to", () => {
+    expect(hydrateSnapshotServices([], [])).toEqual([]);
+  });
+});

--- a/apps/dashboard/src/context/deployment/load-session.ts
+++ b/apps/dashboard/src/context/deployment/load-session.ts
@@ -1,0 +1,71 @@
+import { ApiError, getApiErrorMessage } from "@/lib/api/client";
+import {
+  carryServiceIds,
+  normalizeComposeService,
+  type ComposeServiceInfo,
+  type RawComposeService,
+} from "./types";
+
+/**
+ * Failure-mode separation for the build page (#604).
+ *
+ * `loadBuildSession` used to collapse every failure into
+ * `{ success: false }`, and the page rendered its one branch for that —
+ * `ResourceNotFound` — for ALL of them. So a client-side exception while
+ * hydrating a SUCCESSFUL response (the reporter's 3-service `services` deploy
+ * hydrating an empty `composeServices`, or any other throw in the ~200-line
+ * restore) presented an existing, ready deployment as "not found".
+ *
+ * That undoes an invariant the backend deliberately establishes
+ * (deployment.controller.ts): a genuine miss is a 404, and everything else is
+ * surfaced as a 500 precisely so it can't be swallowed as a UI "not found".
+ * These helpers restore the distinction on the client.
+ */
+export interface BuildSessionLoadResult {
+  success: boolean;
+  /** `true` ONLY when the server itself said the deployment isn't there — a
+   *  soft-failed status response or an HTTP 404. Never set for a client-side
+   *  hydration exception, a 5xx, or a network failure: those mean "couldn't
+   *  load", not "doesn't exist", and a retry can succeed. */
+  notFound?: boolean;
+  error?: string;
+}
+
+export const BUILD_SESSION_ERROR_FALLBACK = "Failed to load build session";
+
+/**
+ * Classify a thrown failure from `loadBuildSession`'s catch: only an HTTP 404
+ * from the API counts as "the deployment does not exist".
+ */
+export function classifyBuildSessionFailure(err: unknown): {
+  notFound: boolean;
+  error: string;
+} {
+  return {
+    notFound: err instanceof ApiError && err.status === 404,
+    error: getApiErrorMessage(err, BUILD_SESSION_ERROR_FALLBACK),
+  };
+}
+
+/**
+ * Hydrate `config.services` from the deployment snapshot's `composeServices`.
+ *
+ * An EMPTY array must not blank an already-populated list: the API ships
+ * `composeServices: []` for `projectType: "services"` deployments that report
+ * their services through `services`/`serviceStatuses` instead (#604), and the
+ * old `Array.isArray(...)` guard happily replaced a 3-service list with `[]`.
+ * Empty or absent falls back to what's already loaded — same as the non-array
+ * case always did.
+ */
+export function hydrateSnapshotServices(
+  composeServices: unknown,
+  prevServices: ComposeServiceInfo[],
+): ComposeServiceInfo[] {
+  if (!Array.isArray(composeServices) || composeServices.length === 0) {
+    return prevServices;
+  }
+  return carryServiceIds(
+    (composeServices as RawComposeService[]).map(normalizeComposeService),
+    prevServices,
+  );
+}

--- a/apps/dashboard/src/context/deployment/types.ts
+++ b/apps/dashboard/src/context/deployment/types.ts
@@ -3,6 +3,7 @@ import type { FrameworkId, EnvironmentVariable } from "@/components/import-proje
 import type { PrepareComposeService, PrepareSingleAppCandidate } from "@/lib/api/deploy";
 import { getBuildImage, STACKS, resolveWorkload, type WorkloadType, type ProjectType, type BuildStrategy, type DeployTarget, type RuntimeMode, type StackId, type RoutingConfig, type OpenshipReadiness, type ResourceTier as CoreResourceTier } from "@repo/core";
 import type { BuildLog } from "@/utils/deploymentPhaseDetector";
+import type { BuildSessionLoadResult } from "./load-session";
 import { randomUUID } from "@/lib/random-uuid";
 
 // ─── Monorepo sub-app ────────────────────────────────────────────────────────
@@ -895,7 +896,7 @@ export interface DeploymentContextType {
   // Build lifecycle
   startDeployment: (overrides?: { runtimeMode?: RuntimeMode; buildStrategy?: BuildStrategy; saveConfigOnly?: boolean }) => Promise<string | null>;
   connectToBuild: (deploymentId?: string, startBuild?: boolean) => Promise<void>;
-  loadBuildSession: (deploymentId: string) => Promise<{ success: boolean; error?: string }>;
+  loadBuildSession: (deploymentId: string) => Promise<BuildSessionLoadResult>;
   stopDeployment: () => Promise<void>;
   redeploy: (deploymentId: string) => Promise<string | null>;
   respondToPrompt: (action: string) => Promise<void>;

--- a/apps/dashboard/src/context/deployment/useDeploymentBuild.tsx
+++ b/apps/dashboard/src/context/deployment/useDeploymentBuild.tsx
@@ -22,15 +22,18 @@ import {
   BUILD_PHASES,
   DEFAULT_CONFIG,
   INITIAL_STATE,
-  carryServiceIds,
   ensurePublicEndpoints,
-  normalizeComposeService,
   resolveBuildElapsedMs,
   syncPublicEndpointState,
   usesServiceDeployment,
   workloadOf,
 } from "./types";
-import type { RawComposeService } from "./types";
+import {
+  BUILD_SESSION_ERROR_FALLBACK,
+  classifyBuildSessionFailure,
+  hydrateSnapshotServices,
+  type BuildSessionLoadResult,
+} from "./load-session";
 import type { WorkloadType } from "@repo/core";
 import {
   deployErrorCloudCapability,
@@ -1086,7 +1089,7 @@ export function useDeploymentBuild(
   ]);
 
   const loadBuildSession = useCallback(
-    async (deploymentId: string): Promise<{ success: boolean; error?: string }> => {
+    async (deploymentId: string): Promise<BuildSessionLoadResult> => {
       try {
         lastErrorRef.current = null;
 
@@ -1100,9 +1103,13 @@ export function useDeploymentBuild(
         const data = await deployApi.getBuildStatus(deploymentId);
 
         if (!data.success) {
-          const errorMessage = data.error || "Failed to load build session";
+          const errorMessage = data.error || BUILD_SESSION_ERROR_FALLBACK;
           showToast(errorMessage, "error", "Error");
-          return { success: false, error: errorMessage };
+          // The server answered and said no: the only arm that legitimately
+          // renders the page's "not found" state (a genuine miss comes through
+          // here as a soft failure or, more often, as the 404 classified in the
+          // catch below). Everything else must stay distinguishable from it.
+          return { success: false, notFound: true, error: errorMessage };
         }
 
         // Restore config from session
@@ -1188,15 +1195,13 @@ export function useDeploymentBuild(
             // "Edit Configuration" — so the compose wizard shows them even when
             // the service table is empty (e.g. a deploy that failed before its
             // rows were persisted). Falls back to whatever's already loaded.
-            // `carryServiceIds`: the snapshot has no service-row ids, and this assignment
-            // REPLACES the list — so without it, hydrating here after the rows had loaded
-            // dropped the ids the env editor needs to reveal stored values.
-            services: Array.isArray(data.composeServices)
-              ? carryServiceIds(
-                  (data.composeServices as RawComposeService[]).map(normalizeComposeService),
-                  prev.services,
-                )
-              : prev.services,
+            // `carryServiceIds` (inside the helper): the snapshot has no service-row ids,
+            // and this assignment REPLACES the list — so without it, hydrating here after
+            // the rows had loaded dropped the ids the env editor needs to reveal stored
+            // values. The helper also falls back to the loaded list when the snapshot ships
+            // an EMPTY array, which a `services`-type deploy does (#604): `[]` must not
+            // blank a populated list.
+            services: hydrateSnapshotServices(data.composeServices, prev.services),
             options: {
               buildCommand: apiConfig.buildCommand || prev.options.buildCommand,
               outputDirectory: apiConfig.outputDirectory || prev.options.outputDirectory,
@@ -1327,9 +1332,14 @@ export function useDeploymentBuild(
         return { success: true };
       } catch (err) {
         console.error("Error loading build session:", err);
-        const errorMessage = getApiErrorMessage(err, "Failed to load build session");
+        // Only a server-confirmed 404 is "this deployment does not exist". A
+        // throw while hydrating a successful response — or a 5xx/network
+        // failure — is a load error the page can retry, not proof the resource
+        // is gone (#604: this catch used to feed every one of them into the
+        // "not found" screen).
+        const { notFound, error: errorMessage } = classifyBuildSessionFailure(err);
         showToast(errorMessage, "error", "Error");
-        return { success: false, error: errorMessage };
+        return { success: false, notFound, error: errorMessage };
       }
     },
     [buildStream, setConfig, showToast, writeToTerminal, handleSuccessMessage, handleFailureMessage, handleCanceled],


### PR DESCRIPTION
## Why

On `/build/:id`, a **successful** deployment can render the `ResourceNotFound` screen (#604). The route is fine — the page's own `notFound` state is reached because `loadBuildSession` collapses **every** failure into `{ success: false }`, and the page has exactly one branch for that. So any client-side exception during hydration (the reporter's 3-service `projectType: "services"` deploy, or any other throw inside the ~200-line restore) presents an existing, ready deployment as "not found".

That defeats an invariant the API deliberately establishes (`deployment.controller.ts`): a genuine miss is a 404 and everything else is surfaced as a 500 *precisely so it doesn't get swallowed as a UI "not found"* — and the client then swallows its own exceptions into exactly that UI.

## What changed

- **`loadBuildSession` now distinguishes the two failure modes.** A soft-failed status response or an HTTP 404 returns `notFound: true` (genuine miss); a hydration exception, a 5xx, or a network failure returns `notFound: false` with the error message. Classification lives in a new pure helper (`classifyBuildSessionFailure`) so it's unit-testable.
- **The build page renders the non-not-found arm as an error state with a retry** (reusing the existing `chrome.error.*` copy and the shared `ResourceNotFound` panel), instead of "Deployment not found". A retry re-runs the load for the same deployment id.
- **An empty `composeServices` array no longer blanks an already-loaded service list.** The API ships `composeServices: []` for `services`-type deployments that report their services through `services`/`serviceStatuses` instead; the old `Array.isArray(...)` guard replaced the loaded list with `[]`. Empty now falls back to what's already loaded, same as the absent case always did (`hydrateSnapshotServices`).

## Verification

**Test that fails without the change** (`load-session.test.ts`, 9 new tests):

```
cd apps/dashboard && bun run test src/context/deployment/load-session.test.ts
```

- `hydrateSnapshotServices([], loaded)` keeps the loaded list — with the previous inline code, the empty array produced `[]` (the reported blanking).
- `classifyBuildSessionFailure` marks only `ApiError(404)` as not-found; a 500, a hydration `TypeError`, and a network failure all classify as load errors.

Full local verification on upstream `main` (`00326a2e`):

```
bun install --frozen-lockfile
cd apps/dashboard
bun run test    # 80 files, 977 tests passed (includes the 9 new)
bun run lint    # tsc --noEmit, clean
```

`bun format` was run on the touched files; the two pre-existing formatting-drift hunks in files this PR doesn't restructure were left untouched.

Fixes #604
