### PR TITLE
fix(mail): read the DB probe verdict past docker's stderr warnings (#783)

### DIFF
--- a/apps/api/src/modules/mail/mail-engine.ts
+++ b/apps/api/src/modules/mail/mail-engine.ts
@@ -591,13 +591,22 @@ export function parseMailUnitProbe(
 ): MailUnitState {
   if (flavor === "container") {
     if (key === "postgresql") {
-      const value = firstOutputLine(raw);
-      if (value === "true") return { status: "active" };
-      if (value === "false") return { status: "inactive" };
+      // The verdict may not be the FIRST line: `2>&1` (deliberate — see
+      // mailUnitProbeCommand) folds the CLI's stderr into the stream, and docker
+      // prints its warnings ("WARNING: Error loading config file: …",
+      // `level=warning` notices) ahead of the inspect result. Judging line one
+      // turned a healthy sidecar into a required-component failure that halted
+      // mail setup (#783). The template prints exactly `true` or `false`, so an
+      // exact line match anywhere in the output is the daemon's answer and
+      // nothing else's — the same past-the-noise reading the supervisorctl and
+      // systemd branches below already do.
+      const lines = raw.split("\n").map((l) => l.trim());
+      if (lines.includes("true")) return { status: "active" };
+      if (lines.includes("false")) return { status: "inactive" };
       // Only docker saying the container isn't there means missing. A refused
       // daemon or a permission error is a probe we can't conclude from.
-      if (/no such object|no such container/i.test(value)) return { status: "missing" };
-      return { status: "unknown", detail: value || "probe returned no output" };
+      if (/no such object|no such container/i.test(raw)) return { status: "missing" };
+      return { status: "unknown", detail: firstOutputLine(raw) || "probe returned no output" };
     }
     // supervisord always names the program it reports on — "postfix RUNNING pid 12,
     // uptime 0:03:11", or "postfix: ERROR (no such process)". No such line means

--- a/apps/api/test/modules/mail/mail-health-probe.test.ts
+++ b/apps/api/test/modules/mail/mail-health-probe.test.ts
@@ -100,6 +100,28 @@ describe("parseMailUnitProbe — container flavor", () => {
       expect(state.status).toBe("unknown");
       expect(state.detail).toContain("permission denied");
     });
+
+    // `2>&1` folds the CLI's stderr in ahead of the verdict, so warnings used to
+    // become the "first line" and a healthy sidecar read as unknown — which is
+    // required-severity, so mail setup halted on it (#783).
+    it("finds the verdict past docker's stderr warnings (#783)", () => {
+      expect(
+        pg(
+          "WARNING: Error loading config file: /root/.docker/config.json: permission denied\ntrue",
+        ).status,
+      ).toBe("active");
+      expect(
+        pg('time="2026-09-02T06:00:00Z" level=warning msg="failed to fetch metadata"\nfalse')
+          .status,
+      ).toBe("inactive");
+    });
+
+    it("still reports missing when warnings precede docker's answer", () => {
+      expect(
+        pg("WARNING: some notice\nError response from daemon: No such object: openship-mail-db")
+          .status,
+      ).toBe("missing");
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #783.

## Problem

The PostgreSQL sidecar probe is `docker inspect -f '{{.State.Running}}' openship-mail-db 2>&1 || true`. The `2>&1` is deliberate (a failed probe has to stay readable), but docker prints its stderr warnings — `WARNING: Error loading config file: …`, `level=warning` notices — **ahead of** the inspect result, and `parseMailUnitProbe`'s postgresql branch judged only the first line.

A warning there parsed as `unknown`; PostgreSQL is `severity: "required"`, so the step-5 gate in `mail.service.ts` halted setup with *"Mail engine started but these components are not running: PostgreSQL"* despite a healthy container. The Health tab painted the same false red, since it reads the same probe.

The postgresql branch was the odd one out: the supervisorctl branch already searches for the program's state line past any banner, and the systemd branch parses `key=value` lines wherever they are. Only this branch trusted line one.

## Fix

- Scan **every** line for the exact `true`/`false` the inspect template prints — an exact line match is the daemon's answer and nothing else's, so warning noise can't shadow it.
- Match the `no such object` / `no such container` pattern against the whole output, since warnings can precede that answer too.
- `unknown` keeps the first line as its `detail`, unchanged.

## Testing

- New regression tests: verdict found past a `WARNING:` line and past a `level=warning` notice; `missing` still detected when warnings precede docker's error.
- Existing behavior pinned by the suite is unchanged (exact `true`/`false`, missing only on docker's own words, unknown-with-reason on daemon failures) — `mail-health-probe.test.ts` 19/19, full `test/modules/mail` 294/294, `tsc --noEmit` clean.