### PR TITLE
fix(docker): stop build immediately on memory starvation and add actionable OOM diagnostics

### DIFF
--- a/packages/adapters/src/runtime/docker-build-oom.test.ts
+++ b/packages/adapters/src/runtime/docker-build-oom.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Readable } from "node:stream";
+import { DockerRuntime, getDockerBuildIdleTimeoutMs } from "./docker";
+import { BuildLogger } from "./build-pipeline";
+
+describe("Docker build OOM diagnostics and starvation detection", () => {
+  const originalEnv = process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = originalEnv;
+    } else {
+      delete process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS;
+    }
+  });
+
+  describe("getDockerBuildIdleTimeoutMs", () => {
+    it("defaults to 10 minutes (600_000 ms)", () => {
+      delete process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS;
+      expect(getDockerBuildIdleTimeoutMs()).toBe(10 * 60 * 1000);
+    });
+
+    it("respects OPENSHIP_BUILD_IDLE_TIMEOUT_MS when valid number provided", () => {
+      process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = "300000";
+      expect(getDockerBuildIdleTimeoutMs()).toBe(300_000);
+    });
+
+    it("falls back to default if environment variable is invalid or non-positive", () => {
+      process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = "invalid";
+      expect(getDockerBuildIdleTimeoutMs()).toBe(10 * 60 * 1000);
+
+      process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = "-5";
+      expect(getDockerBuildIdleTimeoutMs()).toBe(10 * 60 * 1000);
+    });
+  });
+
+  describe("extractBuildFailureHint", () => {
+    const runtime = new (DockerRuntime as any)({
+      kind: "local",
+      socketPath: "/var/run/docker.sock",
+    });
+
+    it("decodes exit code 137 as OOM killer with actionable hint", () => {
+      const line = "The command '/bin/sh -c npm run build' returned a non-zero code: 137";
+      const hint = runtime.extractBuildFailureHint(line);
+      expect(hint).toContain("Out-Of-Memory (OOM) killer (exit code 137)");
+      expect(hint).toContain("Increase the project's Build Memory in OpenShip Settings -> Resources");
+    });
+
+    it("decodes exit code 143 as SIGTERM", () => {
+      const line = "The command '/bin/sh -c npm run build' returned a non-zero code: 143";
+      const hint = runtime.extractBuildFailureHint(line);
+      expect(hint).toContain("terminated by SIGTERM (exit code 143)");
+    });
+
+    it("passes ordinary non-zero exit codes through untouched", () => {
+      const line = "The command '/bin/sh -c npm test' returned a non-zero code: 1";
+      const hint = runtime.extractBuildFailureHint(line);
+      expect(hint).toBe(line);
+    });
+
+    it("identifies JavaScript heap out of memory errors", () => {
+      const line = "<--- Last few GCs --->\nFATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory";
+      const hint = runtime.extractBuildFailureHint(line);
+      expect(hint).toContain("Process ran out of memory");
+      expect(hint).toContain("NODE_OPTIONS=\"--max-old-space-size=...\"");
+    });
+
+    it("identifies npm ENOMEM errors", () => {
+      const line = "npm ERR! code ENOMEM\nnpm ERR! syscall spawn";
+      const hint = runtime.extractBuildFailureHint(line);
+      expect(hint).toContain("npm ran out of memory while installing dependencies");
+    });
+
+    it("identifies Go runtime out of memory errors", () => {
+      const line = "fatal error: runtime: out of memory";
+      const hint = runtime.extractBuildFailureHint(line);
+      expect(hint).toContain("Process ran out of memory");
+    });
+  });
+
+  describe("streamDockerodeBuild memory starvation watchdog", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("detects pinned memory starvation (>=95%) and terminates immediately", async () => {
+      const killMock = vi.fn().mockResolvedValue({});
+      const statsMock = vi.fn().mockResolvedValue({
+        memory_stats: {
+          usage: 1020 * 1024 * 1024, // 1020MB
+          limit: 1024 * 1024 * 1024, // 1024MB (99.6%)
+        },
+      });
+
+      const listContainersMock = vi.fn().mockResolvedValue([
+        {
+          Id: "test-starving-container-123",
+          Created: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      const mockDocker = {
+        listContainers: listContainersMock,
+        getContainer: vi.fn(() => ({
+          stats: statsMock,
+          kill: killMock,
+        })),
+        modem: {
+          followProgress: (_stream: any, onFinished: any) => {
+            // Keep stream open to simulate stalled build
+          },
+        },
+      };
+
+      const runtime = new (DockerRuntime as any)({
+        kind: "local",
+        socketPath: "/var/run/docker.sock",
+      });
+      (runtime as any)._docker = mockDocker;
+
+      const log = new BuildLogger();
+      const stream = new Readable({ read() {} });
+      stream.on("error", () => {});
+
+      let error: any;
+      const buildPromise = runtime
+        .streamDockerodeBuild(stream, log, undefined, {
+          memoryMb: 1024,
+          cpuCores: 1,
+        })
+        .catch((err: any) => {
+          error = err;
+        });
+
+      // Advance timers to trigger the watchdog checks:
+      // First check at 30s (consecutiveStarvingChecks = 1, logs warning)
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(listContainersMock).toHaveBeenCalled();
+      expect(statsMock).toHaveBeenCalled();
+      expect(killMock).not.toHaveBeenCalled();
+
+      // Second check at 45s (consecutiveStarvingChecks = 2, triggers termination)
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await buildPromise;
+      expect(error).toBeDefined();
+      expect(error.message).toMatch(/container is memory-starved/);
+      expect(killMock).toHaveBeenCalled();
+    });
+
+    it("includes resource constraint context when idle timeout expires", async () => {
+      const mockDocker = {
+        listContainers: vi.fn().mockResolvedValue([]),
+        modem: {
+          followProgress: (_stream: any, onFinished: any) => {
+            // Stream stays open with no progress
+          },
+        },
+      };
+
+      const runtime = new (DockerRuntime as any)({
+        kind: "local",
+        socketPath: "/var/run/docker.sock",
+      });
+      (runtime as any)._docker = mockDocker;
+
+      const log = new BuildLogger();
+      const stream = new Readable({ read() {} });
+      stream.on("error", () => {});
+
+      let error: any;
+      const buildPromise = runtime
+        .streamDockerodeBuild(stream, log, undefined, {
+          memoryMb: 512,
+          cpuCores: 1,
+        })
+        .catch((err: any) => {
+          error = err;
+        });
+
+      // Fast forward past the 10m idle timeout
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+
+      await buildPromise;
+      expect(error).toBeDefined();
+      expect(error.message).toMatch(
+        /Docker build produced no output for 10 minutes and timed out.*constrained to 512MB RAM/,
+      );
+    });
+  });
+});

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -48,6 +48,7 @@ import type {
   ShellOptions,
   ShellSession,
   ProvisionLock,
+  ResourceConfig,
 } from "../types";
 import type { PortProbeExecutor } from "../system/port-listen";
 import { PassThrough, Writable, type Readable } from "node:stream";
@@ -200,7 +201,17 @@ const RESTART_POLICIES: Record<string, { Name: string; MaximumRetryCount: number
   no: { Name: "no", MaximumRetryCount: 0 },
 };
 
-const DOCKER_BUILD_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+/**
+ * Max idle duration (time without progress output from the Docker build) before
+ * terminating the build as stalled. Defaults to 10 minutes (overridable via
+ * OPENSHIP_BUILD_IDLE_TIMEOUT_MS).
+ */
+export function getDockerBuildIdleTimeoutMs(): number {
+  const envVal = Number(process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS);
+  return Number.isFinite(envVal) && envVal > 0 ? envVal : 10 * 60 * 1000;
+}
+
+export const DOCKER_BUILD_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
  * A deployment build and its cancellation request may resolve separate
@@ -1288,8 +1299,28 @@ export class DockerRuntime implements RuntimeAdapter {
   }
 
   private extractBuildFailureHint(line: string): string | null {
-    if (/returned a non-zero code:\s*\d+/i.test(line)) {
+    const nonZeroMatch = line.match(/returned a non-zero code:\s*(\d+)/i);
+    if (nonZeroMatch) {
+      const code = Number(nonZeroMatch[1]);
+      if (code === 137) {
+        return `${line} — The build process was killed by the Out-Of-Memory (OOM) killer (exit code 137). The build exceeded its allocated memory limit. Increase the project's Build Memory in OpenShip Settings -> Resources, or allocate more RAM/swap to the host.`;
+      }
+      if (code === 143) {
+        return `${line} — The build process was terminated by SIGTERM (exit code 143). The container was stopped or cancelled.`;
+      }
       return line;
+    }
+
+    if (
+      /JavaScript heap out of memory|Fatal process out of memory|fatal error: runtime: out of memory/i.test(
+        line,
+      )
+    ) {
+      return `${line} — Process ran out of memory. Increase Build Memory in OpenShip Settings -> Resources or configure NODE_OPTIONS="--max-old-space-size=...".`;
+    }
+
+    if (/npm ERR! code ENOMEM/i.test(line)) {
+      return `${line} — npm ran out of memory while installing dependencies. Increase Build Memory in OpenShip Settings -> Resources.`;
     }
 
     // The legacy builder's own wording for "this Dockerfile needs BuildKit". Reached
@@ -1529,7 +1560,14 @@ export class DockerRuntime implements RuntimeAdapter {
     // different: surface it as a cancelled BuildResult instead of continuing
     // through image verification and deploy.
     if (signal?.aborted) throw new BuildCancelledError();
-    if (code !== 0) throw new Error(`docker build exited with code ${code}`);
+    if (code !== 0) {
+      if (code === 137) {
+        throw new Error(
+          `docker build was killed by the Out-Of-Memory (OOM) killer (exit code 137). The build exceeded available RAM on the remote server. Increase Build Memory in OpenShip Settings -> Resources or allocate more RAM/swap to the server.`,
+        );
+      }
+      throw new Error(`docker build exited with code ${code}`);
+    }
     this.emitDockerStep(log, "install", "completed", "Image build finished");
   }
 
@@ -1875,7 +1913,7 @@ export class DockerRuntime implements RuntimeAdapter {
       });
 
       log.log("Connected to Docker daemon. Build output follows:");
-      await this.streamDockerodeBuild(stream, log, builder.trace);
+      await this.streamDockerodeBuild(stream, log, builder.trace, config.resources);
       log.log("Docker daemon finished streaming build output. Finalizing image...\n");
     } catch (err) {
       // A context-pack failure aborts the request, so the rejection here is the
@@ -1904,57 +1942,134 @@ export class DockerRuntime implements RuntimeAdapter {
     stream: NodeJS.ReadableStream,
     log: BuildLogger,
     trace?: BuildKitTraceDecoder,
+    buildLimits?: Partial<ResourceConfig> | null,
   ): Promise<void> {
     let fatalBuildError: string | null = null;
+    const buildStartTime = Date.now();
+    const timeoutMs = getDockerBuildIdleTimeoutMs();
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
       let idleTimer: NodeJS.Timeout | null = null;
-      let keepaliveTimer: NodeJS.Timeout | null = null;
-      let idleMinutes = 0;
+      let watchdogTimer: NodeJS.Timeout | null = null;
+      let silentSeconds = 0;
+      let consecutiveStarvingChecks = 0;
 
       const clearTimers = () => {
         if (idleTimer) {
           clearTimeout(idleTimer);
           idleTimer = null;
         }
-        if (keepaliveTimer) {
-          clearInterval(keepaliveTimer);
-          keepaliveTimer = null;
+        if (watchdogTimer) {
+          clearInterval(watchdogTimer);
+          watchdogTimer = null;
         }
-        idleMinutes = 0;
+        silentSeconds = 0;
+        consecutiveStarvingChecks = 0;
       };
 
-      const fail = (error: Error) => {
+      const failOnce = (error: Error) => {
         if (settled) return;
         settled = true;
         clearTimers();
-        (stream as any).destroy?.(error);
+        try {
+          (stream as any).destroy?.();
+        } catch {
+          // ignore
+        }
         reject(error);
       };
 
-      const succeed = () => {
+      const succeedOnce = () => {
         if (settled) return;
         settled = true;
         clearTimers();
         resolve();
       };
 
+      // Memory starvation watchdog: inspect intermediate build container stats during silence.
+      // If pinned at >= 95% memory limit for consecutive checks, terminate immediately.
+      const checkMemoryStarvation = async () => {
+        if (settled) return;
+        if (!buildLimits?.memoryMb || buildLimits.memoryMb <= 0) return;
+
+        try {
+          const containers = await this.docker.listContainers({ limit: 10 });
+          if (settled) return;
+          for (const c of containers) {
+            if (settled) return;
+            if (c.Created * 1000 >= buildStartTime - 10_000) {
+              const stats = await this.docker.getContainer(c.Id).stats({ stream: false });
+              if (settled) return;
+              const usage = stats.memory_stats?.usage ?? 0;
+              const limit = stats.memory_stats?.limit ?? 0;
+              if (limit > 0 && usage > 0) {
+                const ratio = usage / limit;
+                if (ratio >= 0.95) {
+                  consecutiveStarvingChecks += 1;
+                  const usageMb = Math.round(usage / (1024 * 1024));
+                  const limitMb = Math.round(limit / (1024 * 1024));
+                  if (consecutiveStarvingChecks >= 2) {
+                    const starvingErr = new Error(
+                      `Docker build terminated: container is memory-starved (${usageMb}MB / ${limitMb}MB, ${(ratio * 100).toFixed(1)}% limit reached). The compiler or build process ran out of RAM and stalled in swap thrashing. Increase the project's Build Memory limit in OpenShip Settings -> Resources.`,
+                    );
+                    failOnce(starvingErr);
+                    void this.docker.getContainer(c.Id).kill().catch(() => {});
+                    return;
+                  } else {
+                    log.log(
+                      `Build memory warning: container is near memory limit (${usageMb}MB / ${limitMb}MB, ${(ratio * 100).toFixed(1)}%). If it runs out of memory, the build will be terminated.`,
+                      "warn",
+                    );
+                  }
+                } else {
+                  consecutiveStarvingChecks = 0;
+                }
+              }
+            }
+          }
+        } catch {
+          // Non-fatal if container stats cannot be read
+        }
+      };
+
       const resetIdleTimer = () => {
         clearTimers();
-        keepaliveTimer = setInterval(() => {
-          idleMinutes += 1;
-          log.log(`Still building... (no output for ${idleMinutes}m)`);
-        }, 60_000);
-        if ((keepaliveTimer as any).unref) (keepaliveTimer as any).unref();
+
+        watchdogTimer = setInterval(() => {
+          silentSeconds += 15;
+          if (silentSeconds % 60 === 0) {
+            const idleMinutes = silentSeconds / 60;
+            const memoryMb = buildLimits?.memoryMb;
+            if (idleMinutes >= 2 && memoryMb && memoryMb > 0) {
+              log.log(
+                `Still building... (no output for ${idleMinutes}m · build memory limit is ${memoryMb}MB)`,
+                "warn",
+              );
+            } else {
+              log.log(`Still building... (no output for ${idleMinutes}m)`);
+            }
+          }
+
+          if (silentSeconds >= 30) {
+            void checkMemoryStarvation();
+          }
+        }, 15_000);
+        if ((watchdogTimer as any).unref) (watchdogTimer as any).unref();
 
         idleTimer = setTimeout(() => {
-          fail(
+          if (settled) return;
+          const memoryMb = buildLimits?.memoryMb;
+          const resourceContext =
+            memoryMb && memoryMb > 0
+              ? ` The build was constrained to ${memoryMb}MB RAM (OpenShip Build Resources). Resource-intensive compilers (Next.js/Turbopack, Vite, Webpack, Rust) often require >1GB and cause silent swap thrashing if memory is constrained. Increase Build Memory in Project Settings -> Resources.`
+              : "";
+          failOnce(
             new Error(
-              "Docker build produced no output for 30 minutes. This usually means the remote server cannot reach the package registry, has broken DNS, or the Docker daemon stalled during the build.",
+              `Docker build produced no output for ${Math.round(timeoutMs / 60_000)} minutes and timed out.${resourceContext} Other common causes: remote server cannot reach package registry, broken DNS, or a stalled process waiting for input.`,
             ),
           );
-        }, DOCKER_BUILD_IDLE_TIMEOUT_MS);
+        }, timeoutMs);
         if ((idleTimer as any).unref) (idleTimer as any).unref();
       };
 
@@ -1964,10 +2079,10 @@ export class DockerRuntime implements RuntimeAdapter {
         stream,
         (err: Error | null) => {
           if (err) {
-            fail(err);
+            failOnce(err);
             return;
           }
-          succeed();
+          succeedOnce();
         },
         (event) => {
           resetIdleTimer();
@@ -2951,7 +3066,12 @@ export class DockerRuntime implements RuntimeAdapter {
                 ...builder.options,
                 abortSignal,
               });
-              await this.streamDockerodeBuild(stream, spec.logger, builder.trace);
+              await this.streamDockerodeBuild(
+                stream,
+                spec.logger,
+                builder.trace,
+                spec.config.resources,
+              );
             } catch (err) {
               const contextErr = takeError();
               throw contextErr


### PR DESCRIPTION
### Summary

When a project build (e.g. Next.js/Turbopack, Vite, Rust) exceeds its allocated RAM limit inside Docker:
1. The container hits 95–99% memory usage and enters an intense Linux kernel swap-thrashing loop (in production benchmarks, this produced >270 GB of block I/O).
2. The compiler produces zero stdout/stderr output while thrashing.
3. OpenShip previously waited for a hardcoded **30 minutes** (`DOCKER_BUILD_IDLE_TIMEOUT_MS = 30 * 60 * 1000`) before timing out, printing generic `Still building... (no output for Xm)` messages.
4. On timeout, the error was misleading: *"Docker build produced no output for 30 minutes. This usually means the remote server cannot reach the package registry, has broken DNS, or the Docker daemon stalled during the build."*
5. When processes were killed by the Linux kernel OOM killer (`exit code 137`), OpenShip outputted raw `returned a non-zero code: 137` without explaining that code 137 is Out Of Memory.

### Changes

1. **Active Memory Starvation Watchdog**:
   - In `streamDockerodeBuild`, a watchdog checks intermediate build container stats during silent periods.
   - If an active build container is pinned at >= 95% memory usage with zero log output for >= 30 seconds, OpenShip **immediately kills the container and halts the deployment**, preventing disk thrashing and providing clear diagnostics:
     > `Docker build terminated: container is memory-starved (XMB / YMB, 99.5% limit reached). The compiler or build process ran out of RAM and stalled in swap thrashing. Increase the project's Build Memory limit in OpenShip Settings -> Resources.`
2. **Actionable Exit Code 137 (OOM) Diagnostics**:
   - In `extractBuildFailureHint`, translates exit code `137` into an explicit Out-Of-Memory explanation with immediate resolution steps.
   - Detects `JavaScript heap out of memory`, `Fatal process out of memory`, and npm `ENOMEM`.
   - In `buildImageOnRemote`, decodes exit code 137 across remote SSH builds.
3. **Configurable & Reasonable Idle Timeout**:
   - Lowered default idle timeout from 30 minutes to **10 minutes** (`OPENSHIP_BUILD_IDLE_TIMEOUT_MS`).
   - Included configured RAM limit in the timeout error message.
