### PR TITLE
fix(deploy): avoid host ports pinned to other projects in compose deploys

### DIFF
--- a/apps/api/src/modules/deployments/build-pipeline.ts
+++ b/apps/api/src/modules/deployments/build-pipeline.ts
@@ -85,10 +85,23 @@ import {
 import { firePreDeployBackups } from "../backups/triggers/pre-deploy";
 import { buildBackgroundContext } from "../../lib/request-context";
 import * as sessionManager from "./session-manager";
-import { onFailure, onSuccess, onCancelled, reportPipelineError, setDeploymentStatus, routeIssuesWarning, type LifecycleContext } from "./deployment-lifecycle";
+import {
+  onFailure,
+  onSuccess,
+  onCancelled,
+  reportPipelineError,
+  setDeploymentStatus,
+  routeIssuesWarning,
+  type LifecycleContext,
+} from "./deployment-lifecycle";
 import { auditPorts } from "./port-audit.service";
+import { listOrgPinnedHostPorts } from "./pinned-host-ports";
 import { verifyDeployedContainers } from "./stability-audit.service";
-import { resolveReadinessGate, runReadinessGate, type ResolvedReadinessGate } from "./readiness-gate";
+import {
+  resolveReadinessGate,
+  runReadinessGate,
+  type ResolvedReadinessGate,
+} from "./readiness-gate";
 import { auditStaticOutput, staticOutputTargets } from "./output-audit.service";
 import { createBuildConfig } from "./build-config";
 import { pinnedAppImage, pinnedStaticDir, snapshotNeedsGitSource } from "./pinned-artifacts";
@@ -103,9 +116,7 @@ import {
   shouldUseProjectServicePipeline,
 } from "./compose";
 import { serviceKind, type DeployableService } from "../../lib/deployable-service";
-import {
-  resolveProjectRouteState,
-} from "../domains/project-route.service";
+import { resolveProjectRouteState } from "../domains/project-route.service";
 import { type DeploymentConfigSnapshot } from "./build.service";
 import * as settingsService from "../settings/settings.service";
 
@@ -233,7 +244,10 @@ export async function kickoffBuild(project: Project, dep: Deployment): Promise<s
  * skips. Otherwise marks failed, flushes a final log line through SSE so the
  * dashboard stops spinning, and ends the session.
  */
-async function markDeploymentFailedFromOutside(deploymentId: string, error: unknown): Promise<void> {
+async function markDeploymentFailedFromOutside(
+  deploymentId: string,
+  error: unknown,
+): Promise<void> {
   const message = safeErrorMessage(error);
   try {
     const dep = await repos.deployment.findById(deploymentId).catch(() => null);
@@ -246,12 +260,16 @@ async function markDeploymentFailedFromOutside(deploymentId: string, error: unkn
       return;
     }
     await repos.deployment.updateStatus(deploymentId, "failed").catch(() => {});
-    const buildSession = await repos.deployment.findBuildSessionByDeploymentId(deploymentId).catch(() => null);
+    const buildSession = await repos.deployment
+      .findBuildSessionByDeploymentId(deploymentId)
+      .catch(() => null);
     if (buildSession) {
-      await repos.deployment.updateBuildSession(buildSession.id, {
-        status: "failed",
-        finishedAt: new Date(),
-      }).catch(() => {});
+      await repos.deployment
+        .updateBuildSession(buildSession.id, {
+          status: "failed",
+          finishedAt: new Date(),
+        })
+        .catch(() => {});
     }
     // SSE: surface the error to anyone watching the stream and close it.
     sessionManager.appendLog(deploymentId, {
@@ -261,10 +279,12 @@ async function markDeploymentFailedFromOutside(deploymentId: string, error: unkn
     });
     sessionManager.updateStatus(deploymentId, "failed");
   } catch (handlerErr) {
-    console.error(`[DEPLOY] markDeploymentFailedFromOutside crashed for ${deploymentId}:`, handlerErr);
+    console.error(
+      `[DEPLOY] markDeploymentFailedFromOutside crashed for ${deploymentId}:`,
+      handlerErr,
+    );
   }
 }
-
 
 /**
  * Hand the finished deployment to the rollback orchestrator: it retains the
@@ -329,7 +349,11 @@ async function reuseRetainedArtifact(opts: {
   const { snapshot, runtime, buildSessionId, targetExecutor, logger } = opts;
 
   const reuse = (artifactRef: string) => {
-    logger.step("build", "completed", `Reusing retained artifact ${artifactRef} — no rebuild needed`);
+    logger.step(
+      "build",
+      "completed",
+      `Reusing retained artifact ${artifactRef} — no rebuild needed`,
+    );
     return {
       sessionId: buildSessionId,
       status: "deploying" as const,
@@ -515,7 +539,8 @@ async function executeBuildAndDeploy(project: Project, dep: Deployment, buildSes
     // but keep a BARE serve/lifecycle identity (files served by the edge — a
     // persisted "docker" would make rollback/purge 404-no-op on the release dir and
     // leak it). Cloud static + Docker-less desktop-local static keep their own mode.
-    const willRunServices = (await resolveServicePipelineMode(project, snapshot)).useServicePipeline;
+    const willRunServices = (await resolveServicePipelineMode(project, snapshot))
+      .useServicePipeline;
     // The runtime/workload axis, resolved from the frozen snapshot triple
     // (issue #538). `web` | `worker` | `static` replaces the old `hasServer`
     // boolean, which couldn't tell a portless worker from a static site.
@@ -616,7 +641,10 @@ async function executeBuildAndDeploy(project: Project, dep: Deployment, buildSes
       // Best-effort: fan-out is a dashboard concern. A crash here must
       // not block the main build.
       console.warn(`[build] preCreateServiceDeployments crashed for ${dep.id}:`, err);
-      return new Map<string, { id: string; serviceId: string; serviceName: string; targeted: boolean }>();
+      return new Map<
+        string,
+        { id: string; serviceId: string; serviceName: string; targeted: boolean }
+      >();
     });
 
     await emitInitialServiceChecks(serviceFanOut, project, dep);
@@ -638,9 +666,7 @@ async function executeBuildAndDeploy(project: Project, dep: Deployment, buildSes
       (dep.envVars ?? {}) as Record<string, string>,
       (key: string, err: unknown) => {
         failedEnvKeys.push(key);
-        console.warn(
-          `[build] failed to decrypt env var ${key}: ${safeErrorMessage(err)}`,
-        );
+        console.warn(`[build] failed to decrypt env var ${key}: ${safeErrorMessage(err)}`);
       },
     );
     // Surface dropped env in the BUILD LOG (not just the server console) so a
@@ -902,9 +928,7 @@ async function executeBuildAndDeploy(project: Project, dep: Deployment, buildSes
       // monorepo entry in causes a ghost compose-kind row to be inserted
       // alongside the real monorepo row (no DB unique constraint on
       // (projectId, name)). Filter to compose-kind before handing it off.
-      const composeOnly = snapshot.composeServices?.filter(
-        (s) => serviceKind(s) === "compose",
-      );
+      const composeOnly = snapshot.composeServices?.filter((s) => serviceKind(s) === "compose");
       if (composeOnly?.length) {
         // removeMissing: false — this list is the release's frozen snapshot, not
         // an authoritative inventory. On a rollback it predates services added
@@ -1010,8 +1034,7 @@ async function executeBuildAndDeploy(project: Project, dep: Deployment, buildSes
         targetExecutor,
         staticExecutor,
         logger,
-      })) ??
-      (await buildFromSource());
+      })) ?? (await buildFromSource());
     provisioned.imageRef = buildResult.imageRef;
 
     if (buildResult.status === "cancelled") {
@@ -1129,7 +1152,18 @@ async function executeStaticEdgeDeploy(
   phase: DeployPhaseInputs,
   runtime: CloudRuntime,
 ): Promise<void> {
-  const { ctx, project, dep, snapshot, buildSessionId, routeState, buildResult, envMap, prodResources, logger } = phase;
+  const {
+    ctx,
+    project,
+    dep,
+    snapshot,
+    buildSessionId,
+    routeState,
+    buildResult,
+    envMap,
+    prodResources,
+    logger,
+  } = phase;
 
   logger.step("deploy", "running", "Deploying to edge (static)...");
 
@@ -1393,7 +1427,9 @@ function buildDeployEnvironment(
         if (targetExecutor) return targetExecutor.rm(id);
         return previousRuntime.destroy(id);
       }
-      return previousRuntime.name === "bare" ? previousRuntime.stop(id) : previousRuntime.destroy(id);
+      return previousRuntime.name === "bare"
+        ? previousRuntime.stop(id)
+        : previousRuntime.destroy(id);
     },
     // The non-overlap pre-stop: free the port, but keep the old workload
     // restorable until the new one proves out. STOP for both runtimes — Docker
@@ -1403,8 +1439,7 @@ function buildDeployEnvironment(
     // A path-shaped id is a static release DIR: nothing is "running", so there is
     // no port to free and nothing to stop. Leaving it in place is what makes it
     // restorable; `deactivate` above still removes it on the overlap/success path.
-    deactivateRetaining: (id) =>
-      id.includes("/") ? Promise.resolve() : previousRuntime.stop(id),
+    deactivateRetaining: (id) => (id.includes("/") ? Promise.resolve() : previousRuntime.stop(id)),
     // Discard the retained container after success. Container runtimes only: bare's
     // stopped release is a DIRECTORY owned by the retention/rollback window, and
     // destroying it here would delete a release that rollback still expects (bare
@@ -1428,7 +1463,13 @@ function buildDeployEnvironment(
       if (strategy === "loopback-port" && runtime.name !== "bare") {
         hostPort = (await runtime.getContainerInfo(id).catch(() => null))?.hostPort ?? undefined;
       }
-      return resolveUpstreamUrl({ strategy, runtime, containerId: id, containerPort: port, hostPort });
+      return resolveUpstreamUrl({
+        strategy,
+        runtime,
+        containerId: id,
+        containerPort: port,
+        hostPort,
+      });
     },
   };
 }
@@ -1436,9 +1477,20 @@ function buildDeployEnvironment(
 /** Server deploy via runDeployPipeline (VM / Docker / Bare). Handles static-self-hosted too. */
 async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
   const {
-    ctx, project, dep, snapshot, buildSessionId,
-    runtime, routing, ssl, usesManagedRouting,
-    routeState, buildResult, envMap, prodResources, logger,
+    ctx,
+    project,
+    dep,
+    snapshot,
+    buildSessionId,
+    runtime,
+    routing,
+    ssl,
+    usesManagedRouting,
+    routeState,
+    buildResult,
+    envMap,
+    prodResources,
+    logger,
   } = phase;
 
   // Static sites are served as files by the edge (OpenResty `root`), regardless
@@ -1541,7 +1593,9 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
         ensureRuntimeReady: async () => {
           const system = phase.system;
           if (!system) return;
-          await system.ensureFeature("deploy", (entry) => logger.log(`${entry.message}\n`, entry.level));
+          await system.ensureFeature("deploy", (entry) =>
+            logger.log(`${entry.message}\n`, entry.level),
+          );
         },
         ensurePorts: async (cfg, promptUser) => {
           const executor = phase.targetExecutor;
@@ -1576,7 +1630,8 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
             new Set(
               (routeState.publicEndpoints.length > 0
                 ? routeState.publicEndpoints
-                : [{ port: cfg.port }])
+                : [{ port: cfg.port }]
+              )
                 .map((endpoint) => endpoint.port ?? cfg.port)
                 .filter((port): port is number => Number.isFinite(port)),
             ),
@@ -1591,7 +1646,9 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
           // source apps so injected internal hosts (e.g. db:5432) resolve. The
           // compose path does this in compose/deploy.service.ts; this closes the
           // single-container gap. Advisory — never fails the deploy.
-          await attachLinkedNetworks(project.id, runtime, (m, level) => logger.log(`${m}\n`, level));
+          await attachLinkedNetworks(project.id, runtime, (m, level) =>
+            logger.log(`${m}\n`, level),
+          );
           return deployed;
         },
         resolveRoute: undefined,
@@ -1649,14 +1706,7 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
       // containers may not be listening right now, so the live scan alone
       // wouldn't see them and two projects could collide on the same loopback
       // port (ensurePortAvailable is only the deploy-time backstop).
-      const avoid = (
-        await repos.project
-          .listByOrganization(project.organizationId, { perPage: 1000 })
-          .then((r) => r.rows)
-          .catch(() => [] as { id: string; hostPort: number | null }[])
-      )
-        .filter((p) => p.id !== project.id && typeof p.hostPort === "number")
-        .map((p) => p.hostPort as number);
+      const avoid = await listOrgPinnedHostPorts(project.organizationId, project.id);
       // The deploy's own executor when it has one; otherwise the POOLED host
       // channel — never a bare `createHostExecutor()`, which builds a fresh
       // SSH connection per call and leaked one sshd session each time (#291).
@@ -1688,7 +1738,12 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
       }
       await repos.project
         .update(project.id, { hostPort: pinnedHostPort })
-        .catch((err) => logger.log(`Couldn't persist host port ${pinnedHostPort}: ${safeErrorMessage(err)}\n`, "warn"));
+        .catch((err) =>
+          logger.log(
+            `Couldn't persist host port ${pinnedHostPort}: ${safeErrorMessage(err)}\n`,
+            "warn",
+          ),
+        );
     }
   } else {
     pinnedHostPort = undefined; // don't publish a pinned port under container-ip / bare / static
@@ -1780,22 +1835,21 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
   // than nuke every route. The plannedHostnames check is belt-and-braces:
   // never prune a hostname this same deploy is registering.
   const activeRouteIds = new Set(
-    routeState.publicEndpoints
-      .map((endpoint) => endpoint.id)
-      .filter((id): id is string => !!id),
+    routeState.publicEndpoints.map((endpoint) => endpoint.id).filter((id): id is string => !!id),
   );
   const plannedHostnames = new Set(plannedDomains.map((domain) => domain.hostname.toLowerCase()));
-  const obsoleteProjectDomains = activeRouteIds.size > 0
-    ? projectDomains.filter(
-        (domain) =>
-          !domain.serviceId &&
-          // Never sweep a user-connected custom domain (may be portless / not a
-          // build endpoint) — only free/generated routes are eligible.
-          domain.domainType !== "custom" &&
-          !activeRouteIds.has(domain.id) &&
-          !plannedHostnames.has(domain.hostname.toLowerCase()),
-      )
-    : [];
+  const obsoleteProjectDomains =
+    activeRouteIds.size > 0
+      ? projectDomains.filter(
+          (domain) =>
+            !domain.serviceId &&
+            // Never sweep a user-connected custom domain (may be portless / not a
+            // build endpoint) — only free/generated routes are eligible.
+            domain.domainType !== "custom" &&
+            !activeRouteIds.has(domain.id) &&
+            !plannedHostnames.has(domain.hostname.toLowerCase()),
+        )
+      : [];
 
   // Persist a domain record for each planned route. Track the ones we
   // CREATE here (vs pre-existing rows) so they can be rolled back if the
@@ -1871,9 +1925,7 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
   // otherwise orphan. Skip the one runDeployPipeline already handles and the
   // sentinel. Best-effort; never blocks the deploy.
   if (prevDep) {
-    const prevServiceDeps = await repos.service
-      .listByDeployment(prevDep.id)
-      .catch(() => []);
+    const prevServiceDeps = await repos.service.listByDeployment(prevDep.id).catch(() => []);
     for (const sd of prevServiceDeps) {
       if (!isRealContainerRef(sd.containerId) || sd.containerId === prevDep.containerId) {
         continue;
@@ -1948,20 +2000,27 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
     // piled up (3 for one project). Destroy it via the current runtime now.
     // Static deploys have no container. Best-effort + idempotent.
     if (deployResult.containerId && !isStaticFileServe) {
-      await runtime.destroy(deployResult.containerId).catch((err) =>
-        logger.log(
-          `Warning: failed to clean up container after deploy failure: ${safeErrorMessage(err)}\n`,
-          "warn",
-        ),
-      );
+      await runtime
+        .destroy(deployResult.containerId)
+        .catch((err) =>
+          logger.log(
+            `Warning: failed to clean up container after deploy failure: ${safeErrorMessage(err)}\n`,
+            "warn",
+          ),
+        );
     }
     // Roll back the domain rows this deploy created — it didn't take, so
     // its routes must not linger (they'd resurface as planned routes next
     // deploy). Best-effort; pre-existing rows are left untouched.
     for (const id of createdDomainIds) {
-      await repos.domain.remove(id).catch((err) =>
-        logger.log(`Warning: failed to roll back domain record: ${safeErrorMessage(err)}\n`, "warn"),
-      );
+      await repos.domain
+        .remove(id)
+        .catch((err) =>
+          logger.log(
+            `Warning: failed to roll back domain record: ${safeErrorMessage(err)}\n`,
+            "warn",
+          ),
+        );
     }
     await onFailure(ctx, deployResult.error, buildResult.durationMs, {
       errorCode: deployResult.errorCode,
@@ -1994,7 +2053,8 @@ async function executeServerDeploy(phase: DeployPhaseInputs): Promise<void> {
     new Set(
       (deployConfig.publicEndpoints && deployConfig.publicEndpoints.length > 0
         ? deployConfig.publicEndpoints
-        : [{ port: deployConfig.port }])
+        : [{ port: deployConfig.port }]
+      )
         .map((endpoint) => endpoint.port ?? deployConfig.port)
         .filter((port): port is number => Number.isFinite(port)),
     ),
@@ -2125,8 +2185,13 @@ async function runPostDeploySync(opts: {
   logger: BuildLogger;
 }): Promise<{ warningMessage?: string }> {
   const {
-    plannedDomains, obsoleteProjectDomains, routing, usesManagedRouting,
-    organizationId, serverId, logger,
+    plannedDomains,
+    obsoleteProjectDomains,
+    routing,
+    usesManagedRouting,
+    organizationId,
+    serverId,
+    logger,
   } = opts;
 
   // Collect free-domain edge-sync failures so a self-hosted + free-.opsh.io
@@ -2155,13 +2220,19 @@ async function runPostDeploySync(opts: {
     if (routing) {
       await routing.removeRoute(domain.hostname).catch((err) => {
         const message = safeErrorMessage(err);
-        logger.log(`Warning: failed to remove stale route ${domain.hostname}: ${message}\n`, "warn");
+        logger.log(
+          `Warning: failed to remove stale route ${domain.hostname}: ${message}\n`,
+          "warn",
+        );
       });
     }
 
     await repos.domain.remove(domain.id).catch((err) => {
       const message = safeErrorMessage(err);
-      logger.log(`Warning: failed to remove stale domain record ${domain.hostname}: ${message}\n`, "warn");
+      logger.log(
+        `Warning: failed to remove stale domain record ${domain.hostname}: ${message}\n`,
+        "warn",
+      );
     });
   }
 

--- a/apps/api/src/modules/deployments/compose/carried-host-port.test.ts
+++ b/apps/api/src/modules/deployments/compose/carried-host-port.test.ts
@@ -48,10 +48,7 @@ describe("pickHostPort's preferred-port contract", () => {
 });
 
 describe("the deploy routes the carried port through the allocator", () => {
-  const src = readFileSync(
-    new URL("./deploy.service.ts", import.meta.url),
-    "utf8",
-  );
+  const src = readFileSync(new URL("./deploy.service.ts", import.meta.url), "utf8");
   /** The loopback-port allocation block, bounded by its own loop. */
   const block = (() => {
     const from = src.indexOf("for (const containerPort of routedContainerPorts) {");
@@ -68,8 +65,9 @@ describe("the deploy routes the carried port through the allocator", () => {
     expect(block).not.toMatch(/if \(carried\) \{\s*hostPort = carried;/);
   });
 
-  it("still avoids ports this same deploy already handed out", () => {
-    expect(block).toContain("avoid: usedHostPorts");
+  it("still avoids ports already handed out to other projects or siblings", () => {
+    expect(block).toMatch(/avoid[,:]/);
+    expect(src).toContain("listOrgPinnedHostPorts(project.organizationId, project.id)");
   });
 
   it("says so when it had to move a carried port", () => {

--- a/apps/api/src/modules/deployments/compose/deploy.service.ts
+++ b/apps/api/src/modules/deployments/compose/deploy.service.ts
@@ -55,11 +55,8 @@ import { isLoopbackHost, resolveServerHost } from "../../../lib/server-target";
 import { resolveEdgeTargetHost } from "../../../lib/edge-target";
 import { containerIdForService } from "../../services/service-container";
 import { isConnectionLoss } from "../../../lib/remote-state";
-import {
-  appConfigHostPath,
-  withAppConfigHost,
-  writeAppConfigFile,
-} from "./app-config-host";
+import { appConfigHostPath, withAppConfigHost, writeAppConfigFile } from "./app-config-host";
+import { listOrgPinnedHostPorts } from "../pinned-host-ports";
 import {
   auditRoutedDomainTls,
   buildServiceRouteDomains,
@@ -78,7 +75,11 @@ import {
 import { ensureManagedEdgeProxy } from "../../../lib/managed-edge-proxy";
 import { ensureRoutingReady } from "../../../lib/edge-reconcile";
 import * as sessionManager from "../session-manager";
-import { isStaticService, parseServicePort, serviceAliasExtras } from "../../../lib/deployable-service";
+import {
+  isStaticService,
+  parseServicePort,
+  serviceAliasExtras,
+} from "../../../lib/deployable-service";
 import { computeKeepSet } from "../image-gc";
 import { auditPorts } from "../port-audit.service";
 import {
@@ -89,10 +90,7 @@ import {
 } from "../stability-audit.service";
 import { resolveReadinessGate, type ResolvedReadinessGate } from "../readiness-gate";
 import { probeDeployedReadiness } from "../readiness-probe";
-import {
-  hostChannelDeployNotice,
-  type PortCheckResult,
-} from "../../../lib/deployment-runtime";
+import { hostChannelDeployNotice, type PortCheckResult } from "../../../lib/deployment-runtime";
 import { isRealContainerRef } from "../../../lib/container-ref";
 import { resolveServicePort } from "./domain-helpers";
 import { compileProjectRoutingFields } from "../../../lib/project-routing-fields";
@@ -104,10 +102,7 @@ import {
   resolveDeployImage,
 } from "./service-scope";
 import { buildUpstreamUrl, resolveRouteStrategy } from "../../../lib/upstream-url";
-import {
-  withLoopbackPublishAll,
-  upstreamHostPortFor,
-} from "../../../lib/loopback-publish";
+import { withLoopbackPublishAll, upstreamHostPortFor } from "../../../lib/loopback-publish";
 
 export interface ComposeDeployResult {
   /** `reconciling` when at least one service's outcome is UNKNOWN because the
@@ -593,7 +588,6 @@ function resolveServiceResources(
     diskMb: base.diskMb,
   };
 }
-
 
 function createServiceRuntimeConfig(opts: {
   project: Project;
@@ -1210,6 +1204,10 @@ export async function deployComposeServices(
   for (const prev of previousByServiceId.values()) {
     if (prev.hostPort) usedHostPorts.add(prev.hostPort);
   }
+  const orgPinnedPorts = await listOrgPinnedHostPorts(project.organizationId, project.id);
+  for (const p of orgPinnedPorts) {
+    usedHostPorts.add(p);
+  }
 
   // #438: app-template config files (`advanced.files`) are host-side state living
   // under `/var/lib/openship`, the root-owned tree the edge's own vhosts sit in.
@@ -1518,7 +1516,9 @@ export async function deployComposeServices(
         svc.name,
         `no public URL is known for ${unresolvedEnvUrls
           .map((u) => `${u.key}=${u.tokens.join("")}`)
-          .join(", ")} — ${unresolvedEnvUrls.length === 1 ? "that variable is" : "those variables are"} left UNSET rather than blank`,
+          .join(
+            ", ",
+          )} — ${unresolvedEnvUrls.length === 1 ? "that variable is" : "those variables are"} left UNSET rather than blank`,
       );
     }
 
@@ -1846,7 +1846,10 @@ export async function deployComposeServices(
     // just belongs on the service that owns the interfaces, and the log says so.
     if (hasNoRoutableAddress) {
       const providers = composeNamespaceDependencies(svc.advanced as ComposeAdvanced | null);
-      const where = providers.length > 0 ? `shares ${providers.join(", ")}'s network namespace` : "has no network of its own";
+      const where =
+        providers.length > 0
+          ? `shares ${providers.join(", ")}'s network namespace`
+          : "has no network of its own";
       logger.log(
         `Service "${svc.name}" ${where}, so it has no address to route to — skipping its ` +
           `domains and its published ports. Move them to the service it shares.\n`,
@@ -1951,9 +1954,13 @@ export async function deployComposeServices(
          * another if it isn't. Passing it there rather than branching around the allocator means
          * one rule for both cases and no second place that decides what a free port is.
          */
+        const avoid = new Set(usedHostPorts);
+        if (carried) {
+          avoid.delete(carried);
+        }
         const allocation = await allocateHostPort(opts.executor, {
           preferred: carried,
-          avoid: usedHostPorts,
+          avoid,
         });
         const hostPort = allocation.port;
         if (carried && hostPort !== carried) {
@@ -2338,9 +2345,7 @@ export async function deployComposeServices(
     const probes = Promise.all(
       portAuditTargets.map(async (target) => {
         const [pc] = await auditPorts(runtime, target.containerId, [target.port], logger);
-        return pc
-          ? { ...pc, serviceId: target.serviceId, serviceName: target.serviceName }
-          : null;
+        return pc ? { ...pc, serviceId: target.serviceId, serviceName: target.serviceName } : null;
       }),
     );
     const audited = await Promise.race([
@@ -2437,9 +2442,7 @@ export async function deployComposeServices(
         f.target.serviceId &&
         readinessByServiceId.get(f.target.serviceId)?.onFailure === "fail",
     );
-    for (const finding of findings.filter(
-      (f) => !f.verdict.ok && !vetoing.includes(f),
-    )) {
+    for (const finding of findings.filter((f) => !f.verdict.ok && !vetoing.includes(f))) {
       // "warn": say what didn't hold, but leave the service's deploy result alone
       // so the stack stays up. Opting into the watch to get the signal must not
       // also opt into a veto.
@@ -2701,9 +2704,7 @@ export async function deployComposeServices(
     const domainRows = needsDomainMap
       ? [...domainByHostname.values()]
       : await repos.domain.listByProject(project.id).catch(() => []);
-    const candidates = enabled.filter((svc) =>
-      withContainer.some((r) => r.serviceId === svc.id),
-    );
+    const candidates = enabled.filter((svc) => withContainer.some((r) => r.serviceId === svc.id));
     const primaryId = pickPrimaryServiceId(candidates, domainRows);
     return (
       withContainer.find((r) => r.serviceId === primaryId)?.containerId ??
@@ -2827,7 +2828,10 @@ export async function deployComposeServices(
         // compiled ones would ASSIGN over them, silently dropping a vercel.json external
         // rewrite on a path-routed domain. Fan-out first, so its explicit per-path
         // upstreams are matched ahead of a broader compiled rule.
-        const proxyLocations = [...(reg.proxyLocations ?? []), ...(routingFields.proxyLocations ?? [])];
+        const proxyLocations = [
+          ...(reg.proxyLocations ?? []),
+          ...(routingFields.proxyLocations ?? []),
+        ];
         await routeContext.routing.registerRoute({
           domain: reg.hostname,
           tls: true,

--- a/apps/api/src/modules/deployments/pinned-host-ports.test.ts
+++ b/apps/api/src/modules/deployments/pinned-host-ports.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const listByOrganization = vi.fn();
+const listByDeployments = vi.fn();
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    project: {
+      listByOrganization: (...args: unknown[]) => listByOrganization(...args),
+    },
+    serviceDeployment: {
+      listByDeployments: (...args: unknown[]) => listByDeployments(...args),
+    },
+  },
+}));
+
+import { listOrgPinnedHostPorts } from "./pinned-host-ports";
+
+describe("listOrgPinnedHostPorts", () => {
+  beforeEach(() => {
+    listByOrganization.mockReset();
+    listByDeployments.mockReset().mockResolvedValue(new Map());
+  });
+
+  it("collects pinned host ports from both single-service and compose projects", async () => {
+    listByOrganization.mockResolvedValue({
+      rows: [
+        // Single-service project with pinned hostPort
+        { id: "proj-1", hostPort: 20001, activeDeploymentId: "dep-1" },
+        // Compose project: hostPort on project is null, but active deployment has service deployments
+        { id: "proj-2", hostPort: null, activeDeploymentId: "dep-2" },
+        // Current project (to be excluded)
+        { id: "current-proj", hostPort: 20007, activeDeploymentId: "dep-current" },
+        // Project with no deployment and no hostPort
+        { id: "proj-3", hostPort: null, activeDeploymentId: null },
+      ],
+    });
+
+    listByDeployments.mockResolvedValue(
+      new Map([
+        [
+          "dep-2",
+          [
+            { serviceName: "server", hostPort: 20005 },
+            { serviceName: "worker", hostPort: null },
+            { serviceName: "web", hostPort: 20006 },
+          ],
+        ],
+      ]),
+    );
+
+    const pinned = await listOrgPinnedHostPorts("org-1", "current-proj");
+
+    expect(pinned).toContain(20001);
+    expect(pinned).toContain(20005);
+    expect(pinned).toContain(20006);
+    expect(pinned).not.toContain(20007);
+    expect(listByDeployments).toHaveBeenCalledWith(["dep-1", "dep-2"]);
+  });
+
+  it("handles empty organization or database errors without throwing", async () => {
+    listByOrganization.mockRejectedValue(new Error("db connection error"));
+
+    const pinned = await listOrgPinnedHostPorts("org-1", "current-proj");
+    expect(pinned).toEqual([]);
+  });
+
+  it("filters out non-positive or invalid port numbers", async () => {
+    listByOrganization.mockResolvedValue({
+      rows: [
+        { id: "proj-1", hostPort: 0, activeDeploymentId: "dep-1" },
+        { id: "proj-2", hostPort: -1, activeDeploymentId: null },
+        { id: "proj-3", hostPort: 20010, activeDeploymentId: null },
+      ],
+    });
+
+    listByDeployments.mockResolvedValue(
+      new Map([
+        [
+          "dep-1",
+          [
+            { serviceName: "api", hostPort: 0 },
+            { serviceName: "db", hostPort: 20011 },
+          ],
+        ],
+      ]),
+    );
+
+    const pinned = await listOrgPinnedHostPorts("org-1");
+    expect(pinned).toEqual([20010, 20011]);
+  });
+});

--- a/apps/api/src/modules/deployments/pinned-host-ports.ts
+++ b/apps/api/src/modules/deployments/pinned-host-ports.ts
@@ -1,0 +1,56 @@
+import { repos } from "@repo/db";
+
+/**
+ * Collect all loopback host ports currently pinned to OTHER projects in the organization.
+ *
+ * This includes:
+ * 1. Single-service projects whose `project.hostPort` is set.
+ * 2. Compose / multi-service projects whose active deployment has `service_deployment.hostPort` rows.
+ *
+ * When containers are stopped or restarting (e.g. after a crash or during maintenance),
+ * live TCP port scanning on the host cannot see them. Seeding `avoid` with these database-pinned
+ * ports prevents another project's deploy from stealing a stopped container's port and causing
+ * a Docker bind collision when it restarts.
+ */
+export async function listOrgPinnedHostPorts(
+  organizationId: string,
+  excludeProjectId?: string | null,
+): Promise<number[]> {
+  const otherProjects = (
+    await repos.project
+      .listByOrganization(organizationId, { perPage: 1000 })
+      .then((r) => r.rows)
+      .catch(
+        () =>
+          [] as Array<{ id: string; hostPort: number | null; activeDeploymentId: string | null }>,
+      )
+  ).filter((p) => !excludeProjectId || p.id !== excludeProjectId);
+
+  const pinned = new Set<number>();
+  const activeDeploymentIds: string[] = [];
+
+  for (const p of otherProjects) {
+    if (typeof p.hostPort === "number" && p.hostPort > 0) {
+      pinned.add(p.hostPort);
+    }
+    if (p.activeDeploymentId) {
+      activeDeploymentIds.push(p.activeDeploymentId);
+    }
+  }
+
+  if (activeDeploymentIds.length > 0) {
+    const serviceDepsMap = await repos.serviceDeployment
+      .listByDeployments(activeDeploymentIds)
+      .catch(() => new Map<string, Array<{ hostPort: number | null }>>());
+
+    for (const deps of serviceDepsMap.values()) {
+      for (const sd of deps) {
+        if (typeof sd.hostPort === "number" && sd.hostPort > 0) {
+          pinned.add(sd.hostPort);
+        }
+      }
+    }
+  }
+
+  return Array.from(pinned);
+}


### PR DESCRIPTION
Closes #682

### Problem
When deploying a Compose stack (`deploy.service.ts`), loopback host port allocation only avoided ports belonging to sibling services in the current project. If a container belonging to another project was stopped, restarting, or crashed during the deployment, host port scanning did not detect it as listening on TCP. The deploy then allocated that port to the Compose service. When the offline container attempted to start, Docker rejected the bind (`Bind for 127.0.0.1:<port> failed: port is already allocated`), causing a permanent restart failure.

Additionally, `build-pipeline.ts` previously only inspected `project.hostPort` when computing `avoid`, missing active host ports belonging to Compose stacks.

### Solution
- Created `listOrgPinnedHostPorts` in `apps/api/src/modules/deployments/pinned-host-ports.ts` to aggregate all active host ports pinned across the organization (both single-service `project.hostPort` and Compose stack active `service_deployment.hostPort` rows).
- Seeded `usedHostPorts` in `deploy.service.ts` with organization-pinned ports and ensured a service's own `carried` port is not in its own `avoid` set so it can be reused as preferred.
- Updated `build-pipeline.ts` to use `listOrgPinnedHostPorts`.
- Added unit tests in `pinned-host-ports.test.ts` and updated `carried-host-port.test.ts`.