### PR TITLE
fix(webmail): populate reply recipients and subject

### DIFF
--- a/apps/email/client/components/create/email-composer.tsx
+++ b/apps/email/client/components/create/email-composer.tsx
@@ -137,7 +137,6 @@ export function EmailComposer({
   const [imageQuality, setImageQuality] = useState<ImageQuality>(
     (settings?.settings?.imageCompression as unknown as ImageQuality) || 'medium',
   );
-  const [activeReplyId] = useQueryState('activeReplyId');
   const [toggleToolbar, setToggleToolbar] = useState(false);
   const processAndSetAttachments = async (
     filesToProcess: File[],
@@ -689,36 +688,34 @@ export function EmailComposer({
         </div>
 
         {/* Subject */}
-        {!activeReplyId ? (
-          <div className="flex items-center gap-2 border-b p-3">
-            <p className="text-sm font-medium text-[#8C8C8C]">Subject:</p>
-            <input
-              className="h-4 w-full bg-transparent text-sm font-normal leading-normal text-black placeholder:text-[#797979] focus:outline-none dark:text-white/90"
-              placeholder="Re: Design review feedback"
-              value={subjectInput}
-              onChange={(e) => {
-                const value = replaceEmojiShortcodes(e.target.value);
-                setValue('subject', value);
-                setHasUnsavedChanges(true);
-              }}
-            />
-            <button
-              onClick={handleGenerateSubject}
-              disabled={isLoading || isGeneratingSubject || messageLength < 1}
-              className="hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded p-1"
-            >
-              <div className="flex items-center justify-center gap-2.5 pl-0.5">
-                <div className="flex h-5 items-center justify-center gap-1 rounded-sm">
-                  {isGeneratingSubject ? (
-                    <Loader className="h-3.5 w-3.5 animate-spin fill-black dark:fill-white" />
-                  ) : (
-                    <Sparkles className="h-3.5 w-3.5 fill-black dark:fill-white" />
-                  )}
-                </div>
+        <div className="flex items-center gap-2 border-b p-3">
+          <p className="text-sm font-medium text-[#8C8C8C]">Subject:</p>
+          <input
+            className="h-4 w-full bg-transparent text-sm font-normal leading-normal text-black placeholder:text-[#797979] focus:outline-none dark:text-white/90"
+            placeholder="Re: Design review feedback"
+            value={subjectInput}
+            onChange={(e) => {
+              const value = replaceEmojiShortcodes(e.target.value);
+              setValue('subject', value);
+              setHasUnsavedChanges(true);
+            }}
+          />
+          <button
+            onClick={handleGenerateSubject}
+            disabled={isLoading || isGeneratingSubject || messageLength < 1}
+            className="hover:bg-gray-50 dark:hover:bg-[#404040] transition-colors cursor-pointer rounded p-1"
+          >
+            <div className="flex items-center justify-center gap-2.5 pl-0.5">
+              <div className="flex h-5 items-center justify-center gap-1 rounded-sm">
+                {isGeneratingSubject ? (
+                  <Loader className="h-3.5 w-3.5 animate-spin fill-black dark:fill-white" />
+                ) : (
+                  <Sparkles className="h-3.5 w-3.5 fill-black dark:fill-white" />
+                )}
               </div>
-            </button>
-          </div>
-        ) : null}
+            </div>
+          </button>
+        </div>
 
         {/* From */}
         {aliases && aliases.length > 1 ? (

--- a/apps/email/client/components/mail/reply-composer.tsx
+++ b/apps/email/client/components/mail/reply-composer.tsx
@@ -2,6 +2,7 @@ import { useUndoSend } from '@/hooks/use-undo-send';
 import { constructReplyBody, constructForwardBody } from '@/lib/utils';
 import { useActiveConnection } from '@/hooks/use-connections';
 import { useEmailAliases } from '@/hooks/use-email-aliases';
+import { getReplyDefaults, type ReplyMode } from '@/lib/reply-defaults';
 import { EmailComposer } from '../create/email-composer';
 import { useHotkeysContext } from 'react-hotkeys-hook';
 import { useTRPC } from '@/providers/query-provider';
@@ -14,7 +15,7 @@ import { useDraft } from '@/hooks/use-drafts';
 import { m } from '@/paraglide/messages';
 import type { Sender } from '@/types';
 import { useQueryState } from 'nuqs';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import posthog from 'posthog-js';
 import { toast } from 'sonner';
 
@@ -43,60 +44,16 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
   const replyToMessage =
     (messageId && emailData?.messages.find((msg) => msg.id === messageId)) || emailData?.latest;
 
-  // Initialize recipients and subject when mode changes
-  useEffect(() => {
-    if (!replyToMessage || !mode || !activeConnection?.email) return;
-
-    const userEmail = activeConnection.email.toLowerCase();
-    const senderEmail = replyToMessage.sender.email.toLowerCase();
-
-    // Set subject based on mode
-
-    if (mode === 'reply') {
-      // Reply to sender
-      const to: string[] = [];
-
-      // If the sender is not the current user, add them to the recipients
-      if (senderEmail !== userEmail) {
-        to.push(replyToMessage.sender.email);
-      } else if (replyToMessage.to && replyToMessage.to.length > 0 && replyToMessage.to[0]?.email) {
-        // If we're replying to our own email, reply to the first recipient
-        to.push(replyToMessage.to[0].email);
-      }
-
-      // Initialize email composer with these recipients
-      // Note: The actual initialization happens in the EmailComposer component
-    } else if (mode === 'replyAll') {
-      const to: string[] = [];
-      const cc: string[] = [];
-
-      // Add original sender if not current user
-      if (senderEmail !== userEmail) {
-        to.push(replyToMessage.sender.email);
-      }
-
-      // Add original recipients from To field
-      replyToMessage.to?.forEach((recipient) => {
-        const recipientEmail = recipient.email.toLowerCase();
-        if (recipientEmail !== userEmail && recipientEmail !== senderEmail) {
-          to.push(recipient.email);
-        }
-      });
-
-      // Add CC recipients
-      replyToMessage.cc?.forEach((recipient) => {
-        const recipientEmail = recipient.email.toLowerCase();
-        if (recipientEmail !== userEmail && !to.includes(recipient.email)) {
-          cc.push(recipient.email);
-        }
-      });
-
-      // Initialize email composer with these recipients
-    } else if (mode === 'forward') {
-      // For forward, we start with empty recipients
-      // Just set the subject and include the original message
+  const replyDefaults = useMemo(() => {
+    if (!replyToMessage || !mode || !activeConnection?.email) {
+      return { to: [], cc: [], subject: '' };
     }
-  }, [mode, replyToMessage, activeConnection?.email]);
+
+    return getReplyDefaults(replyToMessage, mode as ReplyMode, [
+      activeConnection.email,
+      ...(aliases ?? []).map((alias) => alias.email),
+    ]);
+  }, [activeConnection?.email, aliases, mode, replyToMessage]);
 
   const handleSendEmail = async (data: {
     to: string[];
@@ -270,10 +227,10 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
           setActiveReplyId(null);
         }}
         initialMessage={draft?.content ?? latestDraft?.decodedBody}
-        initialTo={ensureEmailArray(draft?.to)}
-        initialCc={ensureEmailArray(draft?.cc)}
+        initialTo={draft?.to ? ensureEmailArray(draft.to) : replyDefaults.to}
+        initialCc={draft?.cc ? ensureEmailArray(draft.cc) : replyDefaults.cc}
         initialBcc={ensureEmailArray(draft?.bcc)}
-        initialSubject={draft?.subject}
+        initialSubject={draft?.subject || replyDefaults.subject}
         autofocus={true}
         settingsLoading={settingsLoading}
         replyingTo={replyToMessage?.sender.email}

--- a/apps/email/client/lib/reply-defaults.ts
+++ b/apps/email/client/lib/reply-defaults.ts
@@ -1,0 +1,46 @@
+type Address = { email: string };
+
+type ReplyMessage = {
+  sender: Address;
+  to?: Address[];
+  cc?: Address[];
+  subject?: string | null;
+};
+
+export type ReplyMode = "reply" | "replyAll" | "forward";
+
+export function getReplyDefaults(message: ReplyMessage, mode: ReplyMode, ownEmails: string[]) {
+  const ownAddresses = new Set(ownEmails.map((email) => email.toLowerCase()));
+  const uniqueExternal = (addresses: string[]) =>
+    addresses.filter(
+      (email, index, all) =>
+        !ownAddresses.has(email.toLowerCase()) &&
+        all.findIndex((candidate) => candidate.toLowerCase() === email.toLowerCase()) === index,
+    );
+  const originalSubject = message.subject?.trim() || "";
+  const prefix = mode === "forward" ? "Fwd:" : "Re:";
+  const subject = new RegExp(`^${prefix}`, "i").test(originalSubject)
+    ? originalSubject
+    : `${prefix} ${originalSubject}`.trim();
+
+  if (mode === "forward") return { to: [], cc: [], subject };
+
+  const sender = message.sender.email;
+  const fallbackRecipient = message.to?.find(
+    (recipient) => !ownAddresses.has(recipient.email.toLowerCase()),
+  )?.email;
+  const to = uniqueExternal(
+    [
+      ownAddresses.has(sender.toLowerCase()) ? (fallbackRecipient ?? "") : sender,
+      ...(mode === "replyAll" ? (message.to ?? []).map((recipient) => recipient.email) : []),
+    ].filter(Boolean),
+  );
+  const cc =
+    mode === "replyAll"
+      ? uniqueExternal((message.cc ?? []).map((recipient) => recipient.email)).filter(
+          (email) => !to.some((toEmail) => toEmail.toLowerCase() === email.toLowerCase()),
+        )
+      : [];
+
+  return { to, cc, subject };
+}

--- a/apps/email/server/test/reply-defaults.test.ts
+++ b/apps/email/server/test/reply-defaults.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { getReplyDefaults } from "../../client/lib/reply-defaults";
+
+const message = {
+  sender: { email: "sender@example.com" },
+  to: [{ email: "me@example.com" }, { email: "teammate@example.com" }],
+  cc: [{ email: "copy@example.com" }, { email: "ME@example.com" }],
+  subject: "Project update",
+};
+
+describe("getReplyDefaults", () => {
+  it("addresses a reply to the sender and preserves a reply subject", () => {
+    expect(getReplyDefaults(message, "reply", ["me@example.com"])).toEqual({
+      to: ["sender@example.com"],
+      cc: [],
+      subject: "Re: Project update",
+    });
+  });
+
+  it("addresses reply-all without the current user or duplicate recipients", () => {
+    expect(getReplyDefaults(message, "replyAll", ["me@example.com"])).toEqual({
+      to: ["sender@example.com", "teammate@example.com"],
+      cc: ["copy@example.com"],
+      subject: "Re: Project update",
+    });
+  });
+
+  it("replies to an external recipient when the original sender is the current user", () => {
+    expect(
+      getReplyDefaults({ ...message, sender: { email: "me@example.com" } }, "reply", [
+        "me@example.com",
+      ]),
+    ).toMatchObject({ to: ["teammate@example.com"] });
+  });
+
+  it("does not duplicate an existing subject prefix", () => {
+    expect(
+      getReplyDefaults({ ...message, subject: "Re: Project update" }, "reply", ["me@example.com"])
+        .subject,
+    ).toBe("Re: Project update");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes webmail reply and reply-all composers so recipient chips and the reply subject are initialized from the selected message.

## Motivation

The existing reply effect computed recipient arrays but discarded them, while the shared email composer hid the subject whenever a reply ID was present. As a result, replies could open without usable recipients and without a visible or sent subject.

## Related issue

None — this is a focused bug fix, which `CONTRIBUTING.md` permits as a direct pull request.

## Changes

- Added a pure helper for reply/reply-all recipient and subject defaults.
- Initialized To, Cc, and Subject from the selected message while preserving draft values.
- Excluded the user's own aliases and case-insensitive duplicates from reply-all.
- Kept the subject field visible for replies so the subject is sent.
- Added regression coverage for reply, reply-all, own-sent messages, and subject-prefix deduplication.

## Verification

```text
bun test apps/email/server/test/reply-defaults.test.ts
# 4 passed, 0 failed

(cd apps/email/server && bun test)
# 58 passed, 0 failed

bun run --cwd apps/email/client build
# passed

bun run --cwd apps/email/server build
# passed

bun run test
# Reached the CLI suite; 3 unrelated completion tests failed because the
# current Node runtime emits a module.register() deprecation warning to stderr.
# CLI result: 484 passed, 3 failed.
```

`bun run --cwd apps/email/client lint` cannot start on the upstream checkout because the existing `eslint.config.ts` imports missing package `@zero/eslint-config`.

The two new files pass scoped Prettier checks. The two existing client files retain their upstream formatting to avoid an unrelated whole-file reformat.

## Screenshots

Not applicable; this restores existing reply fields and data flow.

## Checklist

- [x] This PR contains one change (no grab-bag).
- [x] The diff is scoped and contains no unrelated formatting or refactors.
- [x] I added a regression test that fails before and passes after the fix.
- [ ] `bun run test`, relevant lint/typechecks, and `bun format` pass locally (upstream/environment blockers documented above; relevant tests and builds pass).
- [x] I understand every line in the diff.
