### PR TITLE
chore: add categorized issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report unexpected or incorrect behavior in OpenShip
+title: "[Bug]: "
+labels: ["bug"]
+type: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve OpenShip. Please provide enough detail for us to reproduce the problem.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Existing issue
+      description: Search the existing issues before submitting a new report.
+      options:
+        - label: I have searched the existing issues and found no duplicate.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: What happened, and what did you expect to happen instead?
+      placeholder: Describe the problem and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest set of steps that reliably reproduces the problem.
+      placeholder: |
+        1. Go to ...
+        2. Configure ...
+        3. Run ...
+        4. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the details that are relevant to this problem.
+      value: |
+        - OpenShip version/commit:
+        - Deployment method:
+        - Operating system:
+        - Browser (if applicable):
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and screenshots
+      description: Paste relevant logs or attach screenshots. Remove secrets and other sensitive data first.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other information that may help us investigate.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,58 @@
+name: Documentation issue
+description: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels: ["documentation"]
+type: task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us make the OpenShip documentation clearer and more accurate.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Existing issue
+      description: Search the existing issues before submitting a new report.
+      options:
+        - label: I have searched the existing issues and found no duplicate.
+          required: true
+
+  - type: dropdown
+    id: issue-kind
+    attributes:
+      label: Documentation problem
+      description: What kind of documentation change is needed?
+      options:
+        - Missing documentation
+        - Incorrect documentation
+        - Unclear documentation
+        - Outdated documentation
+        - Example or tutorial request
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link to the relevant page or provide the file path or section name.
+      placeholder: https://... or docs/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Explain what is missing, incorrect, unclear, or outdated.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested change
+      description: If possible, describe or draft the documentation you would like to see.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest new functionality for OpenShip
+title: "[Feature]: "
+labels: ["enhancement"]
+type: feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature. Explain the problem first so we can evaluate the best solution.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Existing issue
+      description: Search the existing issues before submitting a new request.
+      options:
+        - label: I have searched the existing issues and found no duplicate.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem would this feature solve, and who would benefit from it?
+      placeholder: Describe the need rather than only the proposed implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe how you would like the feature to work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative solutions you have considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add mockups, links, examples, or any other useful context.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,51 @@
+name: Improvement proposal
+description: Propose an improvement to existing OpenShip behavior
+title: "[Improvement]: "
+labels: ["enhancement"]
+type: feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to suggest a better version of existing behavior. Use the feature request form for entirely new functionality.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Existing issue
+      description: Search the existing issues before submitting a new proposal.
+      options:
+        - label: I have searched the existing issues and found no duplicate.
+          required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: What existing behavior, workflow, or interface could be improved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-improvement
+    attributes:
+      label: Proposed improvement
+      description: Describe the desired behavior and why it would be better.
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefits
+    attributes:
+      label: Benefits
+      description: Who benefits from this change, and what measurable improvement would it provide?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add examples, mockups, benchmarks, or any other useful context.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,51 @@
+name: Question
+description: Ask for help or clarification about OpenShip
+title: "[Question]: "
+labels: ["question"]
+type: task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when the documentation and existing issues do not answer your question.
+
+  - type: checkboxes
+    id: prior-research
+    attributes:
+      label: Prior research
+      description: Check the documentation and existing issues before asking a new question.
+      options:
+        - label: I have searched the documentation and existing issues for an answer.
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: State the question clearly and explain what you are trying to accomplish.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attempts
+    attributes:
+      label: What have you tried?
+      description: Share the documentation, commands, configuration, or approaches you have already tried.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include relevant version, deployment, operating system, or browser details.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add logs, screenshots, links, or any other useful information. Remove secrets first.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,23 @@
 
 Thanks for your interest in contributing! This guide covers everything you need to get started.
 
+## Before you open an issue
+
+Every issue must use exactly one of the repository's issue categories. Choose the matching form from
+the **New issue** page; blank, untyped issues are not accepted.
+
+| Category      | Title prefix    | Label           | GitHub issue type |
+| ------------- | --------------- | --------------- | ----------------- |
+| Bug           | `[Bug]`         | `bug`           | Bug               |
+| Feature       | `[Feature]`     | `enhancement`   | Feature           |
+| Improvement   | `[Improvement]` | `enhancement`   | Feature           |
+| Documentation | `[Docs]`        | `documentation` | Task              |
+| Question      | `[Question]`    | `question`      | Task              |
+
+If you create an issue through an API, CLI, or AI assistant instead of the GitHub form chooser,
+you must apply the matching title prefix, label, and GitHub issue type from the table above. Never
+create a generic or untyped issue. Issues without a category are incomplete and may be closed.
+
 ## Before you open a pull request
 
 **Bug fixes, tests, docs, and small self-contained improvements** are welcome as direct pull
@@ -45,6 +62,8 @@ Every PR is reviewed by a human, so make it easy to trust:
 
 AI tools are fine to use — but **you** are the author and are accountable for every line you submit:
 
+- **Type every issue.** When an AI assistant opens an issue, it must use one of the five issue forms
+  or apply the exact category mapping above. It must never create a generic or untyped issue.
 - **Understand your whole diff.** If you can't explain a line in review, don't submit it.
 - **Verify, don't trust.** Actually run the change and confirm it does what the PR claims. Do not
   paste generated code — or a generated PR description — that you haven't checked against the real


### PR DESCRIPTION
## Summary

- add dedicated issue forms for bugs, features, improvements, documentation, and questions
- apply the existing repository labels and native GitHub issue types automatically
- require contributors to choose a form by disabling blank issues
- document the required category mapping for API, CLI, and AI-created issues
- explicitly prohibit AI assistants from creating generic or untyped issues
- collect category-specific details to make triage and review easier

## Validation

- parsed all YAML configuration files successfully
- validated all five forms against the official GitHub issue form schema
- verified referenced labels and issue types against the repository and organization configuration
- checked the documentation diff for whitespace errors