### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ Same interface regardless of where you deploy.
 
 ---
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Openship/)
+
+---
+
 ## Status
 
 Production-ready core, actively developed. Self-hosting is **free** (no billing).


### PR DESCRIPTION
Add a one-click deploy button for RepoCloud to provide a seamless deployment option for Openship.

- Added `☁️ One-Click Deploy` section after Deploy Anywhere
- Button links to https://repocloud.io/details/Openship/