### PR TITLE
Show the real changelog after updates

### DIFF
--- a/apps/dashboard/src/components/updates/useUpdates.ts
+++ b/apps/dashboard/src/components/updates/useUpdates.ts
@@ -13,6 +13,8 @@ import { useCallback, useEffect, useState } from "react";
 import {
   RELEASES_LATEST_API,
   advisoryManifestUrl,
+  changelogMarkdownUrl,
+  extractChangelogSection,
   parseManifest,
   resolveUpdateState,
   matchAdvisories,
@@ -102,16 +104,21 @@ async function fetchRemote(): Promise<{ latest: LatestRelease | null; manifest: 
         headers: { Accept: "application/vnd.github+json" },
       });
       if (res.ok) {
-        const data = (await res.json()) as { tag_name?: string; body?: string };
+        const data = (await res.json()) as { tag_name?: string };
         const tag = data.tag_name ?? "";
         if (tag) {
-          latest = { version: tag.replace(/^v/, ""), tag, notes: data.body ?? "" };
+          latest = { version: tag.replace(/^v/, ""), tag, notes: "" };
           // Advisories pinned to the release TAG — main commits never surface.
           try {
-            const m = await fetch(advisoryManifestUrl(tag), { headers: { Accept: "application/json" } });
+            const [changelog, m] = await Promise.all([
+              fetch(changelogMarkdownUrl(tag)),
+              fetch(advisoryManifestUrl(tag), { headers: { Accept: "application/json" } }),
+            ]);
+            if (changelog.ok)
+              latest.notes = extractChangelogSection(await changelog.text(), latest.version);
             if (m.ok) manifest = parseManifest(await m.json());
           } catch {
-            /* no manifest at this tag → no advisories */
+            /* no changelog/manifest at this tag → no release details */
           }
         }
       }

--- a/packages/core/src/updates/changelog.ts
+++ b/packages/core/src/updates/changelog.ts
@@ -1,0 +1,16 @@
+import { GITHUB_REPO } from "./types";
+
+/** Raw repository changelog pinned to a branch or tag. */
+export function changelogMarkdownUrl(ref: string): string {
+  return `https://raw.githubusercontent.com/${GITHUB_REPO}/${encodeURIComponent(ref)}/CHANGELOG.md`;
+}
+
+/** Extract one version body from the repository changelog. */
+export function extractChangelogSection(markdown: string, version: string): string {
+  const lines = markdown.split(/\r?\n/);
+  const target = version.replace(/^v/, "");
+  const start = lines.findIndex((line) => line.match(/^##\s+v?(\d+\.\d+\.\d+)\b/)?.[1] === target);
+  if (start < 0) return "";
+  const end = lines.findIndex((line, index) => index > start && /^##\s+v?\d+\.\d+\.\d+\b/.test(line));
+  return lines.slice(start + 1, end < 0 ? undefined : end).join("\n").trim();
+}

--- a/packages/core/src/updates/index.ts
+++ b/packages/core/src/updates/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./changelog";
 export * from "./semver";
 export * from "./identity";
 export * from "./advisories";

--- a/packages/core/src/updates/types.ts
+++ b/packages/core/src/updates/types.ts
@@ -119,6 +119,6 @@ export function advisoryManifestUrl(tag: string): string {
 /** Human-facing changelog link — a specific tag's notes, or all releases. */
 export function changelogUrl(tag?: string): string {
   return tag
-    ? `https://github.com/${GITHUB_REPO}/releases/tag/${encodeURIComponent(tag)}`
+    ? `https://github.com/${GITHUB_REPO}/blob/main/CHANGELOG.md#${tag.replace(/^v/, "").replaceAll(".", "")}`
     : `https://github.com/${GITHUB_REPO}/releases`;
 }

--- a/packages/core/test/updates-resolve.test.ts
+++ b/packages/core/test/updates-resolve.test.ts
@@ -8,6 +8,8 @@ import {
   type GithubReleasePayload,
 } from "../src/updates/resolve";
 import { parseManifest } from "../src/updates/advisories";
+import { changelogMarkdownUrl, extractChangelogSection } from "../src/updates/changelog";
+import { changelogUrl } from "../src/updates/types";
 
 // A realistic `releases/latest` payload — asset names match .github/workflows/release.yml.
 const RELEASE_0_2_0: GithubReleasePayload = {
@@ -20,6 +22,32 @@ const RELEASE_0_2_0: GithubReleasePayload = {
     { name: "Openship.AppImage", browser_download_url: "https://x/app.AppImage", size: 13 },
   ],
 };
+
+describe("changelog release details", () => {
+  const changelog = `# Changelog
+
+## 0.6.10
+
+- newer
+
+## 0.6.9
+
+- **Dashboard** — useful details
+
+## 0.6.8
+
+- older`;
+
+  it("extracts the exact version section and links its heading", () => {
+    expect(extractChangelogSection(changelog, "0.6.9")).toBe("- **Dashboard** — useful details");
+    expect(changelogMarkdownUrl("v0.6.9")).toBe(
+      "https://raw.githubusercontent.com/oblien/openship/v0.6.9/CHANGELOG.md",
+    );
+    expect(changelogUrl("v0.6.9")).toBe(
+      "https://github.com/oblien/openship/blob/main/CHANGELOG.md#069",
+    );
+  });
+});
 
 describe("desktopAssetName", () => {
   it("maps each platform/arch to the published asset (Windows = zip, NOT Setup.exe)", () => {


### PR DESCRIPTION
The post-update popup currently repeats an empty GitHub Release instead of the matching version changelog.

<table>
<thead>
<tr>
<th width="30%">Current release notes</th>
<th width="70%">Expected changelog</th>
</tr>
</thead>
<tbody>
<tr>
<td width="30%" valign="top"><code>Bump to v0.6.9 + announce</code></td>
<td width="70%" valign="top">
<strong>0.6.9</strong>
<p>This critical deployment-safety hotfix makes legacy Docker Compose ownership and routing fail closed. Existing unmanaged stacks can no longer be mistaken for an Openship deployment or silently duplicated, and an ordinary same-server redeploy cannot move a routed service onto a different host port.</p>
<h3>Deployments and routing</h3>
<ul>
<li><strong>Existing Compose stacks are never adopted implicitly:</strong> before changing containers or routes, a normal deployment checks the target for an untracked Docker Compose stack with the same project slug and service names. A collision now stops with <code>FOREIGN_COMPOSE_STACK</code> and tells the operator to import/adopt, remove, or rename it. Explicitly adopted containers and containers already tracked by Openship continue normally.</li>
<li><strong>Same-server host ports stay locked across redeploys:</strong> a routed service keeps its active host port on its current physical server. If that port cannot be reclaimed safely, deployment stops before routing changes instead of allocating a new port and leaving the public hostname pointed at the wrong workload. A real server migration may still allocate a new host port.</li>
<li><strong>Duplicate-container warnings require ownership evidence:</strong> normal projects no longer claim same-slug containers through Docker Compose labels alone. Native Openship labels, the canonical managed name, or the tracked container id prove ownership. Compose-label recovery remains available only for an explicit adoption.</li>
</ul>
<h3>Compose reconciliation</h3>
<ul>
<li><strong>Legacy parser metadata does not create false repository drift:</strong> adding environment/build-argument template provenance to an older service baseline is treated as a one-time metadata upgrade, not as a Compose edit. Real changes arriving with that metadata are still reported, and operator-edited live values remain intact while the baseline advances.</li>
</ul>
<h3>Monitoring</h3>
<ul>
<li><strong>Issues is now the Monitoring workspace:</strong> the dashboard adds a Health view for every tracked project service, with fleet counts and state charts for healthy, unhealthy, crash-looping, down, and unknown workloads. Rows show the serving server and last observation, and link back to the service that owns the container.</li>
<li><strong>Health reads reuse the existing watcher:</strong> the page reads an in-memory snapshot produced by the grouped health sweep and Docker-event accelerator. It does not create a poller per container or perform Docker I/O on page refresh. Per-service monitoring can be disabled before the workload enters the watch, inspection, event, or notification path.</li>
<li><strong>Fleet updates and rescans continue in the background:</strong> bulk component updates start together without holding a modal open, retain their durable sessions across navigation and refresh, and allow an operator to reattach to a specific log. The checker batch similarly exposes one shared progress session so multiple tabs cannot multiply Git, DNS, Docker, or version scans.</li>
</ul>
<blockquote><strong>Upgrade priority: critical for legacy or externally created Compose workloads.</strong> Fully tracked Openship deployments are not expected to hit the collision path, but installations that previously deployed a same-slug stack outside the current control-plane records should upgrade before redeploying it.</blockquote>
</td>
</tr>
</tbody>
</table>

Closes #752