### PR TITLE
Clone exact revisions on API-host fallback

### DIFF
--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -387,7 +387,7 @@ function toRuntimeMode(value: string | null | undefined): "bare" | "docker" | un
 /** Build a config snapshot from the project - pure pass-through, no fallbacks.
  *  All values must be set by prepare / ensureProject before this is called. */
 export function buildConfigSnapshot(project: Project, branch?: string): DeploymentConfigSnapshot {
-  const runtimeImage = resolveRuntimeImage(project);
+  const deploymentClass = projectToClass(project);
 
   return {
     // Owning org — needed by every downstream that does an org-scoped
@@ -402,7 +402,7 @@ export function buildConfigSnapshot(project: Project, branch?: string): Deployme
     branch: branch || project.gitBranch || (project.localPath ? "main" : ""),
     framework: project.framework!,
     buildImage: project.buildImage!,
-    runtimeImage,
+    runtimeImage: resolveRuntimeImage(project),
     packageManager: project.packageManager!,
     installCommand: project.installCommand!,
     buildCommand: project.buildCommand!,
@@ -420,8 +420,8 @@ export function buildConfigSnapshot(project: Project, branch?: string): Deployme
     // it via snapshotToClass and never re-derives — a redeploy of THIS release
     // classifies as it did the day it was built, even after the project's flags
     // change.
-    ...projectToClass(project),
-    localPath: project.localPath || undefined,
+    ...deploymentClass,
+    localPath: deploymentClass.source === "upload" ? project.localPath || undefined : undefined,
     // Per packages/db/src/schema/project.ts:231 — `cloudWorkspaceId IS
     // NOT NULL` is THE canonical "is this a cloud project?" test.
     // Default the snapshot's deployTarget from that so preflight,

--- a/apps/api/test/modules/deployments/build.service.test.ts
+++ b/apps/api/test/modules/deployments/build.service.test.ts
@@ -104,6 +104,7 @@ vi.mock("../../../src/modules/deployments/smart-route", () => ({
 
 import {
   applyReleaseSourceToSnapshot,
+  buildConfigSnapshot,
   redeployBuildSession,
   requestBuildAccess,
   resolveSnapshotTarget,
@@ -228,6 +229,20 @@ function releaseSnapshot(
     ...overrides,
   };
 }
+
+describe("buildConfigSnapshot", () => {
+  it("clones git snapshots instead of packaging their saved checkout path (#748)", () => {
+    const snapshot = buildConfigSnapshot(
+      baseProject({ gitProvider: "github", gitUrl: "https://github.com/acme/app.git" }) as never,
+    );
+
+    expect(snapshot).toMatchObject({ source: "git", localPath: undefined });
+  });
+
+  it("keeps the source path for local folder snapshots", () => {
+    expect(buildConfigSnapshot(baseProject() as never).localPath).toBe("/srv/my-stack");
+  });
+});
 
 describe("applyReleaseSourceToSnapshot", () => {
   it("freezes the normalized version, raw tag, and rendered image without repurposing buildImage", async () => {


### PR DESCRIPTION
API-host fallback could package a stale Desktop checkout instead of the selected commit.

```diff
- localPath: project.localPath || undefined
+ localPath: deploymentClass.source === "upload" ? project.localPath || undefined : undefined
```

- git deployments now clone the selected revision
- folder uploads still use their local source
- available through `openship deploy --commit <sha> --watch`

Fixes #748 cc: @Hydralerne 
