### PR TITLE
fix(github): honor explicit gh config directory

### DIFF
--- a/apps/api/src/modules/github/github.local-auth.ts
+++ b/apps/api/src/modules/github/github.local-auth.ts
@@ -336,7 +336,9 @@ const GH_FALLBACK_PATHS = [
 /** One-shot exec attempt — resolves to the trimmed stdout on success,
  *  or an error object the caller can log. Used to walk fallback paths
  *  without burying the actual ENOENT/EPERM under a silent null. */
-function tryGhExec(bin: string): Promise<{ token: string } | { error: NodeJS.ErrnoException; stderr?: string }> {
+function tryGhExec(
+  bin: string,
+): Promise<{ token: string } | { error: NodeJS.ErrnoException; stderr?: string }> {
   return new Promise((resolve) => {
     execFile(bin, ["auth", "token"], { timeout: 10_000 }, (err, stdout, stderr) => {
       if (err) return resolve({ error: err as NodeJS.ErrnoException, stderr: stderr?.toString() });
@@ -400,20 +402,23 @@ async function ghAuthTokenViaCli(): Promise<string | null> {
 }
 
 /**
- * Read token from the gh CLI config file. Tries (in order):
- *   - $GH_CONFIG_DIR/hosts.yml (explicit override)
- *   - $XDG_CONFIG_HOME/gh/hosts.yml (XDG spec)
- *   - ~/.config/gh/hosts.yml (default)
+ * Read token from the gh CLI config file. An explicit `$GH_CONFIG_DIR` or
+ * `$XDG_CONFIG_HOME` is authoritative; otherwise use `~/.config/gh/hosts.yml`.
+ * This prevents a sandboxed or service-specific config lookup from silently
+ * falling back to another user's credentials.
  *
  * Logs the path it actually attempted on failure so operators can see
  * the resolved location.
  */
 async function ghAuthTokenViaConfig(): Promise<string | null> {
   const candidates: string[] = [];
-  if (process.env.GH_CONFIG_DIR) candidates.push(join(process.env.GH_CONFIG_DIR, "hosts.yml"));
-  if (process.env.XDG_CONFIG_HOME)
+  if (process.env.GH_CONFIG_DIR) {
+    candidates.push(join(process.env.GH_CONFIG_DIR, "hosts.yml"));
+  } else if (process.env.XDG_CONFIG_HOME) {
     candidates.push(join(process.env.XDG_CONFIG_HOME, "gh", "hosts.yml"));
-  candidates.push(join(homedir(), ".config", "gh", "hosts.yml"));
+  } else {
+    candidates.push(join(homedir(), ".config", "gh", "hosts.yml"));
+  }
 
   for (const path of candidates) {
     try {


### PR DESCRIPTION
## Summary

Make an explicit `GH_CONFIG_DIR` or `XDG_CONFIG_HOME` authoritative when OpenShip reads a GitHub CLI credential.

## Motivation

Before this change, a missing explicit config file caused the lookup to fall back to `~/.config/gh/hosts.yml`. In service or multi-user environments, that could silently discover and use another user’s credential. This was reproduced by the existing health test when `GH_CONFIG_DIR` pointed at a nonexistent isolated directory.

## Related issue

Closes #687

## Changes

- Treat `GH_CONFIG_DIR` as the only config location when it is set.
- Otherwise treat `XDG_CONFIG_HOME` as the only config location when it is set.
- Use the default `~/.config/gh/hosts.yml` path only when neither override is present.

## Verification

```bash
bun run --cwd apps/api test test/modules/github/gh-identity-health.test.ts
# 8 tests passed

bun run --cwd apps/api test
# 404 test files passed; 4862 tests passed; 3 skipped

bun run --cwd apps/api lint
# passed

bunx prettier --check apps/api/src/modules/github/github.local-auth.ts
# passed

bun run --cwd apps/api build
# Build success

git diff --check
# passed
```

The targeted regression failed before this change with `AssertionError: expected true to be false` and passes with it.

## Screenshots

Not applicable.

## Checklist

- [x] One change per PR — one bug, with nothing unrelated bundled in
- [x] The diff is scoped — no unrelated reformatting or lint fixes
- [x] The existing regression test fails without this change and passes with it
- [x] API tests, lint, formatting, build, and diff checks pass locally
- [x] I understand every line of this diff and can explain it in review
