### PR TITLE
feat(backups): publish live upload progress

### DIFF
--- a/apps/api/src/modules/backups/PENDING.md
+++ b/apps/api/src/modules/backups/PENDING.md
@@ -47,20 +47,17 @@ Needs: cancel columns on `backup_run`, the route + controller + an orchestrator
 `cancel()`, a `signal` on `StreamPathOpts`/`ProducerOpts` threaded into `streamPath`
 so capture joins `createAbortWatch`, and a UI entry point.
 
-### No upload progress, and `uploading` stays out of the idle sweep
+### `uploading` still stays out of the idle sweep
 
-The idle predicate is `preparing | snapshotting | verifying`
-(`packages/db/src/repos/backup.repo.ts`); `uploading` is reachable only through the 6h
-absolute ceiling. Deliberate, because nothing heartbeats mid-stream:
-`HashingPassthrough` (`common/sha256-stream.ts:16-47`) has no progress callback and
-its byte count is readable only via `summary()`, which throws before the stream ends;
-`PutOpts` (`types.ts:450-464`) has no `onProgress`, so a destination cannot report
-upward (S3 tracks `httpUploadProgress` into a local counter only); and the
-orchestrator writes `bytesTransferred` only at artifact boundaries.
+Upload streams now report throttled cumulative `bytesTransferred` and bump
+`lastEventAt`, so the row can distinguish moving bytes from silence. That is not
+enough to sweep safely: changing the row to `server_error` does not abort the
+producer/destination promise holding the worker slot. It would report recovery
+without recovering capacity, and a resumed worker could race the terminal verdict.
 
-One change buys both halves: a throttled progress signal that writes
-`bytesTransferred` and bumps `lastEventAt` mid-upload, which lets `uploading` back
-into the idle branch and gives the UI real progress at the same time.
+Include `uploading` in the idle predicate only after capture cancellation above
+provides a durable abort request plus an in-process signal. The existing executor
+idle watchdogs and six-hour database ceiling remain the backstops meanwhile.
 
 ### A single artifact past ~281 GiB still cannot complete on S3
 

--- a/apps/api/src/modules/backups/backup.orchestrator.ts
+++ b/apps/api/src/modules/backups/backup.orchestrator.ts
@@ -81,10 +81,29 @@ const TRUNCATE_ERROR = 4096;
 const TRUNCATE_HOOK_LOG = 64 * 1024;
 /** Cap on waiting for a finished hook's stdout to drain (see runHook). */
 const HOOK_DRAIN_TIMEOUT_MS = 500;
+
+/**
+ * Minimum gap between mid-upload progress writes. The stream reports per
+ * chunk; a chunk storm must not become a DB-write storm. One write per second
+ * per run keeps the SSE counter live and `lastEventAt` current. Artifact
+ * boundaries always persist through the `uploading` transition regardless of
+ * this window.
+ */
+const UPLOAD_PROGRESS_INTERVAL_MS = 1_000;
 /** Short form for the notification payload + destination verify note. */
 const TRUNCATE_ERROR_SUMMARY = 500;
 /** A `PutResult.etag` in this shape is a sha256 we can compare ours against. */
 const SHA256_HEX = /^[0-9a-f]{64}$/i;
+
+/** A different writer reached a terminal verdict first. The repository owns
+ *  that verdict; this worker must clean up and stop without publishing a
+ *  contradictory state. */
+class BackupRunFinalizedElsewhereError extends Error {
+  constructor(runId: string, attemptedStatus: BackupRunStatus) {
+    super(`Backup run ${runId} was finalized before transition to ${attemptedStatus}`);
+    this.name = "BackupRunFinalizedElsewhereError";
+  }
+}
 
 // ─── Public surface ──────────────────────────────────────────────────────────
 
@@ -285,6 +304,9 @@ export class BackupOrchestrator {
      */
     const uploadedKeys: string[] = [];
     let destination: ReturnType<typeof resolveDestination> | null = null;
+    /** Serialized because stream callbacks cannot await. */
+    let progressInFlight: Promise<void> | null = null;
+    let pendingProgress: { bytesTransferred: number; currentArtifact: string } | null = null;
 
     try {
       await this.transition(runId, "preparing");
@@ -443,11 +465,50 @@ export class BackupOrchestrator {
       // artifact whose recorded codec no restore can read. See that function.
       const producerOpts = sanitizeProducerOpts(policy.payloadConfig);
 
+      // Live upload progress. Cumulative across the WHOLE run — the current
+      // artifact's moving count rides on top of the bytes every finished
+      // artifact already landed, so the counter never resets per file.
+      let finishedArtifactBytes = 0;
+      let lastProgressWriteAt = 0;
+      const flushUploadProgress = () => {
+        if (progressInFlight) return;
+        progressInFlight = (async () => {
+          while (pendingProgress) {
+            const progress = pendingProgress;
+            pendingProgress = null;
+            await this.persistUploadProgress(
+              runId,
+              progress.bytesTransferred,
+              progress.currentArtifact,
+            );
+          }
+        })().finally(() => {
+          progressInFlight = null;
+        });
+      };
+      const reportUploadProgress = (artifactBytes: number, artifactName: string) => {
+        const now = Date.now();
+        if (now - lastProgressWriteAt < UPLOAD_PROGRESS_INTERVAL_MS) return;
+        lastProgressWriteAt = now;
+        pendingProgress = {
+          bytesTransferred: finishedArtifactBytes + artifactBytes,
+          currentArtifact: artifactName,
+        };
+        flushUploadProgress();
+      };
+
       for await (const artifact of producer.produce(serviceHandle, executor, producerOpts)) {
-        const recorded = await this.uploadArtifact(destination, baseKey, artifact);
+        const recorded = await this.uploadArtifact(destination, baseKey, artifact, (n) =>
+          reportUploadProgress(n, artifact.name),
+        );
         uploadedKeys.push(recorded.key);
         artifactsRecorded.push(recorded);
         totalBytes += recorded.sizeBytes;
+        finishedArtifactBytes = totalBytes;
+        // A throttled write may still be waiting on the database. Settle it
+        // before broadcasting the exact artifact boundary, otherwise its older
+        // SSE value could arrive afterwards and move the dashboard backward.
+        await progressInFlight;
         await this.transition(runId, "uploading", {
           artifacts: storableArtifacts(artifactsRecorded),
           bytesTransferred: totalBytes,
@@ -554,6 +615,11 @@ export class BackupOrchestrator {
         }
       }
 
+      // Flush the last throttled progress write before the terminal one: the
+      // value below is the exact uploaded total, and no in-flight estimate may
+      // land after it (the repo would refuse, but the run ends cleaner when the
+      // chain is settled — no pending write outlives the run).
+      await progressInFlight;
       await this.transition(runId, "succeeded", {
         manifestKey: manifestK,
         bytesTransferred: totalBytes,
@@ -575,12 +641,33 @@ export class BackupOrchestrator {
         },
       });
     } catch (err) {
+      // Settle any throttled progress write before the failed transition
+      // stamps `bytesTransferred: 0` — an in-flight estimate must not be the
+      // last byte count this run records (terminal-guarded in the repo too).
+      await progressInFlight;
       // Both forms are scrubbed independently: a second `.slice` over an
       // already-scrubbed string can split a surrogate pair back open.
       const raw = safeErrorMessage(err);
       const message = boundedStorableText(raw, TRUNCATE_ERROR);
       const summary = boundedStorableText(raw, TRUNCATE_ERROR_SUMMARY);
-      console.error(`[backup-orchestrator] run ${runId} failed: ${message}`);
+      const finalizedElsewhere = err instanceof BackupRunFinalizedElsewhereError;
+      if (finalizedElsewhere) {
+        console.warn(`[backup-orchestrator] run ${runId}: ${message}`);
+      } else {
+        console.error(`[backup-orchestrator] run ${runId} failed: ${message}`);
+      }
+
+      // A duplicate worker can lose to a genuinely succeeded run. Its keys are
+      // the same run-scoped keys as the winner's, so deleting them would destroy
+      // a valid restore point. For other known terminal verdicts the objects are
+      // unusable and should still be reclaimed. If the winner cannot be read,
+      // preserve data rather than risk deleting a successful backup.
+      const winningRun = finalizedElsewhere
+        ? await repos.backupRun.findById(runId).catch(() => undefined)
+        : undefined;
+      const mayReclaimObjects = finalizedElsewhere
+        ? winningRun !== undefined && winningRun.status !== "succeeded"
+        : true;
 
       // Reclaim every object this run put at the destination, whatever went wrong.
       //
@@ -588,7 +675,7 @@ export class BackupOrchestrator {
       // skips non-succeeded runs — so these bytes can only ever be billed, never used.
       // ONE place, so a future failure path cannot forget. Best-effort by construction: a
       // cleanup that fails must never replace the operator's real error.
-      if (destination && uploadedKeys.length > 0) {
+      if (mayReclaimObjects && destination && uploadedKeys.length > 0) {
         // `deleteMany` reports per-key failures instead of throwing, so catching alone
         // saw only a total collapse — a bucket policy that denies delete on half the
         // keys resolved cleanly and the orphans went unnamed.
@@ -611,6 +698,11 @@ export class BackupOrchestrator {
             ),
           );
       }
+
+      // The row is already terminal. Cleanup above still matters because this
+      // worker may have uploaded objects before losing the race, but the winning
+      // writer exclusively owns the status, SSE verdict, and notification.
+      if (finalizedElsewhere) return;
 
       // Only a destination that failed PREFLIGHT is marked unhealthy. Once preflight
       // has passed, this run has proved the destination reachable and writable, and
@@ -692,7 +784,11 @@ export class BackupOrchestrator {
     status: BackupRunStatus,
     patch?: Parameters<typeof repos.backupRun.transition>[2],
   ): Promise<void> {
-    await repos.backupRun.transition(runId, status, patch);
+    const applied = await repos.backupRun.transition(runId, status, patch);
+    // Only an explicit refusal means another writer already finalized the row.
+    if (applied === false) {
+      throw new BackupRunFinalizedElsewhereError(runId, status);
+    }
     try {
       backupRunBus.publish(runId, {
         type: "transition",
@@ -714,10 +810,45 @@ export class BackupOrchestrator {
     }
   }
 
+  /**
+   * One throttled progress write + its SSE echo. Telemetry, not FSM: a failed
+   * write is logged and swallowed — progress must never fail the backup it
+   * describes, and the bus must not either. Monotonicity and terminal refusal
+   * live in the repo (`recordUploadProgress`), so a late or reordered delivery
+   * is harmless by construction; callers coalesce and serialize samples so
+   * the SSE stream reads in order without a queue growing behind a slow DB.
+   */
+  private async persistUploadProgress(
+    runId: string,
+    bytesTransferred: number,
+    currentArtifact: string,
+  ): Promise<void> {
+    let applied: boolean;
+    try {
+      applied = await repos.backupRun.recordUploadProgress(runId, bytesTransferred);
+    } catch (err) {
+      console.warn(
+        `[backup-orchestrator] run ${runId}: progress write failed: ${safeErrorMessage(err)}`,
+      );
+      return;
+    }
+    // Never amplify a value the source of truth refused. Besides status races,
+    // this suppresses an older estimate that lost to an artifact-boundary write.
+    if (!applied) return;
+    try {
+      backupRunBus.publish(runId, { type: "progress", bytesTransferred, currentArtifact });
+    } catch {
+      // bus failures never block the FSM
+    }
+  }
+
   private async uploadArtifact(
     destination: ReturnType<typeof resolveDestination>,
     baseKey: { projectSlug: string; serviceName: string; runId: string },
     artifact: Artifact,
+    /** Per-chunk cumulative byte count for THIS artifact (throttled + aggregated
+     *  into the run total by the caller). */
+    onBytes?: (bytesWritten: number) => void,
   ): Promise<{
     name: string;
     key: string;
@@ -727,7 +858,7 @@ export class BackupOrchestrator {
     metadata: Record<string, unknown>;
   }> {
     const key = artifactKey(baseKey, artifact.name);
-    const hasher = new HashingPassthrough();
+    const hasher = new HashingPassthrough({ onBytes });
 
     // Pipe artifact stream → hasher → destination. The hasher computes
     // sha256 + byte count as bytes flow.

--- a/apps/api/test/modules/backups/backup-run-durability.test.ts
+++ b/apps/api/test/modules/backups/backup-run-durability.test.ts
@@ -325,10 +325,11 @@ describe("a terminal status is final — one owner per verdict", () => {
     const pg = makePgFake({ id: "bkr_9", status: "succeeded" });
     const repo = createBackupRunRepo(pg.db as never);
 
-    await repo.transition("bkr_9", "server_error", {
+    const applied = await repo.transition("bkr_9", "server_error", {
       errorMessage: "stale heartbeat ceiling",
     } as never);
 
+    expect(applied).toBe(false);
     expect(pg.row.status).toBe("succeeded");
     // And the payload does not sneak in behind the refused status.
     expect(pg.row.errorMessage).toBeUndefined();
@@ -338,8 +339,9 @@ describe("a terminal status is final — one owner per verdict", () => {
     const pg = makePgFake({ id: "bkr_10", status: "failed", errorMessage: "pg_dump exited 1" });
     const repo = createBackupRunRepo(pg.db as never);
 
-    await repo.transition("bkr_10", "succeeded", { bytesTransferred: 4096 } as never);
+    const applied = await repo.transition("bkr_10", "succeeded", { bytesTransferred: 4096 } as never);
 
+    expect(applied).toBe(false);
     expect(pg.row.status).toBe("failed");
     expect(pg.row.bytesTransferred).toBeUndefined();
   });
@@ -349,9 +351,9 @@ describe("a terminal status is final — one owner per verdict", () => {
     const pg = makePgFake({ id: "bkr_11", status: "queued" });
     const repo = createBackupRunRepo(pg.db as never);
 
-    await repo.transition("bkr_11", "uploading", { bytesTransferred: 10 } as never);
+    expect(await repo.transition("bkr_11", "uploading", { bytesTransferred: 10 } as never)).toBe(true);
     expect(pg.row.status).toBe("uploading");
-    await repo.transition("bkr_11", "succeeded", { bytesTransferred: 20 } as never);
+    expect(await repo.transition("bkr_11", "succeeded", { bytesTransferred: 20 } as never)).toBe(true);
     expect(pg.row.status).toBe("succeeded");
     expect(pg.row.bytesTransferred).toBe(20);
   });

--- a/apps/api/test/modules/backups/backup-stale-sweep.test.ts
+++ b/apps/api/test/modules/backups/backup-stale-sweep.test.ts
@@ -34,11 +34,10 @@ function makePgFake(rows: Array<Record<string, unknown>>): PgFake {
             if (terminal.includes(status) || row.finishedAt) continue;
 
             // Mirror of sweepRunsWithStaleHeartbeat's WHERE. Two states are NOT
-            // idle-swept. `uploading`, because a single-artifact dump holds
-            // (uploading, bytes=NULL, lastEventAt=frozen) for the whole honest
-            // upload. And `queued`, because lastEventAt does not move while a run
-            // waits for a worker, so an idle window there measures queue depth —
-            // both are bounded by the ceiling only.
+            // idle-swept. `uploading`, because changing its row cannot abort the
+            // producer/destination promise that owns the worker slot. And
+            // `queued`, because lastEventAt does not move while a run waits for
+            // a worker — both are bounded by the ceiling only.
             const stale =
               (["preparing", "snapshotting", "verifying"].includes(status) && last < idleCutoff) ||
               last < ceilingCutoff;
@@ -125,12 +124,10 @@ describe("backupRun.sweepRunsWithStaleHeartbeat", () => {
     expect(pg.rows[0].status).toBe("server_error");
   });
 
-  it("does NOT idle-sweep an uploading run with null bytes (honest large dump, #516)", async () => {
-    // A single-artifact pg_dump/mysqldump/mongodump streams the whole payload
-    // through one destination.put; bytesTransferred stays NULL and lastEventAt
-    // is frozen at the transition into `uploading` until the artifact finishes.
-    // Idle-sweeping this would kill the exact backup #516 is about. A genuine
-    // wedge is reaped in-process by the executor's per-stream idle watchdog.
+  it("does NOT idle-sweep an uploading run without an abort path", async () => {
+    // A database update cannot stop the producer/destination promise holding
+    // the worker slot. Until capture has abort plumbing, changing this row to a
+    // terminal state would report recovery without actually recovering capacity.
     const pg = makePgFake([
       {
         id: "bkr_u",

--- a/apps/api/test/modules/backups/backup-upload-progress.test.ts
+++ b/apps/api/test/modules/backups/backup-upload-progress.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Live upload progress + the uploading heartbeat.
+ *
+ * A single-artifact pg_dump streams the whole payload through ONE
+ * `destination.put`, and the run row used to sit (uploading, bytes=NULL,
+ * lastEventAt=frozen) for the entire transfer — indistinguishable from a
+ * wedge, which is why the idle sweep had to leave `uploading` alone (#516).
+ *
+ * This pins the fix:
+ *   - the upload stream reports cumulative bytes MID-artifact;
+ *   - progress is aggregated across artifacts, never reset per file;
+ *   - persistence is throttled (a chunk storm is not a write storm) and every
+ *     persisted value rides out on the existing SSE `progress` event;
+ *   - the repo write is monotonic and accepts only `uploading`, so a late
+ *     update can neither rewind the counter nor mutate another state;
+ *   - the terminal write still records the exact uploaded total;
+ *   - a failed run is not followed by late progress writes.
+ */
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import { createBackupRunRepo } from "../../../../../packages/db/src/repos/backup.repo";
+
+const h = vi.hoisted(() => ({
+  /** Artifacts the fake producer yields; `chunks` ARE the payload. */
+  artifacts: [] as Array<{ name: string; chunks: number[] }>,
+  row: {} as Record<string, unknown>,
+  notifications: [] as string[],
+  puts: [] as string[],
+  deleted: [] as string[],
+  /** Every throttled progress write that reached the repo, in order. */
+  progressWrites: [] as number[],
+  /** Every mutation of row.bytesTransferred, in order (monotonicity proof). */
+  bytesHistory: [] as number[],
+  /** Write-order log so "no late write after terminal" is checkable. */
+  writeLog: [] as string[],
+  failPutFor: null as string | null,
+  rejectProgress: false,
+  finalizeAfterPutAs: null as "succeeded" | "server_error" | null,
+  progressResponseGate: null as Promise<void> | null,
+  releaseProgressResponse: null as (() => void) | null,
+  progressWriteStarted: null as (() => void) | null,
+}));
+
+vi.mock("@repo/db", () => ({
+  repos: {
+    backupRun: {
+      findById: async () => ({
+        id: "bkr_live",
+        status: typeof h.row.status === "string" ? h.row.status : "queued",
+        policyId: "pol_1",
+        serviceId: "svc_1",
+        mailServerId: null,
+        organizationId: "org_1",
+      }),
+      transition: async (_id: string, status: string, patch?: Record<string, unknown>) => {
+        if (["succeeded", "failed", "cancelled", "server_error"].includes(String(h.row.status))) {
+          return false;
+        }
+        h.writeLog.push(`transition:${status}`);
+        Object.assign(h.row, { status }, patch ?? {});
+        if (typeof patch?.bytesTransferred === "number") {
+          h.bytesHistory.push(patch.bytesTransferred);
+        }
+        return true;
+      },
+      // Mirrors the real repo method's two guards: only `uploading` accepts the
+      // write, and a value that does not advance the counter is refused.
+      recordUploadProgress: async (_id: string, bytes: number) => {
+        if (h.rejectProgress || h.row.status !== "uploading") return false;
+        if (typeof h.row.bytesTransferred === "number" && h.row.bytesTransferred >= bytes) {
+          return false;
+        }
+        h.writeLog.push(`progress:${bytes}`);
+        h.progressWrites.push(bytes);
+        h.bytesHistory.push(bytes);
+        Object.assign(h.row, { bytesTransferred: bytes, lastEventAt: new Date() });
+        h.progressWriteStarted?.();
+        await h.progressResponseGate;
+        return true;
+      },
+    },
+    backupPolicy: {
+      findById: async () => ({
+        id: "pol_1",
+        destinationId: "dst_1",
+        sourceKind: "service",
+        mailServerId: null,
+        projectId: "prj_1",
+        serviceId: "svc_1",
+        payloadKind: "auto",
+        preHook: null,
+        postHook: null,
+        hookTimeoutSeconds: 30,
+        payloadConfig: {},
+      }),
+    },
+    backupDestination: {
+      findById: async () => ({
+        id: "dst_1",
+        organizationId: "org_1",
+        name: "R2",
+        pathPrefix: "openship",
+      }),
+      setLastVerified: async () => {},
+    },
+    service: {
+      findById: async () => ({
+        id: "svc_1",
+        projectId: "prj_1",
+        name: "postgres",
+        image: "postgres:16-alpine",
+        environment: null,
+        volumes: null,
+        namespaceVolumes: false,
+        ports: null,
+        command: null,
+      }),
+    },
+    project: {
+      findById: async () => ({
+        id: "prj_1",
+        slug: "openship",
+        name: "Openship",
+        organizationId: "org_1",
+        activeDeploymentId: "dep_1",
+      }),
+      listEnvVars: async () => [],
+      getEnvMap: async () => ({}),
+    },
+    deployment: { findById: async () => ({ id: "dep_1", meta: {} }) },
+  },
+}));
+
+vi.mock("@repo/adapters", async () => {
+  const { Readable, PassThrough } = await import("node:stream");
+  const { PRESERVED_ARTIFACT_METADATA_KEYS } =
+    await import("../../../../../packages/adapters/src/backup/common/artifact-metadata");
+  const { sanitizeProducerOpts } =
+    await import("../../../../../packages/adapters/src/backup/common/producer-opts");
+  /**
+   * Same contract as the real HashingPassthrough — counts the bytes it saw —
+   * plus the onBytes callback under test, fired per chunk with the cumulative
+   * count, exactly like the real one.
+   */
+  class FakeHasher extends PassThrough {
+    private seen = 0;
+    private readonly onBytes?: (bytesWritten: number) => void;
+    constructor(opts?: { onBytes?: (bytesWritten: number) => void }) {
+      super();
+      this.onBytes = opts?.onBytes;
+    }
+    summary() {
+      return { sha256: "d0", bytesWritten: this.seen };
+    }
+    override _transform(
+      chunk: Buffer,
+      _enc: BufferEncoding,
+      cb: (e?: Error | null, data?: unknown) => void,
+    ) {
+      this.seen += chunk.byteLength;
+      this.onBytes?.(this.seen);
+      cb(null, chunk);
+    }
+  }
+  return {
+    HashingPassthrough: FakeHasher,
+    PRESERVED_ARTIFACT_METADATA_KEYS,
+    sanitizeProducerOpts,
+    artifactKey: (_b: unknown, name: string) => `openship/openship/postgres/bkr_live/${name}`,
+    manifestKey: () => "openship/openship/postgres/bkr_live/manifest.json",
+    runPrefix: () => "openship/openship/postgres/bkr_live",
+    buildManifest: () => ({ version: 1 }),
+    resolveDestination: () => ({
+      preflight: async () => ({ ok: true }),
+      put: async (key: string, body: AsyncIterable<Buffer>) => {
+        h.puts.push(key);
+        for await (const _chunk of body) {
+          if (h.failPutFor && key.endsWith(h.failPutFor)) {
+            throw new Error("destination connection dropped mid-artifact");
+          }
+        }
+        if (h.finalizeAfterPutAs) {
+          const status = h.finalizeAfterPutAs;
+          h.finalizeAfterPutAs = null;
+          Object.assign(h.row, { status, finishedAt: new Date() });
+        }
+        return {};
+      },
+      deleteMany: async (keys: string[]) => {
+        h.deleted.push(...keys);
+        return { deleted: keys, failed: [] };
+      },
+    }),
+    resolveExecutor: () => ({ readContainerEnv: async () => ({}) }),
+    resolveProducerForService: () => ({
+      kind: "volume",
+      async *produce() {
+        for (const a of h.artifacts) {
+          yield {
+            name: a.name,
+            stream: Readable.from(a.chunks.map((n) => Buffer.alloc(n))),
+            payloadKind: "volume",
+            metadata: {},
+          };
+        }
+      },
+    }),
+    resolveProducer: () => ({ kind: "volume", async *produce() {} }),
+  };
+});
+
+vi.mock("../../../src/lib/job-runner", () => ({
+  getJobRunner: async () => ({ enqueueRun: async () => {} }),
+}));
+vi.mock("../../../src/lib/deployment-runtime", () => ({
+  disposeRuntime: () => {},
+  disposePlatform: () => {},
+  resolveDeploymentPlatform: async () => ({ platform: { runtime: { name: "docker" } } }),
+  resolveTargetPlatform: async () => ({ runtime: { name: "docker" } }),
+}));
+vi.mock("../../../src/lib/encryption", () => ({ decryptEnvMap: (v: unknown) => v }));
+vi.mock("../../../src/lib/notification-dispatcher", () => ({
+  notification: {
+    emit: (e: { eventType: string }) => {
+      h.notifications.push(e.eventType);
+    },
+  },
+}));
+vi.mock("../../../src/modules/backup-destinations/hydrate-server", () => ({
+  toAdapterRow: async (row: unknown) => row,
+}));
+vi.mock("../../../src/modules/services/service-container", () => ({
+  liveContainerIdForService: async () => "c_pg",
+  liveContainerForService: async () => ({ containerId: "c_pg", running: true }),
+}));
+
+import { BackupOrchestrator } from "../../../src/modules/backups/backup.orchestrator";
+import { backupRunBus } from "../../../src/modules/backups/backup.sse";
+
+beforeEach(() => {
+  h.artifacts = [];
+  h.row = {};
+  h.notifications.length = 0;
+  h.puts.length = 0;
+  h.deleted.length = 0;
+  h.progressWrites.length = 0;
+  h.bytesHistory.length = 0;
+  h.writeLog.length = 0;
+  h.failPutFor = null;
+  h.rejectProgress = false;
+  h.finalizeAfterPutAs = null;
+  h.progressResponseGate = null;
+  h.releaseProgressResponse = null;
+  h.progressWriteStarted = null;
+});
+
+describe("live upload progress", () => {
+  it("reports cumulative bytes mid-artifact, throttled, and finishes exact", async () => {
+    // Two artifacts, several chunks each. The whole run completes in under the
+    // one-second persist interval, so exactly ONE throttled write may land —
+    // the first chunk of the first artifact (lastWriteAt starts at 0).
+    h.artifacts = [
+      { name: "volume-pgdata.tar.zst", chunks: [100, 100, 100] },
+      { name: "volume-wal.tar.zst", chunks: [50, 50] },
+    ];
+    const events: Array<Record<string, unknown>> = [];
+    const unsubscribe = backupRunBus.subscribe("bkr_live", (e) =>
+      events.push(e as Record<string, unknown>),
+    );
+
+    try {
+      await new BackupOrchestrator().execute("bkr_live");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(h.row.status).toBe("succeeded");
+    // The terminal value is the exact uploaded total, not a throttled estimate.
+    expect(h.row.bytesTransferred).toBe(400);
+
+    // Throttled: six chunks, ONE progress write.
+    expect(h.progressWrites).toEqual([100]);
+
+    // The persisted value went out on the existing SSE progress channel.
+    const progressEvents = events.filter((e) => e.type === "progress");
+    expect(progressEvents).toEqual([
+      { type: "progress", bytesTransferred: 100, currentArtifact: "volume-pgdata.tar.zst" },
+    ]);
+
+    // Never backward: progress write → per-artifact transitions → terminal.
+    const increasing = h.bytesHistory.every((v, i) => i === 0 || v >= h.bytesHistory[i - 1]);
+    expect(increasing).toBe(true);
+    expect(h.bytesHistory).toContain(300); // artifact boundary, cumulative
+  });
+
+  it("leaves no pending progress write behind a failed run", async () => {
+    h.artifacts = [
+      { name: "volume-pgdata.tar.zst", chunks: [100, 100] },
+      { name: "volume-wal.tar.zst", chunks: [50] },
+    ];
+    h.failPutFor = "volume-wal.tar.zst";
+
+    await new BackupOrchestrator().execute("bkr_live");
+
+    expect(h.row.status).toBe("failed");
+    // A failed run advertises nothing (its objects were reclaimed).
+    expect(h.row.bytesTransferred).toBe(0);
+    // The failed transition is the LAST write — no throttled progress landed
+    // after it (the repo's terminal guard refuses any that try).
+    expect(h.writeLog[h.writeLog.length - 1]).toBe("transition:failed");
+  });
+
+  it("coalesces behind a delayed write and settles before the artifact boundary", async () => {
+    const runId = "bkr_delayed_progress";
+    h.artifacts = [{ name: "volume-pgdata.tar.zst", chunks: [100, 100, 100] }];
+    h.progressResponseGate = new Promise<void>((resolve) => {
+      h.releaseProgressResponse = resolve;
+    });
+    const progressStarted = new Promise<void>((resolve) => {
+      h.progressWriteStarted = resolve;
+    });
+    const now = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_100)
+      .mockReturnValueOnce(3_200);
+    const events: Array<Record<string, unknown>> = [];
+    const unsubscribe = backupRunBus.subscribe(runId, (event) =>
+      events.push(event as Record<string, unknown>),
+    );
+
+    const execution = new BackupOrchestrator().execute(runId);
+    try {
+      await progressStarted;
+      // The database has accepted the estimate, but its promise has not returned.
+      // Later samples coalesce behind it and the artifact boundary must wait.
+      expect(h.progressWrites).toEqual([100]);
+      expect(h.writeLog).not.toContain("transition:succeeded");
+      h.releaseProgressResponse?.();
+      await execution;
+    } finally {
+      h.releaseProgressResponse?.();
+      await execution.catch(() => {});
+      unsubscribe();
+      now.mockRestore();
+    }
+
+    const liveBytes = events.flatMap((event) =>
+      typeof event.bytesTransferred === "number" ? [event.bytesTransferred] : [],
+    );
+    expect(liveBytes.every((value, index) => index === 0 || value >= liveBytes[index - 1])).toBe(
+      true,
+    );
+    expect(h.progressWrites).toEqual([100, 300]);
+    expect(liveBytes[liveBytes.length - 1]).toBe(300);
+  });
+
+  it("does not broadcast progress that the repository refused", async () => {
+    const runId = "bkr_refused_progress";
+    h.artifacts = [{ name: "volume-pgdata.tar.zst", chunks: [100] }];
+    h.rejectProgress = true;
+    const events: Array<Record<string, unknown>> = [];
+    const unsubscribe = backupRunBus.subscribe(runId, (event) =>
+      events.push(event as Record<string, unknown>),
+    );
+
+    await new BackupOrchestrator().execute(runId);
+    unsubscribe();
+
+    expect(events.filter((event) => event.type === "progress")).toEqual([]);
+    expect(h.row.bytesTransferred).toBe(100);
+  });
+
+  it("stops without a contradictory SSE verdict when another writer finalized the run", async () => {
+    const runId = "bkr_finalized_elsewhere";
+    h.artifacts = [{ name: "volume-pgdata.tar.zst", chunks: [100] }];
+    h.finalizeAfterPutAs = "server_error";
+    const events: Array<Record<string, unknown>> = [];
+    const unsubscribe = backupRunBus.subscribe(runId, (event) =>
+      events.push(event as Record<string, unknown>),
+    );
+
+    await new BackupOrchestrator().execute(runId);
+    unsubscribe();
+
+    expect(h.row.status).toBe("server_error");
+    expect(events.some((event) => event.type === "complete")).toBe(false);
+    expect(events.some((event) => event.status === "succeeded")).toBe(false);
+    expect(h.notifications).toEqual([]);
+    expect(h.deleted).toContain("openship/openship/postgres/bkr_live/volume-pgdata.tar.zst");
+  });
+
+  it("does not delete a successful winner's run-scoped objects", async () => {
+    h.artifacts = [{ name: "volume-pgdata.tar.zst", chunks: [100] }];
+    h.finalizeAfterPutAs = "succeeded";
+
+    await new BackupOrchestrator().execute("bkr_duplicate_worker");
+
+    expect(h.row.status).toBe("succeeded");
+    expect(h.deleted).toEqual([]);
+    expect(h.notifications).toEqual([]);
+  });
+
+  it("keeps heartbeating across a long upload while coalescing chunk storms", async () => {
+    h.artifacts = [{ name: "volume-pgdata.tar.zst", chunks: [100, 100, 100] }];
+    const now = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_500)
+      .mockReturnValueOnce(2_100);
+
+    try {
+      await new BackupOrchestrator().execute("bkr_live");
+    } finally {
+      now.mockRestore();
+    }
+
+    expect(h.progressWrites).toEqual([100, 300]);
+    expect(h.row.bytesTransferred).toBe(300);
+  });
+});
+
+describe("backupRun.recordUploadProgress", () => {
+  /** Fake drizzle chain for the progress write: update().set().where() with
+   *  the status + monotonic guards mirrored by hand (same convention as
+   *  backup-stale-sweep.test.ts — keep in sync with the repo). */
+  function makeRunFake(initial: Record<string, unknown>) {
+    const state = {
+      db: null as unknown,
+      row: { ...initial },
+      applied: [] as Array<Record<string, unknown>>,
+    };
+    state.db = {
+      update: () => ({
+        set: (values: Record<string, unknown>) => ({
+          where: () => ({
+            returning: async () => {
+              if (state.row.status !== "uploading") return [];
+              const incoming = values.bytesTransferred as number;
+              if (
+                typeof state.row.bytesTransferred === "number" &&
+                state.row.bytesTransferred >= incoming
+              ) {
+                return [];
+              }
+              state.applied.push(values);
+              Object.assign(state.row, values);
+              return [{ id: state.row.id }];
+            },
+          }),
+        }),
+      }),
+    };
+    return state;
+  }
+
+  it("persists bytes and bumps the lastEventAt heartbeat on an uploading run", async () => {
+    const fake = makeRunFake({
+      id: "bkr_1",
+      status: "uploading",
+      bytesTransferred: null,
+      lastEventAt: new Date(Date.now() - 60_000),
+    });
+    const repo = createBackupRunRepo(fake.db as never);
+
+    expect(await repo.recordUploadProgress("bkr_1", 1_048_576)).toBe(true);
+
+    expect(fake.row.bytesTransferred).toBe(1_048_576);
+    expect((fake.row.lastEventAt as Date).getTime()).toBeGreaterThan(Date.now() - 5_000);
+  });
+
+  it("refuses a value that does not advance the counter", async () => {
+    const fake = makeRunFake({
+      id: "bkr_1",
+      status: "uploading",
+      bytesTransferred: 2_000,
+      lastEventAt: new Date(),
+    });
+    const repo = createBackupRunRepo(fake.db as never);
+
+    expect(await repo.recordUploadProgress("bkr_1", 1_500)).toBe(false);
+    expect(await repo.recordUploadProgress("bkr_1", 2_000)).toBe(false);
+
+    expect(fake.applied).toEqual([]);
+    expect(fake.row.bytesTransferred).toBe(2_000);
+  });
+
+  it("refuses a terminal row — a late write cannot resurrect a decided run", async () => {
+    const fake = makeRunFake({
+      id: "bkr_1",
+      status: "failed",
+      bytesTransferred: 0,
+      lastEventAt: new Date(),
+    });
+    const repo = createBackupRunRepo(fake.db as never);
+
+    expect(await repo.recordUploadProgress("bkr_1", 1_048_576)).toBe(false);
+
+    expect(fake.applied).toEqual([]);
+    expect(fake.row.bytesTransferred).toBe(0);
+  });
+});

--- a/apps/api/test/modules/backups/custom-command-config.test.ts
+++ b/apps/api/test/modules/backups/custom-command-config.test.ts
@@ -51,7 +51,9 @@ vi.mock("@repo/db", () => ({
       }),
       transition: async (_id: string, status: string, patch?: Record<string, unknown>) => {
         Object.assign(h.row, { status }, patch ?? {});
+        return true;
       },
+      recordUploadProgress: async () => true,
     },
     backupPolicy: {
       findById: async () => ({

--- a/packages/adapters/src/backup/common/sha256-stream.ts
+++ b/packages/adapters/src/backup/common/sha256-stream.ts
@@ -8,6 +8,11 @@
  *   producerStream.pipe(hasher).pipe(destinationPut);
  *   await destinationPutFinished;
  *   const { sha256, bytesWritten } = hasher.summary();
+ *
+ * `onBytes` reports the CUMULATIVE count per chunk, for callers that publish
+ * live progress mid-stream. It fires synchronously from `_transform`; any
+ * throttling or persistence happens at the caller (per image-transfer.ts's
+ * onProgress convention).
  */
 
 import { createHash, type Hash } from "node:crypto";
@@ -17,15 +22,18 @@ export class HashingPassthrough extends Transform {
   private readonly hash: Hash;
   private bytes = 0;
   private finalDigest: string | null = null;
+  private readonly onBytes?: (bytesWritten: number) => void;
 
-  constructor() {
+  constructor(opts?: { onBytes?: (bytesWritten: number) => void }) {
     super();
     this.hash = createHash("sha256");
+    this.onBytes = opts?.onBytes;
   }
 
   override _transform(chunk: Buffer, _enc: BufferEncoding, cb: TransformCallback): void {
     this.hash.update(chunk);
     this.bytes += chunk.byteLength;
+    this.onBytes?.(this.bytes);
     cb(null, chunk);
   }
 

--- a/packages/adapters/test/sha256-stream-progress.test.ts
+++ b/packages/adapters/test/sha256-stream-progress.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Live byte progress for a streaming upload.
+ *
+ * `summary()` answers only after EOF — useless while a multi-GB artifact is
+ * still moving. `onBytes` fires per chunk with the CUMULATIVE count, so the
+ * backup orchestrator can persist + broadcast progress mid-stream (throttling
+ * is the caller's job — this stream must not know about databases or buses).
+ */
+
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it, vi } from "vitest";
+
+import { HashingPassthrough } from "../src/backup/common/sha256-stream";
+
+const drain = () =>
+  new Writable({
+    write(_chunk, _enc, cb) {
+      cb();
+    },
+  });
+
+describe("HashingPassthrough onBytes", () => {
+  it("reports the cumulative byte count on every chunk", async () => {
+    const seen: number[] = [];
+    const hasher = new HashingPassthrough({ onBytes: (n) => seen.push(n) });
+
+    await pipeline(
+      Readable.from([Buffer.alloc(100), Buffer.alloc(5), Buffer.alloc(1000)]),
+      hasher,
+      drain(),
+    );
+
+    expect(seen).toEqual([100, 105, 1105]);
+    expect(hasher.summary().bytesWritten).toBe(1105);
+  });
+
+  it("stays silent for a zero-byte stream and still summarizes", async () => {
+    const onBytes = vi.fn();
+    const hasher = new HashingPassthrough({ onBytes });
+
+    await pipeline(Readable.from([]), hasher, drain());
+
+    expect(onBytes).not.toHaveBeenCalled();
+    expect(hasher.summary().bytesWritten).toBe(0);
+  });
+
+  it("is optional — a bare instance hashes exactly as before", async () => {
+    const hasher = new HashingPassthrough();
+
+    await pipeline(Readable.from([Buffer.from("abc")]), hasher, drain());
+
+    expect(hasher.summary()).toEqual({
+      sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      bytesWritten: 3,
+    });
+  });
+});

--- a/packages/db/src/repos/backup.repo.ts
+++ b/packages/db/src/repos/backup.repo.ts
@@ -65,6 +65,13 @@ export const IN_FLIGHT_RUN_STATUSES: BackupRunStatus[] = [
   "verifying",
 ];
 
+const TERMINAL_RUN_STATUSES: BackupRunStatus[] = [
+  "succeeded",
+  "failed",
+  "cancelled",
+  "server_error",
+];
+
 export const IN_FLIGHT_RESTORE_STATUSES: BackupRestoreStatus[] = [
   "queued",
   "preparing",
@@ -110,7 +117,7 @@ async function persistTransition(
    * `succeeded` with `manifest_key` still null.
    */
   write: (values: Record<string, unknown>, guarded: boolean) => Promise<unknown>,
-): Promise<void> {
+): Promise<boolean> {
   const core_result = await write(core, true);
   // An empty `returning()` means the guarded WHERE matched nothing: the row is already
   // terminal and this transition lost the race. Logged, never swallowed — the write being
@@ -121,20 +128,20 @@ async function persistTransition(
       `[db] ${label} ${id}: refused transition to "${status}" — the row is already in a ` +
         `terminal state. Whoever finished it first owns the verdict; this write was dropped.`,
     );
-    return;
+    return false;
   }
-  if (!patch) return;
+  if (!patch) return true;
   // `status` never rides the payload — the core write above owns it.
   const rest: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(patch)) {
     if (key !== "status") rest[key] = value;
   }
   const keys = Object.keys(rest);
-  if (keys.length === 0) return;
+  if (keys.length === 0) return true;
 
   try {
     await write(rest, false);
-    return;
+    return true;
   } catch (err) {
     console.error(
       `[db] ${label} ${id}: payload rejected (${detailOf(err)}) — status "${status}" is persisted; salvaging per column`,
@@ -158,6 +165,7 @@ async function persistTransition(
       console.error(`[db] ${label} ${id}: column ${key} rejected (${detail}) — left unset`);
     }
   }
+  return true;
 }
 
 // ─── Destination repo ────────────────────────────────────────────────────────
@@ -580,11 +588,10 @@ export function createBackupRunRepo(db: Database) {
       id: string,
       status: BackupRunStatus,
       patch?: Partial<Omit<NewBackupRun, "id" | "startedAt">>,
-    ): Promise<void> {
-      const TERMINAL: BackupRunStatus[] = ["succeeded", "failed", "cancelled", "server_error"];
-      const finishing = TERMINAL.includes(status);
+    ): Promise<boolean> {
+      const finishing = TERMINAL_RUN_STATUSES.includes(status);
       const now = new Date();
-      await persistTransition(
+      return persistTransition(
         "backup_run",
         id,
         status,
@@ -603,11 +610,46 @@ export function createBackupRunRepo(db: Database) {
             // reaches terminal first.
             .where(
               guarded
-                ? and(eq(backupRun.id, id), notInArray(backupRun.status, TERMINAL))
+                ? and(eq(backupRun.id, id), notInArray(backupRun.status, TERMINAL_RUN_STATUSES))
                 : eq(backupRun.id, id),
             )
             .returning(),
       );
+    },
+
+    /**
+     * Mid-upload progress: cumulative `bytesTransferred` + a `lastEventAt`
+     * heartbeat while a run sits in `uploading` between artifact boundaries.
+     * Called throttled from the upload stream; NOT a transition — status is
+     * untouched, `finishedAt` is untouched.
+     *
+     * Two guards, both in the WHERE so the check is atomic with the write:
+     *   - only `uploading` accepts progress: a throttled write still in flight
+     *     after any later state must not mutate or heartbeat that state;
+     *   - the value must ADVANCE: writes are serialized by the orchestrator
+     *     but the monotonic clause is what makes a reordered or duplicated
+     *     delivery harmless instead of a backward-moving counter.
+     *
+     * A refused write is silent by design: progress is telemetry, and the only
+     * information it carried (a later heartbeat) is stale once the row is no
+     * longer uploading.
+     */
+    async recordUploadProgress(id: string, bytesTransferred: number): Promise<boolean> {
+      const result = await db
+        .update(backupRun)
+        .set({ bytesTransferred, lastEventAt: new Date() })
+        .where(
+          and(
+            eq(backupRun.id, id),
+            eq(backupRun.status, "uploading"),
+            or(
+              isNull(backupRun.bytesTransferred),
+              lt(backupRun.bytesTransferred, bytesTransferred),
+            ),
+          ),
+        )
+        .returning();
+      return result.length > 0;
     },
 
     /**
@@ -670,17 +712,12 @@ export function createBackupRunRepo(db: Database) {
      * durable in Redis. The 6h `ceilingCutoff` still applies as the genuine backstop —
      * a row that has sat queued that long is a real anomaly, not a busy queue.
      *
-     * `uploading` is deliberately NOT idle-swept. A single-artifact dump
-     * (pg_dump/mysqldump/mongodump) streams the whole payload through one
-     * `destination.put`, and the orchestrator writes `bytesTransferred` / bumps
-     * `lastEventAt` only at artifact boundaries — never mid-stream. So for the
-     * entire upload the row sits `(uploading, bytesTransferred=NULL,
-     * lastEventAt=frozen)`, which is indistinguishable by DB state alone from a
-     * wedge. Idle-sweeping it here would kill honest multi-GB uploads that
-     * legitimately run past `idleCutoff` — the exact managed-postgres case #516
-     * is about. A genuinely wedged upload is reaped in-process by the executor's
-     * per-stream idle watchdog (which also frees the worker slot); this sweep
-     * only backstops `uploading` via the 6h `ceilingCutoff`.
+     * `uploading` is deliberately NOT idle-swept even though it now heartbeats.
+     * This repository can decide that a row is stale, but it cannot abort the
+     * producer/destination promise holding the worker slot. Marking that row
+     * terminal would therefore report recovery without actually releasing the
+     * blocked work. Upload executors retain their in-process idle watchdogs; the
+     * database sweep can include this state only when capture has an abort path.
      */
     async sweepRunsWithStaleHeartbeat(params: {
       idleCutoff: Date;


### PR DESCRIPTION
## Summary

Reports cumulative backup bytes while an artifact is still uploading, using the existing backup-run SSE path. Progress writes are throttled, monotonic, and ordered with artifact and terminal transitions.

## Motivation

A large single-artifact backup only updated `bytesTransferred` after the upload finished. During the transfer the database heartbeat stayed frozen and the dashboard had no live byte progress, making a healthy upload indistinguishable from a stalled one.

## Related issue

None — this is a self-contained improvement from the existing backups PENDING notes. It adds no endpoint, schema migration, dependency, or frontend behavior.

## Changes

- `packages/adapters`: add an optional cumulative-byte callback to `HashingPassthrough`.
- `packages/db`: atomically persist advancing progress only while the run is `uploading`, and report whether guarded transitions were accepted.
- `apps/api`: throttle and coalesce stream samples, publish SSE only after accepted persistence, flush progress before exact/terminal writes, and preserve an existing terminal verdict when writers race.
- Keep `uploading` out of the database idle sweep until capture has a real abort path; update the pending note accordingly.
- Reuse the existing dashboard backup stream consumer; no frontend changes.

## Verification

```bash
bun run --cwd apps/api test -- test/modules/backups
# Test Files 22 passed (22)
# Tests      245 passed (245)

bun run --cwd packages/adapters test -- test/sha256-stream-progress.test.ts
# Test Files 1 passed (1)
# Tests      3 passed (3)

bun run --cwd apps/api lint
bun run --cwd packages/db lint
bun run --cwd packages/adapters lint
bun run --cwd apps/dashboard lint
# tsc --noEmit passed in all four workspaces

git diff --check upstream/main..HEAD
# clean
```

Regression coverage includes cumulative multi-artifact progress, one-second throttling, coalescing behind a delayed database write, monotonic SSE ordering, refused progress writes, failure ordering, and competing terminal writers.

An earlier repository-wide API/DB sweep encountered shifting PGlite setup and worker-startup timeouts; no assertions failed, and the affected API files passed when rerun independently.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I was not otherwise changing
- [x] A test fails without this change and passes with it
- [ ] Full root `bun run test` is green (focused suites and all relevant typechecks are green; repository-wide PGlite runs hit the infrastructure timeouts noted above)
- [x] I understand every line of this diff and can explain it in review