### PR TITLE
fix(server): require Docker for remote setup

### DIFF
--- a/apps/api/src/modules/system/server-check.controller.ts
+++ b/apps/api/src/modules/system/server-check.controller.ts
@@ -60,6 +60,7 @@ import {
   setupPromptState,
 } from "./setup-session";
 import type { PromptUserFn } from "@repo/adapters";
+import { resolveRequiredComponents } from "./server-check.requirements";
 
 // ─── Allowlisted components ──────────────────────────────────────────────────
 
@@ -97,16 +98,9 @@ async function withCapabilities<T extends { name: string; installed?: boolean }>
 }
 
 /**
- * Core components required for the current deployment mode.
+ * Core components required on every remote deployment server.
  * These are always shown in System Health regardless of install state.
  */
-function resolveRequiredComponents(): string[] {
-  const mode = env.DEPLOY_MODE;
-  if (mode === "docker") return ["docker", "git"];
-  if (mode === "bare") return ["git"];
-  return ["git"];
-}
-
 /**
  * Infrastructure components - optional but important for app deployment.
  * Shown in System Health only when detected (installed) on the server.

--- a/apps/api/src/modules/system/server-check.requirements.test.ts
+++ b/apps/api/src/modules/system/server-check.requirements.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { resolveRequiredComponents } from "./server-check.requirements";
+
+describe("remote server requirements", () => {
+  it("requires Docker even when the control plane runs in bare mode", () => {
+    expect(resolveRequiredComponents()).toEqual(["docker", "git"]);
+  });
+});

--- a/apps/api/src/modules/system/server-check.requirements.ts
+++ b/apps/api/src/modules/system/server-check.requirements.ts
@@ -1,0 +1,9 @@
+/** Components every remote deployment target needs.
+ *
+ * DEPLOY_MODE describes the control plane, not the remote server. Remote
+ * deployments use Docker and the managed edge is a container even when the
+ * OpenShip control plane itself was installed in bare mode.
+ */
+export function resolveRequiredComponents(): string[] {
+  return ["docker", "git"];
+}


### PR DESCRIPTION
## Summary

Makes Docker an explicit required prerequisite for every managed remote deployment server, including when the OpenShip control plane itself runs in bare mode.

## Motivation

The server health-check endpoint derived remote requirements from the control plane's `DEPLOY_MODE`. A bare control plane therefore required only Git and omitted Docker from the new-server setup results, even though remote application deployments and the managed Edge container depend on Docker. This allowed setup to appear ready and Edge installation to fail later.

## Related issue

Closes #767

## Changes

- Removed the control-plane deployment-mode dependency from remote server requirements.
- Always require Docker and Git on managed remote deployment targets.
- Extracted the requirement policy into a small pure module.
- Added regression coverage proving Docker remains required for a bare-mode control plane.
- Reused the existing Docker check, installer, UI row, and automatic installation order.

## Verification

```text
bun run test -- src/modules/system/server-check.requirements.test.ts
# 1 passed, 0 failed

bun run build
# API build passed

bun run test
# 5,155 passed; two environment-restricted tests failed inside the sandbox:
# - ssh-key-path fixture could not write beneath the user home directory
# - safe-fetch could not bind 127.0.0.1

bun run test -- test/lib/ssh-key-path.test.ts test/lib/safe-fetch.test.ts src/modules/system/server-check.requirements.test.ts
# Rerun with normal filesystem/socket access: 34 passed, 0 failed

bunx prettier --check src/modules/system/server-check.requirements.ts src/modules/system/server-check.requirements.test.ts
# passed
```

The existing controller file does not pass a whole-file Prettier check on upstream. It was not reformatted to avoid unrelated formatting changes.

## Screenshots

Not included. The existing Docker component row is now returned by the backend when missing; this change does not introduce a new UI component.

## Checklist

- [x] This PR contains one change (no grab-bag).
- [x] The diff is scoped and contains no unrelated formatting or refactors.
- [x] I added a regression test that fails before and passes after the fix.
- [x] Relevant tests, build, and formatting checks pass locally; sandbox-only failures were rerun successfully with the required access.
- [x] I understand every line in the diff.
