### PR TITLE
fix(adapters): safely recover rejected SSH exec requests

### DIFF
--- a/apps/api/src/lib/remote-state.test.ts
+++ b/apps/api/src/lib/remote-state.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { isConnectionLoss } from "./remote-state";
+
+describe("isConnectionLoss", () => {
+  it("recognizes a serialized ssh2 exec-request rejection", () => {
+    expect(isConnectionLoss(new Error("Unable to exec"))).toBe(true);
+    expect(isConnectionLoss("Unable to exec")).toBe(true);
+  });
+
+  it("does not classify lookalike remote command failures as connection loss", () => {
+    expect(isConnectionLoss(new Error("sudo: unable to execute helper"))).toBe(false);
+    expect(isConnectionLoss("sudo: unable to execute helper")).toBe(false);
+  });
+});

--- a/apps/api/src/lib/remote-state.ts
+++ b/apps/api/src/lib/remote-state.ts
@@ -33,6 +33,7 @@ export function isConnectionLoss(err: unknown): boolean {
     /timed out|timeout|etimedout|econnreset|econnrefused|ehostunreach|enetunreach/.test(msg) ||
     msg.includes("channel open failure") ||
     msg.includes("open failed") ||
+    msg.includes("unable to exec") ||
     // Deliberately here and NOT in the adapters' retryable set, because the two lists
     // answer different questions. "Did we reach the host?" — no, so a 503 naming the
     // target beats a 500 blaming the request. "Should we run the whole callback again?" —

--- a/apps/api/src/lib/remote-state.ts
+++ b/apps/api/src/lib/remote-state.ts
@@ -33,7 +33,10 @@ export function isConnectionLoss(err: unknown): boolean {
     /timed out|timeout|etimedout|econnreset|econnrefused|ehostunreach|enetunreach/.test(msg) ||
     msg.includes("channel open failure") ||
     msg.includes("open failed") ||
-    msg.includes("unable to exec") ||
+    // A serialized SshExecRequestError loses its type at result boundaries.
+    // Match ssh2's complete sentinel only; remote stderr such as "unable to
+    // execute helper" is an operation failure, not lost connectivity.
+    msg === "unable to exec" ||
     // Deliberately here and NOT in the adapters' retryable set, because the two lists
     // answer different questions. "Did we reach the host?" — no, so a 503 naming the
     // target beats a 500 blaming the request. "Should we run the whole callback again?" —

--- a/packages/adapters/src/system/errors.test.ts
+++ b/packages/adapters/src/system/errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRemoteConnectionError,
+  isRetryableRemoteConnectionError,
+  isSshExecRequestError,
+  SshExecRequestError,
+} from "./errors";
+
+describe("SSH exec-request error classification", () => {
+  it("classifies the tagged error as remote without replaying whole callbacks", () => {
+    const tagged = new SshExecRequestError(new Error("Unable to exec"));
+
+    expect(isSshExecRequestError(tagged)).toBe(true);
+    expect(isRetryableRemoteConnectionError(tagged)).toBe(false);
+    expect(isRemoteConnectionError(tagged)).toBe(true);
+  });
+
+  it("does not classify ordinary command errors by message text", () => {
+    expect(isRetryableRemoteConnectionError(new Error("Unable to exec"))).toBe(false);
+    expect(
+      isRetryableRemoteConnectionError(
+        new Error("sudo: unable to execute helper: Permission denied"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/adapters/src/system/errors.ts
+++ b/packages/adapters/src/system/errors.ts
@@ -25,9 +25,6 @@ const RETRYABLE_CONNECTION_ERROR_PATTERNS = [
   // "first redeploy fails, second click works" pattern.
   "Channel open failure",
   "open failed",
-  // ssh2 emits "Unable to exec" when the SSH server rejects an exec channel
-  // request (SSH_MSG_CHANNEL_FAILURE) on an open session channel.
-  "Unable to exec",
   // NOT "socket hang up": it is what an HTTP client reports for ANY far end that vanished
   // mid-request, including a permission-denied Docker socket and a wedged channel, neither
   // of which a fresh connection fixes. A match here makes `withExecutor` replay its whole
@@ -49,6 +46,26 @@ export class SshDisconnectedError extends Error {
     super(message);
     this.name = "SshDisconnectedError";
   }
+}
+
+/**
+ * `ssh2.Client.exec()` reached the server, but the server rejected the exec
+ * request before returning a command stream. The distinction is important:
+ * arbitrary remote stderr is also surfaced as an Error, and must never become
+ * a reason to replay a command merely because it contains similar words.
+ */
+export class SshExecRequestError extends Error {
+  constructor(cause: Error) {
+    super(cause.message, { cause });
+    this.name = "SshExecRequestError";
+  }
+}
+
+export function isSshExecRequestError(err: unknown): boolean {
+  return (
+    err instanceof SshExecRequestError ||
+    (err instanceof Error && err.name === "SshExecRequestError")
+  );
 }
 
 export function isSshDisconnectedError(err: unknown): err is SshDisconnectedError {
@@ -110,7 +127,15 @@ export function isRetryableRemoteConnectionError(err: unknown): boolean {
 }
 
 export function isRemoteConnectionError(err: unknown): boolean {
-  return isSshAuthError(err) || isRetryableRemoteConnectionError(err);
+  // An exec-request rejection is remote/protocol failure, so human-facing
+  // probes must abort instead of claiming a binary is absent. It deliberately
+  // is NOT globally retryable: SshExecutor already retries that command once,
+  // while a manager-level retry would replay the caller's entire callback.
+  return (
+    isSshAuthError(err) ||
+    isRetryableRemoteConnectionError(err) ||
+    isSshExecRequestError(err)
+  );
 }
 
 const MAX_COMMAND_CHARS = 120;

--- a/packages/adapters/src/system/errors.ts
+++ b/packages/adapters/src/system/errors.ts
@@ -25,6 +25,9 @@ const RETRYABLE_CONNECTION_ERROR_PATTERNS = [
   // "first redeploy fails, second click works" pattern.
   "Channel open failure",
   "open failed",
+  // ssh2 emits "Unable to exec" when the SSH server rejects an exec channel
+  // request (SSH_MSG_CHANNEL_FAILURE) on an open session channel.
+  "Unable to exec",
   // NOT "socket hang up": it is what an HTTP client reports for ANY far end that vanished
   // mid-request, including a permission-denied Docker socket and a wedged channel, neither
   // of which a fresh connection fixes. A match here makes `withExecutor` replay its whole

--- a/packages/adapters/src/system/probe-exec.test.ts
+++ b/packages/adapters/src/system/probe-exec.test.ts
@@ -70,6 +70,12 @@ describe("probeExec", () => {
     );
   });
 
+  it("re-throws 'Unable to exec' channel failure instead of reporting component as missing", async () => {
+    await expect(probeExec(throwing(new Error("Unable to exec")), "git --version", "test")).rejects.toThrow(
+      "Unable to exec",
+    );
+  });
+
   it("trims the output it reports", async () => {
     expect((await probeExec({ exec: async () => "git version 2.43.0\n" }, "g", "test")).output).toBe(
       "git version 2.43.0",

--- a/packages/adapters/src/system/probe-exec.test.ts
+++ b/packages/adapters/src/system/probe-exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { SshDisconnectedError } from "./errors";
+import { SshDisconnectedError, SshExecRequestError } from "./errors";
 import { probeExec, tryExec, withReason } from "./probe-exec";
 import type { ExecOnly } from "../types";
 
@@ -71,9 +71,20 @@ describe("probeExec", () => {
   });
 
   it("re-throws 'Unable to exec' channel failure instead of reporting component as missing", async () => {
-    await expect(probeExec(throwing(new Error("Unable to exec")), "git --version", "test")).rejects.toThrow(
-      "Unable to exec",
+    const failure = new SshExecRequestError(new Error("Unable to exec"));
+    await expect(probeExec(throwing(failure), "git --version", "test")).rejects.toThrow(SshExecRequestError);
+  });
+
+  it("keeps lookalike command stderr as an ordinary probe failure", async () => {
+    const outcome = await probeExec(
+      throwing(new Error("sudo: unable to execute helper: Permission denied")),
+      "git --version",
+      "test",
     );
+    expect(outcome).toEqual({
+      output: "",
+      error: "sudo: unable to execute helper: Permission denied",
+    });
   });
 
   it("trims the output it reports", async () => {

--- a/packages/adapters/src/system/ssh-executor.test.ts
+++ b/packages/adapters/src/system/ssh-executor.test.ts
@@ -53,6 +53,13 @@ const untilExec = (client: ReturnType<typeof fakeClient>) =>
     if (!client.exec.mock.calls.length) throw new Error("exec not called yet");
   });
 
+const untilExecCount = (client: ReturnType<typeof fakeClient>, count: number) =>
+  vi.waitFor(() => {
+    if (client.exec.mock.calls.length < count) {
+      throw new Error(`exec called ${client.exec.mock.calls.length}/${count} times`);
+    }
+  });
+
 beforeEach(() => {
   connectSshClient.mockReset();
 });
@@ -167,5 +174,81 @@ describe("channel retry", () => {
     await expect(p).resolves.toBe("git version 2.55.0");
     expect(attempts).toBe(2);
     expect(client1.end).toHaveBeenCalled();
+  });
+
+  it("does not retry an executed command whose stderr equals the ssh2 sentinel", async () => {
+    const channel = new FakeChannel();
+    const client = fakeClient((_cmd, cb) => cb(null, channel));
+    connectSshClient.mockResolvedValue(client);
+
+    const executor = new SshExecutor(CONFIG);
+    const pending = executor.exec("run-mutating-command");
+
+    await untilExec(client);
+    channel.stderr.emit("data", Buffer.from("Unable to exec\n"));
+    channel.emit("exit", 1);
+    channel.emit("close", 1);
+
+    await expect(pending).rejects.toThrow("Unable to exec");
+    expect(client.exec).toHaveBeenCalledTimes(1);
+    expect(connectSshClient).toHaveBeenCalledTimes(1);
+    expect(client.end).not.toHaveBeenCalled();
+    expect(client.destroy).not.toHaveBeenCalled();
+  });
+
+  it("retries a rejected request without interrupting another in-flight command", async () => {
+    const liveChannel = new FakeChannel();
+    const retryChannel = new FakeChannel();
+    const client = fakeClient((_cmd, cb) => {
+      const attempt = client.exec.mock.calls.length;
+      if (attempt === 1) cb(null, liveChannel);
+      else if (attempt === 2) cb(new Error("Unable to exec"), null as unknown as FakeChannel);
+      else cb(null, retryChannel);
+    });
+    connectSshClient.mockResolvedValue(client);
+
+    const executor = new SshExecutor(CONFIG);
+    const live = executor.exec("long-running-command");
+    await untilExecCount(client, 1);
+
+    const retried = executor.exec("git --version");
+    await untilExecCount(client, 3);
+    retryChannel.emit("data", Buffer.from("git version 2.55.0\n"));
+    retryChannel.emit("exit", 0);
+    retryChannel.emit("close", 0);
+
+    await expect(retried).resolves.toBe("git version 2.55.0");
+    expect(connectSshClient).toHaveBeenCalledTimes(1);
+    expect(client.end).not.toHaveBeenCalled();
+    expect(client.destroy).not.toHaveBeenCalled();
+
+    liveChannel.emit("data", Buffer.from("done\n"));
+    liveChannel.emit("exit", 0);
+    liveChannel.emit("close", 0);
+    await expect(live).resolves.toBe("done");
+  });
+
+  it("retries streamExec when ssh2 rejects the exec request", async () => {
+    const channel = new FakeChannel();
+    const client1 = fakeClient((_cmd, cb) =>
+      cb(new Error("Unable to exec"), null as unknown as FakeChannel),
+    );
+    const client2 = fakeClient((_cmd, cb) => cb(null, channel));
+    connectSshClient.mockResolvedValueOnce(client1).mockResolvedValueOnce(client2);
+
+    const executor = new SshExecutor(CONFIG);
+    const logs: string[] = [];
+    const pending = executor.streamExec("echo ready", (entry) => logs.push(entry.message));
+
+    await untilExec(client2);
+    channel.emit("data", Buffer.from("ready\n"));
+    channel.emit("exit", 0);
+    channel.emit("close", 0);
+
+    await expect(pending).resolves.toEqual({ code: 0, output: "ready\n" });
+    expect(logs).toEqual(["ready\n"]);
+    expect(client1.end).toHaveBeenCalled();
+    expect(client1.exec).toHaveBeenCalledTimes(1);
+    expect(client2.exec).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/adapters/src/system/ssh-executor.test.ts
+++ b/packages/adapters/src/system/ssh-executor.test.ts
@@ -138,3 +138,34 @@ describe("exec timeout", () => {
     expect(channel.close).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("channel retry", () => {
+  it("recovers and retries when client.exec fails with 'Unable to exec'", async () => {
+    const channel = new FakeChannel();
+    let attempts = 0;
+    const client1 = fakeClient((_cmd, cb) => {
+      attempts += 1;
+      cb(new Error("Unable to exec"), null as unknown as FakeChannel);
+    });
+    const client2 = fakeClient((_cmd, cb) => {
+      attempts += 1;
+      cb(null, channel);
+    });
+
+    connectSshClient
+      .mockResolvedValueOnce(client1)
+      .mockResolvedValueOnce(client2);
+
+    const executor = new SshExecutor(CONFIG);
+    const p = executor.exec("git --version");
+
+    await untilExec(client2);
+    channel.emit("data", Buffer.from("git version 2.55.0\n"));
+    channel.emit("exit", 0);
+    channel.emit("close", 0);
+
+    await expect(p).resolves.toBe("git version 2.55.0");
+    expect(attempts).toBe(2);
+    expect(client1.end).toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/src/system/ssh-executor.ts
+++ b/packages/adapters/src/system/ssh-executor.ts
@@ -5,15 +5,14 @@ import { tmpdir } from "node:os";
 import { join, posix } from "node:path";
 
 import { prepareSourceTarArgs } from "../archive";
-import type {
-  CommandExecutor,
-  LogEntry,
-  ShellOptions,
-  ShellSession,
-  SshConfig,
-} from "../types";
+import type { CommandExecutor, LogEntry, ShellOptions, ShellSession, SshConfig } from "../types";
 import { logEntry, sq } from "./local-shell";
-import { canUseRemoteRsync, extractRemoteArchive, packLocalArchive, uploadFileWithRsync } from "./remote-transfer";
+import {
+  canUseRemoteRsync,
+  extractRemoteArchive,
+  packLocalArchive,
+  uploadFileWithRsync,
+} from "./remote-transfer";
 import type { Client as SshClient, ClientChannel, SFTPWrapper } from "ssh2";
 import type { Readable, Duplex } from "node:stream";
 import {
@@ -23,7 +22,12 @@ import {
   openDockerDialStdioChannel,
   type StreamLocalCapableClient,
 } from "./ssh-client";
-import { commandForError, SshDisconnectedError } from "./errors";
+import {
+  commandForError,
+  isSshExecRequestError,
+  SshDisconnectedError,
+  SshExecRequestError,
+} from "./errors";
 import { TRANSFER_EXCLUDES, formatBytes } from "@repo/core";
 
 /**
@@ -46,6 +50,16 @@ const SFTP_OPERATION_TIMEOUT_MS = 30_000;
  * can no longer receive mutations before the deployment lock is released. */
 const CHANNEL_CLOSE_GRACE_MS = 750;
 const TRANSPORT_CLOSE_GRACE_MS = 250;
+
+/**
+ * ssh2 exposes SSH_MSG_CHANNEL_FAILURE for an exec request as one untyped
+ * sentinel. Tag it while we still know the error came from `Client.exec`'s
+ * pre-stream callback; matching later would confuse remote command stderr with
+ * a command that never started.
+ */
+function tagExecRequestError(error: Error): Error {
+  return error.message === "Unable to exec" ? new SshExecRequestError(error) : error;
+}
 
 function abortError(operation: string, signal: AbortSignal): Error {
   const reason = signal.reason;
@@ -451,20 +465,18 @@ export class SshExecutor implements CommandExecutor {
   /** Returns true if the error is an SSH channel-open or channel-exec failure. */
   private static isChannelError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
+    if (isSshExecRequestError(err)) return true;
     const msg = err.message.toLowerCase();
-    return (
-      msg.includes("channel open failure") ||
-      msg.includes("open failed") ||
-      msg.includes("unable to exec")
-    );
+    return msg.includes("channel open failure") || msg.includes("open failed");
   }
 
   /**
    * Run an operation, and if it fails opening an SSH channel on a half-dead
    * cached connection ("Channel open failure: open failed" — common after the
-   * idle timeout drops the socket), drop the connection and retry ONCE on a
-   * fresh one. This is why `exec` survives a stale connection; the SFTP-based
-   * ops (writeFile/readFile/exists) must go through it too, or a deploy's route
+   * idle timeout drops the socket), recover channel capacity and retry ONCE.
+   * An idle connection is replaced; a busy one stays alive so its other command
+   * is not aborted (see recoverFromChannelError). The SFTP-based ops
+   * (writeFile/readFile/exists) must go through this too, or a deploy's route
    * write fails spuriously and only succeeds on a manual redeploy.
    */
   private async withChannelRetry<T>(fn: () => Promise<T>): Promise<T> {
@@ -548,7 +560,7 @@ export class SshExecutor implements CommandExecutor {
       timer.unref?.();
 
       client.exec(SshExecutor.ENV_PREFIX + command, (err, stream) => {
-        if (err) return finish(() => reject(err));
+        if (err) return finish(() => reject(tagExecRequestError(err)));
         channel = stream;
         if (terminating) {
           try { stream.close(); } catch {}
@@ -661,7 +673,7 @@ export class SshExecutor implements CommandExecutor {
       }
 
       client.exec(SshExecutor.ENV_PREFIX + command, (err, stream) => {
-        if (err) return finish(() => reject(err));
+        if (err) return finish(() => reject(tagExecRequestError(err)));
         channel = stream;
         // The abort may have fired between the check above and the channel opening.
         if (terminating || signal?.aborted) {

--- a/packages/adapters/src/system/ssh-executor.ts
+++ b/packages/adapters/src/system/ssh-executor.ts
@@ -448,11 +448,15 @@ export class SshExecutor implements CommandExecutor {
     else this.resetConnection();
   }
 
-  /** Returns true if the error is an SSH channel-open failure. */
+  /** Returns true if the error is an SSH channel-open or channel-exec failure. */
   private static isChannelError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
     const msg = err.message.toLowerCase();
-    return msg.includes("channel open failure") || msg.includes("open failed");
+    return (
+      msg.includes("channel open failure") ||
+      msg.includes("open failed") ||
+      msg.includes("unable to exec")
+    );
   }
 
   /**

--- a/packages/core/src/connectivity.ts
+++ b/packages/core/src/connectivity.ts
@@ -60,7 +60,8 @@ const MESSAGE_PATTERNS: Array<[RegExp, ConnectivityCode]> = [
   [/econnrefused|connection refused|ehostunreach|enetunreach|no route to host|host unreachable|enotfound|getaddrinfo|dns/i, "unreachable"],
   [/etimedout|timed out|timeout|keepalive timeout/i, "timeout"],
   [/socket hang up|epipe|premature close/i, "protocol_error"],
-  [/econnreset|connection reset|connection lost|connection closed|handshake failed|not connected|channel open failure|open failed|unable to exec|unexpected response/i, "protocol_error"],
+  [/^unable to exec$/i, "protocol_error"],
+  [/econnreset|connection reset|connection lost|connection closed|handshake failed|not connected|channel open failure|open failed|unexpected response/i, "protocol_error"],
   [/eacces|permission denied|not permitted|access denied|forbidden|read-only|not writable/i, "permission_denied"],
 ];
 

--- a/packages/core/src/connectivity.ts
+++ b/packages/core/src/connectivity.ts
@@ -60,7 +60,7 @@ const MESSAGE_PATTERNS: Array<[RegExp, ConnectivityCode]> = [
   [/econnrefused|connection refused|ehostunreach|enetunreach|no route to host|host unreachable|enotfound|getaddrinfo|dns/i, "unreachable"],
   [/etimedout|timed out|timeout|keepalive timeout/i, "timeout"],
   [/socket hang up|epipe|premature close/i, "protocol_error"],
-  [/econnreset|connection reset|connection lost|connection closed|handshake failed|not connected|channel open failure|open failed|unexpected response/i, "protocol_error"],
+  [/econnreset|connection reset|connection lost|connection closed|handshake failed|not connected|channel open failure|open failed|unable to exec|unexpected response/i, "protocol_error"],
   [/eacces|permission denied|not permitted|access denied|forbidden|read-only|not writable/i, "permission_denied"],
 ];
 

--- a/packages/core/test/connectivity.test.ts
+++ b/packages/core/test/connectivity.test.ts
@@ -58,6 +58,7 @@ describe("classifyConnectivityError", () => {
     expect(classifyConnectivityError("Handshake failed").code).toBe("protocol_error");
     expect(classifyConnectivityError("Channel open failure: open failed").code).toBe("protocol_error");
     expect(classifyConnectivityError("Unable to exec").code).toBe("protocol_error");
+    expect(classifyConnectivityError("sudo: unable to execute helper").code).toBe("unknown");
   });
 
   it("classifies a socket destroyed with no reply, rather than leaving it unknown", () => {

--- a/packages/core/test/connectivity.test.ts
+++ b/packages/core/test/connectivity.test.ts
@@ -57,6 +57,7 @@ describe("classifyConnectivityError", () => {
   it("maps handshake / channel / reset to protocol_error", () => {
     expect(classifyConnectivityError("Handshake failed").code).toBe("protocol_error");
     expect(classifyConnectivityError("Channel open failure: open failed").code).toBe("protocol_error");
+    expect(classifyConnectivityError("Unable to exec").code).toBe("protocol_error");
   });
 
   it("classifies a socket destroyed with no reply, rather than leaving it unknown", () => {


### PR DESCRIPTION
## Summary

Fixes #807 without treating arbitrary command output as a connection failure.

`ssh2` reports a rejected exec request as the untyped exact error `Unable to exec`. This PR now tags that sentinel at the `Client.exec` callback boundary, where it can be distinguished from remote command stderr, and retries only the rejected command once.

## Behavior

- Retry an exact pre-stream `Unable to exec` rejection once.
- Replace an idle stale connection before retrying.
- Preserve a busy connection so concurrent in-flight commands are not aborted.
- Support the same recovery for `exec` and `streamExec`.
- Re-throw the typed protocol failure from component probes instead of reporting installed tools as missing.
- Keep it out of the global retryable-error set so `withExecutor` cannot replay an entire mutating callback.
- Classify only the exact serialized sentinel in API remote-state and core connectivity paths.

## Safety coverage

- Remote stderr equal to `Unable to exec` is not retried.
- Lookalikes such as `unable to execute helper` are not classified or retried.
- A concurrent live command survives recovery.
- Stream output and logs survive a successful retry.
- Adapters, core, and API typechecks pass.
- Focused regression suite: 35 tests pass.
- Full adapters/core suites were also run locally: 4,406 tests pass.
