### PR TITLE
fix(proxy): preserve nginx exact-match locations (#732)

### DIFF
--- a/apps/api/src/modules/deployments/compose/composite-route.test.ts
+++ b/apps/api/src/modules/deployments/compose/composite-route.test.ts
@@ -30,6 +30,21 @@ describe("buildDomainFanoutRegistrations", () => {
     ]);
   });
 
+  it("preserves exact-match locations in the generated registration", () => {
+    const exact: ProjectCompositeRoute = {
+      ...onvo,
+      locations: [{ pathPrefix: "/mcp", serviceId: "svc-api", exact: true }],
+    };
+    const regs = buildDomainFanoutRegistrations({
+      routes: [exact],
+      resolveTargetUrl: (id) => upstreams[id],
+    });
+
+    expect(regs[0].proxyLocations).toEqual([
+      { pathPrefix: "/mcp", targetUrl: "http://10.0.0.2:1020", exact: true },
+    ]);
+  });
+
   it("skips the whole domain when the ROOT upstream can't resolve", () => {
     const regs = buildDomainFanoutRegistrations({
       routes: [onvo],

--- a/apps/api/src/modules/deployments/compose/composite-route.ts
+++ b/apps/api/src/modules/deployments/compose/composite-route.ts
@@ -186,7 +186,13 @@ export function buildDomainFanoutRegistrations(input: {
     const proxyLocations: RouteProxyLocation[] = [];
     for (const loc of route.locations) {
       const url = input.resolveTargetUrl(loc.serviceId);
-      if (url) proxyLocations.push({ pathPrefix: loc.pathPrefix, targetUrl: url });
+      if (url) {
+        proxyLocations.push({
+          pathPrefix: loc.pathPrefix,
+          targetUrl: url,
+          ...(loc.exact ? { exact: true } : {}),
+        });
+      }
     }
     out.push({
       hostname: route.hostname,

--- a/apps/api/src/modules/migration/docker-reconcile.test.ts
+++ b/apps/api/src/modules/migration/docker-reconcile.test.ts
@@ -159,6 +159,44 @@ describe("splitEnvByProvenance — inverts Docker's create-time env merge (#394)
 });
 
 describe("toDiscoveredService — env import separates operator config from image defaults (#394)", () => {
+  it("preserves an exact-match flag from the proxy route index", () => {
+    const detail = container({
+      labels: {},
+      ports: [{ privatePort: 3000, publicPort: 3100, type: "tcp" }],
+    });
+    const svc = toDiscoveredService(
+      detail,
+      undefined,
+      undefined,
+      undefined,
+      new Map([
+        [
+          3100,
+          [
+            {
+              port: 3100,
+              path: "/mcp",
+              exact: true,
+              domains: ["mcp.example.com"],
+              ssl: { enabled: false },
+            },
+          ],
+        ],
+      ]),
+    );
+
+    expect(svc.existingRoute).toEqual([
+      {
+        port: 3100,
+        path: "/mcp",
+        exact: true,
+        domains: ["mcp.example.com"],
+        ssl: { enabled: false },
+        source: undefined,
+      },
+    ]);
+  });
+
   it("imports the operator's vars and reports the image-supplied ones with values", () => {
     const detail = container({ labels: {}, env: CAPTURED.overrideMatchingDefault });
 

--- a/apps/api/src/modules/migration/docker-reconcile.ts
+++ b/apps/api/src/modules/migration/docker-reconcile.ts
@@ -94,12 +94,14 @@ export interface DiscoveredService {
   edgePorts?: number[];
   /** Routes the server's EXISTING (foreign) reverse proxy already serves for this
    *  container, matched by published host port — so the wizard can show the
-   *  current domain(s)+path+SSL and offer to keep them. ONE ENTRY PER (port,path):
+   *  current domain(s)+path+SSL and offer to keep them. ONE ENTRY PER
+   *  (port,path,match mode):
    *  a container behind a path-fan-out domain (`/ → :1010`, `/v3 → :1020`) or with
    *  several published ports collects several. Absent = no proxied route detected. */
   existingRoute?: Array<{
     port: number;
     path: string;
+    exact?: boolean;
     domains: string[];
     ssl: { enabled: boolean; certPath?: string; keyPath?: string };
     /** Adoptable reverse-proxy tunables the foreign vhost declared (upload limit,
@@ -524,8 +526,8 @@ export function toDiscoveredService(
     // IPv4 (0.0.0.0) and IPv6 (::), so detail.ports lists the same publicPort
     // twice — without deduping we'd push the same route (same domain) twice and
     // the wizard would show each domain doubled (and submit two identical
-    // endpoints). proxyRoutesByPort already holds one entry per (port,path), so
-    // visiting each port ONCE preserves path-fan-out while killing the IPv4/IPv6
+    // endpoints). proxyRoutesByPort already holds one entry per (port,path,match
+    // mode), so visiting each port ONCE preserves every match while killing the IPv4/IPv6
     // double-count. (portsToComposeStrings already dedups the same way.)
     const publicPorts = [
       ...new Set(
@@ -539,6 +541,7 @@ export function toDiscoveredService(
         routes.push({
           port: hit.port,
           path: hit.path,
+          ...(hit.exact ? { exact: true } : {}),
           domains: hit.domains,
           ssl: hit.ssl,
           ...(hit.proxy ? { proxy: hit.proxy } : {}),

--- a/apps/api/src/modules/migration/migration-input.test.ts
+++ b/apps/api/src/modules/migration/migration-input.test.ts
@@ -167,6 +167,38 @@ describe("sanitizeRoutes", () => {
     });
   });
 
+  it("preserves exact matching, including an exact root path", () => {
+    expect(
+      sanitizeRoutes({
+        mcp: {
+          domainType: "custom",
+          customDomain: "mcp.example.com",
+          targetPath: "/mcp",
+          exact: true,
+        },
+        root: {
+          domainType: "custom",
+          customDomain: "root.example.com",
+          targetPath: "/",
+          exact: true,
+        },
+      }),
+    ).toEqual({
+      mcp: {
+        domainType: "custom",
+        customDomain: "mcp.example.com",
+        targetPath: "/mcp",
+        exact: true,
+      },
+      root: {
+        domainType: "custom",
+        customDomain: "root.example.com",
+        targetPath: "/",
+        exact: true,
+      },
+    });
+  });
+
   it("drops a spec with no resolvable domain, and returns undefined when nothing is left", () => {
     expect(sanitizeRoutes({ a: { domainType: "free" } })).toBeUndefined();
     expect(sanitizeRoutes(undefined)).toBeUndefined();

--- a/apps/api/src/modules/migration/migration-input.ts
+++ b/apps/api/src/modules/migration/migration-input.ts
@@ -14,6 +14,7 @@ export interface MigrationRouteSpec {
   domain?: string;
   customDomain?: string;
   targetPath?: string;
+  exact?: boolean;
 }
 
 /** Normalize a location path prefix to a leading-slash form (`v3` → `/v3`),
@@ -137,6 +138,7 @@ export function sanitizeRoutes(
       domain?: unknown;
       customDomain?: unknown;
       targetPath?: unknown;
+      exact?: unknown;
     };
     const domainType = r.domainType === "custom" ? "custom" : "free";
     const domain = typeof r.domain === "string" ? r.domain.trim().toLowerCase() : undefined;
@@ -146,14 +148,20 @@ export function sanitizeRoutes(
     if (!value) continue; // nothing to publish without a domain
     // A non-root location prefix (e.g. "/v3") → this service serves a PATH of the
     // domain (path fan-out); root ("/") is the default and carries no targetPath.
-    const path = typeof r.targetPath === "string" ? normalizePathPrefix(r.targetPath) : undefined;
+    const path =
+      typeof r.targetPath === "string"
+        ? normalizePathPrefix(r.targetPath)
+        : r.exact === true
+          ? "/"
+          : undefined;
     out[name] = {
       domainType,
       ...(domainType === "custom" ? { customDomain: value } : { domain: value }),
       ...(r.exposedPort != null && String(r.exposedPort).trim()
         ? { exposedPort: String(r.exposedPort).trim() }
         : {}),
-      ...(path && path !== "/" ? { targetPath: path } : {}),
+      ...(path && (path !== "/" || r.exact === true) ? { targetPath: path } : {}),
+      ...(r.exact === true ? { exact: true } : {}),
     };
     if (Object.keys(out).length >= 100) break;
   }

--- a/apps/api/src/modules/migration/migration.orchestrator.ts
+++ b/apps/api/src/modules/migration/migration.orchestrator.ts
@@ -2181,7 +2181,10 @@ class MigrationOrchestratorImpl {
         [...entries].sort(
           (a, b) => (a.spec.targetPath ?? "/").length - (b.spec.targetPath ?? "/").length,
         )[0];
-      const extras = entries.filter((e) => e !== root && e.spec.targetPath);
+      // If an exact route is the only match for a domain it also has to seed the
+      // mandatory root upstream, but retain it as an explicit location so the
+      // exact-match bit survives persistence and every later re-render.
+      const extras = entries.filter((e) => e.spec.targetPath && (e !== root || e.spec.exact));
 
       // Root mints the domain row + exposes.
       try {
@@ -2216,7 +2219,11 @@ class MigrationOrchestratorImpl {
           hostname: domain,
           isCustomDomain: root.spec.domainType === "custom",
           rootServiceId: root.svcId,
-          locations: extras.map((e) => ({ pathPrefix: e.spec.targetPath!, serviceId: e.svcId })),
+          locations: extras.map((e) => ({
+            pathPrefix: e.spec.targetPath!,
+            serviceId: e.svcId,
+            ...(e.spec.exact ? { exact: true } : {}),
+          })),
         });
       }
     }

--- a/apps/api/src/modules/projects/project-runtime.service.ts
+++ b/apps/api/src/modules/projects/project-runtime.service.ts
@@ -515,8 +515,8 @@ function liveUpstreamPort(site: ImportedSite): number | null {
   const upstreams =
     site.routes ?? (site.target.kind === "proxy" ? [{ path: "/", url: site.target.url }] : []);
   const ordered = [
-    ...upstreams.filter((u) => u.path === "/"),
-    ...upstreams.filter((u) => u.path !== "/"),
+    ...upstreams.filter((u) => u.path === "/" && !u.exact),
+    ...upstreams.filter((u) => u.path !== "/" || u.exact),
   ];
   for (const up of ordered) {
     try {

--- a/apps/dashboard/src/components/migration/ServerMigrationWizard.tsx
+++ b/apps/dashboard/src/components/migration/ServerMigrationWizard.tsx
@@ -291,6 +291,7 @@ type ServerRouteSpec = {
   domain?: string;
   customDomain?: string;
   targetPath?: string;
+  exact?: boolean;
 };
 function toServerRoutes(
   routes: Record<string, PublicEndpoint[]> | undefined,
@@ -307,7 +308,8 @@ function toServerRoutes(
       domainType: ep.domainType === "custom" ? "custom" : "free",
       ...(ep.domainType === "custom" ? { customDomain: domain } : { domain }),
       ...(ep.port ? { exposedPort: String(ep.port) } : {}),
-      ...(targetPath && targetPath !== "/" ? { targetPath } : {}),
+      ...(targetPath && (targetPath !== "/" || ep.exact) ? { targetPath } : {}),
+      ...(ep.exact ? { exact: true } : {}),
     };
   }
   return Object.keys(out).length > 0 ? out : undefined;
@@ -993,7 +995,8 @@ export function ServerMigrationWizard({
                 port: firstContainerPort(s),
                 domainType: "custom",
                 customDomain: r.domains[0],
-                ...(r.path && r.path !== "/" ? { targetPath: r.path } : {}),
+                ...(r.path && (r.path !== "/" || r.exact) ? { targetPath: r.path } : {}),
+                ...(r.exact ? { exact: true } : {}),
               }),
             );
         } else if (mode === "free" || mode === "custom") {
@@ -3766,7 +3769,7 @@ function ServiceConfigCard({
   // Flat {domain, path} pairs the foreign proxy already serves for this service —
   // a path-fan-out vhost yields several (e.g. api.onvo.me `/`, api.onvo.me `/v3`).
   const keptRoutes = (existing ?? []).flatMap((r) =>
-    r.domains.map((domain) => ({ domain, path: r.path })),
+    r.domains.map((domain) => ({ domain, path: r.path, exact: r.exact })),
   );
   const keptDomain0 = keptRoutes[0]?.domain;
   const volumeNames = service.volumes
@@ -3951,9 +3954,9 @@ function ServiceConfigCard({
                     >
                       {r.domain}
                     </a>
-                    {r.path !== "/" && (
+                    {(r.path !== "/" || r.exact) && (
                       <span className="rounded bg-muted px-1 py-px text-[11px] font-mono text-muted-foreground">
-                        {r.path}
+                        {r.exact ? `= ${r.path}` : r.path}
                       </span>
                     )}
                   </div>

--- a/apps/dashboard/src/context/deployment/types.ts
+++ b/apps/dashboard/src/context/deployment/types.ts
@@ -177,6 +177,8 @@ export interface PublicEndpoint {
   id: string;
   port: string;
   targetPath: string;
+  /** Preserve an imported nginx `location = <path>` route during migration. */
+  exact?: boolean;
   domain: string;
   customDomain: string;
   domainType: "free" | "custom";
@@ -566,6 +568,7 @@ export function createPublicEndpoint(
     id: overrides.id ?? randomUUID(),
     port: overrides.port ?? "",
     targetPath: overrides.targetPath ?? "",
+    ...(overrides.exact ? { exact: true } : {}),
     domain: overrides.domain ?? "",
     customDomain: overrides.customDomain ?? "",
     domainType: overrides.domainType ?? "free",

--- a/apps/dashboard/src/lib/api/server-migration.ts
+++ b/apps/dashboard/src/lib/api/server-migration.ts
@@ -38,12 +38,13 @@ export interface DiscoveredService {
   /** Host edge ports (80/443) it publishes — reserved for Openship's edge. */
   edgePorts?: number[];
   /** Routes the server's existing (foreign) reverse proxy already serves for this
-   *  container, matched by published host port. ONE ENTRY PER (port,path): a
+   *  container, matched by published host port. ONE ENTRY PER (port,path,match mode): a
    *  path-fan-out domain (`/ → :1010`, `/v3 → :1020`) or a multi-port container
    *  collects several. Absent = none detected. */
   existingRoute?: Array<{
     port: number;
     path: string;
+    exact?: boolean;
     domains: string[];
     ssl: { enabled: boolean; certPath?: string; keyPath?: string };
     source?: string;
@@ -528,6 +529,7 @@ export const dockerMigrationApi = {
         domain?: string;
         customDomain?: string;
         targetPath?: string;
+        exact?: boolean;
       }
     >;
     /** serviceName → target-volume conflict resolution (override/clone/keep). */

--- a/packages/adapters/src/infra/nginx.test.ts
+++ b/packages/adapters/src/infra/nginx.test.ts
@@ -2344,6 +2344,41 @@ describe("vercel.json path redirects", () => {
     expect(c).not.toContain("rewrite ");
   });
 
+  test("emits exact and prefix locations for the same path independently", async () => {
+    const { nginx, conf } = setup();
+    await nginx.registerRoute({
+      ...PROXY,
+      proxyLocations: [
+        { pathPrefix: "/mcp", targetUrl: "http://10.0.0.5:3000", exact: true },
+        { pathPrefix: "/mcp", targetUrl: "http://10.0.0.6:3000" },
+        { pathPrefix: "/", targetUrl: "http://10.0.0.7:3000", exact: true },
+      ],
+    });
+    const c = appConf(conf);
+
+    expect(c).toContain("location = /mcp {");
+    expect(c).toContain("location ^~ /mcp {");
+    expect(c).toContain("location = / {");
+    expect(c.match(/location = \/mcp \{/g)).toHaveLength(1);
+    expect(c.match(/location \^~ \/mcp \{/g)).toHaveLength(1);
+  });
+
+  test("keeps validating the path separately from its exact-match flag", async () => {
+    const { nginx } = setup();
+    await expect(
+      nginx.registerRoute({
+        ...PROXY,
+        proxyLocations: [
+          {
+            pathPrefix: "/mcp;add_header X-Injected yes",
+            targetUrl: "http://10.0.0.5:3000",
+            exact: true,
+          },
+        ],
+      }),
+    ).rejects.toThrow(/proxy location prefix/);
+  });
+
   // The rewrite twin of the `location /` duplication fixed for redirects above: a
   // capture-free destination keeps `pathPrefix: "/"` (Vercel's own documented shape), and
   // nginx compares location NAMES — `^~` only sets `noregex` — so `^~ /` next to `/` is
@@ -2390,7 +2425,14 @@ describe("vercel.json path redirects", () => {
     await nginx.registerRoute({
       ...PROXY,
       webhookProxy: "http://127.0.0.1:4000/api/webhooks/",
-      proxyLocations: [{ pathPrefix: "/_openship/hooks/", targetUrl: "http://attacker.example" }],
+      proxyLocations: [
+        { pathPrefix: "/_openship/hooks/", targetUrl: "http://attacker.example" },
+        {
+          pathPrefix: "/_openship/hooks/",
+          targetUrl: "http://exact-attacker.example",
+          exact: true,
+        },
+      ],
     });
     const c = appConf(conf);
     expect(c.match(/location \^~ \/_openship\/hooks\/ \{/g)).toHaveLength(1);

--- a/packages/adapters/src/infra/nginx.ts
+++ b/packages/adapters/src/infra/nginx.ts
@@ -273,8 +273,9 @@ const WEBHOOK_LOCATION_PREFIX = "/_openship/hooks/";
  * rewrites. `httpsUpgrade` adds {@link HTTPS_UPGRADE} ahead of that chain, for the one
  * block that must bounce plain HTTP.
  *
- * The emitted set is unique BY NAME, built through `claimed`: nginx's duplicate check
- * compares location names and `^~` only sets `noregex`, so a `pathPrefix: "/"` — which a
+ * The emitted set is unique BY MATCH TYPE + NAME, built through `claimed`: nginx permits
+ * an exact and inclusive location for the same path, but compares inclusive location
+ * names without regard to `^~`. Thus a prefix `pathPrefix: "/"` — which a
  * capture-free `vercel.json` rewrite produces, one of Vercel's own documented shapes —
  * sat next to `location /` as `[emerg] duplicate location "/"`. The whole vhost is then
  * refused, and since a routing failure never fails a deploy the domain went dark behind
@@ -288,7 +289,13 @@ const WEBHOOK_LOCATION_PREFIX = "/_openship/hooks/";
 function renderProxyLocations(route: RouteConfig, opts: { httpsUpgrade: boolean }): string {
   if (!route.proxyLocations || route.proxyLocations.length === 0) return "";
   const head = `${opts.httpsUpgrade ? HTTPS_UPGRADE : ""}${renderRedirectRules(route, "        ")}`;
-  const claimed = new Set<string>(["/", WEBHOOK_LOCATION_PREFIX]);
+  const claimed = new Set<string>([
+    "prefix:/",
+    `prefix:${WEBHOOK_LOCATION_PREFIX}`,
+    // An exact webhook match would not be a duplicate, but it would outrank and
+    // hijack the edge-owned delivery endpoint just as surely as a prefix would.
+    `exact:${WEBHOOK_LOCATION_PREFIX}`,
+  ]);
   const blocks: string[] = [];
   for (const loc of route.proxyLocations) {
     assertValidUpstream(loc.targetUrl);
@@ -296,10 +303,12 @@ function renderProxyLocations(route: RouteConfig, opts: { httpsUpgrade: boolean 
     const headers = loc.external ? externalProxyHeaders(loc.targetUrl) : PROXY_HEADERS;
     if (!loc.pattern || !loc.upstreamPath) {
       assertValidLiteralPath(loc.pathPrefix, "proxy location prefix");
-      if (claimed.has(loc.pathPrefix)) continue;
-      claimed.add(loc.pathPrefix);
+      const kind = loc.exact ? "exact" : "prefix";
+      const key = `${kind}:${loc.pathPrefix}`;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
       blocks.push(`
-    location ^~ ${loc.pathPrefix} {
+    location ${loc.exact ? "=" : "^~"} ${loc.pathPrefix} {
         ${head}proxy_pass ${loc.targetUrl};
         ${headers}
     }`);
@@ -312,8 +321,8 @@ function renderProxyLocations(route: RouteConfig, opts: { httpsUpgrade: boolean 
     // only the pattern's own captures may be `$…` there.
     assertNoRuntimeVariable(loc.upstreamPath, "rewrite upstream path", true);
     const match = `^${toNginxPattern(loc.pattern)}$`;
-    if (claimed.has(`~ ${match}`)) continue;
-    claimed.add(`~ ${match}`);
+    if (claimed.has(`regex:${match}`)) continue;
+    claimed.add(`regex:${match}`);
     blocks.push(`
     location ~ ${match} {
         ${head}rewrite ${match} ${loc.upstreamPath} break;

--- a/packages/adapters/src/system/proxy/api.ts
+++ b/packages/adapters/src/system/proxy/api.ts
@@ -57,8 +57,10 @@ export interface ProxySiteRouteSsl {
 export interface ProxySiteRoute {
   /** Published host port the proxy forwards to — the container-join key. */
   port: number;
-  /** Location path prefix this upstream serves (e.g. "/", "/v3"). */
+  /** Location path this upstream serves (e.g. "/", "/v3"). */
   path: string;
+  /** Whether the source used nginx's exact-match selector (`location = …`). */
+  exact?: boolean;
   domains: string[];
   ssl: ProxySiteRouteSsl;
   /**
@@ -79,8 +81,9 @@ export interface ProxySiteRoute {
  * path-fan-out domain (`/ → :1010`, `/v3 → :1020`) yields one entry PER port,
  * each carrying its path — letting a join attach `/v3` to the `:1020` service.
  * Each port maps to a LIST (a port can serve multiple paths / come from multiple
- * vhosts). Static docroots (no upstream port) are skipped. Same (port,path) from
- * multiple vhosts union their domains and prefer an SSL-terminating one's cert.
+ * vhosts). Static docroots (no upstream port) are skipped. Same (port,path,match
+ * mode) from multiple vhosts union their domains and prefer an SSL-terminating
+ * one's cert.
  */
 export function buildProxyRouteIndex(sites: ImportedSite[]): Map<number, ProxySiteRoute[]> {
   const byPort = new Map<number, ProxySiteRoute[]>();
@@ -99,7 +102,9 @@ export function buildProxyRouteIndex(sites: ImportedSite[]): Map<number, ProxySi
       if (!Number.isFinite(port) || port <= 0) continue;
 
       const list = byPort.get(port) ?? [];
-      const existing = list.find((r) => r.path === up.path);
+      const existing = list.find(
+        (r) => r.path === up.path && Boolean(r.exact) === Boolean(up.exact),
+      );
       if (existing) {
         existing.domains = [...new Set([...existing.domains, ...site.serverNames])];
         if (site.ssl) {
@@ -116,6 +121,7 @@ export function buildProxyRouteIndex(sites: ImportedSite[]): Map<number, ProxySi
         list.push({
           port,
           path: up.path,
+          ...(up.exact ? { exact: true } : {}),
           domains: [...site.serverNames],
           ...(site.proxy ? { proxy: site.proxy } : {}),
           ssl: site.ssl

--- a/packages/adapters/src/system/proxy/import/nginx.ts
+++ b/packages/adapters/src/system/proxy/import/nginx.ts
@@ -242,13 +242,41 @@ function locationBlocks(serverBody: string): { path: string; body: string }[] {
  * order. `proxy_pass` is only valid inside a location (or `if`) in nginx, so
  * this — not a server-level scan — is where real routes live.
  */
-function extractLocationProxies(serverBody: string): { path: string; proxyPass: string }[] {
-  const out: { path: string; proxyPass: string }[] = [];
+function extractLocationProxies(serverBody: string): {
+  routes: { path: string; proxyPass: string; exact?: boolean }[];
+  unsupported: string[];
+  sawProxyLocation: boolean;
+} {
+  const routes: { path: string; proxyPass: string; exact?: boolean }[] = [];
+  const unsupported: string[] = [];
+  let sawProxyLocation = false;
   for (const loc of locationBlocks(serverBody)) {
     const pp = firstDirective(loc.body, "proxy_pass");
-    if (pp) out.push({ path: loc.path, proxyPass: pp });
+    if (!pp) continue;
+    sawProxyLocation = true;
+
+    // Keep nginx's match mode separate from the path. Feeding the raw selector
+    // (`= /mcp`) to the route writer makes its injection guard correctly reject
+    // the whitespace, while stripping `=` without remembering it silently widens
+    // an exact route into a prefix. Regex and named locations have no equivalent
+    // in the imported route model, so drop only that location, not the whole vhost.
+    const exact = loc.path.match(/^=\s+(.+)$/);
+    if (exact) {
+      routes.push({ path: exact[1].trim(), proxyPass: pp, exact: true });
+      continue;
+    }
+    const strongPrefix = loc.path.match(/^\^~\s+(.+)$/);
+    if (strongPrefix) {
+      routes.push({ path: strongPrefix[1].trim(), proxyPass: pp });
+      continue;
+    }
+    if (/^~\*?(?:\s|$)/.test(loc.path) || loc.path.startsWith("@")) {
+      unsupported.push(loc.path);
+      continue;
+    }
+    routes.push({ path: loc.path, proxyPass: pp });
   }
-  return out;
+  return { routes, unsupported, sawProxyLocation };
 }
 
 /** Blank out quoted tokens so a directive-shaped word inside a VALUE can't be read
@@ -450,26 +478,34 @@ function parseServer(
 
   // All routes for this vhost. Locations are the real source; fall back to a
   // (technically-invalid but seen-in-the-wild) server-level proxy_pass.
-  const rawTargets = extractLocationProxies(body);
-  if (rawTargets.length === 0) {
+  const extracted = extractLocationProxies(body);
+  const rawTargets = extracted.routes;
+  for (const selector of extracted.unsupported) {
+    warnings.push(
+      `nginx: ${names[0]} location "${selector}" uses an unsupported regex or named selector (skipped)`,
+    );
+  }
+  if (rawTargets.length === 0 && !extracted.sawProxyLocation) {
     const serverLevel = firstDirective(body, "proxy_pass");
     if (serverLevel) rawTargets.push({ path: "/", proxyPass: serverLevel });
   }
 
-  const resolved: { path: string; url: string }[] = [];
+  const resolved: { path: string; url: string; exact?: boolean }[] = [];
   for (const t of rawTargets) {
     const r = resolveProxyTarget(t.proxyPass, upstreams);
     if ("reason" in r) warnings.push(`nginx: ${names[0]} ${t.path} — ${r.reason} (skipped)`);
-    else resolved.push({ path: t.path, url: r.url });
+    else resolved.push({ path: t.path, url: r.url, ...(t.exact ? { exact: true } : {}) });
   }
 
   let target: ImportedSite["target"];
-  let routes: { path: string; url: string }[] | undefined;
+  let routes: ImportedSite["routes"];
   if (resolved.length > 0) {
-    // Primary = the root location ("/") if present, else the first resolved.
+    // Primary = the inclusive root location ("/") if present, else the first
+    // resolved route. An exact `location = /` is an extra match, not the prefix
+    // fallback that serves every other path.
     // `routes` carries the FULL per-path set so a path-fan-out vhost (e.g.
     // `/ → :1010`, `/v3 → :1020`) is preserved — the edge can path-route it.
-    const primary = resolved.find((r) => r.path === "/") ?? resolved[0];
+    const primary = resolved.find((r) => r.path === "/" && !r.exact) ?? resolved[0];
     target = { kind: "proxy", url: primary.url };
     routes = resolved;
   } else if (isHttpsUpgradeForSelf(body, names)) {

--- a/packages/adapters/src/system/proxy/import/proxy-import.test.ts
+++ b/packages/adapters/src/system/proxy/import/proxy-import.test.ts
@@ -93,6 +93,63 @@ describe("scanNginx", () => {
     expect(res.warnings.find((x) => x.includes("path-routes"))).toBeUndefined();
   });
 
+  test("preserves an exact-match location as a clean path plus an exact flag", async () => {
+    const conf = `
+      server {
+        listen 80;
+        server_name example.com;
+        location = /mcp {
+          proxy_pass http://127.0.0.1:3100;
+        }
+      }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].target).toEqual({ kind: "proxy", url: "http://127.0.0.1:3100" });
+    expect(res.sites[0].routes).toEqual([
+      { path: "/mcp", url: "http://127.0.0.1:3100", exact: true },
+    ]);
+    expect(res.warnings).toEqual([]);
+  });
+
+  test("normalizes ^~ prefixes and skips only regex/named proxy locations", async () => {
+    const conf = `
+      server {
+        server_name mixed.example.com;
+        location / { proxy_pass http://127.0.0.1:3000; }
+        location ^~ /assets/ { proxy_pass http://127.0.0.1:3100; }
+        location ~ ^/users/[0-9]+$ { proxy_pass http://127.0.0.1:3200; }
+        location ~* \\.php$ { proxy_pass http://127.0.0.1:3300; }
+        location @fallback { proxy_pass http://127.0.0.1:3400; }
+      }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+
+    expect(res.sites).toHaveLength(1);
+    expect(res.sites[0].routes).toEqual([
+      { path: "/", url: "http://127.0.0.1:3000" },
+      { path: "/assets/", url: "http://127.0.0.1:3100" },
+    ]);
+    expect(res.warnings).toHaveLength(3);
+    expect(
+      res.warnings.every((w) => w.includes("mixed.example.com") && w.includes("skipped")),
+    ).toBe(true);
+  });
+
+  test("does not widen an unsupported-only location into a root route", async () => {
+    const conf = `
+      server {
+        server_name regex.example.com;
+        location ~ ^/private { proxy_pass http://127.0.0.1:3200; }
+      }
+    `;
+    const res = await scanNginx(makeExecutor([["nginx -T", conf]]));
+
+    expect(res.sites).toEqual([]);
+    expect(res.warnings.some((w) => w.includes('location "~ ^/private"'))).toBe(true);
+  });
+
   test("nested if/location braces don't truncate the block", async () => {
     const conf = `
       server {

--- a/packages/adapters/src/system/proxy/register-imported-sites.test.ts
+++ b/packages/adapters/src/system/proxy/register-imported-sites.test.ts
@@ -76,6 +76,39 @@ describe("registerImportedSites", () => {
     expect(o.warnings).toEqual([]);
   });
 
+  it("carries exact-match locations into route registration, including exact root", async () => {
+    const { routing, ssl } = providers();
+    const sites: ImportedSite[] = [
+      {
+        serverNames: ["exact.com"],
+        ssl: false,
+        target: { kind: "proxy", url: "http://127.0.0.1:3000" },
+        routes: [
+          { path: "/", url: "http://127.0.0.1:3000" },
+          { path: "/", url: "http://127.0.0.1:3001", exact: true },
+          { path: "/mcp", url: "http://127.0.0.1:3100", exact: true },
+        ],
+      },
+    ];
+
+    await registerImportedSites(
+      routing as RoutingProvider,
+      ssl as SslProvider,
+      fakeExecutor(),
+      sites,
+      opts(),
+    );
+
+    expect(routing.registerRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxyLocations: [
+          { pathPrefix: "/", targetUrl: "http://127.0.0.1:3001", exact: true },
+          { pathPrefix: "/mcp", targetUrl: "http://127.0.0.1:3100", exact: true },
+        ],
+      }),
+    );
+  });
+
   it("installs inline certPems without reading the filesystem", async () => {
     const { routing, ssl } = providers();
     const exec = fakeExecutor();

--- a/packages/adapters/src/system/proxy/route-index.test.ts
+++ b/packages/adapters/src/system/proxy/route-index.test.ts
@@ -65,6 +65,29 @@ describe("buildProxyRouteIndex", () => {
     ]);
   });
 
+  it("keeps exact and prefix matches for the same path as distinct routes", () => {
+    const idx = buildProxyRouteIndex([
+      proxySite({
+        url: "http://localhost:1010",
+        routes: [
+          { path: "/mcp", url: "http://localhost:1010" },
+          { path: "/mcp", url: "http://localhost:1010", exact: true },
+        ],
+      }),
+    ]);
+
+    expect(idx.get(1010)).toEqual([
+      { port: 1010, path: "/mcp", domains: ["app.example.com"], ssl: { enabled: false } },
+      {
+        port: 1010,
+        path: "/mcp",
+        exact: true,
+        domains: ["app.example.com"],
+        ssl: { enabled: false },
+      },
+    ]);
+  });
+
   it("skips static docroots (no upstream port)", () => {
     const idx = buildProxyRouteIndex([
       { serverNames: ["static.example.com"], ssl: true, target: { kind: "static", root: "/var/www" } },

--- a/packages/adapters/src/system/proxy/takeover.ts
+++ b/packages/adapters/src/system/proxy/takeover.ts
@@ -118,11 +118,16 @@ export async function registerImportedSites(
     for (const domain of domains) {
       try {
         if (site.target.kind === "proxy") {
-          // Non-root locations become path-prefix proxy locations ahead of `/`
-          // so a fan-out vhost (`/ → A`, `/v3 → B`) is kept, not collapsed.
+          // Non-root locations, plus an exact `/`, become proxy locations ahead
+          // of the inclusive primary `/` so both fan-out and nginx exact matching
+          // survive the takeover.
           const proxyLocations = (site.routes ?? [])
-            .filter((r) => r.path !== "/")
-            .map((r) => ({ pathPrefix: r.path, targetUrl: r.url }));
+            .filter((r) => r.path !== "/" || r.exact)
+            .map((r) => ({
+              pathPrefix: r.path,
+              targetUrl: r.url,
+              ...(r.exact ? { exact: true } : {}),
+            }));
           await routing.registerRoute({
             domain,
             tls: site.ssl,

--- a/packages/adapters/src/system/types.ts
+++ b/packages/adapters/src/system/types.ts
@@ -240,10 +240,11 @@ export interface ImportedSite {
     | { kind: "proxy"; url: string }
     | { kind: "static"; root: string };
   /** Every reverse-proxy upstream this vhost serves, in source order, one per
-   *  location path (e.g. `/ → :1010`, `/v3 → :1020`). Absent for a static site.
+   *  location (e.g. `/ → :1010`, `/v3 → :1020`). `exact` preserves nginx's
+   *  `location = <path>` match mode. Absent for a static site.
    *  Lets an importer keep a path-fan-out domain instead of collapsing to the
    *  primary. `routes[].url` is the resolved `http://host:port` upstream. */
-  routes?: { path: string; url: string }[];
+  routes?: { path: string; url: string; exact?: boolean }[];
   /** Existing certificate paths, if the source terminated TLS itself (reusable). */
   tls?: { certPath: string; keyPath: string };
   /**

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -532,10 +532,12 @@ export interface ResourceUsage {
   networkTxBytes: number;
 }
 
-/** An extra path-prefix location that reverse-proxies to another target. */
+/** An extra literal-path location that reverse-proxies to another target. */
 export interface RouteProxyLocation {
-  /** nginx location prefix, e.g. "/api/". */
+  /** nginx location path, e.g. "/api/". */
   pathPrefix: string;
+  /** true -> `location = <path>`; unset/false -> `location ^~ <path>`. */
+  exact?: boolean;
   /** Proxy target, e.g. "http://10.0.0.5:3000". When `upstreamPath` is set this is
    *  the ORIGIN only (no path) — the path comes from the template instead. */
   targetUrl: string;

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -78,8 +78,8 @@ export interface ProjectCompositeRoute {
   isCustomDomain: boolean;
   /** Service served at `/` (the route's primary upstream). */
   rootServiceId: string;
-  /** Extra path-prefix locations, resolved to their service's upstream at deploy. */
-  locations: { pathPrefix: string; serviceId: string }[];
+  /** Extra literal-path locations, resolved to their service's upstream at deploy. */
+  locations: { pathPrefix: string; serviceId: string; exact?: boolean }[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Preserve nginx exact-match locations during proxy migration by representing the match mode separately from the validated path and rendering it back as `location = <path>`.

## Motivation

The nginx importer treated the complete selector `= /mcp` as a path. The route writer then correctly rejected its whitespace as an nginx-injection risk, causing the affected vhost to be omitted during edge takeover. Weakening that guard would be unsafe; the match operator needs its own typed field.

Closes #732.

## Changes

- Parse `location = /path` into `{ path: "/path", exact: true }` and normalize `^~` prefix selectors.
- Skip unsupported regex and named proxy locations individually with warnings instead of rejecting an otherwise representable site.
- Render exact proxy locations with `location =`, while retaining path/upstream validation and allowing exact and prefix matches at the same path.
- Carry the `exact` flag through direct edge takeover and Docker migration discovery, request sanitization, persisted composite routes, and redeploy reconstruction.
- Keep exact `/` distinct from the normal root prefix, and keep edge-owned webhook/challenge locations protected.

## Verification

```text
packages/adapters: 172 files passed, 3444 tests passed
apps/dashboard:     108 files passed, 1118 tests passed
apps/api focused:   3 files passed, 62 tests passed
TypeScript:         adapters, core, api, and dashboard all pass tsc --noEmit
```

The full API run completed 461/462 files (5456 tests passed, 5 skipped); one unrelated route-module import exceeded its 10-second hook timeout under concurrent load. Its isolated rerun passed 2/2 in 15.25s total (6.64s test time).

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] Relevant tests and workspace typechecks pass locally
- [x] I understand every line of this diff and can explain it in review
