### PR TITLE
fix(domains): add mcp metadata to DELETE /api/domains/:id route (#720)

### DIFF
--- a/apps/api/src/modules/domains/domain.routes.ts
+++ b/apps/api/src/modules/domains/domain.routes.ts
@@ -38,7 +38,15 @@ r.post("/preview", { tag: "domain:read", readOnly: true, body: PreviewDomainBody
 // a domain belonging to a cloud project is proxied to the SaaS; a local domain
 // falls through to the local handler.
 r.get("/:id", { tag: "domain:read", mcp: { description: "Read one domain's verify + SSL state." } }, cloudDomainProxy, ctrl.get);
-r.delete("/:id", { tag: "domain:admin" }, cloudDomainProxy, ctrl.remove);
+r.delete(
+  "/:id",
+  {
+    tag: "domain:admin",
+    mcp: { description: "Delete a domain by id." },
+  },
+  cloudDomainProxy,
+  ctrl.remove,
+);
 r.post("/:id/verify", { tag: "domain:write", mcp: { description: "Verify a domain's ownership / DNS." } }, cloudDomainProxy, ctrl.verify);
 // Self-hosted live-log verify (SSE): streams certbot's standalone HTTP-01 run.
 r.post("/:id/verify/stream", { tag: "domain:write" }, ctrl.verifyStream);

--- a/apps/api/test/modules/mcp/mcp-domain-tools.test.ts
+++ b/apps/api/test/modules/mcp/mcp-domain-tools.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "../../../src/modules/domains/domain.routes";
+import { getMcpTools, resetMcpToolCache } from "../../../src/modules/mcp/mcp-tools";
+
+describe("Domain routes MCP tool generation", () => {
+  beforeEach(() => {
+    resetMcpToolCache();
+  });
+
+  it("exposes delete_domains_by_id tool for DELETE /api/domains/:id", () => {
+    const tools = getMcpTools();
+    const deleteTool = tools.find((t) => t.method === "DELETE" && t.path === "/api/domains/:id");
+    expect(deleteTool).toBeDefined();
+    expect(deleteTool?.name).toBe("delete_domains_by_id");
+    expect(deleteTool?.description).toMatch(/Delete a domain/i);
+  });
+});


### PR DESCRIPTION
Closes #720

### Changes
- In `apps/api/src/modules/domains/domain.routes.ts`, added `mcp: { description: "Delete a domain by id." }` to `r.delete("/:id")` so the OpenAPI/MCP route scanner generates the `delete_domains_by_id` MCP tool definition.
- Added test `apps/api/test/modules/mcp/mcp-domain-tools.test.ts` asserting that `getMcpTools()` contains `delete_domains_by_id`.