### PR TITLE
fix(api): preserve secret env values at runtime

### DIFF
--- a/apps/api/src/modules/deployments/build-access-env.test.ts
+++ b/apps/api/src/modules/deployments/build-access-env.test.ts
@@ -1,0 +1,104 @@
+import { ENV_MASK } from "@repo/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveBuildAccessEnv, type StoredProjectEnvVar } from "./build-access-env";
+
+const stored: StoredProjectEnvVar[] = [
+  { key: "API_TOKEN", value: "cipher:original-secret", isSecret: true },
+  { key: "PUBLIC_URL", value: "cipher:https://old.example", isSecret: false },
+];
+
+const encryptValue = (value: string) => `cipher:${value}`;
+
+describe("resolveBuildAccessEnv", () => {
+  it("preserves a stored secret when an older client sends an empty placeholder", () => {
+    const resolved = resolveBuildAccessEnv(
+      { API_TOKEN: "", PUBLIC_URL: "https://new.example" },
+      stored,
+      encryptValue,
+    );
+
+    expect(resolved.deploymentEnvVars).toEqual({
+      API_TOKEN: "cipher:original-secret",
+      PUBLIC_URL: "cipher:https://new.example",
+    });
+    expect(resolved.projectEnvVars).toEqual([
+      { key: "API_TOKEN", value: "cipher:original-secret", isSecret: true },
+      { key: "PUBLIC_URL", value: "cipher:https://new.example", isSecret: false },
+    ]);
+  });
+
+  it("preserves a stored secret when the mask sentinel is echoed", () => {
+    const resolved = resolveBuildAccessEnv({ API_TOKEN: ENV_MASK }, stored, encryptValue);
+
+    expect(resolved.deploymentEnvVars).toEqual({ API_TOKEN: "cipher:original-secret" });
+    expect(resolved.projectEnvVars).toEqual([
+      { key: "API_TOKEN", value: "cipher:original-secret", isSecret: true },
+    ]);
+  });
+
+  it("drops a mask sentinel that has no stored secret behind it", () => {
+    const encrypt = vi.fn(encryptValue);
+
+    const resolved = resolveBuildAccessEnv({ UNKNOWN: ENV_MASK }, stored, encrypt);
+
+    expect(encrypt).not.toHaveBeenCalled();
+    expect(resolved.deploymentEnvVars).toBeNull();
+    expect(resolved.projectEnvVars).toEqual([]);
+  });
+
+  it("encrypts and stores an explicitly changed secret", () => {
+    const encrypt = vi.fn(encryptValue);
+
+    const resolved = resolveBuildAccessEnv({ API_TOKEN: "rotated" }, stored, encrypt);
+
+    expect(encrypt).toHaveBeenCalledWith("rotated");
+    expect(resolved.deploymentEnvVars).toEqual({ API_TOKEN: "cipher:rotated" });
+    expect(resolved.projectEnvVars).toEqual([
+      { key: "API_TOKEN", value: "cipher:rotated", isSecret: true },
+    ]);
+  });
+
+  it("keeps an empty non-secret value as an explicit empty value", () => {
+    const resolved = resolveBuildAccessEnv({ PUBLIC_URL: "" }, stored, encryptValue);
+
+    expect(resolved.deploymentEnvVars).toEqual({ PUBLIC_URL: "cipher:" });
+    expect(resolved.projectEnvVars).toEqual([
+      { key: "PUBLIC_URL", value: "cipher:", isSecret: false },
+    ]);
+  });
+
+  it("uses all stored values without scheduling a project write when env is omitted", () => {
+    const encrypt = vi.fn(encryptValue);
+
+    const resolved = resolveBuildAccessEnv(undefined, stored, encrypt);
+
+    expect(encrypt).not.toHaveBeenCalled();
+    expect(resolved.deploymentEnvVars).toEqual({
+      API_TOKEN: "cipher:original-secret",
+      PUBLIC_URL: "cipher:https://old.example",
+    });
+    expect(resolved.projectEnvVars).toBeNull();
+  });
+
+  it("retains full-map replacement semantics for omitted keys", () => {
+    const resolved = resolveBuildAccessEnv(
+      { PUBLIC_URL: "https://only.example" },
+      stored,
+      encryptValue,
+    );
+
+    expect(resolved.deploymentEnvVars).toEqual({
+      PUBLIC_URL: "cipher:https://only.example",
+    });
+    expect(resolved.projectEnvVars).toEqual([
+      { key: "PUBLIC_URL", value: "cipher:https://only.example", isSecret: false },
+    ]);
+  });
+
+  it("treats an empty map like an omitted map", () => {
+    expect(resolveBuildAccessEnv({}, stored, encryptValue)).toEqual(
+      resolveBuildAccessEnv(undefined, stored, encryptValue),
+    );
+  });
+});

--- a/apps/api/src/modules/deployments/build-access-env.ts
+++ b/apps/api/src/modules/deployments/build-access-env.ts
@@ -1,0 +1,70 @@
+import { isMaskedValue, looksLikeSecretKey } from "@repo/core";
+
+export interface StoredProjectEnvVar {
+  key: string;
+  value: string;
+  isSecret: boolean;
+}
+
+export interface PersistedBuildAccessEnvVar {
+  key: string;
+  value: string;
+  isSecret: boolean;
+}
+
+export interface BuildAccessEnvResolution {
+  /** Encrypted values frozen onto the deployment and later decrypted for the runtime. */
+  deploymentEnvVars: Record<string, string> | null;
+  /** Full replacement for project defaults; null means the request supplied no env map. */
+  projectEnvVars: PersistedBuildAccessEnvVar[] | null;
+}
+
+/**
+ * Resolve the flat env map accepted by the build-access endpoint against the
+ * project's stored encrypted rows.
+ *
+ * The dashboard cannot send an existing secret back in plaintext: its public
+ * representation is either the mask sentinel or (for older clients) an empty
+ * string. Both mean "unchanged" for an existing secret, so retain its ciphertext
+ * in the deployment snapshot and in the full project-env replacement. Empty
+ * non-secret values remain real values, and omitted keys remain deleted by the
+ * caller's full-map write.
+ */
+export function resolveBuildAccessEnv(
+  incoming: Record<string, string> | null | undefined,
+  stored: readonly StoredProjectEnvVar[],
+  encryptValue: (value: string) => string,
+): BuildAccessEnvResolution {
+  if (!incoming || Object.keys(incoming).length === 0) {
+    const deploymentEnvVars = Object.fromEntries(stored.map((row) => [row.key, row.value]));
+    return {
+      deploymentEnvVars: Object.keys(deploymentEnvVars).length > 0 ? deploymentEnvVars : null,
+      projectEnvVars: null,
+    };
+  }
+
+  const storedByKey = new Map(stored.map((row) => [row.key, row]));
+  const projectEnvVars: PersistedBuildAccessEnvVar[] = [];
+  for (const [key, value] of Object.entries(incoming)) {
+    const previous = storedByKey.get(key);
+    const keepStoredSecret = previous?.isSecret && (value === "" || isMaskedValue(value));
+
+    // A mask with no secret behind it is display data, never a runtime value.
+    // Dropping it mirrors unmaskEnv's whole-map semantics.
+    if (isMaskedValue(value) && !keepStoredSecret) continue;
+
+    projectEnvVars.push({
+      key,
+      value: keepStoredSecret ? previous.value : encryptValue(value),
+      isSecret: previous?.isSecret ?? looksLikeSecretKey(key),
+    });
+  }
+
+  return {
+    deploymentEnvVars:
+      projectEnvVars.length > 0
+        ? Object.fromEntries(projectEnvVars.map((row) => [row.key, row.value]))
+        : null,
+    projectEnvVars,
+  };
+}

--- a/apps/api/src/modules/deployments/build.service.ts
+++ b/apps/api/src/modules/deployments/build.service.ts
@@ -28,7 +28,6 @@ import {
   isReleaseProvider,
   releaseArtifactKind,
   renderReleaseImage,
-  looksLikeSecretKey,
   resolveProjectVolumes,
   type StackId,
   type DeployTarget,
@@ -96,6 +95,7 @@ import {
 } from "../../lib/release-resolver";
 import { commitSourceKey, projectBranch } from "../projects/project-crud.service";
 import { env } from "../../config";
+import { resolveBuildAccessEnv } from "./build-access-env";
 
 function throwPreflightFailure(preflight: PreflightResult): never {
   const failedChecks = preflight.checks.filter((check) => check.status === "fail");
@@ -1495,20 +1495,26 @@ export async function requestBuildAccess(
     snapshot.branch,
   );
 
-  // Caller-supplied envVars win (and get persisted as the new project
-  // defaults below); when this deploy request didn't include any — the
-  // typical wizard/CLI "just redeploy" call — fall back to the project's
-  // already-saved env vars, the same way triggerDeployment's fresh-deploy
-  // path does. Without this, a bare/server-build deploy silently ships with
-  // no env at all even though `PATCH /api/projects/:id/env` succeeded.
-  let deploymentEnvVars = encryptEnvVars(envVars);
-  if (!deploymentEnvVars) {
-    // A deployment snapshot is project-scoped. Service-scoped rows are loaded
-    // live, per service, by the compose deployer; flattening them into this map
-    // leaks one service's values into every other service and destroys scope.
-    const rawEnvMap = await repos.project.getEnvMap(project.id, env, null);
-    deploymentEnvVars = Object.keys(rawEnvMap).length > 0 ? rawEnvMap : null;
-  }
+  // Resolve a supplied map against project-level rows before freezing the
+  // deployment snapshot. Existing secret values are never returned to the
+  // dashboard, so an empty/masked placeholder means "unchanged", not "replace
+  // this secret with blank". A deploy that supplied no env map keeps the cheap
+  // encrypted-map lookup used by redeploy callers.
+  const resolvedEnv =
+    envVars && Object.keys(envVars).length > 0
+      ? resolveBuildAccessEnv(
+          envVars,
+          // Explicit `null` scope is load-bearing: service env belongs to the
+          // compose deployer and must not leak into this project map.
+          await repos.project.listEnvVars(project.id, env, null),
+          encrypt,
+        )
+      : {
+          deploymentEnvVars: await repos.project
+            .getEnvMap(project.id, env, null)
+            .then((stored) => (Object.keys(stored).length > 0 ? stored : null)),
+          projectEnvVars: null,
+        };
 
   const dep = await createQueuedDeployment({
     projectId: project.id,
@@ -1519,7 +1525,7 @@ export async function requestBuildAccess(
     environment: env,
     framework: snapshot.framework,
     meta: metaWithPrevious(snapshot, project),
-    envVars: deploymentEnvVars,
+    envVars: resolvedEnv.deploymentEnvVars,
     rollbackStrategy,
     commitShaBefore,
     // Service-scoped folder-upload/MCP deploy: only these services are (re)built;
@@ -1532,26 +1538,8 @@ export async function requestBuildAccess(
   });
 
   // Store env vars on project as "latest defaults"
-  if (envVars && Object.keys(envVars).length > 0) {
-    // These arrive as a flat name→value map — a pasted `.env`, an upload, a CLI deploy —
-    // carrying no per-variable intent, and every one of them used to be stored
-    // `isSecret: false`. So an `OPENAI_API_KEY`, or a `DATABASE_URL` with a password in
-    // it, was flagged an ordinary value: returned in cleartext by GET /env and rendered
-    // as readable text in the editor to anyone with project access (#587). The name is
-    // the only signal available here, so default from it and let the operator correct it
-    // with the editor's per-row secret toggle.
-    //
-    // An EXISTING variable keeps its stored flag. `bulkSetEnvVars` replaces the whole
-    // set, so re-deriving the default every time would overturn that toggle on the
-    // operator's very next deploy.
-    const prior = await repos.project.listEnvVars(project.id, env).catch(() => []);
-    const priorSecret = new Map(prior.map((v) => [v.key, v.isSecret]));
-    const vars = Object.entries(envVars).map(([key, value]) => ({
-      key,
-      value: encrypt(value),
-      isSecret: priorSecret.get(key) ?? looksLikeSecretKey(key),
-    }));
-    await repos.project.bulkSetEnvVars(project.id, env, vars);
+  if (resolvedEnv.projectEnvVars) {
+    await repos.project.bulkSetEnvVars(project.id, env, resolvedEnv.projectEnvVars);
   }
 
   // Kick off the build BEFORE returning so the dashboard can attach via the

--- a/apps/api/test/modules/deployments/build.service.test.ts
+++ b/apps/api/test/modules/deployments/build.service.test.ts
@@ -27,6 +27,8 @@ const {
     project: {
       findById: vi.fn(),
       getEnvMap: vi.fn(),
+      listEnvVars: vi.fn(),
+      bulkSetEnvVars: vi.fn(),
       listEnvVarChangeMeta: vi.fn(),
       update: vi.fn(),
     },
@@ -1406,6 +1408,8 @@ describe("requestBuildAccess — folder-upload compose services", () => {
       baseProject({ gitProvider: "upload", localPath: null, runtimeMode: null }),
     );
     repos.project.getEnvMap.mockResolvedValue({});
+    repos.project.listEnvVars.mockResolvedValue([]);
+    repos.project.bulkSetEnvVars.mockResolvedValue(undefined);
     repos.deployment.findById.mockResolvedValue(null);
     repos.deployment.listByProject.mockResolvedValue({ rows: [] });
     repos.deployment.getLatestSuccessfulForBranch.mockResolvedValue(null);
@@ -1475,6 +1479,35 @@ describe("requestBuildAccess — folder-upload compose services", () => {
         composeServices: scannedServices,
       }),
     );
+  });
+
+  it("freezes and persists the stored ciphertext when a secret placeholder is submitted", async () => {
+    const uploadSessionId = seedSession();
+    repos.project.listEnvVars.mockResolvedValue([
+      {
+        id: "env-1",
+        projectId: "project-1",
+        environment: "production",
+        serviceId: null,
+        key: "API_TOKEN",
+        value: "cipher:original-secret",
+        isSecret: true,
+      },
+    ]);
+
+    await requestBuildAccess(ctx, {
+      projectId: "project-1",
+      uploadSessionId,
+      envVars: { API_TOKEN: "" },
+    });
+
+    expect(repos.project.listEnvVars).toHaveBeenCalledWith("project-1", "production", null);
+    expect(repos.deployment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ envVars: { API_TOKEN: "cipher:original-secret" } }),
+    );
+    expect(repos.project.bulkSetEnvVars).toHaveBeenCalledWith("project-1", "production", [
+      { key: "API_TOKEN", value: "cipher:original-secret", isSecret: true },
+    ]);
   });
 
   it("prefers the caller's services over the session's", async () => {


### PR DESCRIPTION
## Summary

- resolve build-access env maps against stored project-level rows before freezing the deployment snapshot
- preserve ciphertext when an existing secret is submitted as an empty or masked placeholder
- keep explicit blank non-secret values and full-map deletion semantics unchanged
- prevent an orphan mask sentinel from becoming a runtime value

## Root cause

`requestBuildAccess` treated the dashboard payload as plaintext authority. When the payload contained an empty placeholder for a stored secret, it encrypted that empty string into the deployment snapshot and then replaced the saved project value with it. The runtime correctly consumed the snapshot, but received the corrupted blank value.

## Tests

- `bun run test -- src/modules/deployments/build-access-env.test.ts test/modules/deployments/build.service.test.ts`
- `bun run lint`
- the three unrelated full-suite timeout failures pass when rerun in isolation

Fixes #801