### PR TITLE
fix(dashboard): allow unauthenticated access to /accept-invite route

### DIFF
--- a/apps/dashboard/src/proxy.test.ts
+++ b/apps/dashboard/src/proxy.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "./proxy";
+
+describe("dashboard proxy middleware", () => {
+  it("allows unauthenticated access to /accept-invite without redirecting to /login", () => {
+    const req = new NextRequest("http://localhost:3001/accept-invite/inv_12345");
+    const res = proxy(req);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("redirects unauthenticated access to private dashboard route to /login", () => {
+    const req = new NextRequest("http://localhost:3001/projects");
+    const res = proxy(req);
+    expect(res.headers.get("location")).toBe("http://localhost:3001/login?from=%2Fprojects");
+  });
+});

--- a/apps/dashboard/src/proxy.ts
+++ b/apps/dashboard/src/proxy.ts
@@ -21,6 +21,7 @@ const PUBLIC_ROUTES = [
   // `returnTo`/`callback`), so intercepting it stranded the user on `/` and the
   // MCP client's flow never completed.
   "/mcp/authorize",
+  "/accept-invite",
 ];
 
 const SESSION_COOKIE_SUFFIX = ".session_token";


### PR DESCRIPTION

 

 
## Summary
Allows unauthenticated users to access the `/accept-invite/[id]` route so newly invited members can register and accept team invitations on self-hosted instances.
 
## Motivation
When a newly invited user clicks the invitation link received via email (`/accept-invite/[id]`), the dashboard proxy middleware (`apps/dashboard/src/proxy.ts`) checks for a session cookie (`.session_token`). Because the invited user does not have an active session and `"/accept-invite"` was missing from `PUBLIC_ROUTES`, the middleware redirected them to `/login?from=%2Faccept-invite%2F[id]`.
 
On self-hosted deployments, public registration is disabled (`SIGNUP_DISABLED`). The `/accept-invite/[id]` page already implements an inline sign-up form that calls the token-bound `/api/system/invite-signup` endpoint, but unauthenticated invitees could never reach the page to complete their registration.
 
## Related issue
None
 
## Changes
### apps/dashboard
- Added `"/accept-invite"` to `PUBLIC_ROUTES` in `src/proxy.ts`.
- Added a unit test in `src/proxy.test.ts` verifying unauthenticated access to `/accept-invite/*` passes without redirection, and that other private routes still redirect to `/login`.
## Verification
Ran the dashboard proxy route unit test with Vitest:
 
```bash
bun run --cwd apps/dashboard test src/proxy.test.ts
```
 
```
✓ src/proxy.test.ts (2 tests)
  ✓ dashboard proxy middleware > allows unauthenticated access to /accept-invite without redirecting to /login
  ✓ dashboard proxy middleware > redirects unauthenticated access to private dashboard route to /login
 
 Test Files  1 passed (1)
      Tests  2 passed (2)
```
 
- **Before**: Requesting `/accept-invite/[id]` without a session cookie resulted in a 307 redirect to `/login?from=%2Faccept-invite%2F[id]`.
- **After**: Requesting `/accept-invite/[id]` allows the request through so the invitation/account creation form renders correctly.
## Checklist
- [x] One change per PR — one bug, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test`, `bun run --cwd apps/dashboard lint`, and `bun format` all pass locally
- [x] I understand every line of this diff and can explain it in review
 