### PR TITLE
feat(services): support recreate option on service restart

### DIFF
--- a/apps/api/src/modules/services/service.controller.ts
+++ b/apps/api/src/modules/services/service.controller.ts
@@ -306,9 +306,17 @@ export async function restartContainer(c: Context) {
   const ctx = getRequestContext(c);
   const projectId = param(c, "id");
   const serviceId = param(c, "serviceId");
+  const recreateParam = c.req.query("recreate");
+  let recreate = recreateParam === "true" || recreateParam === "1";
+  if (!recreate && c.req.header("content-type")?.includes("application/json")) {
+    const body = await c.req.json<{ recreate?: boolean }>().catch(() => null);
+    if (body?.recreate) recreate = true;
+  }
   try {
-    await serviceService.restartServiceContainer(ctx, projectId, serviceId);
-    return c.json({ success: true });
+    const result = await serviceService.restartServiceContainer(ctx, projectId, serviceId, {
+      recreate,
+    });
+    return c.json({ success: true, ...result });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to restart container";
     return c.json({ success: false, error: message }, 400);

--- a/apps/api/src/modules/services/service.routes.ts
+++ b/apps/api/src/modules/services/service.routes.ts
@@ -24,6 +24,8 @@ import * as ctrl from "./service.controller";
 import { AgentExecBody } from "../../lib/agent-exec.schema";
 import {
   CreateServiceBody,
+  RestartServiceBody,
+  RestartServiceQuery,
   SetServiceEnvVarsBody,
   SyncServicesBody,
   UpdateServiceBody,
@@ -170,7 +172,20 @@ r.post(
 /* ─── Per-service container actions ─────────────────────────────────────── */
 r.post("/:serviceId/start", { tag: "project:service:write", mcp: { description: "Start this service's container." } }, cloudProjectProxy, ctrl.startContainer);
 r.post("/:serviceId/stop", { tag: "project:service:write", mcp: { description: "Stop this service's container." } }, cloudProjectProxy, ctrl.stopContainer);
-r.post("/:serviceId/restart", { tag: "project:service:write", mcp: { description: "Restart this service's container." } }, cloudProjectProxy, ctrl.restartContainer);
+r.post(
+  "/:serviceId/restart",
+  {
+    tag: "project:service:write",
+    query: RestartServiceQuery,
+    body: RestartServiceBody,
+    mcp: {
+      description:
+        "Restart this service's container (pass recreate: true to recreate with updated env/config).",
+    },
+  },
+  cloudProjectProxy,
+  ctrl.restartContainer,
+);
 
 /* ─── Service environment variables ─────────────────────────────────────── */
 r.get(

--- a/apps/api/src/modules/services/service.schema.ts
+++ b/apps/api/src/modules/services/service.schema.ts
@@ -367,6 +367,24 @@ export const SetServiceEnvVarsBody = Type.Object(
   { additionalProperties: false },
 );
 
+export const RestartServiceQuery = Type.Object({
+  recreate: Type.Optional(
+    Type.Boolean({
+      description:
+        "Recreate the container from its image with fresh environment and config rather than a raw restart.",
+    }),
+  ),
+});
+
+export const RestartServiceBody = Type.Object({
+  recreate: Type.Optional(
+    Type.Boolean({
+      description:
+        "Recreate the container from its image with fresh environment and config rather than a raw restart.",
+    }),
+  ),
+});
+
 export type TCreateServiceBody = Static<typeof CreateServiceBody>;
 export type TUpdateServiceBody = Static<typeof UpdateServiceBody>;
 export type TSyncServicesBody = Static<typeof SyncServicesBody>;

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -1901,13 +1901,21 @@ export async function restartServiceContainer(
   ctx: RequestContext,
   projectId: string,
   serviceId: string,
+  opts?: { recreate?: boolean },
 ) {
   await assertNotControlPlaneById(projectId);
-  const { runtime, containerId, row } = await resolveServiceContainer(
+  if (opts?.recreate) {
+    return provisionServiceContainer(ctx, projectId, serviceId);
+  }
+  const existing = await resolveServiceContainer(
     ctx,
     projectId,
     serviceId,
-  );
+  ).catch(() => null);
+  if (!existing?.containerId) {
+    return provisionServiceContainer(ctx, projectId, serviceId);
+  }
+  const { runtime, containerId, row } = existing;
   try {
     await runtime.restart(containerId);
     if (row) {

--- a/apps/api/test/modules/services/service-restart-recreate.test.ts
+++ b/apps/api/test/modules/services/service-restart-recreate.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectRepo = vi.hoisted(() => ({
+  findById: vi.fn(),
+}));
+
+const deploymentRepo = vi.hoisted(() => ({
+  findById: vi.fn(),
+}));
+
+const serviceRepo = vi.hoisted(() => ({
+  findById: vi.fn(),
+  findByName: vi.fn(),
+  listByProject: vi.fn(),
+  listByDeployment: vi.fn(),
+  update: vi.fn(),
+  updateServiceDeployment: vi.fn(),
+}));
+
+vi.mock("@repo/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/db")>();
+  return {
+    ...actual,
+    repos: {
+      ...actual.repos,
+      project: projectRepo,
+      deployment: deploymentRepo,
+      service: serviceRepo,
+    },
+  };
+});
+
+const mockRuntime = vi.hoisted(() => ({
+  name: "docker",
+  restart: vi.fn(),
+  stop: vi.fn(),
+  start: vi.fn(),
+  runContainer: vi.fn(),
+  removeContainer: vi.fn(),
+  dispose: vi.fn(),
+  supports: vi.fn().mockReturnValue(true),
+  listAllContainers: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../src/lib/deployment-runtime", () => ({
+  resolveDeploymentRuntimeForRead: vi.fn().mockResolvedValue({
+    runtime: mockRuntime,
+    serverId: null,
+  }),
+}));
+
+vi.mock("../../../src/modules/services/service-container", () => ({
+  liveContainerIdWithRuntime: vi.fn().mockResolvedValue("container_existing_12345"),
+  containerIdForService: vi.fn().mockReturnValue("container_existing_12345"),
+  resolveServicePlatform: vi.fn().mockResolvedValue({
+    platform: {
+      runtime: mockRuntime,
+      routing: null,
+      ssl: null,
+      system: null,
+      executor: null,
+      localHost: null,
+    },
+    effectiveTarget: "local",
+    usesManagedRouting: false,
+    serverId: null,
+  }),
+  isMultiServiceRuntime: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../../src/lib/route-apply.service", () => ({
+  reconcileProjectRoutes: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/modules/domains/domain.service", () => ({
+  ensurePendingServiceDomain: vi.fn().mockResolvedValue({ created: false }),
+  removeServiceDomain: vi.fn().mockResolvedValue(undefined),
+  reuseServerCertForDomain: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/lib/free-domain-guard", () => ({
+  assertFreeEndpointsAllowed: vi.fn().mockResolvedValue(undefined),
+}));
+
+const deployComposeServicesMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../src/modules/deployments/compose/deploy.service", () => ({
+  deployComposeServices: deployComposeServicesMock,
+}));
+
+vi.mock("../../../src/modules/deployments/deployment-platform", () => ({
+  resolveServicePlatform: vi.fn().mockResolvedValue({
+    platform: {
+      runtime: mockRuntime,
+      routing: null,
+      ssl: null,
+      system: null,
+      executor: null,
+      localHost: null,
+    },
+    effectiveTarget: "local",
+    usesManagedRouting: false,
+    serverId: null,
+  }),
+  isMultiServiceRuntime: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../../src/modules/plans/plan.service", () => ({
+  assertPlanAllowsServices: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  restartServiceContainer,
+  updateService,
+} from "../../../src/modules/services/service.service";
+
+/**
+ * Fix for Issue #615:
+ * Service restart supports recreating container with fresh environment and config
+ * via recreate: true option, while maintaining fast docker restart by default.
+ */
+describe("Issue #615 - Service restart and recreate support", () => {
+  const ctx = { organizationId: "org_test" } as never;
+  const project = {
+    id: "proj_test",
+    organizationId: "org_test",
+    slug: "my-app",
+    activeDeploymentId: "dep_test",
+    resources: null,
+  };
+
+  const initialService = () => ({
+    id: "svc_web",
+    projectId: "proj_test",
+    name: "web",
+    image: "nginx:latest",
+    kind: "compose",
+    enabled: true,
+    environment: {
+      API_ENDPOINT: "https://v1.api.example.com",
+    },
+    ports: ["8080:8080"],
+    exposed: true,
+    exposedPort: "8080",
+    domain: "my-app-web",
+    customDomain: null,
+    domainType: "free",
+    publicEndpoints: [{ port: 8080, domainType: "free", domain: "my-app-web" }],
+  });
+
+  const deployment = {
+    id: "dep_test",
+    projectId: "proj_test",
+    organizationId: "org_test",
+    meta: { runtimeMode: "docker" },
+  };
+
+  const serviceDeploymentRow = {
+    id: "sd_row_1",
+    deploymentId: "dep_test",
+    serviceId: "svc_web",
+    containerId: "container_existing_12345",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectRepo.findById.mockResolvedValue(project);
+    deploymentRepo.findById.mockResolvedValue(deployment);
+    serviceRepo.findById.mockResolvedValue(initialService());
+    serviceRepo.listByProject.mockResolvedValue([initialService()]);
+    serviceRepo.listByDeployment.mockResolvedValue([serviceDeploymentRow]);
+    serviceRepo.update.mockResolvedValue(undefined);
+    serviceRepo.updateServiceDeployment.mockResolvedValue(undefined);
+    mockRuntime.restart.mockResolvedValue(undefined);
+    deployComposeServicesMock.mockResolvedValue({
+      status: "ready",
+      services: [
+        {
+          serviceId: "svc_web",
+          name: "web",
+          status: "ready",
+          containerId: "container_recreated_67890",
+          ip: "172.30.0.4",
+        },
+      ],
+    });
+  });
+
+  it("performs fast docker restart when recreate is not requested", async () => {
+    const result = await restartServiceContainer(ctx, project.id, "svc_web");
+
+    expect(result).toEqual({ containerId: "container_existing_12345" });
+    expect(mockRuntime.restart).toHaveBeenCalledWith("container_existing_12345");
+    expect(deployComposeServicesMock).not.toHaveBeenCalled();
+  });
+
+  it("recreates the container with fresh environment when recreate: true is passed", async () => {
+    // 1. Operator updates service configuration / environment variables
+    const updatedEnv = {
+      API_ENDPOINT: "https://v2.api.example.com",
+      NEW_FEATURE_FLAG: "enabled",
+    };
+
+    await updateService(ctx, project.id, "svc_web", {
+      environment: updatedEnv,
+    } as never);
+
+    expect(serviceRepo.update).toHaveBeenCalledWith(
+      "svc_web",
+      expect.objectContaining({
+        environment: updatedEnv,
+      }),
+    );
+
+    // 2. Operator triggers service restart with recreate: true
+    const result = await restartServiceContainer(ctx, project.id, "svc_web", { recreate: true });
+
+    // Container is reprovisioned with fresh configuration
+    expect(deployComposeServicesMock).toHaveBeenCalledWith(
+      project,
+      deployment,
+      mockRuntime,
+      expect.anything(),
+      expect.objectContaining({
+        targetServiceIds: new Set(["svc_web"]),
+        strictScope: true,
+      }),
+    );
+    expect(result).toEqual({
+      containerId: "container_recreated_67890",
+      ip: "172.30.0.4",
+    });
+  });
+});


### PR DESCRIPTION
### Problem
Updating service environment variables (or other service configuration) in Openship updates the database records, but calling `POST /api/projects/:id/services/:serviceId/restart` performed a raw `docker restart`. Because container environment variables are fixed at container creation time, the restarted container continued running with its stale configuration until a full project redeployment occurred.

Closes #615

---

### Solution
- Updated `restartServiceContainer` to support `opts?: { recreate?: boolean }`. When `recreate: true` is passed (or when no active container exists), it provisions and recreates the service container with fresh environment and configuration via `provisionServiceContainer`.
- Updated the route `POST /api/projects/:id/services/:serviceId/restart` and controller to accept `recreate?: boolean` via query parameter (`?recreate=true`) or JSON body (`{ "recreate": true }`).
- By default (when `recreate` is omitted/false), fast container restart (`docker restart`) is preserved.
- Added comprehensive unit tests in `apps/api/test/modules/services/service-restart-recreate.test.ts`.