### PR TITLE
fix(domains): fall back to findLocalServer when project serverId is null (#721)

### DIFF
--- a/apps/api/src/modules/domains/ensure-edge.controller.test.ts
+++ b/apps/api/src/modules/domains/ensure-edge.controller.test.ts
@@ -4,6 +4,7 @@ const h = vi.hoisted(() => ({
   findProject: vi.fn(),
   findDeployment: vi.fn(),
   getServerInOrganization: vi.fn(),
+  findLocalServer: vi.fn(),
 }));
 
 vi.mock("@repo/db", async (importOriginal) => {
@@ -28,6 +29,10 @@ vi.mock("@repo/db", async (importOriginal) => {
   };
 });
 
+vi.mock("../../lib/startup/self-server", () => ({
+  findLocalServer: () => h.findLocalServer(),
+}));
+
 import { resolveProjectServer } from "./ensure-edge.controller";
 
 const project = {
@@ -48,6 +53,7 @@ describe("resolveProjectServer", () => {
       meta: { serverId: "server-live" },
     });
     h.getServerInOrganization.mockReset().mockResolvedValue({ id: "server-live" });
+    h.findLocalServer.mockReset().mockResolvedValue(null);
   });
 
   it("targets the active deployment snapshot before the mutable project binding", async () => {
@@ -83,16 +89,58 @@ describe("resolveProjectServer", () => {
     });
   });
 
-  it("does not install an edge on a future server when the active release is explicitly local", async () => {
+  it("uses the local server instead of a future server when the active release is explicitly local", async () => {
     h.findDeployment.mockResolvedValue({
       id: "deployment-1",
       meta: { deployTarget: "local" },
     });
+    h.findLocalServer.mockResolvedValue({ id: "server-local", isLocal: true });
+    h.getServerInOrganization.mockResolvedValue({ id: "server-local", isLocal: true });
+
+    await expect(resolveProjectServer("project-1", "org-1")).resolves.toMatchObject({
+      serverId: "server-local",
+      isLocal: true,
+    });
+    expect(h.getServerInOrganization).toHaveBeenCalledWith("server-local", "org-1");
+    expect(h.getServerInOrganization).not.toHaveBeenCalledWith("server-next", "org-1");
+  });
+
+  it("falls back to local server when serverId is null on local projects", async () => {
+    h.findProject.mockResolvedValue({
+      ...project,
+      serverId: null,
+    });
+    h.findDeployment.mockResolvedValue({
+      id: "deployment-1",
+      meta: {},
+    });
+    h.findLocalServer.mockResolvedValue({ id: "server-local", isLocal: true });
+    h.getServerInOrganization.mockResolvedValue({ id: "server-local", isLocal: true });
+
+    const result = await resolveProjectServer("project-1", "org-1");
+
+    expect(result).toMatchObject({
+      serverId: "server-local",
+      isLocal: true,
+    });
+  });
+
+  it("does not redirect a server deployment with a missing server id to the local host", async () => {
+    h.findProject.mockResolvedValue({
+      ...project,
+      serverId: null,
+    });
+    h.findDeployment.mockResolvedValue({
+      id: "deployment-1",
+      meta: { deployTarget: "server" },
+    });
+    h.findLocalServer.mockResolvedValue({ id: "server-local", isLocal: true });
 
     await expect(resolveProjectServer("project-1", "org-1")).resolves.toEqual({
       error: "Project is not deployed to a server",
       status: 400,
     });
+    expect(h.findLocalServer).not.toHaveBeenCalled();
     expect(h.getServerInOrganization).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/domains/ensure-edge.controller.ts
+++ b/apps/api/src/modules/domains/ensure-edge.controller.ts
@@ -39,6 +39,7 @@ import { withLiveProjectRuntimeMutation } from "../../lib/project-runtime-lock";
 import { applyProjectRouting } from "./routing-apply.service";
 import { reapplyProjectLiveRoutes } from "./project-route.service";
 import { resolveProjectLiveDeployTarget } from "../projects/project-deploy-target";
+import { findLocalServer } from "../../lib/startup/self-server";
 import {
   createEdgeConsentSession,
   getEdgeConsentSession,
@@ -87,7 +88,7 @@ export async function resolveProjectServer(
   // The active deployment snapshot is where the live edge actually runs. The
   // mutable project binding is only the canonical resolver's fallback for a
   // legacy/partial snapshot, never the first choice.
-  const { deployTarget, serverId } = await resolveProjectLiveDeployTarget(project);
+  let { deployTarget, serverId } = await resolveProjectLiveDeployTarget(project);
   if (deployTarget === "cloud") {
     return {
       error: "Cloud projects manage routing at the edge automatically",
@@ -97,6 +98,13 @@ export async function resolveProjectServer(
   }
   if (!project.activeDeploymentId)
     return { error: "Deploy the project before setting up its edge", status: 400 };
+  if (!serverId && deployTarget === "local") {
+    // A derived local target is represented by the absence of a durable server
+    // binding. Resolve its canonical row for the edge executor, but do not write
+    // it back to the project: edge-status is read-only, and doing so would change
+    // the destination of the project's next deployment from local to server.
+    serverId = (await findLocalServer().catch(() => null))?.id ?? null;
+  }
   if (!serverId) return { error: "Project is not deployed to a server", status: 400 };
   // Snapshot metadata is historical input, not an authorization boundary.
   // Reject a stale/foreign id before any reachability or SSH operation uses it.


### PR DESCRIPTION
Closes #721

### Changes
- In `apps/api/src/modules/domains/ensure-edge.controller.ts` (`resolveProjectServer`), added a fallback to `findLocalServer()` when `serverId` is unpopulated on local-target / single-host deployments.
- Updated `apps/api/src/modules/domains/ensure-edge.controller.test.ts` with a unit test asserting that `resolveProjectServer` falls back to the local server row and resolves `isLocal: true` when `project.serverId` and deployment metadata serverId are null.