### PR TITLE
fix(apps): mark custom-app delete as a collection-scoped write (#735)

### DIFF
--- a/apps/api/src/modules/apps/app.routes.ts
+++ b/apps/api/src/modules/apps/app.routes.ts
@@ -53,7 +53,15 @@ r.post(
 );
 r.delete(
   "/custom/:appId",
-  { tag: "project:write", mcp: { description: "Remove a custom app from this org's catalog." } },
+  {
+    tag: "project:write",
+    // `:appId` names a per-org catalog entry, not a project row, so there is no
+    // resource id for the permission layer to check — without `collection` the
+    // middleware demands a `:id` this route doesn't have and 400s every call.
+    // Org scoping happens in the handler, exactly like the POST above.
+    collection: true,
+    mcp: { description: "Remove a custom app from this org's catalog." },
+  },
   ctrl.removeCustom,
 );
 r.post(

--- a/apps/api/test/modules/apps/app.routes.test.ts
+++ b/apps/api/test/modules/apps/app.routes.test.ts
@@ -20,4 +20,23 @@ describe("apps routes are permission-scoped correctly", () => {
 
     expect(spec.collection).toBe(true);
   });
+
+  // `:appId` is a custom-app id, not a project id — without `collection` the
+  // permission middleware demands a `:id` param this route doesn't have and
+  // 400s every delete (#735).
+  it("DELETE /api/apps/custom/:appId is a collection-scoped write route (#735)", () => {
+    const route = getRouteRegistry().find(
+      (r) => r.method === "DELETE" && r.path === "/api/apps/custom/:appId",
+    );
+
+    expect(route, "DELETE /api/apps/custom/:appId must be registered").toBeDefined();
+
+    const spec = route!.spec;
+    expect(isPublicSpec(spec)).toBe(false);
+    if (isPublicSpec(spec)) {
+      throw new Error("DELETE /api/apps/custom/:appId must be a permission route");
+    }
+
+    expect(spec.collection).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #735.

## Problem

`DELETE /api/apps/custom/:appId` unconditionally returns 400:

```
Missing route param :id required by tag "project:write"
```

`requirePermission`'s per-resource fallback resolves the leaf id from the `:id` param (`DEFAULT_ID_PARAMS.project = "id"`), and this route only carries `:appId` — which names a per-org custom-catalog entry, not a project row, so there is no resource id the permission layer could check. `project` is not in `CONDITIONAL_SINGLETON_RESOURCES` either, so every call dies in the middleware before the handler runs.

`POST /api/apps/custom` hit the same trap and was fixed with `collection: true` (#440); the DELETE sibling was missed.

## Fix

Add `collection: true` to the DELETE spec, matching the POST: the middleware asserts org-level `project:write` (org from `X-Organization-Id` / session default) and scoping stays in the handler, which already deletes by `(org, appId)` via `deleteCustomApp(ctx, …)`.

MCP tool advertisement is unaffected: the route carries a path param, so it stays non-wildcard/listable for scoped tokens, per the existing rule in `mcp-tools.ts`.

## Testing

- New registry regression test next to the existing #440 one: `DELETE /api/apps/custom/:appId` must be a collection-scoped permission route — fails on main, passes here.
- `test/modules/apps` 62/62, `test/modules/route-rules` + `test/lib` 1545/1545, `tsc --noEmit` clean.