### PR TITLE
Target remote servers from the CLI

### DIFF
--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -1804,6 +1804,7 @@ export async function triggerDeployment(
     projectId: string;
     branch?: string;
     commitSha?: string;
+    serverId?: string;
     commitMessage?: string;
     environment?: string;
     trigger?: string;
@@ -1989,7 +1990,10 @@ export async function triggerDeployment(
   // gates serverId on target==="server" so a non-server deploy can't carry a stale
   // serverId. (reuse/rollback already carries the frozen target — leave it.)
   if (!reuse) {
-    const resolvedTarget = await resolveSnapshotTarget(project);
+    const resolvedTarget = await resolveSnapshotTarget(
+      project,
+      data.serverId ? { deployTarget: "server", serverId: data.serverId } : undefined,
+    );
     snapshot.deployTarget = resolvedTarget.deployTarget;
     snapshot.serverId = resolvedTarget.serverId;
     snapshot.runtimeMode = resolvedTarget.runtimeMode;

--- a/apps/api/src/modules/deployments/deployment.controller.ts
+++ b/apps/api/src/modules/deployments/deployment.controller.ts
@@ -18,6 +18,7 @@ import { maskEnv, maskScanService } from "../../lib/secret-env";
 import { maybeProxyCloudProject, proxyToSaaS } from "../../lib/cloud/project-router";
 import { promoteProjectToCloud, TransferConflictError } from "../projects/transfer.service";
 import { env } from "../../config";
+import type { TTriggerDeployBody } from "./deployment.schema";
 
 export async function list(c: Context) {
   const ctx = getRequestContext(c);
@@ -44,11 +45,7 @@ export async function list(c: Context) {
 
 export async function create(c: Context) {
   const ctx = getRequestContext(c);
-  const body = await c.req.json<{
-    projectId: string;
-    branch?: string;
-    commitSha?: string;
-    environment?: string;
+  const body = await c.req.json<TTriggerDeployBody & {
     /** Force-rebuild every enabled service. Skips smart per-service routing. */
     forceAll?: boolean;
     /** Smart per-service target list. Mutually exclusive with forceAll. */
@@ -81,6 +78,7 @@ export async function create(c: Context) {
     projectId: body.projectId,
     branch: body.branch,
     commitSha: body.commitSha,
+    serverId: body.serverId,
     environment: body.environment,
     forceAll: body.forceAll,
     serviceIds: body.serviceIds,

--- a/apps/api/src/modules/deployments/deployment.schema.ts
+++ b/apps/api/src/modules/deployments/deployment.schema.ts
@@ -26,6 +26,7 @@ export const TriggerDeployBody = Type.Object({
   projectId: Type.String({ minLength: 1 }),
   branch: Type.Optional(Type.String({ default: "main" })),
   commitSha: Type.Optional(Type.String()),
+  serverId: Type.Optional(Type.String()),
   environment: Type.Optional(Type.Union([Type.Literal("production"), Type.Literal("preview")])),
 });
 

--- a/apps/api/test/modules/deployments/build.service.test.ts
+++ b/apps/api/test/modules/deployments/build.service.test.ts
@@ -494,6 +494,20 @@ describe("triggerDeployment", () => {
     );
   });
 
+  it("targets the server selected by a manual deploy", async () => {
+    await triggerDeployment(ctx, {
+      projectId: "project-1",
+      branch: "main",
+      commitSha: "abc123",
+      serverId: "srv_cli",
+    });
+
+    expect(runPreflightChecks).toHaveBeenCalledWith(
+      expect.objectContaining({ deployTarget: "server", serverId: "srv_cli" }),
+      expect.any(Object),
+    );
+  });
+
   it("bootstraps a declared composePath even when the first webhook changed another file (#689)", async () => {
     const commitSha = "1eeaf7692a19ee6e7ecb64b9d1a5c3ee7c0ac2f5";
     let storedRows: Record<string, unknown>[] = [];

--- a/apps/cli/src/commands/deploy.ts
+++ b/apps/cli/src/commands/deploy.ts
@@ -40,6 +40,7 @@ export const deployCommand = new Command("deploy")
   .option("--project <id>", "Project ID (defaults to the linked project in .openship/project.json)")
   .option("--branch <name>", "Git branch to deploy (defaults to the current branch)")
   .option("--commit <sha>", "Specific commit SHA (defaults to the latest commit on the branch)")
+  .option("--server <id>", "Remote server ID to deploy to")
   .option("--env <environment>", "Target environment: production | preview", "production")
   .option("--force-all", "Rebuild every enabled service (skip smart per-service routing)")
   .option("--service-ids <ids>", "Comma-separated service IDs to deploy (smart routing)")
@@ -78,6 +79,7 @@ export const deployCommand = new Command("deploy")
           cwd: process.cwd(),
           name: opts.name,
           projectId: opts.project || link?.projectId,
+          serverId: opts.server,
           environment: env,
           serviceIds,
           onStep: (m) => {
@@ -120,6 +122,7 @@ export const deployCommand = new Command("deploy")
         projectId,
         branch,
         commitSha: opts.commit || undefined,
+        serverId: opts.server,
         environment: env,
         forceAll: opts.forceAll || undefined,
         serviceIds,

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -51,6 +51,8 @@ function printProject(project: Record<string, unknown>): void {
       project.gitOwner && project.gitRepo ? `${project.gitOwner}/${project.gitRepo}` : null,
     ],
     ["gitBranch", project.gitBranch],
+    ["deployTarget", project.deployTarget],
+    ["serverId", project.serverId],
     ["autoDeploy", project.autoDeploy],
     ["status", project.status],
   ];

--- a/apps/cli/src/lib/folder-deploy.ts
+++ b/apps/cli/src/lib/folder-deploy.ts
@@ -97,6 +97,7 @@ export async function deployFolder(opts: {
   name?: string;
   /** Reuse/update an existing project instead of creating one. */
   projectId?: string;
+  serverId?: string;
   environment?: string;
   /** Scope a folder REDEPLOY to a subset of services; others carry forward
    *  untouched (no needless stateful recreate). Ignored on a first deploy. */
@@ -210,6 +211,8 @@ export async function deployFolder(opts: {
     body: JSON.stringify({
       projectId: ensured.project_id,
       uploadSessionId: session.sessionId,
+      deployTarget: opts.serverId ? "server" : undefined,
+      serverId: opts.serverId,
       ...(opts.environment ? { environment: opts.environment } : {}),
       // Carry the scanned compose services so a multi-service folder deploys as
       // a services project (persisted rows + services-mode preflight). Absent for

--- a/apps/cli/test/e2e/deployment.test.ts
+++ b/apps/cli/test/e2e/deployment.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const { deployFolder } = vi.hoisted(() => ({ deployFolder: vi.fn() }));
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn(() => Buffer.from("false")) }));
+vi.mock("../../src/lib/folder-deploy", () => ({ deployFolder }));
+
 vi.mock("../../src/lib/config", () => ({
   getApiUrl: () => "http://api.test",
   getToken: () => "tok",
 }));
 
 import { deploymentCommand } from "../../src/commands/deployment";
+import { deployCommand } from "../../src/commands/deploy";
 import { runCommand, stubFetch, type FetchStub } from "../helpers/harness";
 
 let fetchStub: FetchStub;
@@ -41,5 +47,35 @@ describe("openship deployment rollback", () => {
     expect(code).toBe(0);
     expect(fetchStub.calls[0].method).toBe("POST");
     expect(fetchStub.calls[0].url).toBe("http://api.test/api/deployments/dep1/rollback");
+  });
+});
+
+describe("openship deploy", () => {
+  it("targets a remote server", async () => {
+    fetchStub = stubFetch(() => ({
+      json: { data: { deployment_id: "dep1", project_id: "p1" } },
+    }));
+    const { code } = await runCommand(deployCommand, [
+      "--project",
+      "p1",
+      "--branch",
+      "main",
+      "--commit",
+      "abc123",
+      "--server",
+      "srv1",
+    ]);
+    expect(code).toBe(0);
+    expect(fetchStub.calls[0].body).toMatchObject({
+      projectId: "p1",
+      serverId: "srv1",
+    });
+  });
+
+  it("forwards the server to folder deployments", async () => {
+    deployFolder.mockResolvedValue({ deploymentId: "dep1", projectId: "p1" });
+    const { code } = await runCommand(deployCommand, ["--project", "p1", "--server", "srv1"]);
+    expect(code).toBe(0);
+    expect(deployFolder).toHaveBeenCalledWith(expect.objectContaining({ serverId: "srv1" }));
   });
 });

--- a/apps/cli/test/e2e/project.test.ts
+++ b/apps/cli/test/e2e/project.test.ts
@@ -30,11 +30,15 @@ describe("openship project list", () => {
 
 describe("openship project get", () => {
   it("GETs /projects/:id", async () => {
-    fetchStub = stubFetch(() => ({ json: { data: { id: "p1", name: "shop" } } }));
+    fetchStub = stubFetch(() => ({
+      json: { data: { id: "p1", name: "shop", deployTarget: "server", serverId: "srv1" } },
+    }));
     const { out, code } = await runCommand(projectCommand, ["get", "p1"]);
     expect(code).toBe(0);
     expect(fetchStub.calls[0].url).toContain("/api/projects/p1");
     expect(out).toContain("shop");
+    expect(out).toContain("deployTarget server");
+    expect(out).toContain("serverId     srv1");
   });
 });
 


### PR DESCRIPTION
New CLI-created projects could only fall through to the host default, so agents could not select a registered remote server without the dashboard.

`openship deploy --project <project-id> --server <server-id> --watch`

- applies the target to Git and folder deployments
- validates through the existing organization-scoped deployment preflight
- persists and reports the server binding after a successful deploy

Fixes #763