### PR TITLE
fix(apps): declare minEngine=0.6.6 on catalog entries that use commandArgv/stopGracePeriod (#599)

### DIFF
--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -2046,6 +2046,7 @@
     {
       "available": true,
       "verified": true,
+      "minEngine": "0.6.6",
       "id": "minio",
       "name": "MinIO",
       "description": "S3-compatible object storage with a web console — point any S3 client (aws-cli, SDKs) at it, or bind a bucket straight into another project's uploads.",
@@ -2540,6 +2541,7 @@
     {
       "available": true,
       "verified": false,
+      "minEngine": "0.6.6",
       "minResources": {
         "memoryMb": 4096,
         "cpuCores": 2
@@ -2719,6 +2721,7 @@
     {
       "available": true,
       "verified": false,
+      "minEngine": "0.6.6",
       "minResources": {
         "memoryMb": 16384,
         "cpuCores": 4
@@ -3497,6 +3500,7 @@
     {
       "available": true,
       "verified": false,
+      "minEngine": "0.6.6",
       "id": "redis",
       "name": "Valkey (Redis)",
       "description": "In-memory data store for caching, sessions, rate limits, and queues — Valkey, the open-source Redis fork. Drop-in Redis-compatible: point any redis client at it. Ships with RedisInsight, a browser UI that arrives already connected to this instance.",
@@ -3975,6 +3979,7 @@
     {
       "available": true,
       "verified": false,
+      "minEngine": "0.6.6",
       "id": "clickhouse",
       "name": "ClickHouse",
       "description": "The columnar SQL database for analytics — billions of rows scanned per second. Ships with the CH-UI console, so you get a SQL editor, schema browser and dashboards the moment it installs: sign in with the ClickHouse user and password below, no extra setup.",

--- a/packages/core/src/apps/catalog.test.ts
+++ b/packages/core/src/apps/catalog.test.ts
@@ -25,6 +25,30 @@ describe("app catalog (JSON)", () => {
     expect(isValidAppTemplate(null)).toBe(false);
     expect(isValidAppTemplate({ id: "x", name: "X", description: "d", kind: "template", logo: "x", category: "bogus" })).toBe(false);
   });
+
+  it("every entry that uses commandArgv/stopGracePeriod declares minEngine >= 0.6.6 (issue #599)", () => {
+    // `commandArgv` and `stopGracePeriod` were added to the serviceSpec schema
+    // in commit 550fe22f, released as v0.6.6. Without minEngine >= 0.6.6 on the
+    // entry, the engine-gate cannot refuse to install the app on a pre-0.6.6
+    // engine — the install silently drops the field and the container runs the
+    // wrong role (PostHog worker, MinIO "sh is not a minio sub-command", …).
+    const MIN_ENGINE = "0.6.6";
+    for (const app of APP_TEMPLATES) {
+      for (const service of app.services ?? []) {
+        const usesPostRelease =
+          service.commandArgv !== undefined || service.stopGracePeriod !== undefined;
+        if (!usesPostRelease) continue;
+        expect(
+          app.minEngine,
+          `${app.id}/${service.name} uses a post-0.6.6 serviceSpec field but entry has no minEngine — engine gate cannot refuse pre-0.6.6 installs`,
+        ).toBeDefined();
+        expect(
+          templateEngineOk(app.minEngine, MIN_ENGINE),
+          `${app.id}/${service.name} declares minEngine=${app.minEngine}, must be >= ${MIN_ENGINE}`,
+        ).toBe(true);
+      }
+    }
+  });
 });
 
 describe("mail has exactly one entry point in the catalog", () => {

--- a/packages/core/src/apps/catalog/clickhouse.json
+++ b/packages/core/src/apps/catalog/clickhouse.json
@@ -1,6 +1,7 @@
 {
   "available": true,
   "verified": false,
+  "minEngine": "0.6.6",
   "id": "clickhouse",
   "name": "ClickHouse",
   "description": "The columnar SQL database for analytics — billions of rows scanned per second. Ships with the CH-UI console, so you get a SQL editor, schema browser and dashboards the moment it installs: sign in with the ClickHouse user and password below, no extra setup.",

--- a/packages/core/src/apps/catalog/minio.json
+++ b/packages/core/src/apps/catalog/minio.json
@@ -1,6 +1,7 @@
 {
   "available": true,
   "verified": true,
+  "minEngine": "0.6.6",
   "id": "minio",
   "name": "MinIO",
   "description": "S3-compatible object storage with a web console — point any S3 client (aws-cli, SDKs) at it, or bind a bucket straight into another project's uploads.",

--- a/packages/core/src/apps/catalog/neon.json
+++ b/packages/core/src/apps/catalog/neon.json
@@ -1,6 +1,7 @@
 {
   "available": true,
   "verified": false,
+  "minEngine": "0.6.6",
   "minResources": {
     "memoryMb": 4096,
     "cpuCores": 2

--- a/packages/core/src/apps/catalog/posthog.json
+++ b/packages/core/src/apps/catalog/posthog.json
@@ -1,6 +1,7 @@
 {
   "available": true,
   "verified": false,
+  "minEngine": "0.6.6",
   "minResources": {
     "memoryMb": 16384,
     "cpuCores": 4

--- a/packages/core/src/apps/catalog/redis.json
+++ b/packages/core/src/apps/catalog/redis.json
@@ -1,6 +1,7 @@
 {
   "available": true,
   "verified": false,
+  "minEngine": "0.6.6",
   "id": "redis",
   "name": "Valkey (Redis)",
   "description": "In-memory data store for caching, sessions, rate limits, and queues — Valkey, the open-source Redis fork. Drop-in Redis-compatible: point any redis client at it. Ships with RedisInsight, a browser UI that arrives already connected to this instance.",


### PR DESCRIPTION
## Problem

Five bundled apps (posthog, clickhouse, minio, neon, redis) ship services that use post-release `serviceSpec` fields (`commandArgv`, `stopGracePeriod`). These fields were added to the template schema in commit 550fe22f and first shipped in v0.6.6, but **no entry declared `minEngine`**, so the engine-gate in `apps/api/src/modules/apps/catalog-source.ts` had nothing to compare against and could not refuse a pre-0.6.6 install.

The silently-dropped field produces wrong-role containers:

- **PostHog** worker installs without a command and silently runs the wrong role (this is the reporter's concrete observation in the issue).
- **MinIO** exits with `'sh' is not a minio sub-command` because the shell-wrapped `command` never reaches the entrypoint.

## Root cause

`packages/core/src/apps/schema.ts` documents the two fields as post-release additions (the commit message in 550fe22f spells out the same MinIO reproducer), but the schema-level `commandArgv`/`stopGracePeriod` are accepted by every entry without a corresponding `minEngine` claim, so the engine-version check in `templateEngineOk(entry.minEngine, engineVersion)` always returns `true` (because `minEngine` is undefined → always ok).

The reporter's claim that "PostHog worker installs with no command" lines up exactly with this: on a pre-0.6.6 engine, the field is dropped and the container starts with whatever the image default is.

## Fix

Add `"minEngine": "0.6.6"` to each of the five catalog entries that use the post-release fields, so the engine-gate now has a real value to compare against:

- `packages/core/src/apps/catalog/posthog.json` — worker / web / ingestion-* use `commandArgv`
- `packages/core/src/apps/catalog/clickhouse.json` — uses `stopGracePeriod`
- `packages/core/src/apps/catalog/minio.json` — uses `commandArgv` (the MinIO reproducer)
- `packages/core/src/apps/catalog/neon.json` — uses `stopGracePeriod`
- `packages/core/src/apps/catalog/redis.json` — valkey uses `commandArgv`

`packages/core/src/apps/catalog.json` is regenerated via `bun scripts/gen-catalog.ts` to mirror the source-of-truth `catalog/*.json` files.

## Verification

Regression test added in `packages/core/src/apps/catalog.test.ts` that walks every entry's services and asserts: any service that sets `commandArgv` or `stopGracePeriod` must declare `entry.minEngine` that satisfies `templateEngineOk(minEngine, "0.6.6")`.

**Sabotage run:** removed `minEngine` from `posthog.json` → new test fails with:

> posthog/redis7 uses a post-0.6.6 serviceSpec field but entry has no minEngine — engine gate cannot refuse pre-0.6.6 installs

Restoring the field → full suite passes:

```
27 pass  0 fail  87 expect() calls  (packages/core/src/apps/catalog.test.ts)
809 pass 0 fail  3895 expect() calls (full packages/core bun test)
```

Targeted `apps/api` checks (`INTERNAL_TOKEN=... DEPLOY_MODE=desktop OPENSHIP_AUTH_MODE=none bun test test/modules/apps/catalog-resolve.test.ts test/modules/apps/app-catalog-listing.test.ts`) → 9 pass / 0 fail.

## Risks

- `minEngine: 0.6.6` will surface a "requires update" placeholder for any user still running a pre-0.6.6 engine. That is exactly the desired behavior — it matches the comment on the issue ("the minEngine gate … is armed on nothing"). The bundled entries still install on every released engine ≥ 0.6.6 because `resolveCatalog` falls back to the bundled copy when a too-new overlay overrides a bundled app; for users on a too-old engine, the placeholder guides them to upgrade instead of running the broken role.
- No schema change. `minEngine` already accepts any semver string and `templateEngineOk` already gates it. Pure data fix.