### PR TITLE
fix(compose): preserve project env vars when compose specifies empty passthrough placeholders

### DIFF
--- a/apps/api/src/modules/apps/app-settings.service.ts
+++ b/apps/api/src/modules/apps/app-settings.service.ts
@@ -365,10 +365,19 @@ export async function getAppConnectionView(
   const envByService = new Map<string, Record<string, string>>();
   for (const name of needed) {
     const svc = byName.get(name);
-    // Effective env, mirroring the deploy merge: the service's compose env map
-    // (JSONB, template literals like ME_CONFIG_BASICAUTH_USERNAME) as the base,
-    // overlaid by the env_vars table (generated secrets / config, decrypted).
-    // Reading only env_vars missed literals that never became env_var rows.
+    // The service's compose env map (JSONB, template literals like
+    // ME_CONFIG_BASICAUTH_USERNAME) as the base, overlaid by the env_vars table
+    // (generated secrets / config, decrypted). Reading only env_vars missed
+    // literals that never became env_var rows.
+    //
+    // This is NOT the full deploy merge: it omits the project-scoped layer
+    // entirely, so a key whose only real value is project-level resolves here to
+    // the row's inline value (possibly ""), while the container gets the project
+    // one (`inlineEmptyDefers` in deployments/compose/service-env-layers.ts).
+    // Adding that layer changes what every existing app connection resolves to,
+    // which is a deliberate call for its own change — not a side effect of the
+    // #614 deploy fix. Until then, treat a connection output as authoritative
+    // only for keys the app template or its generated rows own.
     const map: Record<string, string> = { ...((svc?.environment as Record<string, string>) ?? {}) };
     const rows = svc ? await repos.project.listEnvVars(projectId, ENVIRONMENT, svc.id) : [];
     for (const row of rows) {

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -434,13 +434,33 @@ export function mergeServiceDeployEnv(
   layers: ServiceEnvLayers,
   frozenWins: boolean,
 ): Record<string, string> {
-  return {
-    ...layers.project,
-    ...(frozenWins ? {} : layers.frozen),
-    ...layers.inline,
-    ...layers.service,
-    ...(frozenWins ? layers.frozen : {}),
-  };
+  const result: Record<string, string> = { ...layers.project };
+
+  if (!frozenWins && layers.frozen) {
+    Object.assign(result, layers.frozen);
+  }
+
+  // Layer inline compose environment.
+  // Non-empty inline values override project values (e.g. compose literals).
+  // Empty inline values (from compose passthrough placeholders like ${VAR:-}) do NOT
+  // clobber non-empty project values.
+  for (const [key, value] of Object.entries(layers.inline ?? {})) {
+    if (value === "" && result[key] !== undefined && result[key] !== "") {
+      continue;
+    }
+    result[key] = value;
+  }
+
+  // Layer service-scoped environment rows (explicit service overrides win)
+  for (const [key, value] of Object.entries(layers.service ?? {})) {
+    result[key] = value;
+  }
+
+  if (frozenWins && layers.frozen) {
+    Object.assign(result, layers.frozen);
+  }
+
+  return result;
 }
 
 /**

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -95,6 +95,7 @@ import {
 } from "../../../lib/deployment-runtime";
 import { isRealContainerRef } from "../../../lib/container-ref";
 import { resolveServicePort } from "./domain-helpers";
+import { mergeServiceDeployEnv } from "./service-env-layers";
 import { compileProjectRoutingFields } from "../../../lib/project-routing-fields";
 import { buildCompositeRegistration, buildDomainFanoutRegistrations } from "./composite-route";
 import { newerThanRestoredRelease, serviceKind } from "./project-services";
@@ -400,67 +401,6 @@ export function resolveEnvPublicUrls(
     out[key] = resolved.value;
   }
   return { env: out, unresolved };
-}
-
-/** The four env layers a compose service is deployed with, before token resolution. */
-export interface ServiceEnvLayers {
-  /** Project-scoped rows, live. */
-  project: Record<string, string>;
-  /** This deployment's frozen capture (`dep.envVars`, decrypted). Flat, unscoped. */
-  frozen: Record<string, string>;
-  /** The compose file's inline `environment:` for this service. */
-  inline: Record<string, string>;
-  /** Service-scoped rows for this service, live. */
-  service: Record<string, string>;
-}
-
-/**
- * Layer a service's env. Service rows beat inline compose env beats project rows,
- * so the compose UI can override a global per service.
- *
- * `frozenWins` moves the frozen layer LAST, which is what makes a rollback replay
- * the release it restores instead of running old code against today's config —
- * the one combination nobody ever ran. It is layered last rather than used alone
- * because `dep.envVars` is flat and unscoped: it cannot express "this key was
- * never set here", so dropping the live layers would delete keys the snapshot
- * never captured. Last-wins shadows exactly the keys the release had.
- *
- * It shadows inline and service-scoped values too, which for a key that was
- * project-scoped at capture and is service-scoped now means one value lands on
- * every service. That case is unresolvable from a flat map, so it is surfaced per
- * key as `scopeAmbiguous` in the rollback confirm diff rather than hidden.
- */
-export function mergeServiceDeployEnv(
-  layers: ServiceEnvLayers,
-  frozenWins: boolean,
-): Record<string, string> {
-  const result: Record<string, string> = { ...layers.project };
-
-  if (!frozenWins && layers.frozen) {
-    Object.assign(result, layers.frozen);
-  }
-
-  // Layer inline compose environment.
-  // Non-empty inline values override project values (e.g. compose literals).
-  // Empty inline values (from compose passthrough placeholders like ${VAR:-}) do NOT
-  // clobber non-empty project values.
-  for (const [key, value] of Object.entries(layers.inline ?? {})) {
-    if (value === "" && result[key] !== undefined && result[key] !== "") {
-      continue;
-    }
-    result[key] = value;
-  }
-
-  // Layer service-scoped environment rows (explicit service overrides win)
-  for (const [key, value] of Object.entries(layers.service ?? {})) {
-    result[key] = value;
-  }
-
-  if (frozenWins && layers.frozen) {
-    Object.assign(result, layers.frozen);
-  }
-
-  return result;
 }
 
 /**
@@ -1521,16 +1461,32 @@ export async function deployComposeServices(
     // rollback moves the frozen layer last), THEN resolve
     // `{{publicUrl:<service>}}` against live routing — which is why a frozen
     // token still points at today's hostname rather than the release's.
+    const layered = mergeServiceDeployEnv(
+      {
+        project: decryptedProjectEnv,
+        frozen: depEnv,
+        inline: (svc.environment as Record<string, string>) ?? {},
+        service: decryptedServiceEnv,
+      },
+      frozenEnvWins,
+    );
+    // Say so when a variable is not what any UI shows. The service Env tab and
+    // the wizard both keep rendering the empty value this merge ignored, so the
+    // deploy log is the only surface that can explain the container — same
+    // reason `resolveEnvPublicUrls` reports what it omitted just below. Names
+    // only: values are output-masked everywhere else.
+    if (layered.deferredEmpty.length > 0) {
+      logger.log(
+        `Service "${svc.name}": ${layered.deferredEmpty.join(", ")} ${
+          layered.deferredEmpty.length === 1 ? "is" : "are"
+        } empty in the compose config — using the configured value instead. ` +
+          `(An empty compose value never clears a configured one; to force a variable blank here, set it empty as a service-scoped variable.)\n`,
+        "info",
+        { serviceName: svc.name },
+      );
+    }
     const { env: mergedEnv, unresolved: unresolvedEnvUrls } = resolveEnvPublicUrls(
-      mergeServiceDeployEnv(
-        {
-          project: decryptedProjectEnv,
-          frozen: depEnv,
-          inline: (svc.environment as Record<string, string>) ?? {},
-          service: decryptedServiceEnv,
-        },
-        frozenEnvWins,
-      ),
+      layered.env,
       urlForPublicUrlToken,
     );
     if (unresolvedEnvUrls.length > 0) {

--- a/apps/api/src/modules/deployments/compose/service-env-layers.ts
+++ b/apps/api/src/modules/deployments/compose/service-env-layers.ts
@@ -1,0 +1,135 @@
+/**
+ * The env layering a compose/catalog service is deployed with.
+ *
+ * Its own module because THREE surfaces have to agree on it — the deploy merge,
+ * the rollback confirm diff (`deployments/deployment.service.ts`), and anything
+ * else reporting "what will this container get". Two of them used to spell the
+ * rule out by hand, which is how the confirm dialog came to claim a precedence
+ * the deploy no longer used. One rule, imported.
+ */
+
+/** The four env layers a compose service is deployed with, before token resolution. */
+export interface ServiceEnvLayers {
+  /**
+   * Project-scoped rows, live.
+   *
+   * NOTE the deploy caller builds this with an UNSCOPED `getEnvMap(projectId,
+   * environment)`, so today it is really project rows ∪ every other service's
+   * service-scoped rows. That is a pre-existing defect in the caller, not in this
+   * layering, but it is why {@link mergeServiceDeployEnv} describes what it
+   * compares against as "already layered" rather than "the project's".
+   */
+  project: Record<string, string>;
+  /** This deployment's frozen capture (`dep.envVars`, decrypted). Flat, unscoped. */
+  frozen: Record<string, string>;
+  /** The compose file's inline `environment:` for this service. */
+  inline: Record<string, string>;
+  /** Service-scoped rows for this service, live. */
+  service: Record<string, string>;
+}
+
+export interface MergedServiceEnv {
+  /** The env the container is created with, before `{{publicUrl:…}}` resolution. */
+  env: Record<string, string>;
+  /**
+   * Inline keys whose EMPTY value was not applied because a lower layer already
+   * held a real one — see {@link inlineEmptyDefers}. NAMES ONLY, never values:
+   * this is written to the deploy log, and env is output-masked everywhere else.
+   *
+   * Reported rather than swallowed for the same reason `resolveEnvPublicUrls`
+   * reports what it omitted: silently rewriting a variable leaves no surface that
+   * predicts the container. Both the service Env tab and the deploy wizard go on
+   * displaying the empty value this merge decided to ignore.
+   */
+  deferredEmpty: string[];
+}
+
+/**
+ * Whether an inline compose empty value yields to a value an earlier layer
+ * already supplied.
+ *
+ * The rule, in one sentence an operator can predict: **an empty inline value
+ * never clears a configured one.** It exists because compose's passthrough idiom
+ * (`FOO: ${FOO:-}` / `FOO: ${FOO}`) parses to `""` whenever nothing resolved the
+ * placeholder, and that `""` is persisted onto the service row with its
+ * provenance stripped — the row has no `environmentMeta`, so by deploy time
+ * "the author wrote an empty literal" and "nothing filled this placeholder in"
+ * are the same three characters. Before this rule the placeholder won, so the
+ * project-level value the operator had just typed was replaced with `""` —
+ * which is worse than unset, since `FOO=` also masks the image's own `ENV`
+ * default (issue #614).
+ *
+ * The cost, accepted deliberately: an inline empty that WAS authored on purpose
+ * no longer clears a project-level value for that one service. `advanced` JSONB
+ * could carry the parser's `environmentMeta.source` onto the row and let this
+ * decide on recorded intent instead of value shape (the `entrypoint`/#575
+ * precedent) — that is the endgame, and it is what would also fix the sibling
+ * case this cannot: a PARTIALLY interpolated value, where `postgres://${USER}:
+ * ${PASS}@db/${DB}` resolves to the non-empty garbage `postgres://:@db/` and
+ * still wins. Until then the escape hatch for a deliberate blank is an empty
+ * SERVICE-SCOPED env row, which is layered after this and never skipped.
+ */
+export function inlineEmptyDefers(
+  inlineValue: string,
+  alreadyLayered: string | undefined,
+): boolean {
+  // `!== undefined` is load-bearing: a passthrough key that appears in NO other
+  // layer must still be set (to ""), not dropped. Omitting it would delete the
+  // variable from the container instead of leaving it blank, which is a
+  // different container than either reading of the compose file asked for.
+  return inlineValue === "" && alreadyLayered !== undefined && alreadyLayered !== "";
+}
+
+/**
+ * Layer a service's env. Service rows beat inline compose env beats project rows
+ * — so the compose UI can override a global per service — with the ONE exception
+ * that an empty inline value defers instead of clearing ({@link
+ * inlineEmptyDefers}).
+ *
+ * `frozenWins` moves the frozen layer LAST, which is what makes a rollback replay
+ * the release it restores instead of running old code against today's config —
+ * the one combination nobody ever ran. It is layered last rather than used alone
+ * because `dep.envVars` is flat and unscoped: it cannot express "this key was
+ * never set here", so dropping the live layers would delete keys the snapshot
+ * never captured. Last-wins shadows exactly the keys the release had.
+ *
+ * It shadows inline and service-scoped values too, which for a key that was
+ * project-scoped at capture and is service-scoped now means one value lands on
+ * every service. That case is unresolvable from a flat map, so it is surfaced per
+ * key as `scopeAmbiguous` in the rollback confirm diff rather than hidden.
+ *
+ * Note the frozen layer is layered BEFORE inline on a normal deploy, so an empty
+ * inline value defers to a frozen value as well as a project one. That is the
+ * intent — the frozen capture is a snapshot of the operator's env, not of this
+ * service's inline map — and it is why the deferral compares against the
+ * accumulated result rather than against `layers.project`.
+ */
+export function mergeServiceDeployEnv(
+  layers: ServiceEnvLayers,
+  frozenWins: boolean,
+): MergedServiceEnv {
+  const env: Record<string, string> = { ...layers.project };
+  const deferredEmpty: string[] = [];
+
+  if (!frozenWins) Object.assign(env, layers.frozen);
+
+  for (const [key, value] of Object.entries(layers.inline)) {
+    if (inlineEmptyDefers(value, env[key])) {
+      deferredEmpty.push(key);
+      continue;
+    }
+    env[key] = value;
+  }
+
+  // Explicit service-scoped rows win outright — including an empty one, which is
+  // the supported way to force a variable blank on one service.
+  Object.assign(env, layers.service);
+
+  if (frozenWins) Object.assign(env, layers.frozen);
+
+  // A key that a later layer supplied anyway was never really "deferred" —
+  // reporting it would name a variable whose value this decision didn't pick.
+  const decidedLater = (key: string) =>
+    key in layers.service || (frozenWins && key in layers.frozen);
+  return { env, deferredEmpty: deferredEmpty.filter((key) => !decidedLater(key)) };
+}

--- a/apps/api/src/modules/deployments/deployment.service.ts
+++ b/apps/api/src/modules/deployments/deployment.service.ts
@@ -36,6 +36,7 @@ import {
 import { checkNoActiveBuild } from "./build.service";
 import { livePrimaryContainerId } from "../services/service-container";
 import { decryptEnvMap } from "../../lib/encryption";
+import { inlineEmptyDefers } from "./compose/service-env-layers";
 
 /**
  * #336: present a deployment to a CLIENT — masks `meta.composeServices[].environment`.
@@ -300,15 +301,23 @@ async function describeRestoreConsequences(
       rowsByService.set(row.serviceId, bucket);
     }
 
-    const liveServices = liveServiceRows.map((svc) => ({
-      name: svc.name,
+    const liveServices = liveServiceRows.map((svc) => {
       // Same precedence as the deploy merge: a service's own env rows win over
-      // inline compose `environment:`.
-      overrides: {
-        ...((svc.environment as Record<string, string> | null) ?? {}),
-        ...decryptEnvMap(rowsByService.get(svc.id) ?? {}),
-      },
-    }));
+      // inline compose `environment:` — INCLUDING the deferral, via the shared
+      // `inlineEmptyDefers`. An inline empty the deploy will not apply is not an
+      // override, and listing it here reported a `frozen-wins` revert (plus a
+      // `scopeAmbiguous` warning) for every compose passthrough key the rollback
+      // was never going to touch. This dialog's whole job is to be trusted.
+      const overrides: Record<string, string> = {};
+      for (const [key, value] of Object.entries(
+        (svc.environment as Record<string, string> | null) ?? {},
+      )) {
+        if (inlineEmptyDefers(value, liveProject[key])) continue;
+        overrides[key] = value;
+      }
+      Object.assign(overrides, decryptEnvMap(rowsByService.get(svc.id) ?? {}));
+      return { name: svc.name, overrides };
+    });
 
     return {
       env: diffFrozenEnv({ frozen, liveProject, liveServices, strategy }),

--- a/apps/api/src/modules/deployments/rollback/env-diff.ts
+++ b/apps/api/src/modules/deployments/rollback/env-diff.ts
@@ -66,6 +66,11 @@ export interface EnvDiffInput {
    * Per-service overrides as they resolve today: inline compose `environment:`
    * merged under the service's own env rows (rows win, matching the deploy
    * merge). Empty for a single-app project.
+   *
+   * Must be built with `mergeServiceDeployEnv`'s deferral applied — an inline
+   * empty that yields to a project value (`inlineEmptyDefers`) is NOT an override
+   * and must not appear here, or this diff reports a revert the rollback will
+   * never perform.
    */
   liveServices?: Array<{ name: string; overrides: Record<string, string> }>;
   strategy: EnvRestoreStrategy;

--- a/apps/api/test/modules/deployments/compose-env-passthrough.test.ts
+++ b/apps/api/test/modules/deployments/compose-env-passthrough.test.ts
@@ -1,19 +1,33 @@
+/**
+ * Issue #614: a compose passthrough variable (`${VAR:-}` / `${VAR}`) parses to
+ * `""`, is persisted onto the service row with its provenance stripped, and then
+ * replaced the operator's project-level value with an empty string at deploy —
+ * worse than unset, since `KEY=` also masks the image's own `ENV` default.
+ *
+ * The rule under test: an empty INLINE value never clears a configured one. The
+ * trade-off that buys, and the escape hatch that survives it, are pinned below
+ * so neither can be removed by accident.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import { parseComposeFile } from "../../../src/lib/compose-parser";
 import {
   mergeServiceDeployEnv,
   type ServiceEnvLayers,
-} from "../../../src/modules/deployments/compose/deploy.service";
+} from "../../../src/modules/deployments/compose/service-env-layers";
 
-/**
- * Fix for Issue #614:
- * Compose passthrough environment variables (${VAR:-} / ${VAR}) must not clobber
- * non-empty project-level environment variables during container deploy.
- */
-describe("Issue #614 - Compose environment passthrough vs project env vars", () => {
-  it("imports compose passthrough variable (${VAR:-}) as empty string in service environment", () => {
-    const yaml = `
+const layers = (over: Partial<ServiceEnvLayers> = {}): ServiceEnvLayers => ({
+  project: {},
+  frozen: {},
+  inline: {},
+  service: {},
+  ...over,
+});
+
+describe("compose env passthrough vs configured values (#614)", () => {
+  it("parses passthrough placeholders to empty strings, keeping provenance the row will lose", () => {
+    const parsed = parseComposeFile(`
 services:
   web:
     image: node:20
@@ -21,17 +35,20 @@ services:
       CONFIG_VAR: \${CONFIG_VAR:-}
       ANOTHER_VAR: \${ANOTHER_VAR}
       WITH_DEFAULT: \${WITH_DEFAULT:-default_fallback}
-`;
-    const parsed = parseComposeFile(yaml);
+      AUTHORED_EMPTY: ""
+`);
     const service = parsed.services[0];
 
-    expect(service).toBeDefined();
     expect(service?.environment).toEqual({
       CONFIG_VAR: "",
       ANOTHER_VAR: "",
       WITH_DEFAULT: "default_fallback",
+      AUTHORED_EMPTY: "",
     });
 
+    // The parser CAN tell the two empties apart — a placeholder carries meta, an
+    // authored literal carries none. The service row has no `environmentMeta`
+    // column, which is why the merge has to decide on value shape instead.
     expect(service?.environmentMeta?.CONFIG_VAR).toMatchObject({
       source: "default",
       variable: "CONFIG_VAR",
@@ -41,10 +58,12 @@ services:
       source: "missing",
       variable: "ANOTHER_VAR",
     });
+    expect(service?.environmentMeta?.AUTHORED_EMPTY).toBeUndefined();
   });
 
-  it("preserves non-empty project-level env vars when compose specifies empty passthrough placeholders", () => {
-    const yaml = `
+  it("keeps the project value the operator configured, and reports the substitution", () => {
+    const inline =
+      parseComposeFile(`
 services:
   api:
     image: my-app:latest
@@ -52,77 +71,135 @@ services:
       DATABASE_URL: \${DATABASE_URL:-}
       API_SECRET: \${API_SECRET}
       PORT: "3000"
-`;
-    const parsed = parseComposeFile(yaml);
-    const inlineEnv = parsed.services[0]?.environment ?? {};
+`).services[0]?.environment ?? {};
 
-    // Project-level environment variables configured by the operator:
-    const projectEnv = {
-      DATABASE_URL: "postgresql://user:pass@db:5432/production_db",
-      API_SECRET: "super-secret-token-12345",
-      PORT: "8080",
-    };
+    const merged = mergeServiceDeployEnv(
+      layers({
+        project: {
+          DATABASE_URL: "postgresql://user:pass@db:5432/production_db",
+          API_SECRET: "super-secret-token-12345",
+          PORT: "8080",
+        },
+        inline,
+      }),
+      false,
+    );
 
-    const layers: ServiceEnvLayers = {
-      project: projectEnv,
-      frozen: {},
-      inline: inlineEnv,
-      service: {},
-    };
+    expect(merged.env.DATABASE_URL).toBe("postgresql://user:pass@db:5432/production_db");
+    expect(merged.env.API_SECRET).toBe("super-secret-token-12345");
+    // A non-empty inline literal still wins — that precedence is the point of
+    // the inline layer and is unchanged.
+    expect(merged.env.PORT).toBe("3000");
 
-    const merged = mergeServiceDeployEnv(layers, false);
-
-    // FIXED: Project-level environment variables are preserved
-    expect(merged.DATABASE_URL).toBe("postgresql://user:pass@db:5432/production_db");
-    expect(merged.API_SECRET).toBe("super-secret-token-12345");
-
-    // Literal inline value (PORT: "3000") still overrides project (PORT: "8080")
-    expect(merged.PORT).toBe("3000");
+    // Names only, never values: this goes to the deploy log.
+    expect(merged.deferredEmpty.sort()).toEqual(["API_SECRET", "DATABASE_URL"]);
   });
 
-  it("allows explicit service-scoped overrides to take precedence over project and inline", () => {
-    const projectEnv = {
-      DATABASE_URL: "postgresql://user:pass@db:5432/production_db",
-      API_SECRET: "global-secret",
-    };
+  it("defers to the frozen capture too — the layer every real non-rollback deploy has", () => {
+    // `dep.envVars` is a snapshot of the operator's env, not of this service's
+    // inline map, so on a normal deploy the frozen layer is what an empty inline
+    // value is actually measured against.
+    const merged = mergeServiceDeployEnv(
+      layers({
+        project: { CONFIG_PARAM: "stale-project" },
+        frozen: { CONFIG_PARAM: "captured-at-deploy" },
+        inline: { CONFIG_PARAM: "" },
+      }),
+      false,
+    );
 
-    const inlineEnv = {
-      DATABASE_URL: "",
-      API_SECRET: "",
-    };
-
-    const serviceEnv = {
-      DATABASE_URL: "postgresql://user:pass@db:5432/special_service_db",
-    };
-
-    const layers: ServiceEnvLayers = {
-      project: projectEnv,
-      frozen: {},
-      inline: inlineEnv,
-      service: serviceEnv,
-    };
-
-    const merged = mergeServiceDeployEnv(layers, false);
-
-    // Service-scoped override wins for DATABASE_URL
-    expect(merged.DATABASE_URL).toBe("postgresql://user:pass@db:5432/special_service_db");
-    // Project-level value is preserved for API_SECRET
-    expect(merged.API_SECRET).toBe("global-secret");
+    expect(merged.env.CONFIG_PARAM).toBe("captured-at-deploy");
+    expect(merged.deferredEmpty).toEqual(["CONFIG_PARAM"]);
   });
 
-  it("retains empty string when no project variable exists for the passthrough key", () => {
-    const inlineEnv = {
-      UNSET_PASSTHROUGH: "",
-    };
+  it("replays the release unchanged on a rollback, and reports nothing it did not decide", () => {
+    const merged = mergeServiceDeployEnv(
+      layers({
+        project: { CONFIG_PARAM: "today" },
+        frozen: { CONFIG_PARAM: "release" },
+        inline: { CONFIG_PARAM: "" },
+      }),
+      true,
+    );
 
-    const layers: ServiceEnvLayers = {
-      project: {},
-      frozen: {},
-      inline: inlineEnv,
-      service: {},
-    };
+    // frozenWins: the snapshot is layered last and still wins outright.
+    expect(merged.env.CONFIG_PARAM).toBe("release");
+    // The deferral didn't pick this value, so naming it in the log would point
+    // the operator at the wrong layer.
+    expect(merged.deferredEmpty).toEqual([]);
+  });
 
-    const merged = mergeServiceDeployEnv(layers, false);
-    expect(merged.UNSET_PASSTHROUGH).toBe("");
+  it("still lets a service-scoped row force a variable blank — the escape hatch", () => {
+    const merged = mergeServiceDeployEnv(
+      layers({
+        project: { HTTP_PROXY: "http://corp:3128" },
+        inline: { HTTP_PROXY: "" },
+        service: { HTTP_PROXY: "" },
+      }),
+      false,
+    );
+
+    expect(merged.env.HTTP_PROXY).toBe("");
+    expect(merged.deferredEmpty).toEqual([]);
+  });
+
+  it("ACCEPTED TRADE-OFF: an inline empty can no longer blank a configured value", () => {
+    // Deliberate, and the cost of deciding on value shape rather than on the
+    // parser's recorded intent: an author who wrote `HTTP_PROXY: ""` on purpose
+    // (or blanked it in the service Env tab, which writes the same column) no
+    // longer clears the project value — they must use a service-scoped row, as
+    // in the case above. Carrying `environmentMeta` onto the row via `advanced`
+    // would let this decide on intent instead; if that lands, this expectation
+    // is the one to revisit.
+    const merged = mergeServiceDeployEnv(
+      layers({ project: { HTTP_PROXY: "http://corp:3128" }, inline: { HTTP_PROXY: "" } }),
+      false,
+    );
+
+    expect(merged.env.HTTP_PROXY).toBe("http://corp:3128");
+    expect(merged.deferredEmpty).toEqual(["HTTP_PROXY"]);
+  });
+
+  it("KNOWN GAP: a partially interpolated value is not empty, so it still wins", () => {
+    // The same bug class as #614 with a one-line-different compose file. A
+    // value-shaped rule cannot reach it; only carrying the parser's meta can.
+    // Pinned so the gap is visible rather than assumed fixed.
+    const inline =
+      parseComposeFile(`
+services:
+  api:
+    image: my-app:latest
+    environment:
+      DATABASE_URL: postgres://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@db:5432/\${POSTGRES_DB}
+`).services[0]?.environment ?? {};
+
+    expect(inline.DATABASE_URL).toBe("postgres://:@db:5432/");
+
+    const merged = mergeServiceDeployEnv(
+      layers({ project: { DATABASE_URL: "postgres://real:s3cret@db:5432/prod" }, inline }),
+      false,
+    );
+
+    expect(merged.env.DATABASE_URL).toBe("postgres://:@db:5432/");
+    expect(merged.deferredEmpty).toEqual([]);
+  });
+
+  it("sets a passthrough key that no other layer defines, rather than dropping it", () => {
+    // Skipping instead of assigning would delete the variable from the container
+    // — a third behavior neither reading of the compose file asked for.
+    const merged = mergeServiceDeployEnv(layers({ inline: { UNSET_PASSTHROUGH: "" } }), false);
+
+    expect(merged.env).toHaveProperty("UNSET_PASSTHROUGH", "");
+    expect(merged.deferredEmpty).toEqual([]);
+  });
+
+  it("does not defer when the configured value is itself empty", () => {
+    const merged = mergeServiceDeployEnv(
+      layers({ project: { CONFIG_PARAM: "" }, inline: { CONFIG_PARAM: "" } }),
+      false,
+    );
+
+    expect(merged.env.CONFIG_PARAM).toBe("");
+    expect(merged.deferredEmpty).toEqual([]);
   });
 });

--- a/apps/api/test/modules/deployments/compose-env-passthrough.test.ts
+++ b/apps/api/test/modules/deployments/compose-env-passthrough.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { parseComposeFile } from "../../../src/lib/compose-parser";
+import {
+  mergeServiceDeployEnv,
+  type ServiceEnvLayers,
+} from "../../../src/modules/deployments/compose/deploy.service";
+
+/**
+ * Fix for Issue #614:
+ * Compose passthrough environment variables (${VAR:-} / ${VAR}) must not clobber
+ * non-empty project-level environment variables during container deploy.
+ */
+describe("Issue #614 - Compose environment passthrough vs project env vars", () => {
+  it("imports compose passthrough variable (${VAR:-}) as empty string in service environment", () => {
+    const yaml = `
+services:
+  web:
+    image: node:20
+    environment:
+      CONFIG_VAR: \${CONFIG_VAR:-}
+      ANOTHER_VAR: \${ANOTHER_VAR}
+      WITH_DEFAULT: \${WITH_DEFAULT:-default_fallback}
+`;
+    const parsed = parseComposeFile(yaml);
+    const service = parsed.services[0];
+
+    expect(service).toBeDefined();
+    expect(service?.environment).toEqual({
+      CONFIG_VAR: "",
+      ANOTHER_VAR: "",
+      WITH_DEFAULT: "default_fallback",
+    });
+
+    expect(service?.environmentMeta?.CONFIG_VAR).toMatchObject({
+      source: "default",
+      variable: "CONFIG_VAR",
+      defaultValue: "",
+    });
+    expect(service?.environmentMeta?.ANOTHER_VAR).toMatchObject({
+      source: "missing",
+      variable: "ANOTHER_VAR",
+    });
+  });
+
+  it("preserves non-empty project-level env vars when compose specifies empty passthrough placeholders", () => {
+    const yaml = `
+services:
+  api:
+    image: my-app:latest
+    environment:
+      DATABASE_URL: \${DATABASE_URL:-}
+      API_SECRET: \${API_SECRET}
+      PORT: "3000"
+`;
+    const parsed = parseComposeFile(yaml);
+    const inlineEnv = parsed.services[0]?.environment ?? {};
+
+    // Project-level environment variables configured by the operator:
+    const projectEnv = {
+      DATABASE_URL: "postgresql://user:pass@db:5432/production_db",
+      API_SECRET: "super-secret-token-12345",
+      PORT: "8080",
+    };
+
+    const layers: ServiceEnvLayers = {
+      project: projectEnv,
+      frozen: {},
+      inline: inlineEnv,
+      service: {},
+    };
+
+    const merged = mergeServiceDeployEnv(layers, false);
+
+    // FIXED: Project-level environment variables are preserved
+    expect(merged.DATABASE_URL).toBe("postgresql://user:pass@db:5432/production_db");
+    expect(merged.API_SECRET).toBe("super-secret-token-12345");
+
+    // Literal inline value (PORT: "3000") still overrides project (PORT: "8080")
+    expect(merged.PORT).toBe("3000");
+  });
+
+  it("allows explicit service-scoped overrides to take precedence over project and inline", () => {
+    const projectEnv = {
+      DATABASE_URL: "postgresql://user:pass@db:5432/production_db",
+      API_SECRET: "global-secret",
+    };
+
+    const inlineEnv = {
+      DATABASE_URL: "",
+      API_SECRET: "",
+    };
+
+    const serviceEnv = {
+      DATABASE_URL: "postgresql://user:pass@db:5432/special_service_db",
+    };
+
+    const layers: ServiceEnvLayers = {
+      project: projectEnv,
+      frozen: {},
+      inline: inlineEnv,
+      service: serviceEnv,
+    };
+
+    const merged = mergeServiceDeployEnv(layers, false);
+
+    // Service-scoped override wins for DATABASE_URL
+    expect(merged.DATABASE_URL).toBe("postgresql://user:pass@db:5432/special_service_db");
+    // Project-level value is preserved for API_SECRET
+    expect(merged.API_SECRET).toBe("global-secret");
+  });
+
+  it("retains empty string when no project variable exists for the passthrough key", () => {
+    const inlineEnv = {
+      UNSET_PASSTHROUGH: "",
+    };
+
+    const layers: ServiceEnvLayers = {
+      project: {},
+      frozen: {},
+      inline: inlineEnv,
+      service: {},
+    };
+
+    const merged = mergeServiceDeployEnv(layers, false);
+    expect(merged.UNSET_PASSTHROUGH).toBe("");
+  });
+});

--- a/apps/api/test/modules/deployments/rollback-frozen-env.test.ts
+++ b/apps/api/test/modules/deployments/rollback-frozen-env.test.ts
@@ -13,13 +13,19 @@
 
 import { describe, expect, it } from "vitest";
 
+import { resolveEnvPublicUrls } from "../../../src/modules/deployments/compose/deploy.service";
 import {
-  mergeServiceDeployEnv,
-  resolveEnvPublicUrls,
-} from "../../../src/modules/deployments/compose/deploy.service";
+  inlineEmptyDefers,
+  mergeServiceDeployEnv as mergeLayers,
+} from "../../../src/modules/deployments/compose/service-env-layers";
 import { diffFrozenEnv, ENV_DIFF_CAP } from "../../../src/modules/deployments/rollback";
 
-const layers = (over: Partial<Parameters<typeof mergeServiceDeployEnv>[0]> = {}) => ({
+/** Unwraps `{ env, deferredEmpty }` so these cases keep asserting on the env map. */
+const mergeServiceDeployEnv = (
+  ...args: Parameters<typeof mergeLayers>
+): Record<string, string> => mergeLayers(...args).env;
+
+const layers = (over: Partial<Parameters<typeof mergeLayers>[0]> = {}) => ({
   project: {},
   frozen: {},
   inline: {},
@@ -194,6 +200,32 @@ describe("diffFrozenEnv", () => {
     });
     expect(diff.changes).toHaveLength(1);
     expect(diff.changes[0]).toMatchObject({ key: "LOG_LEVEL", direction: "frozen-wins" });
+  });
+
+  it("does not report a revert for a compose passthrough key the rollback won't touch", () => {
+    // #614: the service row holds `CONFIG_PARAM: ""` from `${CONFIG_PARAM:-}`,
+    // but the deploy merge defers it to the project value — so this key resolves
+    // to the SAME value the release froze and nothing changes. Building
+    // `overrides` as a raw spread of the row listed it as a per-service override,
+    // which reported a `frozen-wins` revert plus a scopeAmbiguous warning for a
+    // key the rollback leaves alone. `describeRestorePlan` applies the same
+    // `inlineEmptyDefers` the deploy does; this pins the resulting contract.
+    const liveProject = { CONFIG_PARAM: "operator-value" };
+    const row = { CONFIG_PARAM: "" };
+
+    const overrides = Object.fromEntries(
+      Object.entries(row).filter(([key, value]) => !inlineEmptyDefers(value, liveProject[key])),
+    );
+    expect(overrides).toEqual({});
+
+    const diff = diffFrozenEnv({
+      frozen: { CONFIG_PARAM: "operator-value" },
+      liveProject,
+      liveServices: [{ name: "api", overrides }],
+      strategy: "overlay",
+    });
+    expect(diff.changes).toEqual([]);
+    expect(diff.totalChanges).toBe(0);
   });
 
   it("omits a key every service already resolves to the frozen value", () => {


### PR DESCRIPTION
### Problem
When a Docker Compose file defines environment variables using passthrough or default syntax (such as `MY_VAR: ${MY_VAR:-}` or `MY_VAR: ${MY_VAR}`), the compose parser imports these unset variables into the service's inline environment as `""` (empty string).

During deployment, `mergeServiceDeployEnv` layers `project -> inline -> service`. Because the inline environment had `MY_VAR: ""`, it clobbered any configured non-empty project-level environment variable with an empty string.

Closes #614

---

### Solution
- In `mergeServiceDeployEnv`, when merging the inline compose environment over the project environment, skip empty string values (`""`) if the project environment already defines a non-empty value for that key.
- Explicit non-empty inline literals (e.g. `PORT: "3000"`) and explicit service-scoped environment overrides still take precedence as intended.
- Added comprehensive unit tests in `apps/api/test/modules/deployments/compose-env-passthrough.test.ts` to verify and defend this behavior.