### PR TITLE
fix(dashboard): allow signed-out invitees to complete the invitation flow

### DIFF
--- a/apps/dashboard/src/app/accept-invite/[id]/page.tsx
+++ b/apps/dashboard/src/app/accept-invite/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Loader2, Check, X } from "lucide-react";
@@ -22,7 +22,6 @@ type InviteState =
  */
 const orgClient = (authClient as unknown as {
   organization: {
-    getInvitation: (opts: { id: string }) => Promise<{ data?: { invitation: { email: string; role: string; status: string }; organization: { id: string; name: string } }; error?: { message?: string } }>;
     acceptInvitation: (opts: { invitationId: string }) => Promise<{ data?: { invitation: { organizationId: string }; member?: unknown }; error?: { message?: string } }>;
     rejectInvitation: (opts: { invitationId: string }) => Promise<{ error?: { message?: string } }>;
   };
@@ -46,37 +45,64 @@ export default function AcceptInvitePage() {
 
   const inviteId = String(params.id);
 
+  // Once the invitation has been accepted, the effect must not re-run and
+  // clobber the success screen: signing in (right after invite-signup) flips
+  // `session`, which retriggers this effect, and a get-invitation for an
+  // already-accepted invite now fails with "Invitation not found" — which
+  // would paint an error over the success state.
+  const settledRef = useRef(false);
+
   useEffect(() => {
-    if (sessionLoading) return;
+    if (sessionLoading || settledRef.current) return;
+    // Don't probe the invitation again mid-accept / after success — signing in
+    // (invite-signup path) flips `session`, which retriggers this effect while
+    // an accept is already in flight.
+    if (state.kind === "accepting" || state.kind === "accepted") return;
+
+    // A first-time invitee has no session yet, and better-auth's get-invitation
+    // requires one — calling it here dead-ends every new invitee with an error
+    // instead of the signup form. The invitation id in the URL is itself the
+    // credential: /api/system/invite-signup re-validates it server-side
+    // (pending, unexpired, admin inviter) and derives the email from it, so the
+    // logged-out path goes straight to sign-in / create-account. Signed-in
+    // users still get the full get-invitation details (org, role,
+    // wrong-account detection).
+    if (!session?.user) {
+      setState({ kind: "needs-login" });
+      return;
+    }
 
     (async () => {
       try {
-        const res = await orgClient.getInvitation({ id: inviteId });
-        if (res.error) {
-          setState({ kind: "error", message: res.error.message ?? m.invalidInvitation });
+        // NOTE: better-auth's org client emits POST for this route while the
+        // server registers it as GET-only — a guaranteed 404 (observed on
+        // better-auth 1.5.4). Hit the endpoint directly with GET; the session
+        // cookie rides along same-origin.
+        const inv = await api.get<{
+          email: string;
+          role: string;
+          status: string;
+          organizationName?: string;
+        }>(`auth/organization/get-invitation?id=${encodeURIComponent(inviteId)}`);
+        // The accept may have completed while this request was in flight —
+        // never paint a stale error over the success screen.
+        if (settledRef.current) return;
+        if (!inv?.email) {
+          setState({ kind: "error", message: m.invalidInvitation });
           return;
         }
-        const { invitation, organization } = res.data!;
-        if (invitation.status !== "pending") {
+        if (inv.status !== "pending") {
           setState({
             kind: "error",
-            message: interpolate(m.invitationStatus, { status: invitation.status }),
+            message: interpolate(m.invitationStatus, { status: inv.status }),
           });
           return;
         }
-        if (!session?.user) {
-          setState({
-            kind: "needs-login",
-            email: invitation.email,
-            organizationName: organization.name,
-          });
-          return;
-        }
-        if (session.user.email !== invitation.email) {
+        if (session.user.email !== inv.email) {
           setState({
             kind: "error",
             message: interpolate(m.wrongAccount, {
-              email: invitation.email,
+              email: inv.email,
               currentEmail: session.user.email,
             }),
           });
@@ -84,9 +110,9 @@ export default function AcceptInvitePage() {
         }
         setState({
           kind: "ready",
-          email: invitation.email,
-          organizationName: organization.name,
-          role: invitation.role,
+          email: inv.email,
+          organizationName: inv.organizationName ?? "",
+          role: inv.role,
         });
       } catch (err) {
         setState({
@@ -123,6 +149,7 @@ export default function AcceptInvitePage() {
       console.warn("[accept-invite] materialize failed (continuing):", err);
     }
 
+    settledRef.current = true;
     setState({
       kind: "accepted",
       organizationId: res.data.invitation.organizationId,
@@ -151,23 +178,32 @@ export default function AcceptInvitePage() {
     setSignupBusy(true);
     setSignupError(null);
     try {
-      await api.post("system/invite-signup", {
-        invitationId: inviteId,
-        name: signupName.trim(),
+      // The server derives the account email from the invitation token — the
+      // response's email is authoritative, so sign in with it rather than any
+      // client-side value.
+      const created = await api.post<{ ok?: boolean; email?: string }>(
+        "system/invite-signup",
+        {
+          invitationId: inviteId,
+          name: signupName.trim(),
+          password: signupPassword,
+        },
+      );
+      const si = await authClient.signIn.email({
+        email: created?.email || email,
         password: signupPassword,
       });
+      if (si.error) {
+        setSignupBusy(false);
+        setSignupError(si.error.message ?? (m.acceptFailed ?? "Sign-in failed"));
+        return;
+      }
+      await handleAccept();
     } catch (err) {
       setSignupBusy(false);
       setSignupError(getApiErrorMessage(err, m.acceptFailed ?? "Sign-up failed"));
       return;
     }
-    const si = await authClient.signIn.email({ email, password: signupPassword });
-    if (si.error) {
-      setSignupBusy(false);
-      setSignupError(si.error.message ?? (m.acceptFailed ?? "Sign-in failed"));
-      return;
-    }
-    await handleAccept();
   };
 
   return (
@@ -181,13 +217,19 @@ export default function AcceptInvitePage() {
           <>
             <div>
               <h1 className="text-xl font-semibold text-foreground">{m.invitedTitle}</h1>
-              <p className="text-sm text-muted-foreground mt-2">
-                {m.needsLoginPre}
-                <strong>{state.organizationName}</strong>
-                {m.needsLoginMid}
-                <strong>{state.email}</strong>
-                {m.needsLoginPost}
-              </p>
+              {state.organizationName && state.email ? (
+                <p className="text-sm text-muted-foreground mt-2">
+                  {m.needsLoginPre}
+                  <strong>{state.organizationName}</strong>
+                  {m.needsLoginMid}
+                  <strong>{state.email}</strong>
+                  {m.needsLoginPost}
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground mt-2">
+                  {interpolate(m.joinTitle, { org: m.theOrganization })}
+                </p>
+              )}
             </div>
             {showSignup ? (
               <form


### PR DESCRIPTION
## Summary

The `accept-invite` page could not complete its primary use case on self-hosted invite-only instances: a user opening an invitation link without already having an account.

This PR fixes the invitation flow so signed-out invitees can reach the existing create-account flow, sign in automatically after account creation, and accept the invitation without the page falling back into an error state.

This complements **#696**, which made the route publicly accessible. After that change, visitors could reach the page, but the invitation flow still failed before signup.

---

## Problem

Three issues combined to break the experience for first-time invitees:

1. **Invitation details were requested before checking for a session.**

   `organization.getInvitation` requires an authenticated session. Visiting `/accept-invite/[id]` while signed out immediately failed with `401 Not authenticated`, causing the page to render the "Invalid invitation" error instead of the signup UI. As a result, the existing `!session` signup branch was effectively unreachable.

2. **Invitation loading failed on the current self-hosted better-auth setup.**

   On the tested `better-auth` v1.5.4 setup, the dashboard client issued a `POST` request for `organization/get-invitation`, while the server exposed the route as `GET`. The invitation fetch therefore failed even for authenticated users, while `accept-invitation` and `reject-invitation` continued working because those routes are `POST`.

3. **The page re-fetched the invitation after signup completed.**

   Creating an account automatically signs the user in, which changes the session and re-runs the page effect. That second fetch occurs after the invitation has already been accepted, replacing the success UI with the "Can't accept this invite" error state.

---

## Evidence

API request log of one clean incognito run through signup on a self-hosted deployment of current `main`:

```
POST /api/system/invite-signup                       200   account created
POST /api/auth/sign-in/email                         200   auto sign-in
POST /api/auth/organization/accept-invitation        200   accepted
POST /api/permissions/invitations/<id>/materialize   200
POST /api/auth/organization/get-invitation           404   client speaks POST…
GET  /api/auth/organization/get-invitation?id=…      401   …server only routes GET
                                                           (401 = no session in this
                                                            probe; route exists)
```

Both halves reproduced against the running stack:

```
$ curl -X POST …/api/proxy/api/auth/organization/get-invitation
→ 404                                  (route not registered for POST)

$ curl "…/get-invitation?id=<pending id>"             (no cookies)
→ 401 {"message":"Not authenticated"}  (route alive, session required)
```

---

## Changes

**File changed**

`apps/dashboard/src/app/accept-invite/[id]/page.tsx`

### Invitation flow

* Check for an authenticated session **before** attempting to load invitation details.
* Signed-out visitors now immediately see the existing **Sign in / Create account** choice instead of failing on a session-protected request.
* The invitation token in the URL remains the only credential; `/api/system/invite-signup` continues to perform all server-side validation (pending status, expiration, inviter permissions, and email extraction).

### Invitation loading

* Load invitation details through the server's `GET /auth/organization/get-invitation?id=...` endpoint via the app's existing api client, matching the server route used by the current self-hosted setup.
* Accept/reject actions continue using the existing better-auth client methods (those routes are `POST` and were already working).

### State handling

* Skip invitation re-fetches while an acceptance is already in progress or completed.
* Ignore stale fetch results once the invitation has been accepted, preventing the success screen from being overwritten after the session updates.

### Signup

* After account creation, sign in using the **email returned by** `/api/system/invite-signup` instead of any client-derived value.

### UI

* Render "Join {organization} as {email}" only when invitation details are available.
* Signed-out visitors get the existing generic localized invitation copy.
* No locale files changed.

---

## Why this is safe

* No API changes.
* No new endpoints.
* No database changes.
* No dependency changes.
* All invitation validation remains server-side.

The client only changes when and how invitation metadata is requested.

---

## Verification

Tested on a self-hosted Compose deployment built from this commit (API image untouched).

### Before

* Opening `/accept-invite/[id]` in an incognito window immediately rendered **"Can't accept this invite / Invalid invitation"**.
* The invitation endpoint failed before signup could be displayed; console showed `…/api/proxy/api/auth/organization/get-invitation → 404`.

### After

* The same invitation link displays **"You're invited"** with the existing **Create account** flow.
* Creating an account creates the invited user, signs them in automatically, accepts the invitation, and redirects to the dashboard.
* The success state remains visible after signup instead of being replaced by an error.

### Regression checks

* Signed in as a different account → existing wrong-account message still appears.
* Expired or cancelled invitations → still rejected server-side during signup.
* Signed-in invitees now load invitation details correctly (this path also hit the POST/GET mismatch before); wrong-account detection, status display and accept/reject keep their previous behavior.

### Build

* `docker build -f apps/dashboard/Dockerfile .` succeeds (includes type checking).

---

## Checklist

* Fixes a single user-facing bug — one change per PR, no unrelated formatting or refactoring.
* Scoped to one file.
* Existing signed-in behavior preserved.
* Verified end-to-end on a self-hosted deployment.
* Every line of the diff reviewed and understood by the author.
