### PR TITLE
feat(deployments): show live service logs after successful deploy

### DIFF
--- a/apps/api/src/modules/services/service-log-end.test.ts
+++ b/apps/api/src/modules/services/service-log-end.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeSSE = vi.hoisted(() => vi.fn());
+const onAbort = vi.hoisted(() => vi.fn());
+let sseHandler:
+  | ((sseStream: { writeSSE: typeof writeSSE; onAbort: (cb: () => void) => void }) => Promise<void>)
+  | null = null;
+
+vi.mock("../../lib/sse", () => ({
+  streamSSE: vi.fn((_c: unknown, handler: typeof sseHandler) => {
+    sseHandler = handler;
+    return new Response();
+  }),
+}));
+
+vi.mock("../../lib/ssh-manager", () => ({
+  sshManager: { retain: vi.fn(), release: vi.fn() },
+}));
+
+vi.mock("../../lib/request-context", () => ({
+  getRequestContext: vi.fn(() => ({ userId: "u1", organizationId: "o1" })),
+}));
+
+const streamServiceRuntimeLogs = vi.hoisted(() => vi.fn());
+vi.mock("./service.service", () => ({
+  streamServiceRuntimeLogs,
+}));
+
+import { runtimeLogStream } from "./service.controller";
+
+function fakeC() {
+  return {
+    req: {
+      param: (name: string) => ({ id: "proj_1", serviceId: "svc_1" })[name as "id" | "serviceId"],
+      query: (_name: string) => undefined,
+    },
+  } as any;
+}
+
+type SseStream = Parameters<NonNullable<typeof sseHandler>>[0];
+
+function mustSettle<T>(p: Promise<T>, ms = 250): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("handler did not settle")), ms),
+    ),
+  ]);
+}
+
+async function startStream(
+  opts: {
+    stream?: { cleanup: ReturnType<typeof vi.fn>; serverId: string | null };
+    impl?: (...args: unknown[]) => Promise<unknown>;
+  } = {},
+) {
+  const stream = opts.stream ?? { cleanup: vi.fn(), serverId: null };
+  if (opts.impl) streamServiceRuntimeLogs.mockImplementation(opts.impl as any);
+  else streamServiceRuntimeLogs.mockResolvedValue(stream);
+  await runtimeLogStream(fakeC());
+  const running = sseHandler!({
+    writeSSE,
+    onAbort,
+  } as SseStream);
+  await Promise.resolve();
+  expect(streamServiceRuntimeLogs).toHaveBeenCalledTimes(1);
+  const lastCall = streamServiceRuntimeLogs.mock.calls.at(-1)!;
+  return {
+    running,
+    onEnd: lastCall[4]?.onEnd as (() => void) | undefined,
+    stream,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sseHandler = null;
+  writeSSE.mockResolvedValue(undefined);
+});
+
+describe("runtime log stream natural end", () => {
+  it("writes the end event before releasing the response", async () => {
+    let releaseFlush!: () => void;
+    const flush = new Promise<void>((r) => (releaseFlush = r));
+    writeSSE.mockImplementation((frame: { event: string }) =>
+      frame.event === "end" ? flush : Promise.resolve(),
+    );
+
+    const { running, onEnd, stream } = await startStream();
+    onEnd!();
+
+    expect(await Promise.race([running.then(() => "settled"), Promise.resolve("pending")])).toBe(
+      "pending",
+    );
+    expect(stream.cleanup).not.toHaveBeenCalled();
+    expect(writeSSE).toHaveBeenCalledWith(expect.objectContaining({ event: "end" }));
+
+    releaseFlush();
+    await mustSettle(running);
+    expect(stream.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles and cleans up when the container ends during subscription", async () => {
+    const cleanup = vi.fn();
+    const { running } = await startStream({
+      impl: async (...args: unknown[]) => {
+        (args[4] as { onEnd: () => void }).onEnd();
+        return { cleanup, serverId: null };
+      },
+    });
+    await mustSettle(running);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("still releases via client abort and runs cleanup exactly once", async () => {
+    const cleanup = vi.fn();
+    const { running } = await startStream({ stream: { cleanup, serverId: null } });
+    const abortCb = onAbort.mock.calls.at(-1)![0] as () => void;
+
+    abortCb();
+    abortCb();
+    await mustSettle(running);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits one terminal frame when the runtime reports end more than once", async () => {
+    let releaseFlush!: () => void;
+    writeSSE.mockImplementation(() => new Promise<void>((resolve) => (releaseFlush = resolve)));
+    const { running, onEnd } = await startStream();
+
+    onEnd!();
+    onEnd!();
+    expect(writeSSE).toHaveBeenCalledTimes(1);
+
+    releaseFlush();
+    await mustSettle(running);
+  });
+});

--- a/apps/api/src/modules/services/service.controller.ts
+++ b/apps/api/src/modules/services/service.controller.ts
@@ -428,6 +428,33 @@ export async function runtimeLogStream(c: Context) {
   return streamSSE(c, async (sseStream) => {
     let cleanup: (() => void) | null = null;
     let serverId: string | null = null;
+    let finished = false;
+    let cleanupDone = false;
+    let endFramePending = false;
+    let retained = false;
+    let resolveHold: () => void;
+    const hold = new Promise<void>((resolve) => {
+      resolveHold = resolve;
+    });
+
+    const cleanupOnce = () => {
+      if (!cleanup || cleanupDone) return;
+      cleanupDone = true;
+      try {
+        cleanup();
+      } catch {
+        // The response is already ending; cleanup must not strand it.
+      }
+    };
+
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      cleanupOnce();
+      resolveHold();
+    };
+
+    sseStream.onAbort(finish);
 
     try {
       const result = await serviceService.streamServiceRuntimeLogs(
@@ -446,25 +473,43 @@ export async function runtimeLogStream(c: Context) {
             }),
           });
         },
-        { tail },
+        {
+          tail,
+          onEnd: () => {
+            if (finished || endFramePending) return;
+            endFramePending = true;
+            void sseStream
+              .writeSSE({
+                event: "end",
+                data: JSON.stringify({ exitCode: 0, message: "Log stream ended" }),
+              })
+              .catch(() => {})
+              .finally(() => finish());
+          },
+        },
       );
 
       cleanup = result.cleanup;
       serverId = result.serverId;
-      if (serverId) sshManager.retain(serverId);
+      if (finished) {
+        cleanupOnce();
+        return;
+      }
 
-      await new Promise<void>((resolve) => {
-        sseStream.onAbort(() => {
-          cleanup?.();
-          resolve();
-        });
-      });
+      if (serverId) {
+        sshManager.retain(serverId);
+        retained = true;
+      }
+      await hold;
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to stream logs";
-      await sseStream.writeSSE({ event: "error", data: JSON.stringify({ error: message }) });
-      cleanup?.();
+      if (!finished) {
+        const message = err instanceof Error ? err.message : "Failed to stream logs";
+        await sseStream.writeSSE({ event: "error", data: JSON.stringify({ error: message }) });
+      }
+      finish();
     } finally {
-      if (serverId) sshManager.release(serverId);
+      cleanupOnce();
+      if (retained && serverId) sshManager.release(serverId);
     }
   });
 }

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -33,6 +33,7 @@ import {
   type LogEntry,
   type ContainerStatus,
   type RuntimeAdapter,
+  type RuntimeLogStreamOptions,
 } from "@repo/adapters";
 import { scopedVolumeName, type CommandExecutor } from "@repo/adapters";
 import { isArtifactRef } from "../../lib/container-ref";
@@ -2185,7 +2186,7 @@ export async function streamServiceRuntimeLogs(
   projectId: string,
   serviceId: string,
   onLog: (entry: LogEntry) => void,
-  opts?: { tail?: number },
+  opts?: RuntimeLogStreamOptions,
 ) {
   const { runtime, containerId, serverId } = await resolveServiceContainer(
     ctx,

--- a/apps/dashboard/src/components/import-project/compose/ComposeDeploymentProcessing.tsx
+++ b/apps/dashboard/src/components/import-project/compose/ComposeDeploymentProcessing.tsx
@@ -16,7 +16,8 @@ import { useToast } from "@/context/ToastContext";
 import { useTheme } from "@/components/theme-provider";
 import { deployApi } from "@/lib/api";
 import { invalidateProjectCaches } from "@/hooks/useProjectEndpoints";
-import { composeServiceTally } from "@/context/deployment/types";
+import { composeServiceTally, serviceLogSource } from "@/context/deployment/types";
+import { LiveServiceLogsTerminal } from "./LiveServiceLogsTerminal";
 import type { DeploymentStatus, ServiceDeployStatus } from "@/context/deployment/types";
 import { encodeRepoSlug, encodeLocalSlug } from "@/utils/repoSlug";
 import type { BuildLog } from "@/utils/deploymentPhaseDetector";
@@ -408,6 +409,8 @@ const ComposeDeploymentProcessing: React.FC<Props> = ({ onRedeploy }) => {
             activeTab={activeLogTab}
             onTabChange={handleTabChange}
             deploymentStatus={deploymentStatus}
+            decisionPending={showDecision}
+            projectId={state.projectId || config.projectId}
             running={running}
             built={built}
             building={building}
@@ -644,6 +647,8 @@ function ComposeServiceLogsPanel({
   activeTab,
   onTabChange,
   deploymentStatus,
+  decisionPending,
+  projectId,
   running,
   built,
   building,
@@ -659,6 +664,10 @@ function ComposeServiceLogsPanel({
   activeTab: string;
   onTabChange: (tab: string) => void;
   deploymentStatus: DeploymentStatus;
+  /** Held keep/reject decision — suppresses the runtime-stream swap (#667). */
+  decisionPending?: boolean;
+  /** Needed to dial each service's live runtime log stream after success. */
+  projectId?: string;
   running: number;
   /** Image built, container not up yet — see the ComposeSidebar tally. */
   built: number;
@@ -677,6 +686,13 @@ function ComposeServiceLogsPanel({
     const map = new Map<string, string>();
     services.forEach((service) => {
       if (service.serviceId && service.serviceName) map.set(service.serviceId, service.serviceName);
+    });
+    return map;
+  }, [services]);
+  const serviceIdByName = useMemo(() => {
+    const map = new Map<string, string>();
+    services.forEach((service) => {
+      if (service.serviceId && service.serviceName) map.set(service.serviceName, service.serviceId);
     });
     return map;
   }, [services]);
@@ -813,15 +829,36 @@ function ComposeServiceLogsPanel({
             follows: borderless depends on fill contrast, and light has none here. */}
         <div className="relative h-[420px] overflow-hidden rounded-xl border border-border/50 bg-white dark:border-transparent dark:bg-black dim:border-transparent dim:bg-black">
           {terminalTabs.length > 0 ? (
-            terminalTabs.map((tab) => (
-              <ComposeLogTerminal
-                key={tab.id}
-                logs={tab.logs}
-                active={activeTab === tab.id}
-                emptyMessage={tab.emptyMessage}
-                theme={terminalTheme}
-              />
-            ))
+            terminalTabs.map((tab) => {
+              const isPrepare = tab.id === PREPARE_TAB;
+              const serviceId = isPrepare ? undefined : serviceIdByName.get(tab.id);
+              const live =
+                !isPrepare &&
+                !!projectId &&
+                !!serviceId &&
+                serviceLogSource({
+                  deploymentStatus,
+                  decisionPending,
+                  serviceStatus: serviceStatusByName.get(tab.id),
+                }) === "runtime";
+              return live ? (
+                <LiveServiceLogsTerminal
+                  key={tab.id}
+                  projectId={projectId}
+                  serviceId={serviceId}
+                  active={activeTab === tab.id}
+                  theme={terminalTheme}
+                />
+              ) : (
+                <ComposeLogTerminal
+                  key={tab.id}
+                  logs={tab.logs}
+                  active={activeTab === tab.id}
+                  emptyMessage={tab.emptyMessage}
+                  theme={terminalTheme}
+                />
+              );
+            })
           ) : (
             <div className="absolute inset-0 flex items-center justify-center px-6 text-center">
               <p className="text-sm text-muted-foreground">{cd.preparingServiceLogs}</p>

--- a/apps/dashboard/src/components/import-project/compose/LiveServiceLogsTerminal.render.test.tsx
+++ b/apps/dashboard/src/components/import-project/compose/LiveServiceLogsTerminal.render.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LiveServiceLogsTerminal } from "./LiveServiceLogsTerminal";
+
+function render(active: boolean) {
+  return renderToStaticMarkup(
+    <LiveServiceLogsTerminal
+      projectId="project-1"
+      serviceId="service-1"
+      active={active}
+      theme="dark"
+    />,
+  );
+}
+
+describe("LiveServiceLogsTerminal visibility", () => {
+  it("removes an inactive service terminal from painting and hit testing", () => {
+    const html = render(false);
+
+    expect(html).toContain("visibility:hidden");
+    expect(html).toContain("pointer-events:none");
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("shows only the active service terminal", () => {
+    const html = render(true);
+
+    expect(html).toContain("visibility:visible");
+    expect(html).toContain("pointer-events:auto");
+    expect(html).toContain('aria-hidden="false"');
+  });
+});

--- a/apps/dashboard/src/components/import-project/compose/LiveServiceLogsTerminal.tsx
+++ b/apps/dashboard/src/components/import-project/compose/LiveServiceLogsTerminal.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useLogStream } from "@/hooks/useSSEConnection";
+import { endpoints } from "@/lib/api/endpoints";
+import TerminalSurface from "../TerminalSurface";
+import { shouldRetryLiveStream } from "./live-stream-policy";
+
+interface LiveServiceLogsTerminalProps {
+  projectId: string;
+  serviceId: string;
+  /** Only the visible tab owns the single live SSE connection (#667). */
+  active: boolean;
+  theme?: "light" | "dark";
+}
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_DELAY_MS = 2000;
+
+/**
+ * Post-deploy runtime log stream for one compose service tab. The server
+ * backfills `?tail=` before going live; the connection lives only while the
+ * tab is active AND the xterm is ready (earlier lines would be discarded),
+ * and is dropped on tab switch, unmount, or a natural container-stream end.
+ */
+export const LiveServiceLogsTerminal: React.FC<LiveServiceLogsTerminalProps> = ({
+  projectId,
+  serviceId,
+  active,
+  theme,
+}) => {
+  const terminalRef = useRef<any>(null);
+  const [terminalReady, setTerminalReady] = useState(false);
+  // Natural end reported by the server — stop retrying once set.
+  const exitedRef = useRef(false);
+  // Set while WE are tearing the stream down on purpose, so the hook's
+  // onDisconnect/onError never schedules work after unmount.
+  const stoppingRef = useRef(false);
+  const attemptsRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Written through an effect-synced ref because the retry policy closes over
+  // state that itself depends on the stream hook (declared below).
+  const scheduleReconnectRef = useRef<() => void>(() => {});
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const logStream = useLogStream({
+    terminalRef,
+    autoWriteToTerminal: true,
+    callbacks: {
+      onError: (message) => {
+        if (!stoppingRef.current) {
+          terminalRef.current?.write(`\x1b[1;31m[${message}]\x1b[0m\r\n`);
+        }
+      },
+      onContainerExit: (exitCode, message) => {
+        exitedRef.current = true;
+        clearRetryTimer();
+        if (exitCode !== 0 && !stoppingRef.current && terminalRef.current) {
+          terminalRef.current.write(
+            `\x1b[1;31m[${message || `Container exited with code ${exitCode}`}]\x1b[0m\r\n`,
+          );
+        } else if (!stoppingRef.current && terminalRef.current) {
+          terminalRef.current.write(`\x1b[2m[${message || "Log stream ended"}]\x1b[0m\r\n`);
+        }
+      },
+    },
+    onDisconnect: () => scheduleReconnectRef.current(),
+    onError: () => scheduleReconnectRef.current(),
+  });
+
+  const connect = useCallback(async () => {
+    // Every connection re-backfills ?tail=100; a stale buffer would duplicate
+    // those lines, so each (re)connection starts from a clean slate.
+    terminalRef.current?.reset();
+    await logStream.connect(`${endpoints.services.logsStream(projectId, serviceId)}?tail=100`);
+  }, [logStream, projectId, serviceId]);
+
+  // Bounded auto-retry for unexpected drops (transport errors, API restarts).
+  // Deliberate teardowns flip stoppingRef first and never reach here.
+  const scheduleReconnect = useCallback(() => {
+    if (
+      !shouldRetryLiveStream({
+        exited: exitedRef.current,
+        stopping: stoppingRef.current,
+        active,
+        attempts: attemptsRef.current,
+        maxAttempts: MAX_RECONNECT_ATTEMPTS,
+      })
+    ) {
+      return;
+    }
+    attemptsRef.current += 1;
+    clearRetryTimer();
+    retryTimerRef.current = setTimeout(() => {
+      connect().catch(() => scheduleReconnectRef.current());
+    }, RECONNECT_DELAY_MS);
+  }, [active, connect, clearRetryTimer]);
+
+  useEffect(() => {
+    scheduleReconnectRef.current = scheduleReconnect;
+  }, [scheduleReconnect]);
+
+  useEffect(() => {
+    // Wait for BOTH the visible tab and the async-initialized xterm: lines
+    // streamed before onReady have no terminal to land in.
+    if (!active || !terminalReady || !projectId || !serviceId) return;
+    stoppingRef.current = false;
+    exitedRef.current = false;
+    attemptsRef.current = 0;
+    connect().catch(() => scheduleReconnectRef.current());
+    return () => {
+      stoppingRef.current = true;
+      clearRetryTimer();
+      logStream.disconnect();
+    };
+  }, [active, terminalReady, projectId, serviceId, connect, logStream, clearRetryTimer]);
+
+  return (
+    <div
+      className="absolute inset-0"
+      style={{
+        visibility: active ? "visible" : "hidden",
+        pointerEvents: active ? "auto" : "none",
+      }}
+      aria-hidden={!active}
+    >
+      <TerminalSurface
+        terminalRef={terminalRef}
+        onReady={(terminal) => {
+          terminalRef.current = terminal;
+          setTerminalReady(true);
+        }}
+        theme={theme}
+      />
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/import-project/compose/live-stream-policy.test.ts
+++ b/apps/dashboard/src/components/import-project/compose/live-stream-policy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { shouldRetryLiveStream } from "./live-stream-policy";
+
+/**
+ * Retry matrix for #667 live service logs: an unexpected drop retries a
+ * bounded number of times while the tab is watching; container exit, our own
+ * teardown, and a hidden tab never retry.
+ */
+const base = { attempts: 0, maxAttempts: 5 };
+
+describe("shouldRetryLiveStream", () => {
+  it("retries an unexpected drop on the visible tab", () => {
+    expect(shouldRetryLiveStream({ ...base, exited: false, stopping: false, active: true })).toBe(
+      true,
+    );
+  });
+
+  it("stops at the attempt cap", () => {
+    expect(
+      shouldRetryLiveStream({ ...base, attempts: 5, exited: false, stopping: false, active: true }),
+    ).toBe(false);
+    expect(
+      shouldRetryLiveStream({ ...base, attempts: 4, exited: false, stopping: false, active: true }),
+    ).toBe(true);
+  });
+
+  it("never retries after the container stream ended", () => {
+    expect(shouldRetryLiveStream({ ...base, exited: true, stopping: false, active: true })).toBe(
+      false,
+    );
+  });
+
+  it("never retries a teardown we initiated ourselves", () => {
+    expect(shouldRetryLiveStream({ ...base, stopping: true, exited: false, active: true })).toBe(
+      false,
+    );
+  });
+
+  it("never retries for a tab that is no longer visible", () => {
+    expect(shouldRetryLiveStream({ ...base, exited: false, stopping: false, active: false })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/dashboard/src/components/import-project/compose/live-stream-policy.ts
+++ b/apps/dashboard/src/components/import-project/compose/live-stream-policy.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure retry policy for the live service log stream (#667). Extracted from
+ * LiveServiceLogsTerminal so the decision matrix is unit-testable without a
+ * DOM: retries only for unexpected drops while the tab is still watching.
+ */
+export function shouldRetryLiveStream(state: {
+  exited: boolean;
+  stopping: boolean;
+  active: boolean;
+  attempts: number;
+  maxAttempts: number;
+}): boolean {
+  if (state.exited) return false;
+  if (state.stopping) return false;
+  if (!state.active) return false;
+  return state.attempts < state.maxAttempts;
+}

--- a/apps/dashboard/src/context/deployment/service-log-source.test.ts
+++ b/apps/dashboard/src/context/deployment/service-log-source.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { serviceLogSource } from "./types";
+
+/**
+ * #667 — after a SUCCESSFUL deployment finishes, a compose service tab whose
+ * container is running must route its terminal to the live runtime log stream
+ * instead of staying frozen on build logs. Everything else keeps the build
+ * history: the Prepare tab always, any service while the deploy is still
+ * running or ended failed/cancelled, and every service under a held
+ * keep/reject decision (some containers there may not exist at all).
+ */
+describe("serviceLogSource", () => {
+  it("routes a running service to the runtime stream once the deploy is ready", () => {
+    expect(serviceLogSource({ deploymentStatus: "ready", serviceStatus: "running" })).toBe(
+      "runtime",
+    );
+  });
+
+  it("keeps build logs while the deployment is still in progress", () => {
+    for (const deploymentStatus of ["building", "deploying"] as const) {
+      expect(serviceLogSource({ deploymentStatus, serviceStatus: "running" })).toBe("build");
+    }
+  });
+
+  it("never routes to runtime under a held keep/reject decision", () => {
+    expect(
+      serviceLogSource({
+        deploymentStatus: "ready",
+        decisionPending: true,
+        serviceStatus: "running",
+      }),
+    ).toBe("build");
+  });
+
+  it("keeps build logs for services that are not running after success", () => {
+    for (const serviceStatus of ["building", "deploying", "built", "failed", undefined] as const) {
+      expect(serviceLogSource({ deploymentStatus: "ready", serviceStatus })).toBe("build");
+    }
+  });
+
+  it("keeps build logs when the deployment failed or was cancelled", () => {
+    for (const deploymentStatus of ["failed", "cancelled"] as const) {
+      expect(serviceLogSource({ deploymentStatus, serviceStatus: "running" })).toBe("build");
+    }
+  });
+});

--- a/apps/dashboard/src/context/deployment/types.ts
+++ b/apps/dashboard/src/context/deployment/types.ts
@@ -239,6 +239,24 @@ export function composeServiceTally(services: readonly ServiceDeployStatus[]): {
   return { running, built, building, failed };
 }
 
+/**
+ * Which log feed a compose service tab shows (#667): the live runtime stream of
+ * the deployed container, or the recorded build logs. Runtime wins only when
+ * the deploy finished successfully with no held keep/reject decision AND this
+ * service's container is up — everything else (in-progress deploys, failures,
+ * static services that never run) stays on build history. The Prepare tab is
+ * not a service and never reaches this.
+ */
+export function serviceLogSource(opts: {
+  deploymentStatus: DeploymentStatus;
+  decisionPending?: boolean;
+  serviceStatus?: ServiceDeployStatus["status"];
+}): "runtime" | "build" {
+  if (opts.deploymentStatus !== "ready") return "build";
+  if (opts.decisionPending) return "build";
+  return opts.serviceStatus === "running" ? "runtime" : "build";
+}
+
 // ─── Build Strategy ──────────────────────────────────────────────────────────
 
 export type { BuildStrategy, RuntimeMode, DeployTarget } from "@repo/core";

--- a/apps/dashboard/src/lib/sse-message-processors.end.test.ts
+++ b/apps/dashboard/src/lib/sse-message-processors.end.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLogMessageProcessor } from "./sseMessageProcessors";
+
+function harness() {
+  const onContainerExit = vi.fn();
+  const processor = createLogMessageProcessor({ onContainerExit });
+  const feed = (data: Record<string, unknown>) => {
+    const parsed = processor.parseMessage({ type: "end", ...data });
+    processor.handleMessage(parsed as any, { rawText: "", rawBytes: undefined } as any);
+  };
+  return { feed, onContainerExit };
+}
+
+describe("log processor end frames", () => {
+  it("notifies on a quiet stop with exit code 0", () => {
+    const { feed, onContainerExit } = harness();
+    feed({ exitCode: 0, message: "Log stream ended" });
+    expect(onContainerExit).toHaveBeenCalledWith(0, "Log stream ended");
+  });
+
+  it("notifies on a crash with the server message", () => {
+    const { feed, onContainerExit } = harness();
+    feed({ exitCode: 137, message: "Container exited" });
+    expect(onContainerExit).toHaveBeenCalledWith(137, "Container exited");
+  });
+
+  it("synthesizes a crash message when none is provided", () => {
+    const { feed, onContainerExit } = harness();
+    feed({ exitCode: 1 });
+    expect(onContainerExit).toHaveBeenCalledWith(1, "Container exited with code 1");
+  });
+
+  it("defaults an absent exit code to a clean close", () => {
+    const { feed, onContainerExit } = harness();
+    feed({});
+    expect(onContainerExit).toHaveBeenCalledWith(0, "Log stream ended");
+  });
+});

--- a/apps/dashboard/src/lib/sseMessageProcessors.ts
+++ b/apps/dashboard/src/lib/sseMessageProcessors.ts
@@ -393,11 +393,13 @@ export const createLogMessageProcessor = (
           break;
 
         case "end":
-          // Container stream ended
-          if (message.exitCode !== undefined && message.exitCode !== 0) {
-            const exitMessage = message.message || `Container exited with code ${message.exitCode}`;
-            callbacks.onContainerExit?.(message.exitCode, exitMessage);
-          }
+          callbacks.onContainerExit?.(
+            message.exitCode ?? 0,
+            message.message ||
+              (message.exitCode
+                ? `Container exited with code ${message.exitCode}`
+                : "Log stream ended"),
+          );
           break;
 
         case "error":

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -24,6 +24,7 @@ export type {
   BuildStep,
   LogEntry,
   LogCallback,
+  RuntimeLogStreamOptions,
   ContainerInfo,
   ResourceUsage,
   RouteConfig,

--- a/packages/adapters/src/runtime/bare.ts
+++ b/packages/adapters/src/runtime/bare.ts
@@ -25,6 +25,7 @@ import type {
   DeploymentResult,
   LogEntry,
   LogCallback,
+  RuntimeLogStreamOptions,
   ContainerInfo,
   ResourceUsage,
 } from "../types";
@@ -1058,7 +1059,7 @@ export class BareRuntime implements RuntimeAdapter {
   async streamRuntimeLogs(
     containerId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void> {
     const sv = await this.supervisor();
     return sv.streamLogs(containerId, onLog, opts);

--- a/packages/adapters/src/runtime/cloud.ts
+++ b/packages/adapters/src/runtime/cloud.ts
@@ -24,6 +24,7 @@ import {
   type DeploymentResult,
   type LogEntry,
   type LogCallback,
+  type RuntimeLogStreamOptions,
   type CommandExecutor,
   type ContainerInfo,
   type ResourceUsage,
@@ -2583,7 +2584,7 @@ fi`;
   async streamRuntimeLogs(
     containerId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void> {
     let cancelled = false;
 
@@ -2644,7 +2645,9 @@ fi`;
       }
     };
 
-    void run();
+    void run().then(() => {
+      if (!cancelled) opts?.onEnd?.();
+    });
     return () => {
       cancelled = true;
     };

--- a/packages/adapters/src/runtime/docker-runtime-logs.test.ts
+++ b/packages/adapters/src/runtime/docker-runtime-logs.test.ts
@@ -1,0 +1,53 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { DockerRuntime } from "./docker";
+
+async function runtimeWith(stream: PassThrough): Promise<DockerRuntime> {
+  const runtime = await DockerRuntime.create({
+    dockerSocketPath: "/tmp/openship-runtime-logs-test.sock",
+  });
+  (runtime as unknown as { _docker: unknown })._docker = {
+    getContainer: () => ({ logs: vi.fn(async () => stream) }),
+  };
+  return runtime;
+}
+
+describe("DockerRuntime.streamRuntimeLogs", () => {
+  it("reports a natural stream end once", async () => {
+    const stream = new PassThrough();
+    const onEnd = vi.fn();
+    await (await runtimeWith(stream)).streamRuntimeLogs("container-1", vi.fn(), { onEnd });
+
+    stream.end();
+    stream.emit("close");
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report an explicit cleanup as a natural end", async () => {
+    const stream = new PassThrough();
+    const onEnd = vi.fn();
+    const cleanup = await (await runtimeWith(stream)).streamRuntimeLogs(
+      "container-1",
+      vi.fn(),
+      { onEnd },
+    );
+
+    cleanup();
+    stream.emit("end");
+    stream.emit("close");
+
+    expect(onEnd).not.toHaveBeenCalled();
+  });
+
+  it("handles a source error as a terminal stream event", async () => {
+    const stream = new PassThrough();
+    const onEnd = vi.fn();
+    await (await runtimeWith(stream)).streamRuntimeLogs("container-1", vi.fn(), { onEnd });
+
+    stream.emit("error", new Error("socket closed"));
+    stream.emit("close");
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -42,6 +42,7 @@ import type {
   DeploymentResult,
   LogEntry,
   LogCallback,
+  RuntimeLogStreamOptions,
   ContainerInfo,
   ContainerStatus,
   ResourceUsage,
@@ -4063,7 +4064,7 @@ export class DockerRuntime implements RuntimeAdapter {
   async streamRuntimeLogs(
     containerId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void> {
     const container = this.docker.getContainer(containerId);
     const stream = (await container.logs({
@@ -4075,6 +4076,13 @@ export class DockerRuntime implements RuntimeAdapter {
     })) as unknown as NodeJS.ReadableStream;
 
     let destroyed = false;
+    let ended = false;
+
+    const notifyEnd = () => {
+      if (destroyed || ended) return;
+      ended = true;
+      opts?.onEnd?.();
+    };
 
     let buffer = "";
     stream.on("data", (chunk: Buffer) => {
@@ -4098,7 +4106,10 @@ export class DockerRuntime implements RuntimeAdapter {
         });
         buffer = "";
       }
+      notifyEnd();
     });
+    stream.on("error", notifyEnd);
+    stream.on("close", notifyEnd);
 
     return () => {
       if (!destroyed) {

--- a/packages/adapters/src/runtime/supervisor/nohup.ts
+++ b/packages/adapters/src/runtime/supervisor/nohup.ts
@@ -14,7 +14,7 @@
  * Good enough for: development, macOS desktop, CI environments.
  */
 
-import type { CommandExecutor, LogEntry, LogCallback, ResourceUsage } from "../../types";
+import type { CommandExecutor, LogEntry, LogCallback, ResourceUsage, RuntimeLogStreamOptions } from "../../types";
 import type { ProcessSupervisor, SupervisorDeployOpts } from "./types";
 import { sampleBareUsage, ZERO_USAGE } from "./usage";
 import { sq, parseLogLevel } from "../build-pipeline";
@@ -249,7 +249,7 @@ export class NohupSupervisor implements ProcessSupervisor {
   async streamLogs(
     deploymentId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void> {
     const logPath = this.logFile(deploymentId);
     const tailN = opts?.tail ?? 100;
@@ -282,7 +282,14 @@ export class NohupSupervisor implements ProcessSupervisor {
         if (!stopped) onLog({ ...entry, message: entry.message + "\r\n" });
       },
     );
-    promise.catch(() => {});
+    void promise.then(
+      () => {
+        if (!stopped) opts?.onEnd?.();
+      },
+      () => {
+        if (!stopped) opts?.onEnd?.();
+      },
+    );
 
     return () => {
       stopped = true;

--- a/packages/adapters/src/runtime/supervisor/systemd.ts
+++ b/packages/adapters/src/runtime/supervisor/systemd.ts
@@ -13,7 +13,7 @@
  * Unit location: /etc/systemd/system/ (standard for admin-created units)
  */
 
-import type { CommandExecutor, LogEntry, LogCallback, ResourceUsage } from "../../types";
+import type { CommandExecutor, LogEntry, LogCallback, ResourceUsage, RuntimeLogStreamOptions } from "../../types";
 import type { ProcessSupervisor, SupervisorDeployOpts } from "./types";
 import { sampleBareUsage, ZERO_USAGE } from "./usage";
 import { sq, parseLogLevel } from "../build-pipeline";
@@ -281,7 +281,7 @@ WantedBy=multi-user.target
   async streamLogs(
     deploymentId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void> {
     const unitName = this.unitName(deploymentId);
     const tailN = opts?.tail ?? 100;
@@ -299,7 +299,14 @@ WantedBy=multi-user.target
         onLog(cleaned);
       },
     );
-    promise.catch(() => {});
+    void promise.then(
+      () => {
+        if (!stopped) opts?.onEnd?.();
+      },
+      () => {
+        if (!stopped) opts?.onEnd?.();
+      },
+    );
 
     return () => {
       stopped = true;

--- a/packages/adapters/src/runtime/supervisor/types.ts
+++ b/packages/adapters/src/runtime/supervisor/types.ts
@@ -12,7 +12,13 @@
  * while the supervisor handles process lifecycle portably.
  */
 
-import type { CommandExecutor, LogEntry, LogCallback, ResourceUsage } from "../../types";
+import type {
+  CommandExecutor,
+  LogEntry,
+  LogCallback,
+  ResourceUsage,
+  RuntimeLogStreamOptions,
+} from "../../types";
 
 // ─── Deploy options ──────────────────────────────────────────────────────────
 
@@ -74,7 +80,7 @@ export interface ProcessSupervisor {
   streamLogs(
     deploymentId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void>;
 }
 

--- a/packages/adapters/src/runtime/types.ts
+++ b/packages/adapters/src/runtime/types.ts
@@ -18,6 +18,7 @@ import type {
   DeploymentResult,
   LogEntry,
   LogCallback,
+  RuntimeLogStreamOptions,
   ContainerInfo,
   ContainerStatus,
   ResourceUsage,
@@ -305,7 +306,7 @@ export interface RuntimeAdapter {
   streamRuntimeLogs(
     containerId: string,
     onLog: LogCallback,
-    opts?: { tail?: number },
+    opts?: RuntimeLogStreamOptions,
   ): Promise<() => void>;
 
   /** Get current resource usage metrics */

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -751,6 +751,12 @@ export interface SslResult {
 
 export type LogCallback = (entry: LogEntry) => void;
 
+export interface RuntimeLogStreamOptions {
+  tail?: number;
+  /** Called once when the source closes without an explicit cleanup. */
+  onEnd?: () => void;
+}
+
 // ─── SSH configuration ──────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Closes #667

## Summary
- switch successful compose service tabs from frozen build output to the existing per-service runtime log stream
- keep Prepare, failed/non-running services, in-progress deployments, and pending keep/reject decisions on build history
- connect only the active tab, backfill the latest 100 lines, retry unexpected disconnects up to five times, and stop on a terminal stream event
- propagate natural runtime-log completion across runtime adapters and flush the SSE end frame before cleanup, including subscribe-time end and abort races

## Verification
- API: 420 files, 5,118 passed, 3 skipped
- Dashboard: 100 files, 1,100 passed
- Adapters: 167 files, 3,380 passed
- API, dashboard, and adapters `tsc --noEmit`
- `git diff --check`