### PR TITLE
feat(system): make the built-image GC inspectable and runnable by hand (#779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ the in-app updater surfaces critical advisories from `release-advisories.json`.
 
 ## Unreleased
 
+### Maintenance
+
+- **The built-image garbage collector is inspectable and runnable by hand** —
+  `openship system image-gc --dry-run` lists every project's build images on its
+  deploy host with the decision the `images:gc` sweep would take and why (active,
+  pinned, inside the rollback window, in use, operator-retagged, or superseded),
+  the rollback window that decided it, the job's schedule and last run, and the
+  space a run would reclaim. Without `--dry-run` it confirms and runs the sweep,
+  recorded as a manual `images:gc` job run. `--older-than 30d` narrows a run to
+  superseded images at least that old; age never overrides the keep-set. Backed
+  by `GET /api/system/image-gc/plan` and `POST /api/system/image-gc/run`
+  (instance admin). `openship system runtime-images` lists the previous
+  `openship-api` / `openship-dashboard` / `openship-edge` images an update leaves
+  on the host and, with `--prune`, removes all but the referenced version and
+  `--keep` previous ones (#779).
+
 ## 0.6.10
 
 This release hardens the full deployment lifecycle, makes Compose reconciliation

--- a/apps/api/src/modules/deployments/image-gc.test.ts
+++ b/apps/api/src/modules/deployments/image-gc.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import type { Deployment } from "@repo/db";
-import { computeKeepSet, selectImageRemovalRefs } from "./image-gc";
+import {
+  classifyImage,
+  computeKeepSet,
+  computeKeepSetDetail,
+  parseMinAge,
+  selectImageRemovalRefs,
+  type KeepReason,
+} from "./image-gc";
 
 // Minimal deployment shape for the pure keep-set logic (loaders are injected, so
 // no DB). Casts keep the fixtures terse — computeKeepSet only reads id/imageRef/pinned.
@@ -97,5 +104,110 @@ describe("selectImageRemovalRefs (never ruin an operator's image)", () => {
 
   it("removes a truly dangling (untagged) labeled leftover by id", () => {
     expect(selectImageRemovalRefs({ id: "sha6", repoTags: [] }, keep)).toEqual(["sha6"]);
+  });
+});
+
+describe("computeKeepSetDetail (why each ref is kept)", () => {
+  it("names the strongest protection when one image is referenced by several kept deployments", async () => {
+    // d3 (active) and d2 (inside the window) both run the same compose service image.
+    const project = { id: "p4", activeDeploymentId: "d3", rollbackWindow: 2 };
+    const ready = asDeps([
+      { id: "d3", imageRef: "compose", pinned: false },
+      { id: "d2", imageRef: "compose", pinned: true },
+      { id: "d1", imageRef: "compose", pinned: false },
+    ]);
+    const keep = await computeKeepSetDetail(project, {
+      listReadyOrderedDesc: async () => ready,
+      findById: async (id) => ready.find((d) => d.id === id),
+      listByDeployment: async (id) =>
+        id === "d3"
+          ? [{ imageRef: "svc-shared" }]
+          : id === "d2"
+            ? [{ imageRef: "svc-shared" }, { imageRef: "svc-2" }]
+            : [{ imageRef: "svc-1" }],
+    });
+    expect(keep.get("svc-shared")).toBe("active"); // not "pinned" — active outranks it
+    expect(keep.get("svc-2")).toBe("pinned");
+    expect(keep.get("svc-1")).toBe("rollback-window");
+  });
+});
+
+describe("classifyImage (the plan says exactly what the sweep does)", () => {
+  const DAY = 86_400_000;
+  const now = 100 * DAY;
+  const keep = new Map<string, KeepReason>([["openship/app-web:keep", "rollback-window"]]);
+
+  it("reports the keep-set reason for a protected tag", () => {
+    expect(classifyImage({ id: "sha1", repoTags: ["openship/app-web:keep"] }, keep)).toEqual({
+      action: "keep",
+      reason: "rollback-window",
+      refs: [],
+    });
+  });
+
+  it("names an image a container still references as in-use instead of a removal candidate", () => {
+    const img = { id: "sha2", repoTags: ["openship/app-web:bld_old"] };
+    expect(classifyImage(img, keep, { usedImageIds: new Set(["sha2"]) })).toEqual({
+      action: "keep",
+      reason: "in-use",
+      refs: [],
+    });
+    // Without the container listing it is what the sweep would try to remove.
+    expect(classifyImage(img, keep)).toEqual({
+      action: "remove",
+      reason: "superseded",
+      refs: ["openship/app-web:bld_old"],
+    });
+  });
+
+  it("removes only own tags, keeps a re-purposed image, and removes a dangling leftover by id", () => {
+    expect(
+      classifyImage(
+        { id: "sha3", repoTags: ["openship/app-web:bld_old", "myteam/custom:latest"] },
+        keep,
+      ).refs,
+    ).toEqual(["openship/app-web:bld_old"]);
+    expect(classifyImage({ id: "sha4", repoTags: ["postgres:16-alpine"] }, keep)).toEqual({
+      action: "keep",
+      reason: "foreign-tag",
+      refs: [],
+    });
+    expect(classifyImage({ id: "sha5", repoTags: [] }, keep)).toEqual({
+      action: "remove",
+      reason: "dangling",
+      refs: ["sha5"],
+    });
+  });
+
+  it("age filter: keeps a young or age-unknown candidate, still removes an old one, never overrides the keep-set", () => {
+    const opts = { minAgeMs: 30 * DAY, now };
+    const young = { id: "y", repoTags: ["openship/app-web:bld_y"], createdAt: now - 2 * DAY };
+    const old = { id: "o", repoTags: ["openship/app-web:bld_o"], createdAt: now - 45 * DAY };
+    const unknown = { id: "u", repoTags: ["openship/app-web:bld_u"], createdAt: null };
+    expect(classifyImage(young, keep, opts)).toMatchObject({ action: "keep", reason: "min-age" });
+    expect(classifyImage(unknown, keep, opts)).toMatchObject({ action: "keep", reason: "min-age" });
+    expect(classifyImage(old, keep, opts)).toMatchObject({
+      action: "remove",
+      reason: "superseded",
+    });
+    // An ancient image inside the rollback window stays, age or not.
+    expect(
+      classifyImage({ id: "k", repoTags: ["openship/app-web:keep"], createdAt: 0 }, keep, opts),
+    ).toMatchObject({ action: "keep", reason: "rollback-window" });
+  });
+});
+
+describe("parseMinAge", () => {
+  it("accepts d/h/w/m units and bare days", () => {
+    expect(parseMinAge("30d")).toBe(30 * 86_400_000);
+    expect(parseMinAge("12h")).toBe(12 * 3_600_000);
+    expect(parseMinAge("2w")).toBe(14 * 86_400_000);
+    expect(parseMinAge("90m")).toBe(90 * 60_000);
+    expect(parseMinAge("7")).toBe(7 * 86_400_000);
+  });
+
+  it("rejects zero and junk rather than silently running an unfiltered sweep", () => {
+    for (const bad of ["0d", "", "soon", "30 days", "-5d"])
+      expect(() => parseMinAge(bad)).toThrow();
   });
 });

--- a/apps/api/src/modules/deployments/image-gc.ts
+++ b/apps/api/src/modules/deployments/image-gc.ts
@@ -15,18 +15,26 @@
  * is never a candidate; the daemon's in-use 409 is a further backstop.
  *
  * Scheduled as the `images:gc` system job (see modules/jobs/job.registry.ts).
+ *
+ * Every decision goes through ONE classifier (`classifyImage`) that also names
+ * its reason, so the same rules power the sweep AND a read-only plan
+ * (`planImageGc`) an operator can read before trusting the job with a full disk
+ * (#779): what is on each host, what would go, and why the rest stays.
  */
 
 import { repos, type Deployment, type Project } from "@repo/db";
 import { DockerRuntime } from "@repo/adapters";
-import { normalizeRollbackWindow, safeErrorMessage } from "@repo/core";
+import { ValidationError, normalizeRollbackWindow, safeErrorMessage } from "@repo/core";
 import { resolveDeploymentRuntime } from "../../lib/deployment-runtime";
 import { getHostDisk } from "../../lib/host-disk";
 import {
   refreshRollbackCapacity,
-  resolveRollbackWindow,
+  resolveRollbackWindowDetail,
   type RollbackWindowProject,
+  type RollbackWindowSource,
 } from "./release-retention";
+
+export const IMAGE_GC_JOB_KEY = "images:gc";
 
 export interface ImageGcSummary {
   projectsScanned: number;
@@ -36,42 +44,102 @@ export interface ImageGcSummary {
   errors: number;
 }
 
+export interface ImageGcOptions {
+  /**
+   * Only remove a superseded image once it is at least this old. The filter can
+   * only make a sweep MORE conservative: a younger image is kept, an older one is
+   * still removed only when nothing else protects it (active / pinned / rollback
+   * window / in use are never overridden by age).
+   */
+  minAgeMs?: number;
+}
+
+/** The summary shape the `images:gc` job row records — one place, so the
+ *  scheduled tick and a manual run read the same in job history. */
+export function imageGcJobSummary(r: ImageGcSummary): Record<string, number> {
+  return {
+    scanned: r.projectsScanned,
+    removed: r.imagesRemoved,
+    bytesReclaimed: r.bytesReclaimed,
+    skipped: r.skippedInUse,
+    failed: r.errors,
+  };
+}
+
+// ─── Age filter ──────────────────────────────────────────────────────────────
+
+const AGE_UNIT_MS: Record<string, number> = {
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
 /**
- * imageRefs to KEEP for a project: every image referenced by the active
- * deployment, all pinned deployments, and the newest `rollbackWindow` ready
- * deployments — collected at BOTH the deployment level (`dep.imageRef`,
+ * `30d`, `12h`, `2w`, `90m`, or a bare number of days → milliseconds. Rejects
+ * zero and anything else: a filter that parses to "no filter" would silently
+ * run the full sweep the operator was trying to narrow.
+ */
+export function parseMinAge(input: string): number {
+  const m = /^(\d+)\s*([mhdw])?$/i.exec(input.trim());
+  const n = m ? Number(m[1]) : 0;
+  if (!m || n <= 0) {
+    throw new ValidationError(
+      `Invalid age "${input}" — use a positive number with a unit, e.g. 30d, 12h, 2w`,
+    );
+  }
+  return n * AGE_UNIT_MS[(m[2] ?? "d").toLowerCase()]!;
+}
+
+// ─── Keep-set ────────────────────────────────────────────────────────────────
+
+export type KeepReason = "active" | "pinned" | "rollback-window";
+
+/** When one ref is protected for several reasons, report the strongest. */
+const KEEP_PRIORITY: Record<KeepReason, number> = { active: 0, pinned: 1, "rollback-window": 2 };
+
+export interface KeepSetLoaders {
+  listReadyOrderedDesc?: (projectId: string) => Promise<Deployment[]>;
+  findById?: (id: string) => Promise<Deployment | undefined>;
+  listByDeployment?: (depId: string) => Promise<Array<{ imageRef: string | null }>>;
+}
+
+/**
+ * imageRefs to KEEP for a project, each with WHY: every image referenced by the
+ * active deployment, all pinned deployments, and the newest `rollbackWindow`
+ * ready deployments — collected at BOTH the deployment level (`dep.imageRef`,
  * single-app) and the per-service level (`serviceDeployment.imageRef`, compose).
  * Because each retained deployment contributes all of its services' images, a
  * compose service naturally keeps `rollbackWindow` of ITS builds.
  *
  * Exported for unit testing; pure given the injected loaders.
  */
-export async function computeKeepSet(
+export async function computeKeepSetDetail(
   project: Pick<Project, "id" | "activeDeploymentId"> & RollbackWindowProject,
-  loaders?: {
-    listReadyOrderedDesc?: (projectId: string) => Promise<Deployment[]>;
-    findById?: (id: string) => Promise<Deployment | undefined>;
-    listByDeployment?: (depId: string) => Promise<Array<{ imageRef: string | null }>>;
-  },
-): Promise<Set<string>> {
-  const listReady = loaders?.listReadyOrderedDesc ?? ((id: string) => repos.deployment.listReadyOrderedDesc(id));
+  loaders?: KeepSetLoaders,
+): Promise<Map<string, KeepReason>> {
+  const listReady =
+    loaders?.listReadyOrderedDesc ?? ((id: string) => repos.deployment.listReadyOrderedDesc(id));
   const findById = loaders?.findById ?? ((id: string) => repos.deployment.findById(id));
   const listSds = loaders?.listByDeployment ?? ((id: string) => repos.service.listByDeployment(id));
 
-  const keep = new Set<string>();
-  const window = await resolveRollbackWindow(project);
+  const { window } = await resolveRollbackWindowDetail(project);
   const ready = await listReady(project.id); // newest first
 
-  const keepDeployments: Deployment[] = [];
+  const keepDeployments: Array<{ dep: Deployment; reason: KeepReason }> = [];
   let unpinnedKept = 0;
   for (const dep of ready) {
-    if (dep.id === project.activeDeploymentId || dep.pinned) {
-      keepDeployments.push(dep);
+    if (dep.id === project.activeDeploymentId) {
+      keepDeployments.push({ dep, reason: "active" });
+      continue;
+    }
+    if (dep.pinned) {
+      keepDeployments.push({ dep, reason: "pinned" });
       continue;
     }
     if (unpinnedKept < window) {
       unpinnedKept += 1;
-      keepDeployments.push(dep);
+      keepDeployments.push({ dep, reason: "rollback-window" });
     }
     // else: beyond the window and unpinned → its images are prune candidates.
   }
@@ -79,25 +147,126 @@ export async function computeKeepSet(
   // "reconciling" after a connection-loss deploy).
   if (
     project.activeDeploymentId &&
-    !keepDeployments.some((d) => d.id === project.activeDeploymentId)
+    !keepDeployments.some((k) => k.dep.id === project.activeDeploymentId)
   ) {
     const active = await findById(project.activeDeploymentId);
-    if (active) keepDeployments.push(active);
+    if (active) keepDeployments.push({ dep: active, reason: "active" });
   }
 
-  for (const dep of keepDeployments) {
-    if (dep.imageRef) keep.add(dep.imageRef);
+  const keep = new Map<string, KeepReason>();
+  const add = (ref: string | null, reason: KeepReason) => {
+    if (!ref) return;
+    const prior = keep.get(ref);
+    if (prior === undefined || KEEP_PRIORITY[reason] < KEEP_PRIORITY[prior]) keep.set(ref, reason);
+  };
+  for (const { dep, reason } of keepDeployments) {
+    add(dep.imageRef, reason);
     const sds = await listSds(dep.id);
-    for (const sd of sds) if (sd.imageRef) keep.add(sd.imageRef);
+    for (const sd of sds) add(sd.imageRef, reason);
   }
   return keep;
 }
+
+/** The keep-set without reasons — what the sweep's callers historically read. */
+export async function computeKeepSet(
+  project: Pick<Project, "id" | "activeDeploymentId"> & RollbackWindowProject,
+  loaders?: KeepSetLoaders,
+): Promise<Set<string>> {
+  return new Set((await computeKeepSetDetail(project, loaders)).keys());
+}
+
+// ─── Per-image decision ──────────────────────────────────────────────────────
 
 export interface ReapResult {
   removed: number;
   bytes: number;
   skippedInUse: number;
 }
+
+/**
+ * Which of an image's refs WE may remove: its `openship/…` tags — we untag only
+ * what we own, so Docker deletes the image when our last tag is gone, and
+ * removing by tag (not image id) can never yank a foreign tag the operator
+ * added — or the image id when it is truly dangling (NO tags at all: our
+ * superseded, untagged final layer). An image left with only foreign tags was
+ * re-purposed by the operator → nothing.
+ */
+function ownedRemovalRefs(img: { id: string; repoTags: string[] }): string[] {
+  const ownTags = img.repoTags.filter((t) => t.startsWith("openship/"));
+  if (ownTags.length > 0) return ownTags;
+  if (img.repoTags.length === 0) return [img.id];
+  return []; // only foreign tags → never touch
+}
+
+/**
+ * Decide what to remove for ONE listed (label-scoped) image — the safety-
+ * critical selection, kept pure + unit-tested so "never ruin an operator's
+ * image" is verifiable:
+ *   - in the keep-set (active/pinned/rollback-window) → keep (`[]`).
+ *   - otherwise `ownedRemovalRefs` (own tags, or the id when dangling).
+ */
+export function selectImageRemovalRefs(
+  img: { id: string; repoTags: string[] },
+  keep: Set<string>,
+): string[] {
+  if (img.repoTags.some((t) => keep.has(t))) return [];
+  return ownedRemovalRefs(img);
+}
+
+export type ImageKeepReason = KeepReason | "in-use" | "foreign-tag" | "min-age";
+export type ImageRemoveReason = "superseded" | "dangling";
+
+export type ImageDisposition =
+  | { action: "keep"; reason: ImageKeepReason; refs: [] }
+  | { action: "remove"; reason: ImageRemoveReason; refs: string[] };
+
+/**
+ * `selectImageRemovalRefs` with its reasoning attached — the one classifier
+ * behind both the sweep and the read-only plan, so what the plan says would
+ * happen is exactly what the sweep does:
+ *   - a tag in the keep-set → keep, naming the strongest protection.
+ *   - referenced by a container on the host (`usedImageIds`, when the caller
+ *     listed them) → keep `in-use`. The sweep itself learns this from the
+ *     daemon's 409; the plan looks first so it can SAY so.
+ *   - nothing of ours to remove (foreign tags only) → keep `foreign-tag`.
+ *   - younger than `minAgeMs`, or of unknown age when a minimum is set → keep
+ *     `min-age`. Unknown counts as young: the age filter exists to make a sweep
+ *     more conservative, never less.
+ *   - else remove: `superseded` (our tags) or `dangling` (untagged leftover).
+ */
+export function classifyImage(
+  img: { id: string; repoTags: string[]; createdAt?: number | null },
+  keep: ReadonlyMap<string, KeepReason>,
+  opts: { usedImageIds?: ReadonlySet<string>; minAgeMs?: number; now?: number } = {},
+): ImageDisposition {
+  let kept: KeepReason | undefined;
+  for (const tag of img.repoTags) {
+    const reason = keep.get(tag);
+    if (
+      reason !== undefined &&
+      (kept === undefined || KEEP_PRIORITY[reason] < KEEP_PRIORITY[kept])
+    ) {
+      kept = reason;
+    }
+  }
+  if (kept !== undefined) return { action: "keep", reason: kept, refs: [] };
+  if (opts.usedImageIds?.has(img.id)) return { action: "keep", reason: "in-use", refs: [] };
+  const refs = ownedRemovalRefs(img);
+  if (refs.length === 0) return { action: "keep", reason: "foreign-tag", refs: [] };
+  if (opts.minAgeMs !== undefined) {
+    const now = opts.now ?? Date.now();
+    if (
+      img.createdAt === undefined ||
+      img.createdAt === null ||
+      now - img.createdAt < opts.minAgeMs
+    ) {
+      return { action: "keep", reason: "min-age", refs: [] };
+    }
+  }
+  return { action: "remove", reason: img.repoTags.length === 0 ? "dangling" : "superseded", refs };
+}
+
+// ─── Sweep ───────────────────────────────────────────────────────────────────
 
 /**
  * Feed the auto-sized rollback window: mean built-image size for this project +
@@ -132,29 +301,6 @@ async function refreshRollbackCapacityFor(
 }
 
 /**
- * Decide what to remove for ONE listed (label-scoped) image — the safety-
- * critical selection, kept pure + unit-tested so "never ruin an operator's
- * image" is verifiable:
- *   - in the keep-set (active/pinned/rollback-window) → keep (`[]`).
- *   - has `openship/…` tags → return THOSE tags: we untag only what we own, so
- *     Docker deletes the image when our last tag is gone. Removing by these tags
- *     (not the image id) can never yank a foreign tag the operator added.
- *   - truly dangling (NO tags at all) → the image id: our superseded, untagged
- *     final layer, safe to drop.
- *   - only NON-openship tags remain → the operator re-purposed this image → keep.
- */
-export function selectImageRemovalRefs(
-  img: { id: string; repoTags: string[] },
-  keep: Set<string>,
-): string[] {
-  if (img.repoTags.some((t) => keep.has(t))) return [];
-  const ownTags = img.repoTags.filter((t) => t.startsWith("openship/"));
-  if (ownTags.length > 0) return ownTags;
-  if (img.repoTags.length === 0) return [img.id];
-  return []; // only foreign tags → never touch
-}
-
-/**
  * Reclaim one project's superseded built images on its own deploy host, keeping
  * the rollback-window keep-set. Called at REDEPLOY (onDeploymentReady, immediate)
  * and from the daily sweep (backstop). No-op for a project that never deployed
@@ -165,7 +311,10 @@ export function selectImageRemovalRefs(
  * job_run summary. Rollback/backup artifacts are untouched — the keep-set retains
  * every rollback-eligible image, and volumes/backups aren't images.
  */
-export async function reapProjectImages(project: Project): Promise<ReapResult> {
+export async function reapProjectImages(
+  project: Project,
+  opts: ImageGcOptions = {},
+): Promise<ReapResult> {
   const out: ReapResult = { removed: 0, bytes: 0, skippedInUse: 0 };
   if (!project.activeDeploymentId) return out; // no host to resolve
   const activeDep = await repos.deployment.findById(project.activeDeploymentId);
@@ -174,13 +323,13 @@ export async function reapProjectImages(project: Project): Promise<ReapResult> {
   const { runtime } = await resolveDeploymentRuntime(activeDep);
   try {
     if (!(runtime instanceof DockerRuntime)) return out; // cloud/bare — nothing local
-    const keep = await computeKeepSet(project);
+    const keep = await computeKeepSetDetail(project);
     const images = await runtime.listProjectImages(project.id);
     for (const img of images) {
-      const refs = selectImageRemovalRefs(img, keep);
-      if (refs.length === 0) continue; // kept, or operator-repurposed → leave it
+      const verdict = classifyImage(img, keep, { minAgeMs: opts.minAgeMs });
+      if (verdict.action === "keep") continue; // protected, or operator-repurposed → leave it
       try {
-        for (const ref of refs) await runtime.removeImage(ref);
+        for (const ref of verdict.refs) await runtime.removeImage(ref);
         out.removed += 1;
         out.bytes += img.size;
       } catch {
@@ -190,8 +339,10 @@ export async function reapProjectImages(project: Project): Promise<ReapResult> {
         out.skippedInUse += 1;
       }
     }
-    // Reclaim this project's untagged (superseded final) layers too.
-    await runtime.pruneProjectDanglingImages(project.id);
+    // Reclaim this project's untagged (superseded final) layers too. Docker's
+    // prune has no age filter, so an age-limited run leaves the backstop to the
+    // next unfiltered sweep rather than removing something younger than asked.
+    if (opts.minAgeMs === undefined) await runtime.pruneProjectDanglingImages(project.id);
 
     // Re-measure the AUTO rollback window while we're here: we already have this
     // project's image sizes, and host capacity is cached, so retention stays
@@ -239,7 +390,7 @@ export async function reapProjectImagesSafe(
  * Sweep every project's built images. Per-project failures (unreachable host,
  * daemon down) are counted and skipped — never fatal to the sweep.
  */
-export async function runImageGcSweep(): Promise<ImageGcSummary> {
+export async function runImageGcSweep(opts: ImageGcOptions = {}): Promise<ImageGcSummary> {
   const summary: ImageGcSummary = {
     projectsScanned: 0,
     imagesRemoved: 0,
@@ -251,7 +402,7 @@ export async function runImageGcSweep(): Promise<ImageGcSummary> {
   for (const project of projects) {
     summary.projectsScanned += 1;
     try {
-      const r = await reapProjectImages(project);
+      const r = await reapProjectImages(project, opts);
       summary.imagesRemoved += r.removed;
       summary.bytesReclaimed += r.bytes;
       summary.skippedInUse += r.skippedInUse;
@@ -261,4 +412,207 @@ export async function runImageGcSweep(): Promise<ImageGcSummary> {
     }
   }
   return summary;
+}
+
+// ─── Plan (read-only) ────────────────────────────────────────────────────────
+
+export interface ImagePlanEntry {
+  id: string;
+  repoTags: string[];
+  buildId: string | null;
+  deploymentId: string | null;
+  size: number;
+  /** Epoch ms, or null when the daemon didn't report it. */
+  createdAt: number | null;
+  action: "keep" | "remove";
+  reason: ImageKeepReason | ImageRemoveReason;
+  /** What a sweep would pass to `removeImage` — empty for a kept image. */
+  refs: string[];
+}
+
+export type ProjectPlanSkipReason = "no-active-deployment" | "not-docker";
+
+export interface ProjectImagePlan {
+  projectId: string;
+  slug: string;
+  serverId: string | null;
+  rollbackWindow: { window: number; source: RollbackWindowSource } | null;
+  images: ImagePlanEntry[];
+  reclaimableBytes: number;
+  /** Why the host wasn't inspected (nothing deployed / not a Docker runtime). */
+  skipped: ProjectPlanSkipReason | null;
+  /** The host WAS supposed to be inspected and it failed (unreachable, daemon down). */
+  error: string | null;
+}
+
+/**
+ * What `reapProjectImages` WOULD do for one project, with reasons — and strictly
+ * read-only: no prune, no capacity re-measure, nothing written. The extra
+ * container listing is what lets the plan name an in-use image up front instead
+ * of leaving it to the daemon's 409 at removal time.
+ */
+export async function planProjectImages(
+  project: Project,
+  opts: ImageGcOptions & { now?: number } = {},
+): Promise<ProjectImagePlan> {
+  const plan: ProjectImagePlan = {
+    projectId: project.id,
+    slug: project.slug,
+    serverId: null,
+    rollbackWindow: null,
+    images: [],
+    reclaimableBytes: 0,
+    skipped: null,
+    error: null,
+  };
+  if (!project.activeDeploymentId) return { ...plan, skipped: "no-active-deployment" };
+  const activeDep = await repos.deployment.findById(project.activeDeploymentId);
+  if (!activeDep) return { ...plan, skipped: "no-active-deployment" };
+  plan.serverId = (activeDep.meta as { serverId?: string } | null)?.serverId ?? null;
+  const window = await resolveRollbackWindowDetail(project);
+  plan.rollbackWindow = { window: window.window, source: window.source };
+
+  const { runtime } = await resolveDeploymentRuntime(activeDep);
+  try {
+    if (!(runtime instanceof DockerRuntime)) return { ...plan, skipped: "not-docker" };
+    const keep = await computeKeepSetDetail(project);
+    const [images, containers] = await Promise.all([
+      runtime.listProjectImages(project.id),
+      runtime.listAllContainers(),
+    ]);
+    const usedImageIds = new Set(containers.map((c) => c.imageId));
+    for (const img of images) {
+      const verdict = classifyImage(img, keep, {
+        usedImageIds,
+        minAgeMs: opts.minAgeMs,
+        now: opts.now,
+      });
+      plan.images.push({
+        id: img.id,
+        repoTags: img.repoTags,
+        buildId: img.buildId ?? null,
+        deploymentId: img.deploymentId ?? null,
+        size: img.size,
+        createdAt: img.createdAt,
+        action: verdict.action,
+        reason: verdict.reason,
+        refs: verdict.refs,
+      });
+      if (verdict.action === "remove") plan.reclaimableBytes += img.size;
+    }
+  } finally {
+    await runtime.dispose?.();
+  }
+  return plan;
+}
+
+export interface ImageGcJobStatus {
+  enabled: boolean;
+  cron: string | null;
+  lastRun: {
+    id: string;
+    status: string;
+    trigger: string;
+    startedAt: Date;
+    finishedAt: Date | null;
+    durationMs: number | null;
+    summary: Record<string, unknown> | null;
+    error: string | null;
+  } | null;
+}
+
+/** The `images:gc` schedule row + its most recent run, as the Jobs page has them. */
+export async function getImageGcJobStatus(): Promise<ImageGcJobStatus | null> {
+  const row = await repos.job.findByKey(IMAGE_GC_JOB_KEY);
+  if (!row) return null;
+  const [last] = await repos.jobRun.listRecent({ jobId: IMAGE_GC_JOB_KEY, limit: 1 });
+  return {
+    enabled: row.enabled,
+    cron: row.cronExpression,
+    lastRun: last
+      ? {
+          id: last.id,
+          status: last.status,
+          trigger: last.trigger,
+          startedAt: last.startedAt,
+          finishedAt: last.finishedAt,
+          durationMs: last.durationMs,
+          summary: (last.summary as Record<string, unknown> | null) ?? null,
+          error: last.error,
+        }
+      : null,
+  };
+}
+
+export interface ImageGcPlan {
+  generatedAt: string;
+  minAgeMs: number | null;
+  job: ImageGcJobStatus | null;
+  projects: ProjectImagePlan[];
+  totals: {
+    projects: number;
+    /** Projects whose host was actually inspected. */
+    scanned: number;
+    images: number;
+    candidates: number;
+    reclaimableBytes: number;
+    kept: Partial<Record<ImageKeepReason, number>>;
+    errors: number;
+  };
+}
+
+/**
+ * The dry run: every project, the same way `runImageGcSweep` walks them, but
+ * only ever reading. Per-project failures are reported on the project and
+ * counted, never fatal — the point is to show the operator the whole picture.
+ */
+export async function planImageGc(opts: ImageGcOptions = {}): Promise<ImageGcPlan> {
+  const now = Date.now();
+  const projects = await repos.project.listAllForScan();
+  const plans: ProjectImagePlan[] = [];
+  const totals: ImageGcPlan["totals"] = {
+    projects: projects.length,
+    scanned: 0,
+    images: 0,
+    candidates: 0,
+    reclaimableBytes: 0,
+    kept: {},
+    errors: 0,
+  };
+  for (const project of projects) {
+    try {
+      const plan = await planProjectImages(project, { minAgeMs: opts.minAgeMs, now });
+      plans.push(plan);
+      if (!plan.skipped) totals.scanned += 1;
+      for (const img of plan.images) {
+        totals.images += 1;
+        if (img.action === "remove") {
+          totals.candidates += 1;
+          totals.reclaimableBytes += img.size;
+        } else {
+          const reason = img.reason as ImageKeepReason;
+          totals.kept[reason] = (totals.kept[reason] ?? 0) + 1;
+        }
+      }
+    } catch (err) {
+      totals.errors += 1;
+      plans.push({
+        projectId: project.id,
+        slug: project.slug,
+        serverId: null,
+        rollbackWindow: null,
+        images: [],
+        reclaimableBytes: 0,
+        skipped: null,
+        error: safeErrorMessage(err),
+      });
+    }
+  }
+  return {
+    generatedAt: new Date(now).toISOString(),
+    minAgeMs: opts.minAgeMs ?? null,
+    job: await getImageGcJobStatus(),
+    projects: plans,
+    totals,
+  };
 }

--- a/apps/api/src/modules/jobs/job.registry.ts
+++ b/apps/api/src/modules/jobs/job.registry.ts
@@ -22,7 +22,7 @@ import { runRetentionSweep } from "../backups/retention-prune";
 import { runBackupStaleSweep } from "../backups/backup-stale-sweep";
 import { pruneAuditEvents } from "../audit/audit-prune";
 import { runReconcileSweep } from "../deployments/reconcile-schedule";
-import { runImageGcSweep } from "../deployments/image-gc";
+import { imageGcJobSummary, runImageGcSweep } from "../deployments/image-gc";
 import { verifyPendingDomains } from "../domains/domain.service";
 import { runEdgeVerifySweep } from "../domains/edge-verify-schedule";
 import { scanInstanceUpdates } from "../updates/updates.service";
@@ -89,16 +89,7 @@ export const SYSTEM_JOB_DEFS: SystemJobDef[] = [
     // not local Docker, so there's nothing to sweep there.
     defaultCron: "23 4 * * *",
     available: () => platform().target !== "cloud",
-    run: async () => {
-      const r = await runImageGcSweep();
-      return {
-        scanned: r.projectsScanned,
-        removed: r.imagesRemoved,
-        bytesReclaimed: r.bytesReclaimed,
-        skipped: r.skippedInUse,
-        failed: r.errors,
-      };
-    },
+    run: async () => imageGcJobSummary(await runImageGcSweep()),
   },
   {
     key: "permissions:pending-grant-prune",

--- a/apps/api/src/modules/system/image-gc.controller.ts
+++ b/apps/api/src/modules/system/image-gc.controller.ts
@@ -1,0 +1,57 @@
+/**
+ * Built-image GC controller — /api/system/image-gc.
+ *
+ * The operator-facing side of the `images:gc` system job (see
+ * modules/deployments/image-gc.ts). `plan` is a strictly read-only dry run: every
+ * project's built images on its deploy host with the decision the sweep WOULD
+ * take and why (active, pinned, rollback window, in use, operator-retagged,
+ * superseded), the rollback window that decided it, and the bytes a run would
+ * reclaim — so "why is this image still here" and "what is safe to remove" are
+ * answerable without reaching for `docker system prune` (#779). `run` is the
+ * same sweep the schedule fires, recorded as a manual `images:gc` job run so it
+ * shows in job history next to the scheduled ticks.
+ *
+ * Both accept `olderThan` (`30d`, `12h`, …): only remove superseded images at
+ * least that old. Age never overrides the keep-set — it can only narrow a run.
+ *
+ * Instance-admin only: the sweep spans every organisation's projects and hosts,
+ * and the plan reveals them.
+ */
+
+import type { Context } from "hono";
+import { Type } from "@sinclair/typebox";
+import { assertNotCloud } from "../../lib/controller-helpers";
+import { recordJobRun } from "../../lib/system-jobs";
+import {
+  IMAGE_GC_JOB_KEY,
+  imageGcJobSummary,
+  parseMinAge,
+  planImageGc,
+  runImageGcSweep,
+} from "../deployments/image-gc";
+
+export const ImageGcRunBody = Type.Object({
+  /** e.g. "30d", "12h" — see parseMinAge. */
+  olderThan: Type.Optional(Type.String({ minLength: 1, maxLength: 16 })),
+});
+
+/** GET /system/image-gc/plan?olderThan=30d — dry run, changes nothing. */
+export async function plan(c: Context) {
+  const cloudGuard = assertNotCloud(c);
+  if (cloudGuard) return cloudGuard;
+  const olderThan = c.req.query("olderThan");
+  const minAgeMs = olderThan ? parseMinAge(olderThan) : undefined;
+  return c.json({ data: await planImageGc({ minAgeMs }) });
+}
+
+/** POST /system/image-gc/run — the sweep, recorded as a manual job run. */
+export async function run(c: Context) {
+  const cloudGuard = assertNotCloud(c);
+  if (cloudGuard) return cloudGuard;
+  const body = await c.req.json<{ olderThan?: string }>();
+  const minAgeMs = body.olderThan ? parseMinAge(body.olderThan) : undefined;
+  const summary = await recordJobRun(IMAGE_GC_JOB_KEY, { trigger: "manual" }, async () =>
+    imageGcJobSummary(await runImageGcSweep({ minAgeMs })),
+  );
+  return c.json({ data: { key: IMAGE_GC_JOB_KEY, minAgeMs: minAgeMs ?? null, summary } });
+}

--- a/apps/api/src/modules/system/system.routes.ts
+++ b/apps/api/src/modules/system/system.routes.ts
@@ -33,6 +33,7 @@ import * as migration from "./migration/migration.controller";
 import * as dataTransfer from "./data-transfer/data-transfer.controller";
 import * as systemHealth from "./system-health.controller";
 import * as edgeOrphans from "./edge-orphans.controller";
+import * as imageGc from "./image-gc.controller";
 
 const r = secureRouter(new Hono(), {
   module: "system",
@@ -94,6 +95,19 @@ r.post(
   { tag: "settings:admin" },
   requireInstanceAdmin(),
   edgeOrphans.removeUntrackedEdgeSite,
+);
+
+/* ── Built-image GC (the `images:gc` job, operator-facing) ──────────
+ * `plan` is a read-only dry run naming what a sweep would remove and why the
+ * rest stays; `run` is the sweep itself, recorded as a manual job run. Both
+ * walk EVERY org's projects and hosts, so — like /edge/untracked above — the
+ * org-singleton `job:*` tag alone is not a boundary; instance admin is. */
+r.get("/image-gc/plan", { tag: "job:read" }, requireInstanceAdmin(), imageGc.plan);
+r.post(
+  "/image-gc/run",
+  { tag: "job:write", body: imageGc.ImageGcRunBody },
+  requireInstanceAdmin(),
+  imageGc.run,
 );
 
 /* ── Authenticated routes (dashboard settings page) ─────────────── */

--- a/apps/cli/src/commands/system.ts
+++ b/apps/cli/src/commands/system.ts
@@ -9,11 +9,18 @@
 import { Command } from "commander";
 import ora, { type Ora } from "ora";
 import { readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { apiRequest, ApiError } from "../lib/api-client";
 import { fetchCaps, requireSelfHost } from "../lib/caps";
 import { printJson, printTable, isJsonMode, ok, info, err } from "../lib/output";
+import {
+  DOCKER_IMAGES_FORMAT,
+  parseContainerImageRefs,
+  parseDockerImages,
+  planRuntimeImagePrune,
+} from "../lib/runtime-images";
 
 /** Domain target for the "own server" migration path (preflight + start). */
 type DomainChoice =
@@ -527,12 +534,324 @@ dataTransferCommand
     });
   });
 
+/* ── image-gc ────────────────────────────────────────────────────────
+ * GET  /api/system/image-gc/plan → imageGc.plan (read-only dry run)
+ * POST /api/system/image-gc/run  → imageGc.run  (the sweep, recorded as a
+ *                                  manual `images:gc` job run)
+ * The operator-facing side of the built-image garbage collector (#779): what is
+ * on each deploy host, what a sweep would remove, and WHY the rest stays.
+ */
+interface ImageGcPlanImage {
+  repoTags: string[];
+  size: number;
+  createdAt: number | null;
+  action: "keep" | "remove";
+  reason: string;
+}
+
+interface ImageGcPlanProject {
+  slug: string;
+  serverId: string | null;
+  rollbackWindow: { window: number; source: string } | null;
+  images: ImageGcPlanImage[];
+  reclaimableBytes: number;
+  skipped: string | null;
+  error: string | null;
+}
+
+interface ImageGcPlan {
+  generatedAt: string;
+  minAgeMs: number | null;
+  job: {
+    enabled: boolean;
+    cron: string | null;
+    lastRun: {
+      status: string;
+      trigger: string;
+      startedAt: string;
+      summary: Record<string, unknown> | null;
+      error: string | null;
+    } | null;
+  } | null;
+  projects: ImageGcPlanProject[];
+  totals: {
+    projects: number;
+    scanned: number;
+    images: number;
+    candidates: number;
+    reclaimableBytes: number;
+    kept: Record<string, number>;
+    errors: number;
+  };
+}
+
+interface ImageGcRunResult {
+  key: string;
+  minAgeMs: number | null;
+  summary: {
+    scanned: number;
+    removed: number;
+    bytesReclaimed: number;
+    skipped: number;
+    failed: number;
+  };
+}
+
+function fmtBytes(n: number): string {
+  if (n >= 1e9) return `${(n / 1e9).toFixed(2)} GB`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(0)} MB`;
+  return `${(n / 1e3).toFixed(0)} kB`;
+}
+
+function fmtAge(createdAt: number | null, now: number): string {
+  if (createdAt === null) return "?";
+  const days = Math.floor((now - createdAt) / 86_400_000);
+  if (days >= 1) return `${days}d`;
+  return `${Math.max(0, Math.floor((now - createdAt) / 3_600_000))}h`;
+}
+
+function describeLastRun(run: NonNullable<ImageGcPlan["job"]>["lastRun"]): string {
+  if (!run) return "never";
+  const when = new Date(run.startedAt).toISOString().replace("T", " ").slice(0, 16);
+  const s = run.summary ?? {};
+  const detail =
+    run.status === "failed"
+      ? (run.error ?? "failed")
+      : `removed ${s.removed ?? 0}, ${fmtBytes(Number(s.bytesReclaimed ?? 0))} reclaimed, ` +
+        `${s.skipped ?? 0} in use, ${s.failed ?? 0} host error(s)`;
+  return `${when} · ${run.status} (${run.trigger}) · ${detail}`;
+}
+
+function renderImageGcPlan(plan: ImageGcPlan): void {
+  const now = Date.parse(plan.generatedAt);
+  const job = plan.job;
+  printTable(
+    [
+      { setting: "job", value: "images:gc" },
+      { setting: "enabled", value: job ? (job.enabled ? "yes" : "no") : "not seeded" },
+      { setting: "schedule", value: job?.cron ?? "" },
+      { setting: "last run", value: describeLastRun(job?.lastRun ?? null) },
+      {
+        setting: "age filter",
+        value:
+          plan.minAgeMs === null
+            ? "none"
+            : `only images older than ${fmtAge(now - plan.minAgeMs, now)}`,
+      },
+    ],
+    ["setting", "value"],
+  );
+  process.stdout.write("\n");
+
+  const rows: Record<string, unknown>[] = [];
+  for (const p of plan.projects) {
+    const rollback = p.rollbackWindow
+      ? `${p.rollbackWindow.window} (${p.rollbackWindow.source})`
+      : "";
+    if (p.skipped || p.error) {
+      rows.push({
+        project: p.slug,
+        image: p.error ? `error: ${p.error}` : `skipped: ${p.skipped}`,
+        size: "",
+        age: "",
+        rollback,
+        decision: "",
+        reason: "",
+      });
+      continue;
+    }
+    for (const img of p.images) {
+      rows.push({
+        project: p.slug,
+        image: img.repoTags[0] ?? "<untagged>",
+        size: fmtBytes(img.size),
+        age: fmtAge(img.createdAt, now),
+        rollback,
+        decision: img.action,
+        reason: img.reason,
+      });
+    }
+  }
+  printTable(rows, ["project", "image", "size", "age", "rollback", "decision", "reason"]);
+
+  const t = plan.totals;
+  const kept = Object.entries(t.kept)
+    .map(([reason, n]) => `${reason} ${n}`)
+    .join(", ");
+  info(
+    `\n  ${t.images} image(s) across ${t.scanned}/${t.projects} inspected project(s) · ` +
+      `${t.candidates} removable (~${fmtBytes(t.reclaimableBytes)})` +
+      (kept ? ` · kept: ${kept}` : "") +
+      (t.errors ? ` · ${t.errors} host error(s)` : ""),
+  );
+  info(
+    "  Sizes are Docker's per-image figures; shared layers mean the space actually freed can be lower.\n",
+  );
+}
+
+const imageGcCommand = new Command("image-gc")
+  .description("Inspect or run the built-image garbage collector (the images:gc job)")
+  .option(
+    "--dry-run",
+    "Show what a sweep would remove and why the rest stays, without touching Docker",
+  )
+  .option(
+    "--older-than <age>",
+    "Only remove superseded images at least this old (e.g. 30d, 12h, 2w)",
+  )
+  .option("-y, --yes", "Skip the confirmation prompt")
+  .action(async (opts: { dryRun?: boolean; olderThan?: string; yes?: boolean }) => {
+    await guarded(async () => {
+      const qs = opts.olderThan ? `?olderThan=${encodeURIComponent(opts.olderThan)}` : "";
+      const spin = spinner("Inspecting built images on every deploy host…");
+      let plan: ImageGcPlan;
+      try {
+        plan = await apiRequest<ImageGcPlan>(`/system/image-gc/plan${qs}`);
+        spin?.stop();
+      } catch (e) {
+        spin?.fail("Inspection failed.");
+        throw e;
+      }
+
+      if (opts.dryRun) {
+        report(plan, () => renderImageGcPlan(plan));
+        return;
+      }
+
+      if (!isJsonMode()) renderImageGcPlan(plan);
+      if (plan.totals.candidates === 0) {
+        report({ plan, run: null }, () => ok("  Nothing to remove.\n"));
+        return;
+      }
+      const question =
+        `Remove ${plan.totals.candidates} image(s), ~${fmtBytes(plan.totals.reclaimableBytes)}?` +
+        (opts.olderThan ? ` (only those older than ${opts.olderThan})` : "");
+      if (!(await confirm(question, opts.yes === true))) {
+        err("\n  Aborted. Re-run with --yes to skip the prompt, or --dry-run to only inspect.\n");
+        process.exit(1);
+      }
+
+      const sweep = spinner("Removing superseded images…");
+      try {
+        const run = await apiRequest<ImageGcRunResult>("/system/image-gc/run", {
+          method: "POST",
+          body: JSON.stringify(opts.olderThan ? { olderThan: opts.olderThan } : {}),
+        });
+        sweep?.succeed("Sweep finished (recorded as a manual images:gc run).");
+        report({ plan, run }, () => {
+          const s = run.summary;
+          ok(
+            `\n  Removed ${s.removed} image(s), ${fmtBytes(s.bytesReclaimed)} reclaimed · ` +
+              `${s.skipped} kept (in use) · ${s.failed} host error(s) · ${s.scanned} project(s) scanned.\n`,
+          );
+        });
+      } catch (e) {
+        sweep?.fail("Sweep failed.");
+        throw e;
+      }
+    });
+  });
+
+/* ── runtime-images ──────────────────────────────────────────────────
+ * Host-local, no API: the previous openship-api / -dashboard / -edge images
+ * `openship update` leaves on THIS machine (#779). The built-image GC above is
+ * label-scoped to project builds and can never touch these, so they are listed
+ * and — only on --prune — untagged here, keeping the version a container
+ * references plus --keep previous ones for a quick downgrade.
+ */
+const runtimeImagesCommand = new Command("runtime-images")
+  .description("List previous Openship control-plane images left on this host by updates")
+  .option("--prune", "Remove versions beyond the referenced one and --keep previous")
+  .option("--keep <n>", "Previous versions to keep for a quick downgrade", "1")
+  .option("-y, --yes", "Skip the confirmation prompt")
+  .action(async (opts: { prune?: boolean; keep: string; yes?: boolean }) => {
+    const keepPrevious = Number.parseInt(opts.keep, 10);
+    if (!Number.isInteger(keepPrevious) || keepPrevious < 0) {
+      err("\n  --keep must be a whole number of previous versions (0 or more).\n");
+      process.exit(1);
+    }
+    const docker = (args: string[]) => spawnSync("docker", args, { encoding: "utf8" });
+    const images = docker(["images", "--format", DOCKER_IMAGES_FORMAT]);
+    if (images.status !== 0) {
+      err(
+        `\n  Could not list Docker images: ${(images.stderr || images.error?.message || "").trim()}\n`,
+      );
+      process.exit(1);
+    }
+    // Stopped containers count too: a `docker start` of an old container must
+    // never find its image gone.
+    const ps = docker(["ps", "-a", "--format", "{{.Image}}"]);
+    if (ps.status !== 0) {
+      err(`\n  Could not list Docker containers: ${(ps.stderr || "").trim()}\n`);
+      process.exit(1);
+    }
+    const plan = planRuntimeImagePrune(parseDockerImages(images.stdout), {
+      inUse: parseContainerImageRefs(ps.stdout),
+      keepPrevious,
+    });
+    const doomed = plan.filter((v) => v.action === "remove");
+
+    if (!opts.prune) {
+      report(plan, () => {
+        printTable(
+          plan.map((v) => ({
+            image: v.ref,
+            size: v.size,
+            created: v.createdAt,
+            decision: v.action,
+            reason: v.reason,
+          })),
+          ["image", "size", "created", "decision", "reason"],
+        );
+        if (doomed.length > 0) {
+          info(
+            `\n  ${doomed.length} image(s) would be removed by --prune (keeping ${keepPrevious} previous version(s)).\n`,
+          );
+        } else if (plan.length > 0) {
+          info("\n  Nothing beyond the referenced version and the kept previous ones.\n");
+        }
+      });
+      return;
+    }
+
+    if (doomed.length === 0) {
+      report({ plan, removed: [], failed: [] }, () => ok("\n  Nothing to remove.\n"));
+      return;
+    }
+    if (!isJsonMode()) {
+      printTable(
+        doomed.map((v) => ({ image: v.ref, size: v.size, created: v.createdAt })),
+        ["image", "size", "created"],
+      );
+    }
+    if (!(await confirm(`Remove these ${doomed.length} image(s)?`, opts.yes === true))) {
+      err("\n  Aborted. Re-run with --yes to skip the prompt.\n");
+      process.exit(1);
+    }
+    const removed: string[] = [];
+    const failed: { ref: string; error: string }[] = [];
+    for (const v of doomed) {
+      // No --force: if the daemon disagrees about a reference, it wins.
+      const rm = docker(["rmi", v.ref]);
+      if (rm.status === 0) removed.push(v.ref);
+      else failed.push({ ref: v.ref, error: (rm.stderr || "").trim() });
+    }
+    report({ plan, removed, failed }, () => {
+      ok(`\n  Removed ${removed.length} image(s).`);
+      for (const f of failed) err(`  ✗ ${f.ref}: ${f.error}`);
+      process.stderr.write("\n");
+    });
+    if (failed.length > 0) process.exit(1);
+  });
+
 /* ── parent ──────────────────────────────────────────────────────────── */
 export const systemCommand = new Command("system")
-  .description("Instance settings, onboarding, migration, and data transfer")
+  .description("Instance settings, onboarding, migration, data transfer, and image maintenance")
   .addCommand(settingsCommand)
   .addCommand(onboardingCommand)
   .addCommand(upgradeToAuthCommand)
   .addCommand(browseCommand)
   .addCommand(migrationCommand)
-  .addCommand(dataTransferCommand);
+  .addCommand(dataTransferCommand)
+  .addCommand(imageGcCommand)
+  .addCommand(runtimeImagesCommand);

--- a/apps/cli/src/lib/runtime-images.ts
+++ b/apps/cli/src/lib/runtime-images.ts
@@ -1,0 +1,130 @@
+/**
+ * Openship's own control-plane images on THIS host — `openship-api`,
+ * `openship-dashboard`, `openship-edge` under whatever registry the compose stack
+ * pins (`OPENSHIP_IMAGE_REGISTRY`, default ghcr.io/oblien).
+ *
+ * `openship update` pulls the new tag and recreates the stack but never removes
+ * the previous one, so every upgrade leaves a full api + dashboard + edge behind
+ * (#779). These carry no `openship.project` label, so the API-side built-image
+ * GC — deliberately label-scoped — can never touch them either. This is the
+ * host-local sibling: list them, keep the version a container references plus
+ * `keepPrevious` more for a quick downgrade, and mark the rest. Removal is the
+ * command's job and only ever on an explicit `--prune`; nothing referenced by a
+ * container, running OR stopped, is ever a candidate.
+ *
+ * Pure decision logic here so it is unit-testable; the docker calls live in
+ * commands/system.ts.
+ */
+
+export const RUNTIME_IMAGE_NAMES = ["openship-api", "openship-dashboard", "openship-edge"] as const;
+
+export interface HostImage {
+  repository: string;
+  tag: string;
+  id: string;
+  size: string;
+  createdAt: string;
+}
+
+export type RuntimeImageReason = "in-use" | "previous" | "not-a-version" | "superseded";
+
+export interface RuntimeImageVerdict extends HostImage {
+  ref: string;
+  action: "keep" | "remove";
+  reason: RuntimeImageReason;
+}
+
+/** The `--format` this module's parser expects from `docker images`. */
+export const DOCKER_IMAGES_FORMAT = "{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}\t{{.CreatedAt}}";
+
+export function parseDockerImages(stdout: string): HostImage[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [repository = "", tag = "", id = "", size = "", createdAt = ""] = line.split("\t");
+      return { repository, tag, id, size, createdAt };
+    });
+}
+
+/** `ghcr.io/oblien/openship-api`, `registry.local:5000/mirror/openship-edge`, … */
+export function isRuntimeImage(repository: string): boolean {
+  const name = repository.slice(repository.lastIndexOf("/") + 1);
+  return (RUNTIME_IMAGE_NAMES as readonly string[]).includes(name);
+}
+
+/**
+ * Image refs containers reference, from `docker ps -a --format '{{.Image}}'`.
+ * Docker prints the ref the container was created with: `repo:tag`, a bare
+ * `repo` (meaning `:latest`), or an id. Both spellings of an untagged ref are
+ * kept so a lookup by `repo:latest` matches either way.
+ */
+export function parseContainerImageRefs(stdout: string): Set<string> {
+  const refs = new Set<string>();
+  for (const raw of stdout.split("\n")) {
+    const ref = raw.trim();
+    if (!ref) continue;
+    refs.add(ref);
+    const slash = ref.lastIndexOf("/");
+    if (!ref.slice(slash + 1).includes(":") && !ref.startsWith("sha256:"))
+      refs.add(`${ref}:latest`);
+  }
+  return refs;
+}
+
+const VERSION_TAG = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+/** Numeric dotted compare; a pre-release sorts below its release. 0 when either
+ *  side isn't a version tag. */
+export function compareVersionTags(a: string, b: string): number {
+  const pa = VERSION_TAG.exec(a);
+  const pb = VERSION_TAG.exec(b);
+  if (!pa || !pb) return 0;
+  for (let i = 1; i <= 3; i += 1) {
+    const d = Number(pa[i]) - Number(pb[i]);
+    if (d !== 0) return d;
+  }
+  const preA = a.includes("-");
+  const preB = b.includes("-");
+  if (preA !== preB) return preA ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Per repository, newest first: anything a container references is kept
+ * (`in-use`), the next `keepPrevious` versions are kept (`previous`), the rest
+ * are `superseded`. A tag that isn't a version (`latest`, a branch name) is
+ * never a candidate — we can't order it, so we can't call it old.
+ */
+export function planRuntimeImagePrune(
+  images: HostImage[],
+  opts: { inUse: ReadonlySet<string>; keepPrevious: number },
+): RuntimeImageVerdict[] {
+  const byRepo = new Map<string, HostImage[]>();
+  for (const img of images) {
+    if (!isRuntimeImage(img.repository) || img.tag === "<none>") continue;
+    const group = byRepo.get(img.repository) ?? [];
+    group.push(img);
+    byRepo.set(img.repository, group);
+  }
+
+  const out: RuntimeImageVerdict[] = [];
+  for (const repository of [...byRepo.keys()].sort()) {
+    const group = byRepo.get(repository)!;
+    const sorted = [...group].sort((x, y) => compareVersionTags(y.tag, x.tag));
+    let spare = Math.max(0, opts.keepPrevious);
+    for (const img of sorted) {
+      const ref = `${img.repository}:${img.tag}`;
+      const verdict = (action: "keep" | "remove", reason: RuntimeImageReason) =>
+        out.push({ ...img, ref, action, reason });
+      if (opts.inUse.has(ref) || opts.inUse.has(img.id)) verdict("keep", "in-use");
+      else if (!VERSION_TAG.test(img.tag)) verdict("keep", "not-a-version");
+      else if (spare > 0) {
+        spare -= 1;
+        verdict("keep", "previous");
+      } else verdict("remove", "superseded");
+    }
+  }
+  return out;
+}

--- a/apps/cli/test/unit/runtime-images.test.ts
+++ b/apps/cli/test/unit/runtime-images.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * `openship system runtime-images` decides which previous openship-api /
+ * -dashboard / -edge images an update left behind may go. These pin the
+ * safety rules: a referenced image is never a candidate, the kept-previous quota
+ * is per repository, and a tag we can't order is never called old.
+ */
+
+import {
+  compareVersionTags,
+  parseContainerImageRefs,
+  parseDockerImages,
+  planRuntimeImagePrune,
+} from "../../src/lib/runtime-images";
+
+const rows = (...lines: string[]) => parseDockerImages(lines.join("\n") + "\n");
+
+describe("planRuntimeImagePrune", () => {
+  it("keeps the referenced version + N previous per repository, marks older versions superseded, ignores foreign images", () => {
+    const images = rows(
+      "ghcr.io/oblien/openship-api\t0.6.1\ta1\t500MB\t2026-06-01",
+      "ghcr.io/oblien/openship-api\t0.6.9\ta9\t500MB\t2026-08-30",
+      "ghcr.io/oblien/openship-api\t0.6.5\ta5\t500MB\t2026-07-15",
+      "ghcr.io/oblien/openship-api\t0.6.7\ta7\t500MB\t2026-08-01",
+      "ghcr.io/oblien/openship-edge\t0.6.9\te9\t80MB\t2026-08-30",
+      "ghcr.io/oblien/openship-edge\t0.6.7\te7\t80MB\t2026-08-01",
+      "postgres\t16-alpine\tp1\t240MB\t2026-01-01",
+      "openship/rentabo-test\tbld_x\tb1\t900MB\t2026-08-20",
+    );
+    const inUse = parseContainerImageRefs(
+      "ghcr.io/oblien/openship-api:0.6.9\nghcr.io/oblien/openship-edge:0.6.9\npostgres:16-alpine\n",
+    );
+    const plan = planRuntimeImagePrune(images, { inUse, keepPrevious: 1 });
+    expect(plan.map((v) => [v.ref, v.action, v.reason])).toEqual([
+      ["ghcr.io/oblien/openship-api:0.6.9", "keep", "in-use"],
+      ["ghcr.io/oblien/openship-api:0.6.7", "keep", "previous"],
+      ["ghcr.io/oblien/openship-api:0.6.5", "remove", "superseded"],
+      ["ghcr.io/oblien/openship-api:0.6.1", "remove", "superseded"],
+      ["ghcr.io/oblien/openship-edge:0.6.9", "keep", "in-use"],
+      ["ghcr.io/oblien/openship-edge:0.6.7", "keep", "previous"],
+    ]);
+  });
+
+  it("never marks a referenced image even when it is the oldest, and never orders a non-version tag", () => {
+    const images = rows(
+      "ghcr.io/oblien/openship-api\t0.6.9\ta9\t500MB\t2026-08-30",
+      "ghcr.io/oblien/openship-api\t0.6.1\ta1\t500MB\t2026-06-01",
+      "ghcr.io/oblien/openship-api\tlatest\ta9\t500MB\t2026-08-30",
+      "ghcr.io/oblien/openship-api\tmain\tam\t500MB\t2026-08-30",
+    );
+    // A stopped container still pinned to 0.6.1; `docker ps` prints the bare repo for :latest.
+    const inUse = parseContainerImageRefs(
+      "ghcr.io/oblien/openship-api:0.6.1\nghcr.io/oblien/openship-api\n",
+    );
+    const plan = planRuntimeImagePrune(images, { inUse, keepPrevious: 0 });
+    expect(plan.map((v) => [v.tag, v.action, v.reason])).toEqual([
+      ["0.6.9", "remove", "superseded"],
+      ["0.6.1", "keep", "in-use"],
+      ["latest", "keep", "in-use"],
+      ["main", "keep", "not-a-version"],
+    ]);
+  });
+});
+
+describe("compareVersionTags", () => {
+  it("orders numerically, not lexically, and puts a pre-release below its release", () => {
+    expect(compareVersionTags("0.6.10", "0.6.9")).toBeGreaterThan(0);
+    expect(compareVersionTags("v0.7.0", "0.6.10")).toBeGreaterThan(0);
+    expect(compareVersionTags("0.7.0-rc.1", "0.7.0")).toBeLessThan(0);
+    expect(compareVersionTags("latest", "0.6.9")).toBe(0);
+  });
+});

--- a/apps/web/content/docs/api/system.mdx
+++ b/apps/web/content/docs/api/system.mdx
@@ -62,6 +62,8 @@ user or session exists), and the two `/setup` routes are public to the user sess
 | `GET /api/system/install/session` | `server:read` | Get the active (or a specific) install session's state. |
 | `GET /api/system/monitor/stream` | `server:read` | Stream live CPU / memory / disk stats over SSE. |
 | `GET /api/system/browse` | `settings:read` | List child directories of a path (folder picker). |
+| `GET /api/system/image-gc/plan` | `job:read` · instance admin | Dry run of the built-image GC: every project's images with the decision a sweep would take and why. |
+| `POST /api/system/image-gc/run` | `job:write` · instance admin | Run the built-image GC now, recorded as a manual `images:gc` job run. |
 | `POST /api/system/migration/preflight` | `settings:admin` | Team-migration readiness check (read-only). |
 | `POST /api/system/migration/start` | `settings:admin` | Migrate single-user → your own remote server. |
 | `POST /api/system/migration/start-cloud` | `settings:admin` | Migrate → Openship Cloud. |
@@ -325,6 +327,55 @@ openship system browse /srv/apps
 
 Returns `{ path, directories: [{ name, path, isProject }] }` — projects first, then alphabetical. Non-directory
 paths return **400**, missing paths **404**.
+
+## Built-image garbage collection
+
+The `images:gc` system job prunes each project's superseded build images on its deploy host,
+keeping the active deployment, pinned deployments and the newest `rollbackWindow` releases. These
+two endpoints make it inspectable and runnable by hand. Both are instance-admin only: they walk
+every organization's projects and hosts.
+
+`GET /api/system/image-gc/plan` changes nothing. It returns the job's schedule row and last run,
+then one entry per project with the images found on its host:
+
+```json
+{
+  "data": {
+    "generatedAt": "2026-09-02T04:23:00.000Z",
+    "minAgeMs": null,
+    "job": { "enabled": true, "cron": "23 4 * * *", "lastRun": { "status": "success", "trigger": "schedule", "summary": { "removed": 3, "bytesReclaimed": 1200000000 } } },
+    "projects": [
+      {
+        "slug": "rentabo-test",
+        "serverId": "srv_123",
+        "rollbackWindow": { "window": 3, "source": "auto" },
+        "images": [
+          { "repoTags": ["openship/rentabo-test:bld_n15VK9Lb5rpBcFVp"], "size": 812000000, "createdAt": 1756700000000, "action": "keep", "reason": "active", "refs": [] },
+          { "repoTags": ["openship/rentabo-test:bld_BckMwPbMeXtUeuzO"], "size": 810000000, "createdAt": 1756500000000, "action": "keep", "reason": "rollback-window", "refs": [] },
+          { "repoTags": ["openship/rentabo-test:bld_-IcPtKRJN3OA0pZN"], "size": 805000000, "createdAt": 1750000000000, "action": "remove", "reason": "superseded", "refs": ["openship/rentabo-test:bld_-IcPtKRJN3OA0pZN"] }
+        ],
+        "reclaimableBytes": 805000000,
+        "skipped": null,
+        "error": null
+      }
+    ],
+    "totals": { "projects": 1, "scanned": 1, "images": 3, "candidates": 1, "reclaimableBytes": 805000000, "kept": { "active": 1, "rollback-window": 1 }, "errors": 0 }
+  }
+}
+```
+
+Keep reasons are `active`, `pinned`, `rollback-window`, `in-use` (a container on the host still
+references it), `foreign-tag` (only operator-added tags remain) and `min-age` (younger than the
+requested age, or age unknown). Removal reasons are `superseded` (our own tags) and `dangling`
+(an untagged leftover). `skipped` is `no-active-deployment` or `not-docker` when there is no host
+to inspect; `error` carries a host that should have been inspected but couldn't be.
+
+`?olderThan=30d` (also `12h`, `2w`, `90m`) restricts removal candidates to images at least that
+old. Age never overrides a keep reason.
+
+`POST /api/system/image-gc/run` with an optional `{ "olderThan": "30d" }` body runs the sweep and
+returns `{ key, minAgeMs, summary: { scanned, removed, bytesReclaimed, skipped, failed } }` — the
+same summary the scheduled tick records.
 
 ## Team-mode migration
 

--- a/apps/web/content/docs/cli/self-host.mdx
+++ b/apps/web/content/docs/cli/self-host.mdx
@@ -114,6 +114,8 @@ data transfer. Migration is covered in depth in
 | `migration switch-back` | Reverse a migration back to single-user. |
 | `data-transfer export` | Export the entire instance to a JSON file. |
 | `data-transfer import` | Import an instance export file. |
+| `image-gc` | Inspect (`--dry-run`) or run the built-image garbage collector. |
+| `runtime-images` | List, and with `--prune` remove, previous Openship control-plane images on this host. |
 
 ### `settings set`
 
@@ -214,6 +216,49 @@ openship system data-transfer import --file instance.json --passphrase "correct 
 Importing in the default `wipe` mode deletes the current instance data before restoring the file. It asks
 for confirmation unless you pass `-y`. Use `--mode merge` to layer the file on top instead.
 </Callout>
+
+### `image-gc`
+
+The operator-facing side of the built-in `images:gc` job, which prunes each project's superseded
+build images on its deploy host outside the rollback window. `--dry-run` answers "did cleanup run,
+what would it remove, and why is the rest still here" without touching Docker; without it the
+command shows the same report, asks for confirmation, and runs the sweep, recorded as a manual
+`images:gc` run in job history.
+
+| Flag | Purpose |
+|---|---|
+| `--dry-run` | Report only. Lists every image with its decision and reason: `active`, `pinned`, `rollback-window`, `in-use`, `foreign-tag`, `min-age`, or `superseded` / `dangling` for removal candidates. |
+| `--older-than <age>` | Only remove superseded images at least this old (`30d`, `12h`, `2w`). Age never overrides the keep-set — it can only make a run more conservative. |
+| `-y, --yes` | Skip the confirmation prompt. |
+
+```bash
+openship system image-gc --dry-run
+openship system image-gc --older-than 30d
+openship --json system image-gc --dry-run
+```
+
+Sizes are Docker's per-image figures; shared layers mean the space actually freed can be lower.
+Volumes, third-party images (`postgres`, `redis`, …) and anything without an `openship.project`
+label are never candidates.
+
+### `runtime-images`
+
+`openship update` pulls the new `openship-api`, `openship-dashboard` and `openship-edge` images but
+leaves the previous ones on the host, and the project-scoped image GC can't touch them. This lists
+them on the machine the CLI runs on and, with `--prune`, removes every version beyond the one a
+container references plus `--keep` previous ones. Images referenced by any container, running or
+stopped, are never removed, and neither is a tag that isn't a version (`latest`).
+
+| Flag | Purpose |
+|---|---|
+| `--prune` | Remove the superseded versions (asks first). |
+| `--keep <n>` | Previous versions to keep for a quick downgrade. Default `1`. |
+| `-y, --yes` | Skip the confirmation prompt. |
+
+```bash
+openship system runtime-images
+openship system runtime-images --prune --keep 2
+```
 
 ## `openship mail`
 

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -3352,10 +3352,16 @@ export class DockerRuntime implements RuntimeAdapter {
    * reconciles this on-host set against the DB keep-set. Includes untagged
    * (dangling) superseded finals: labels persist after the tag is removed.
    */
-  async listProjectImages(
-    projectId: string,
-  ): Promise<
-    Array<{ id: string; repoTags: string[]; buildId?: string; deploymentId?: string; size: number }>
+  async listProjectImages(projectId: string): Promise<
+    Array<{
+      id: string;
+      repoTags: string[];
+      buildId?: string;
+      deploymentId?: string;
+      size: number;
+      /** Image creation time (epoch ms); null when the daemon didn't report one. */
+      createdAt: number | null;
+    }>
   > {
     const images = await this.docker.listImages({
       filters: { label: [`openship.project=${projectId}`] },
@@ -3366,6 +3372,8 @@ export class DockerRuntime implements RuntimeAdapter {
       buildId: img.Labels?.[OPENSHIP_LABEL.build],
       deploymentId: img.Labels?.[OPENSHIP_LABEL.deployment],
       size: img.Size ?? 0,
+      // Docker reports seconds; every other timestamp in this codebase is ms.
+      createdAt: typeof img.Created === "number" && img.Created > 0 ? img.Created * 1000 : null,
     }));
   }
 


### PR DESCRIPTION
## Summary

Makes the built-image garbage collector (`images:gc`) inspectable and runnable by hand: a read-only dry run that lists every project's build images with the decision a sweep would take **and why**, a manual run recorded in job history, an optional age filter that can only make a run more conservative, and a host-local command for the previous `openship-api` / `-dashboard` / `-edge` images an update leaves behind.

## Motivation

#779: on a self-hosted box at 83% disk, the operator could see that `images:gc` was enabled and scheduled but not whether it had run, what it removed, or why older `openship/<slug>:bld_…` images and three generations of runtime images were still on the host. The only visible lever was `docker system prune -a`, which is exactly what a rollback-capable platform must not push people towards. The GC's decisions were already sound; they just weren't visible.

## Related issue

#779. This is a proposal for the issue's "useful first version" list; scope and approach are open to whatever the maintainers agree on there. Deliberately **not** in this PR: a dashboard view, and any change to what the scheduled sweep removes by default.

## Changes

**apps/api**
- `deployments/image-gc.ts`: `computeKeepSetDetail` keeps *why* each ref is protected (`active` / `pinned` / `rollback-window`, strongest wins; `computeKeepSet` is now derived from it). `classifyImage` is the single classifier — adds `in-use`, `foreign-tag`, `min-age` and the two removal reasons (`superseded`, `dangling`) — and `reapProjectImages` now runs on it, so a plan says exactly what a sweep does. `planImageGc` / `planProjectImages` are the read-only dry run (also lists containers on the host to name in-use images up front instead of leaving it to the daemon's 409). `parseMinAge` (`30d`, `12h`, `2w`, `90m`) rejects zero/junk. An age-limited run skips the dangling prune, which has no age filter of its own. `imageGcJobSummary` is the one summary shape, shared with the registry.
- `system/image-gc.controller.ts` + `system.routes.ts`: `GET /api/system/image-gc/plan?olderThan=30d` and `POST /api/system/image-gc/run`. `job:read` / `job:write` tags **plus `requireInstanceAdmin()`** — both walk every org's projects and hosts, same reasoning as `/edge/untracked`. A manual run goes through `recordJobRun(..., { trigger: "manual" })` so it shows in job history next to the scheduled ticks.
- `jobs/job.registry.ts`: uses `imageGcJobSummary`.

**packages/adapters**
- `runtime/docker.ts`: `listProjectImages` reports `createdAt` (Docker's seconds → ms, `null` when unreported).

**apps/cli**
- `openship system image-gc [--dry-run] [--older-than <age>] [--yes]`: status table (enabled, schedule, last run + its summary, age filter), per-image table (project, image, size, age, rollback window, decision, reason), totals; without `--dry-run` it confirms and runs. `--json` supported.
- `openship system runtime-images [--prune] [--keep <n>] [--yes]`: host-local (no API), lists the control-plane images; `--prune` removes versions beyond the one a container references plus `--keep` previous. Pure selection in `lib/runtime-images.ts`: anything referenced by a container (running **or stopped**) is kept, non-version tags (`latest`) are never candidates, removal is plain `docker rmi` with no `--force`.

**docs / changelog**: `cli/self-host.mdx`, `api/system.mdx`, `CHANGELOG.md` (Unreleased).

## Safety

Nothing changes in what the scheduled sweep removes by default. The label-scoped selection, the keep-set, untag-only-our-tags, and the in-use 409 backstop are untouched — `selectImageRemovalRefs` and its tests still pass unchanged. Age can only narrow a run (an image of unknown age counts as young). The plan never writes: no prune, no capacity re-measure.

## Verification

```bash
# adapters / api / cli typecheck
$ npx tsc --noEmit            # in each of packages/adapters, apps/api, apps/cli → exit 0

# api: deployments + projects + jobs suites (includes the new image-gc tests)
$ npx vitest run src/modules/deployments src/modules/projects src/modules/jobs
 ✓ src/modules/deployments/image-gc.test.ts (15 tests)
 Test Files  54 passed (54)   Tests  560 passed (560)

# adapters runtime suite
$ npx vitest run src/runtime
 Test Files  42 passed (42)   Tests  610 passed (610)

# cli
$ npx vitest run test/unit/runtime-images.test.ts
 ✓ test/unit/runtime-images.test.ts (3 tests)
$ npx vitest run
 Test Files  2 failed | 37 passed   Tests  4 failed | 494 passed
```

The 4 CLI failures (`test/e2e/completion.test.ts` ×3 — a Node `DEP0205` deprecation warning on stderr — and a 5 s timeout in `test/unit/ports.test.ts`) fail identically on a clean `upstream/main` checkout in this environment; they're unrelated to this change.

New tests that fail without the change: keep-reason priority (`active` outranks `pinned` for a shared image), `classifyImage` naming `in-use` only when containers are listed, own-tags-only / foreign-tag / dangling, the age filter keeping young and age-unknown images while still removing old ones and never overriding the keep-set, `parseMinAge` rejecting `0d` and junk; runtime-image prune keeping referenced + N previous per repository and never ordering `latest`/`main`.

Not exercised against a live Docker host from this machine; the daemon-facing surface is one added field (`createdAt`) plus the existing `listAllContainers()`.

## Checklist

- [x] One change per PR — one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] `bun run test` (relevant workspaces), `bun run --cwd <workspace> lint`, and `bun format` (on the touched files) pass locally
- [x] I understand every line of this diff and can explain it in review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
