### PR TITLE
fix(adapters): resolve edge bind-mount sources in a single exec (#774)

### DIFF
--- a/packages/adapters/src/system/proxy/ensure-container-edge.test.ts
+++ b/packages/adapters/src/system/proxy/ensure-container-edge.test.ts
@@ -53,7 +53,7 @@ interface BoxOpts {
    * Flips the pull gate: present ⇒ no pull, absent (prod) ⇒ pull.
    */
   imagePresent?: boolean;
-  /** Physical path returned by `cd <host> && pwd -P`, keyed by logical host path. */
+  /** Physical path returned by the batched mount-resolve exec, keyed by logical host path. */
   canonicalMounts?: Record<string, string>;
   /** Bind sources reported by Docker for an existing edge, keyed by container path. */
   mountedSources?: Record<string, string>;
@@ -123,9 +123,11 @@ function box(opts: BoxOpts = {}) {
       }).join("\n");
     }
     if (cmd.startsWith("docker inspect")) return "";
-    if (cmd.startsWith("cd ") && cmd.endsWith(" && pwd -P")) {
-      const logical = EDGE_CONTAINER_MOUNTS.find((mount) => cmd.includes(`'${mount.host}'`))?.host;
-      return logical ? (opts.canonicalMounts?.[logical] ?? logical) : "";
+    // The batched mount resolve — one exec answers all four `pwd -P`s (#774).
+    if (cmd.includes("pwd -P")) {
+      return EDGE_CONTAINER_MOUNTS.map(
+        (mount) => `__OPENSHIP_MOUNT__\n${opts.canonicalMounts?.[mount.host] ?? mount.host}\n`,
+      ).join("");
     }
     if (cmd.startsWith("docker logs")) return opts.crashLog ?? "";
     if (cmd.startsWith("docker rm -f") || cmd.startsWith("docker stop")) {
@@ -267,17 +269,21 @@ describe("buildEdgeRunCommand", () => {
 });
 
 describe("resolveEdgeContainerMounts", () => {
+  /** Output of the batched resolve script: one marker line, then that mount's segment. */
+  const batchOutput = (segments: string[]) =>
+    segments.map((s) => `__OPENSHIP_MOUNT__\n${s}\n`).join("");
+
+  const canonical = [
+    "/private/var/lib/openship/edge/sites-enabled",
+    "/private/etc/letsencrypt",
+    "/private/var/lib/openship/edge/acme",
+    "/opt/openship/static",
+  ];
+
   it("canonicalizes on the executor's host, not in the API process (#692)", async () => {
     const exec = vi.fn(async (command: string) => {
-      if (command.includes("'/var/lib/openship/edge/sites-enabled'")) {
-        return "/private/var/lib/openship/edge/sites-enabled\n";
-      }
-      if (command.includes("'/var/lib/openship/edge/acme'")) {
-        return "/private/var/lib/openship/edge/acme\n";
-      }
-      if (command.includes("'/etc/letsencrypt'")) return "/private/etc/letsencrypt\n";
-      if (command.includes("'/opt/openship/static'")) return "/opt/openship/static\n";
-      throw new Error(`unexpected command: ${command}`);
+      if (!command.includes("pwd -P")) throw new Error(`unexpected command: ${command}`);
+      return batchOutput(canonical);
     });
 
     await expect(resolveEdgeContainerMounts({ exec })).resolves.toEqual([
@@ -289,9 +295,52 @@ describe("resolveEdgeContainerMounts", () => {
       { host: "/private/var/lib/openship/edge/acme", container: "/var/www/acme" },
       { host: "/opt/openship/static", container: "/opt/openship/static" },
     ]);
-    expect(exec).toHaveBeenCalledWith(
-      "cd '/var/lib/openship/edge/sites-enabled' && pwd -P",
+  });
+
+  // 4 concurrent execs are 4 concurrent channels on ONE multiplexed SSH
+  // connection, and sshd hardened to `MaxSessions 3` rejects the fourth —
+  // failing edge recovery on any CIS-baseline host.
+  it("resolves every mount through a single exec (#774)", async () => {
+    const exec = vi.fn(async (_command: string) => batchOutput(canonical));
+
+    await resolveEdgeContainerMounts({ exec });
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    const command = exec.mock.calls[0][0];
+    for (const mount of EDGE_CONTAINER_MOUNTS) {
+      expect(command).toContain(`(cd '${mount.host}' && pwd -P) 2>&1`);
+    }
+  });
+
+  it("names the failing mount and carries the shell's own words", async () => {
+    const exec = vi.fn(async () =>
+      batchOutput([
+        canonical[0],
+        canonical[1],
+        "sh: 1: cd: can't cd to /var/lib/openship/edge/acme",
+        canonical[3],
+      ]),
     );
+
+    await expect(resolveEdgeContainerMounts({ exec })).rejects.toThrow(
+      /source \/var\/lib\/openship\/edge\/acme .*can't cd/,
+    );
+  });
+
+  it("reports a transport failure without inventing a per-mount cause", async () => {
+    const exec = vi.fn(async () => {
+      throw new Error("(SSH) Channel open failure: open failed");
+    });
+
+    await expect(resolveEdgeContainerMounts({ exec })).rejects.toThrow(
+      /bind-mount sources on the target host: .*Channel open failure/,
+    );
+  });
+
+  it("rejects a garbled batch instead of mismapping paths to mounts", async () => {
+    const exec = vi.fn(async () => batchOutput(canonical.slice(0, 2)));
+
+    await expect(resolveEdgeContainerMounts({ exec })).rejects.toThrow(/expected 4 paths/);
   });
 });
 

--- a/packages/adapters/src/system/proxy/ensure-container-edge.ts
+++ b/packages/adapters/src/system/proxy/ensure-container-edge.ts
@@ -259,6 +259,9 @@ async function startEdgeContainer(
 
 export type EdgeContainerMount = Readonly<{ host: string; container: string }>;
 
+/** Marks the start of each mount's output in the batched resolve exec below. */
+const MOUNT_RESOLVE_MARKER = "__OPENSHIP_MOUNT__";
+
 /**
  * Resolve bind sources on the machine that owns the Docker daemon.
  *
@@ -267,29 +270,51 @@ export type EdgeContainerMount = Readonly<{ host: string; container: string }>;
  * `pwd -P` is POSIX and resolves existing directory symlinks on both macOS and
  * Linux. In particular, it turns macOS `/var` and `/etc` into `/private/var` and
  * `/private/etc`, which Docker Desktop/OrbStack must receive as bind sources.
+ *
+ * All four mounts resolve in ONE exec, never one each (#774): each exec opens
+ * its own channel on the shared multiplexed SSH connection, and four concurrent
+ * channels is one more than sshd grants on hosts hardened to the common
+ * `MaxSessions 3` baseline — the fourth open failed, which failed edge recovery
+ * and route retries outright. Each `cd` runs in a subshell with stderr folded
+ * into its segment, so one missing directory can't leak a working directory
+ * into the next mount and still names its cause; the trailing `true` keeps a
+ * failed segment from turning the whole batch into a nonzero exit.
  */
 export async function resolveEdgeContainerMounts(
   executor: Pick<CommandExecutor, "exec">,
 ): Promise<EdgeContainerMount[]> {
-  return Promise.all(
-    EDGE_CONTAINER_MOUNTS.map(async (mount) => {
-      let host: string;
-      try {
-        host = (await executor.exec(`cd ${sq(mount.host)} && pwd -P`)).trim();
-      } catch (err) {
-        throw new Error(
-          `Could not resolve edge bind-mount source ${mount.host} on the target host: ${safeErrorMessage(err)}`,
-        );
-      }
-      if (!host.startsWith("/") || host.includes("\n")) {
-        throw new Error(
-          `Could not resolve edge bind-mount source ${mount.host} on the target host: ` +
-            `expected one absolute path, received ${JSON.stringify(host)}.`,
-        );
-      }
-      return { host, container: mount.container };
-    }),
-  );
+  const script =
+    EDGE_CONTAINER_MOUNTS.map(
+      (mount) => `echo ${MOUNT_RESOLVE_MARKER}; (cd ${sq(mount.host)} && pwd -P) 2>&1`,
+    ).join("; ") + "; true";
+
+  let raw: string;
+  try {
+    raw = await executor.exec(script);
+  } catch (err) {
+    throw new Error(
+      `Could not resolve edge bind-mount sources on the target host: ${safeErrorMessage(err)}`,
+    );
+  }
+
+  const segments = raw.split(MOUNT_RESOLVE_MARKER).slice(1);
+  if (segments.length !== EDGE_CONTAINER_MOUNTS.length) {
+    throw new Error(
+      `Could not resolve edge bind-mount sources on the target host: ` +
+        `expected ${EDGE_CONTAINER_MOUNTS.length} paths, received ${JSON.stringify(raw)}.`,
+    );
+  }
+
+  return EDGE_CONTAINER_MOUNTS.map((mount, i) => {
+    const host = segments[i].trim();
+    if (!host.startsWith("/") || host.includes("\n")) {
+      throw new Error(
+        `Could not resolve edge bind-mount source ${mount.host} on the target host: ` +
+          `expected one absolute path, received ${JSON.stringify(host)}.`,
+      );
+    }
+    return { host, container: mount.container };
+  });
 }
 
 /** `docker run` argv for the edge: host networking (it owns 80/443) + the mounts. */


### PR DESCRIPTION
Fixes #774.

## Problem

`resolveEdgeContainerMounts` canonicalized each of the four `EDGE_CONTAINER_MOUNTS` sources with its own `cd <path> && pwd -P` exec inside `Promise.all`. Against an SSH target every exec opens its own channel on the one multiplexed connection (`SshExecutor.exec` → `client.exec` directly, no queueing), so the resolve opens 4 concurrent channels. On hosts hardened to the common `MaxSessions 3` baseline (CIS/Lynis), sshd rejects the fourth open and edge recovery / route retry fails with:

```
Couldn't restore the edge before retrying routing: Could not resolve edge bind-mount source /opt/openship/static on the target host: (SSH) Channel open failure: open failed
```

It's worse than one failed path: `withChannelRetry` treats the channel-open failure as a half-dead connection and drops the shared client, aborting the other three in-flight execs, so the whole batch cascades.

## Fix

Resolve all four mounts in ONE exec — a marker-separated script of `(cd <path> && pwd -P) 2>&1` segments:

- one SSH channel and one network round trip instead of four (and a single `sudo` when the executor is elevated);
- each `cd` runs in a subshell so a missing directory can't leak a working directory into the next mount's resolution;
- stderr folds into the failed mount's segment, so the error still names the mount and carries the shell's own words (`sh: 1: cd: can't cd to …`), preserving the previous per-mount diagnostics;
- a trailing `true` keeps one failed segment from turning the batch into a nonzero exit, so per-mount validation stays the error path;
- segment-count validation rejects a garbled batch instead of mismapping paths to mounts.

Per-mount validation is unchanged: exactly one absolute, single-line path.

## Testing

- New test asserting the resolve issues exactly one exec carrying every mount (the #774 regression).
- New tests for a failing mount (names the mount, carries the shell's message), a transport failure, and a garbled batch.
- Existing `#692` canonicalization test and the `ensureContainerEdge` suite updated to answer the batched command — 32/32 pass, full `src/system` suite 1265/1265, `tsc --noEmit` clean.
- Verified the generated script against a real `sh`: symlinked dir resolves to its physical path, missing dir yields the shell's error in its segment, exit code 0.