### PR TITLE
fix(dashboard): guard app install custom domains with DNS pre-deploy gate (#810)

### DIFF
--- a/apps/api/src/modules/domains/domain.controller.ts
+++ b/apps/api/src/modules/domains/domain.controller.ts
@@ -199,7 +199,7 @@ export async function records(c: Context) {
   const ctx = getRequestContext(c);
   const id = param(c, "id");
   await permission.assert(getRequestContext(c), { resourceType: "domain", resourceId: id, action: "read" });
-  const result = await domainService.getDomainRecords(ctx, id);
+  const result = await domainService.getDomainRecords(ctx, id, dnsTargetServerId(c));
   return c.json({ data: result });
 }
 
@@ -208,7 +208,7 @@ export async function dnsPlan(c: Context) {
   const ctx = getRequestContext(c);
   const id = param(c, "id");
   await permission.assert(getRequestContext(c), { resourceType: "domain", resourceId: id, action: "read" });
-  const result = await domainService.planDomainDns(ctx, id);
+  const result = await domainService.planDomainDns(ctx, id, dnsTargetServerId(c));
   return c.json({ data: result });
 }
 
@@ -217,7 +217,7 @@ export async function dnsApply(c: Context) {
   const ctx = getRequestContext(c);
   const id = param(c, "id");
   await permission.assert(getRequestContext(c), { resourceType: "domain", resourceId: id, action: "write" });
-  const result = await domainService.applyDomainDns(ctx, id);
+  const result = await domainService.applyDomainDns(ctx, id, dnsTargetServerId(c));
   audit.recordAsync(auditContextFrom(c, ctx.organizationId, ctx.userId), {
     eventType: "domain.dns_provisioned",
     resourceType: "domain",
@@ -229,6 +229,11 @@ export async function dnsApply(c: Context) {
     },
   });
   return c.json({ data: result });
+}
+
+/** An explicit wizard target overrides a project's prior deployment for DNS guidance. */
+function dnsTargetServerId(c: Context): string | undefined {
+  return c.req.query("serverId")?.trim() || undefined;
 }
 
 /** POST /domains/:id/primary - make this domain the project's primary */

--- a/apps/api/src/modules/domains/domain.service.ts
+++ b/apps/api/src/modules/domains/domain.service.ts
@@ -502,10 +502,22 @@ export async function previewRecords(
 
 // ─── Get DNS records (existing domain) ───────────────────────────────────────
 
-export async function getDomainRecords(ctx: RequestContext, domainId: string) {
+export async function getDomainRecords(
+  ctx: RequestContext,
+  domainId: string,
+  targetServerId?: string,
+) {
   const { domain, project } = await getDomainWithAuth(domainId, ctx.organizationId);
   const token = domain.verificationToken ?? generateToken(domain.hostname);
-  return buildRecords(domain.hostname, token, project, domain.externalIngress, ctx.organizationId);
+  return buildRecords(
+    domain.hostname,
+    token,
+    project,
+    domain.externalIngress,
+    ctx.organizationId,
+    false,
+    targetServerId,
+  );
 }
 
 // ─── Auto-configure DNS (on-demand) ──────────────────────────────────────────
@@ -522,6 +534,7 @@ export async function getDomainRecords(ctx: RequestContext, domainId: string) {
 async function desiredDnsInputs(
   ctx: RequestContext,
   domainId: string,
+  targetServerId?: string,
 ): Promise<{ hostname: string; inputs: DnsRecordInput[] }> {
   const { domain, project } = await getDomainWithAuth(domainId, ctx.organizationId);
   const token = domain.verificationToken ?? generateToken(domain.hostname);
@@ -531,6 +544,8 @@ async function desiredDnsInputs(
     project,
     domain.externalIngress,
     ctx.organizationId,
+    false,
+    targetServerId,
   );
   const { routeName, txtName } = dnsRecordHosts(domain.hostname);
   const own = new Set([routeName.toLowerCase(), txtName.toLowerCase()]);
@@ -541,8 +556,12 @@ async function desiredDnsInputs(
 }
 
 /** Dry-run: what auto-configuring this domain's DNS would do. Reads only. */
-export async function planDomainDns(ctx: RequestContext, domainId: string): Promise<DnsPlanResult> {
-  const { hostname, inputs } = await desiredDnsInputs(ctx, domainId);
+export async function planDomainDns(
+  ctx: RequestContext,
+  domainId: string,
+  targetServerId?: string,
+): Promise<DnsPlanResult> {
+  const { hostname, inputs } = await desiredDnsInputs(ctx, domainId, targetServerId);
   return planRecords(ctx.organizationId, hostname, inputs);
 }
 
@@ -558,8 +577,9 @@ export async function planDomainDns(ctx: RequestContext, domainId: string): Prom
 export async function applyDomainDns(
   ctx: RequestContext,
   domainId: string,
+  targetServerId?: string,
 ): Promise<DnsProvisionResult> {
-  const { hostname, inputs } = await desiredDnsInputs(ctx, domainId);
+  const { hostname, inputs } = await desiredDnsInputs(ctx, domainId, targetServerId);
   return provisionRecords(ctx.organizationId, hostname, inputs);
 }
 
@@ -1638,7 +1658,7 @@ async function buildRecords(
    *  saw only the apex record, then wondered why www never resolved. */
   includeWww = false,
   /** Explicit pre-deploy target. Existing domain rows resolve through project. */
-  previewServerId?: string,
+  targetServerId?: string,
 ): Promise<{ mode: "cloud" | "selfhosted" | "external"; records: DnsRecord[] }> {
   const wwwHostname = includeWww ? wwwSiblingHostname(hostname) : null;
   const { target, runtime } = platform();
@@ -1698,15 +1718,15 @@ async function buildRecords(
   // box's public address (resolved once at ensure-server): the deployed project's
   // server, else this org's "This Server" row for the pre-deploy preview.
   let serverIp =
-    previewServerId && organizationId
-      ? await resolveServerHost(organizationId, previewServerId).catch(() => null)
+    targetServerId && organizationId
+      ? await resolveServerHost(organizationId, targetServerId).catch(() => null)
       : ((await resolveProjectServerHost(project)) ??
         (organizationId ? await resolveLocalServerHost(organizationId) : null));
   // A loopback is the local row's display host when no public IP was known at
   // registration — useless as "point your domain here". Re-detect live for this
   // (user-initiated, off-hot-path) preview; leave EMPTY so the UI shows a
   // placeholder rather than a dead `127.0.0.1` the operator would copy verbatim.
-  if ((!serverIp || isLoopbackHost(serverIp)) && !previewServerId) {
+  if ((!serverIp || isLoopbackHost(serverIp)) && !targetServerId) {
     const detected = await resolveInstancePublicIp().catch(() => null);
     serverIp = detected && !isLoopbackHost(detected) ? detected : null;
   }

--- a/apps/api/test/modules/domains/domain-dns.test.ts
+++ b/apps/api/test/modules/domains/domain-dns.test.ts
@@ -9,6 +9,11 @@ const projectRepo = vi.hoisted(() => ({
   findById: vi.fn(),
 }));
 
+const serverTarget = vi.hoisted(() => ({
+  resolveProjectServerHost: vi.fn(),
+  resolveSelectedServerHost: vi.fn(),
+}));
+
 vi.mock("@repo/db", () => ({
   repos: { domain: domainRepo, project: projectRepo },
 }));
@@ -22,7 +27,8 @@ vi.mock("../../../src/lib/server-target", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../src/lib/server-target")>();
   return {
     ...actual,
-    resolveProjectServerHost: vi.fn().mockResolvedValue("203.0.113.10"),
+    resolveProjectServerHost: serverTarget.resolveProjectServerHost,
+    resolveServerHost: serverTarget.resolveSelectedServerHost,
     resolveInstancePublicIp: vi.fn().mockResolvedValue(null),
     resolveLocalServerHost: vi.fn().mockResolvedValue(null),
   };
@@ -39,7 +45,11 @@ vi.mock("../../../src/modules/dns/dns-credential.service", () => ({
   releaseRecords: vi.fn().mockResolvedValue({ deleted: 0 }),
 }));
 
-import { planDomainDns, applyDomainDns } from "../../../src/modules/domains/domain.service";
+import {
+  applyDomainDns,
+  getDomainRecords,
+  planDomainDns,
+} from "../../../src/modules/domains/domain.service";
 
 const ctx = { organizationId: "org_123", userId: "user_123" } as any;
 
@@ -64,6 +74,10 @@ describe("domain DNS plan/apply mapping", () => {
     domainRepo.findById.mockResolvedValue(domain);
     projectRepo.findById.mockReset();
     projectRepo.findById.mockResolvedValue(project);
+    serverTarget.resolveProjectServerHost.mockReset();
+    serverTarget.resolveProjectServerHost.mockResolvedValue("203.0.113.10");
+    serverTarget.resolveSelectedServerHost.mockReset();
+    serverTarget.resolveSelectedServerHost.mockResolvedValue("198.51.100.42");
     planRecords.mockClear();
     provisionRecords.mockClear();
   });
@@ -91,6 +105,24 @@ describe("domain DNS plan/apply mapping", () => {
     const planned = (planRecords.mock.calls[0] as unknown[])[2];
     const applied = (provisionRecords.mock.calls[0] as unknown[])[2];
     expect(applied).toEqual(planned);
+  });
+
+  it("uses the explicit pre-deploy server for records, plan and apply", async () => {
+    const records = await getDomainRecords(ctx, "dom_1", "server_new");
+    await planDomainDns(ctx, "dom_1", "server_new");
+    await applyDomainDns(ctx, "dom_1", "server_new");
+
+    expect(serverTarget.resolveSelectedServerHost).toHaveBeenCalledTimes(3);
+    expect(serverTarget.resolveSelectedServerHost).toHaveBeenCalledWith("org_123", "server_new");
+    expect(records.records).toEqual([
+      { type: "A", host: "@", name: "example.com", value: "198.51.100.42" },
+    ]);
+    expect((planRecords.mock.calls[0] as unknown[])[2]).toEqual([
+      { type: "A", name: "example.com", content: "198.51.100.42" },
+    ]);
+    expect((provisionRecords.mock.calls[0] as unknown[])[2]).toEqual([
+      { type: "A", name: "example.com", content: "198.51.100.42" },
+    ]);
   });
 
   it("drops a record whose target is unknown rather than planning an empty write", async () => {

--- a/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/DnsConfiguration.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/DnsConfiguration.tsx
@@ -23,6 +23,8 @@ interface DnsConfigurationProps {
   /** A persisted domain's id. When set, the on-demand auto-configure panel is
    *  shown above the manual records — pre-add previews (no id) stay manual. */
   domainId?: string;
+  /** Explicit pre-deploy server; it wins over any previous project deployment. */
+  serverId?: string;
 }
 
 const DnsConfiguration: React.FC<DnsConfigurationProps> = ({
@@ -31,6 +33,7 @@ const DnsConfiguration: React.FC<DnsConfigurationProps> = ({
   mode,
   showHeader = true,
   domainId,
+  serverId,
 }) => {
   const { t } = useI18n();
   const d = t.deploy.dns;
@@ -78,9 +81,9 @@ const DnsConfiguration: React.FC<DnsConfigurationProps> = ({
     <div className="space-y-3">
       {domainId && (
         <AutoDnsPanel
-          plan={() => domainsApi.dnsPlan(domainId).then((r) => r.data)}
-          apply={() => domainsApi.dnsApply(domainId).then((r) => r.data)}
-          reloadKey={domainId}
+          plan={() => domainsApi.dnsPlan(domainId, serverId).then((r) => r.data)}
+          apply={() => domainsApi.dnsApply(domainId, serverId).then((r) => r.data)}
+          reloadKey={`${domainId}:${serverId ?? "project"}`}
         />
       )}
       {manual}

--- a/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/Sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/Sidebar.tsx
@@ -245,6 +245,21 @@ const Sidebar: React.FC = () => {
     // deploy. Informational-blocking: Deploy proceeds, Cancel aborts.
     const dnsTargets = selfHosted ? deploymentDnsTargets(config) : [];
     if (dnsTargets.length > 0) {
+      if (config.projectId) {
+        const projectInfo = await projectsApi.getInfo(config.projectId).catch(() => null);
+        const domainRows = Array.isArray(projectInfo?.data?.project?.domains)
+          ? projectInfo.data.project.domains
+          : [];
+        const domainByHost = new Map<string, string>();
+        for (const d of domainRows) {
+          if (typeof d?.hostname === "string" && typeof d?.id === "string") {
+            domainByHost.set(d.hostname.toLowerCase(), d.id);
+          }
+        }
+        for (const target of dnsTargets) {
+          target.domainId = domainByHost.get(target.hostname.toLowerCase()) ?? null;
+        }
+      }
       let modalId = "";
       modalId = showModal({
         customContent: (

--- a/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/Sidebar.tsx
+++ b/apps/dashboard/src/app/(dashboard)/(deployment)/deploy/[slug]/components/Sidebar.tsx
@@ -27,7 +27,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { invalidateProjectCaches } from "@/hooks/useProjectEndpoints";
 import { projectsApi, githubApi, getApiErrorMessage } from "@/lib/api";
 import { useToast } from "@/context/ToastContext";
-import { deploymentDnsTargets } from "@/lib/deployment-dns";
+import { attachDeploymentDomainIds, deploymentDnsTargets } from "@/lib/deployment-dns";
 
 // ─── Deploy checklist for compose ────────────────────────────────────────────
 
@@ -243,22 +243,14 @@ const Sidebar: React.FC = () => {
     // BEFORE the deploy so DNS is pointed when the first-deploy SSL attempt runs.
     // A failed attempt just marks the domain Action Required — never blocks the
     // deploy. Informational-blocking: Deploy proceeds, Cancel aborts.
-    const dnsTargets = selfHosted ? deploymentDnsTargets(config) : [];
+    let dnsTargets = selfHosted ? deploymentDnsTargets(config) : [];
     if (dnsTargets.length > 0) {
       if (config.projectId) {
         const projectInfo = await projectsApi.getInfo(config.projectId).catch(() => null);
         const domainRows = Array.isArray(projectInfo?.data?.project?.domains)
           ? projectInfo.data.project.domains
           : [];
-        const domainByHost = new Map<string, string>();
-        for (const d of domainRows) {
-          if (typeof d?.hostname === "string" && typeof d?.id === "string") {
-            domainByHost.set(d.hostname.toLowerCase(), d.id);
-          }
-        }
-        for (const target of dnsTargets) {
-          target.domainId = domainByHost.get(target.hostname.toLowerCase()) ?? null;
-        }
+        dnsTargets = attachDeploymentDomainIds(dnsTargets, domainRows);
       }
       let modalId = "";
       modalId = showModal({

--- a/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
@@ -77,6 +77,7 @@ import { AppLogo } from "@/components/AppLogo";
 import { VerifiedBadge } from "@/components/apps/VerifiedBadge";
 import { HostingBadge } from "@/components/apps/HostingBadge";
 import { UnverifiedBadge } from "@/components/apps/UnverifiedBadge";
+import DnsRecordsModal from "@/components/domains/DnsRecordsModal";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { encodeProjectSlug } from "@/utils/repoSlug";
 import { parseContainerPort } from "@/utils/compose-ports";
@@ -251,7 +252,7 @@ export default function AppInstallPage() {
   const { t, locale } = useI18n();
   const w = t.projectSettings.appInstall;
   const { showToast } = useToast();
-  const { baseDomain, deployMode } = usePlatform();
+  const { baseDomain, deployMode, selfHosted } = usePlatform();
   // Desktop mode → the "open on localhost / forward the port" hints are relevant
   // (a VPS is already public; a local app is already localhost).
   const isDesktop = deployMode === "desktop";
@@ -1019,34 +1020,103 @@ export default function AppInstallPage() {
         }
       }
 
-      const dep = await deployApi.buildAccess({
-        projectId: pid,
-        serviceDeploymentMode: "services",
-        // Where to install — reuses the deploy wizard's target selection.
-        // Undefined falls back to the project/meta default server-side.
-        deployTarget: destination?.deployTarget,
-        serverId: destination?.deployTarget === "server" ? destination.serverId : undefined,
-      });
-      const depId =
-        dep?.data?.deployment_id ?? dep?.data?.deploymentId ?? dep?.deployment_id ?? null;
-      setDeploymentId(depId);
-      started = true;
-      // Persist the deployment id in the URL so a hard refresh mid-install
-      // resumes the progress view (re-attaches to the same SSE stream) instead
-      // of dropping back to the form. Client-only; best-effort.
-      if (depId) {
+      const startDeploy = async (targetPid: string) => {
+        setBusy(true);
         try {
-          const url = new URL(window.location.href);
-          url.searchParams.set("deployment", depId);
-          if (pid) url.searchParams.set("projectId", pid);
-          window.history.replaceState(null, "", url.toString());
-        } catch {
-          /* resume just won't survive a reload */
+          const dep = await deployApi.buildAccess({
+            projectId: targetPid,
+            serviceDeploymentMode: "services",
+            // Where to install — reuses the deploy wizard's target selection.
+            // Undefined falls back to the project/meta default server-side.
+            deployTarget: destination?.deployTarget,
+            serverId: destination?.deployTarget === "server" ? destination.serverId : undefined,
+          });
+          const depId =
+            dep?.data?.deployment_id ?? dep?.data?.deploymentId ?? dep?.deployment_id ?? null;
+          setDeploymentId(depId);
+          started = true;
+          // Persist the deployment id in the URL so a hard refresh mid-install
+          // resumes the progress view (re-attaches to the same SSE stream) instead
+          // of dropping back to the form. Client-only; best-effort.
+          if (depId) {
+            try {
+              const url = new URL(window.location.href);
+              url.searchParams.set("deployment", depId);
+              url.searchParams.set("projectId", targetPid);
+              window.history.replaceState(null, "", url.toString());
+            } catch {
+              /* resume just won't survive a reload */
+            }
+          }
+          setPhaseLabel(w.phaseQueued);
+          setStartedAt(Date.now());
+          setPhase("installing");
+        } catch (err) {
+          const msg = getApiErrorMessage(err, w.installFailed).replace(
+            /^Pre-deploy checks failed:\s*/i,
+            "",
+          );
+          if (started) {
+            setErrorMsg(msg);
+            setPhase("error");
+          } else {
+            showToast(msg, "error");
+          }
+        } finally {
+          setBusy(false);
+        }
+      };
+
+      // Pre-deploy DNS gate (self-hosted custom domain): surface the records to add
+      // or auto-configure BEFORE the deploy so DNS is pointed when the first-deploy
+      // SSL attempt runs.
+      const customRoutes = (routes ?? []).filter(
+        (r) => r.mode === "custom" && r.customDomain?.trim(),
+      );
+      if (selfHosted && customRoutes.length > 0) {
+        const projectInfo = await projectsApi.getInfo(pid).catch(() => null);
+        const domainRows = Array.isArray(projectInfo?.data?.project?.domains)
+          ? projectInfo.data.project.domains
+          : [];
+        const domainByHost = new Map<string, string>();
+        for (const d of domainRows) {
+          if (typeof d?.hostname === "string" && typeof d?.id === "string") {
+            domainByHost.set(d.hostname.toLowerCase(), d.id);
+          }
+        }
+        const dnsTargets = customRoutes.map((r) => {
+          const host = normalizeCustomHostname(r.customDomain!);
+          return {
+            hostname: host,
+            domainId: domainByHost.get(host.toLowerCase()) ?? null,
+          };
+        });
+        if (dnsTargets.length > 0) {
+          setBusy(false);
+          let modalId = "";
+          modalId = showModal({
+            customContent: (
+              <DnsRecordsModal
+                targets={dnsTargets}
+                serverId={destination?.deployTarget === "server" ? destination.serverId : undefined}
+                confirmLabel={w.install}
+                onConfirm={() => {
+                  hideModal(modalId);
+                  void startDeploy(pid);
+                }}
+                onCancel={() => {
+                  hideModal(modalId);
+                  setBusy(false);
+                }}
+              />
+            ),
+            maxWidth: "560px",
+          });
+          return;
         }
       }
-      setPhaseLabel(w.phaseQueued);
-      setStartedAt(Date.now());
-      setPhase("installing");
+
+      await startDeploy(pid);
     } catch (err) {
       // Strip the server's "Pre-deploy checks failed:" prefix for a cleaner
       // message. Nothing deployed yet → toast + stay on the form; a deploy that

--- a/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx
@@ -72,6 +72,7 @@ import { LocalDeployComingSoonModal } from "@/components/LocalDeployComingSoonMo
 import { useLocalDeployGate } from "@/hooks/useLocalDeployGate";
 import { defaultDomainType } from "@/lib/default-domain-type";
 import { installSettledMessage } from "@/lib/install-settled-message";
+import { appInstallDnsTargets, attachDeploymentDomainIds } from "@/lib/deployment-dns";
 import { OptionCard } from "@/app/(dashboard)/(deployment)/deploy/[slug]/components/DeployTargetStep";
 import { AppLogo } from "@/components/AppLogo";
 import { VerifiedBadge } from "@/components/apps/VerifiedBadge";
@@ -1070,27 +1071,13 @@ export default function AppInstallPage() {
       // Pre-deploy DNS gate (self-hosted custom domain): surface the records to add
       // or auto-configure BEFORE the deploy so DNS is pointed when the first-deploy
       // SSL attempt runs.
-      const customRoutes = (routes ?? []).filter(
-        (r) => r.mode === "custom" && r.customDomain?.trim(),
-      );
-      if (selfHosted && customRoutes.length > 0) {
+      const pendingDnsTargets = appInstallDnsTargets(routes ?? []);
+      if (selfHosted && pendingDnsTargets.length > 0) {
         const projectInfo = await projectsApi.getInfo(pid).catch(() => null);
         const domainRows = Array.isArray(projectInfo?.data?.project?.domains)
           ? projectInfo.data.project.domains
           : [];
-        const domainByHost = new Map<string, string>();
-        for (const d of domainRows) {
-          if (typeof d?.hostname === "string" && typeof d?.id === "string") {
-            domainByHost.set(d.hostname.toLowerCase(), d.id);
-          }
-        }
-        const dnsTargets = customRoutes.map((r) => {
-          const host = normalizeCustomHostname(r.customDomain!);
-          return {
-            hostname: host,
-            domainId: domainByHost.get(host.toLowerCase()) ?? null,
-          };
-        });
+        const dnsTargets = attachDeploymentDomainIds(pendingDnsTargets, domainRows);
         if (dnsTargets.length > 0) {
           setBusy(false);
           let modalId = "";

--- a/apps/dashboard/src/components/domains/DnsRecordsModal.tsx
+++ b/apps/dashboard/src/components/domains/DnsRecordsModal.tsx
@@ -17,6 +17,7 @@ interface DnsRecordsModalProps {
   }>;
   /** Selected remote deployment target, so A records point at that server. */
   serverId?: string;
+  confirmLabel?: string;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -30,6 +31,7 @@ interface DnsRecordsModalProps {
 export default function DnsRecordsModal({
   targets,
   serverId,
+  confirmLabel,
   onConfirm,
   onCancel,
 }: DnsRecordsModalProps) {
@@ -160,7 +162,7 @@ export default function DnsRecordsModal({
           onClick={onConfirm}
           className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
-          {d.deployAction}
+          {confirmLabel ?? d.deployAction}
         </button>
       </div>
     </div>

--- a/apps/dashboard/src/components/domains/DnsRecordsModal.tsx
+++ b/apps/dashboard/src/components/domains/DnsRecordsModal.tsx
@@ -54,33 +54,17 @@ export default function DnsRecordsModal({
           targets.map(async (target) => {
             try {
               const res = target.domainId
-                ? await domainsApi.records(target.domainId)
+                ? await domainsApi.records(target.domainId, serverId)
                 : await domainsApi.previewRecords(
                     target.hostname,
                     target.includeWww === true,
                     serverId,
                   );
               const mode = res.data.mode === "cloud" ? "cloud" as const : "selfhosted" as const;
-              let records = res.data.records;
-              if (
-                target.includeWww &&
-                mode === "selfhosted" &&
-                !records.some((record) => record.type === "CNAME" && record.host.startsWith("www"))
-              ) {
-                records = [
-                  ...records,
-                  {
-                    type: "CNAME" as const,
-                    host: "www",
-                    name: `www.${target.hostname}`,
-                    value: target.hostname,
-                  },
-                ];
-              }
               return {
                 hostname: target.hostname,
                 domainId: target.domainId ?? undefined,
-                records,
+                records: res.data.records,
                 mode,
               };
             } catch {
@@ -144,6 +128,7 @@ export default function DnsRecordsModal({
               mode={section.mode}
               showHeader={targets.length > 1}
               domainId={section.domainId}
+              serverId={serverId}
             />
           ))}
         </div>

--- a/apps/dashboard/src/components/domains/dns-records-modal.render.test.tsx
+++ b/apps/dashboard/src/components/domains/dns-records-modal.render.test.tsx
@@ -42,4 +42,20 @@ describe("DnsRecordsModal", () => {
     expect(out).toContain("Deploy");
     expect(out).toContain("Cancel");
   });
+
+  it("renders a custom confirmLabel when provided", () => {
+    const out = text(renderToStaticMarkup(
+      <I18nProvider>
+        <DnsRecordsModal
+          targets={[{ hostname: "app.example.com" }]}
+          confirmLabel="Install"
+          onConfirm={() => {}}
+          onCancel={() => {}}
+        />
+      </I18nProvider>,
+    ));
+
+    expect(out).toContain("Install");
+    expect(out).not.toContain("Deploy");
+  });
 });

--- a/apps/dashboard/src/lib/api/domains.target-server.test.ts
+++ b/apps/dashboard/src/lib/api/domains.target-server.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { domainsApi } from "./domains";
+
+function captureRequest() {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+    new Response(JSON.stringify({ data: { mode: "selfhosted", records: [] } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("domain DNS target forwarding", () => {
+  it.each([
+    ["records", () => domainsApi.records("dom_1", "server_new"), "GET"],
+    ["plan", () => domainsApi.dnsPlan("dom_1", "server_new"), "GET"],
+    ["apply", () => domainsApi.dnsApply("dom_1", "server_new"), "POST"],
+  ] as const)("sends the selected server to DNS %s", async (_name, request, method) => {
+    const fetchMock = captureRequest();
+
+    await request();
+
+    const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.get("serverId")).toBe("server_new");
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).method).toBe(method);
+  });
+});

--- a/apps/dashboard/src/lib/api/domains.ts
+++ b/apps/dashboard/src/lib/api/domains.ts
@@ -90,18 +90,24 @@ export const domainsApi = {
 
   /** Fetch the DNS records for an EXISTING (e.g. pending) domain so the user can
    *  re-see exactly what to add at any time — not only right after connect. */
-  records: (domainId: string) =>
-    api.get<{ data: DomainDnsRecords }>(endpoints.domains.records(domainId)),
+  records: (domainId: string, serverId?: string) =>
+    api.get<{ data: DomainDnsRecords }>(endpoints.domains.records(domainId), {
+      params: { serverId },
+    }),
 
   /** Dry-run auto-configure: preview what a connected provider would write for
    *  this domain, before touching anything. Powers the on-demand button. */
-  dnsPlan: (domainId: string) =>
-    api.get<{ data: DnsPlanResult }>(endpoints.domains.dnsPlan(domainId)),
+  dnsPlan: (domainId: string, serverId?: string) =>
+    api.get<{ data: DnsPlanResult }>(endpoints.domains.dnsPlan(domainId), {
+      params: { serverId },
+    }),
 
   /** Write this domain's records through the connected provider, on press.
    *  Atomic per record — in-sync records are skipped, conflicts refused. */
-  dnsApply: (domainId: string) =>
-    api.post<{ data: DnsProvisionResult }>(endpoints.domains.dnsApply(domainId)),
+  dnsApply: (domainId: string, serverId?: string) =>
+    api.post<{ data: DnsProvisionResult }>(endpoints.domains.dnsApply(domainId), undefined, {
+      params: { serverId },
+    }),
 
   /**
    * Recheck SSL: read-only verification that the Let's Encrypt cert is actually

--- a/apps/dashboard/src/lib/deployment-dns.test.ts
+++ b/apps/dashboard/src/lib/deployment-dns.test.ts
@@ -97,4 +97,13 @@ describe("deploymentDnsTargets", () => {
     expect(sidebar).toContain("<DnsRecordsModal");
     expect(sidebar).toContain("targets={dnsTargets}");
   });
+
+  it("guards self-hosted custom domains with DnsRecordsModal in the app installer", () => {
+    const installPage = readFileSync(
+      new URL("../app/(dashboard)/apps/new/[appId]/page.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(installPage).toContain("<DnsRecordsModal");
+    expect(installPage).toContain("selfHosted && customRoutes.length > 0");
+  });
 });

--- a/apps/dashboard/src/lib/deployment-dns.test.ts
+++ b/apps/dashboard/src/lib/deployment-dns.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
-import { deploymentDnsTargets } from "./deployment-dns";
+import {
+  appInstallDnsTargets,
+  attachDeploymentDomainIds,
+  deploymentDnsTargets,
+} from "./deployment-dns";
 
 const endpoint = (customDomain: string) => ({
   id: customDomain,
@@ -88,6 +92,47 @@ describe("deploymentDnsTargets", () => {
     } as never)).toEqual([{ hostname: "app.example.com", includeWww: false }]);
   });
 
+  it("derives the app install gate from custom routes only", () => {
+    expect(appInstallDnsTargets([
+      { mode: "port" },
+      { mode: "free", customDomain: "ignored.example.com" },
+      { mode: "custom", customDomain: "HTTPS://App.Example.com/" },
+      { mode: "custom", customDomain: "app.example.com" },
+    ])).toEqual([{ hostname: "app.example.com", includeWww: false }]);
+  });
+
+  it("attaches persisted domain ids by normalized hostname without mutating targets", () => {
+    const targets = [
+      { hostname: "app.example.com", includeWww: false, domainId: "draft_not_a_domain" },
+      { hostname: "missing.example.com", includeWww: false },
+    ];
+
+    expect(attachDeploymentDomainIds(targets, [
+      { id: "dom_app", hostname: "APP.EXAMPLE.COM" },
+      { id: 123, hostname: "missing.example.com" },
+    ])).toEqual([
+      { hostname: "app.example.com", includeWww: false, domainId: "dom_app" },
+      { hostname: "missing.example.com", includeWww: false, domainId: null },
+    ]);
+    expect(targets).toEqual([
+      { hostname: "app.example.com", includeWww: false, domainId: "draft_not_a_domain" },
+      { hostname: "missing.example.com", includeWww: false },
+    ]);
+  });
+
+  it("expands an apex/www preview pair so each persisted row gets Auto DNS", () => {
+    expect(attachDeploymentDomainIds(
+      [{ hostname: "example.com", includeWww: true }],
+      [
+        { id: "dom_apex", hostname: "example.com" },
+        { id: "dom_www", hostname: "www.example.com" },
+      ],
+    )).toEqual([
+      { hostname: "example.com", includeWww: false, domainId: "dom_apex" },
+      { hostname: "www.example.com", includeWww: false, domainId: "dom_www" },
+    ]);
+  });
+
   it("is the source used by the Deploy-click DNS gate", () => {
     const sidebar = readFileSync(
       new URL("../app/(dashboard)/(deployment)/deploy/[slug]/components/Sidebar.tsx", import.meta.url),
@@ -98,12 +143,13 @@ describe("deploymentDnsTargets", () => {
     expect(sidebar).toContain("targets={dnsTargets}");
   });
 
-  it("guards self-hosted custom domains with DnsRecordsModal in the app installer", () => {
+  it("wires the app install DNS targets into the pre-deploy modal", () => {
     const installPage = readFileSync(
       new URL("../app/(dashboard)/apps/new/[appId]/page.tsx", import.meta.url),
       "utf8",
     );
+    expect(installPage).toContain("appInstallDnsTargets(routes ?? [])");
     expect(installPage).toContain("<DnsRecordsModal");
-    expect(installPage).toContain("selfHosted && customRoutes.length > 0");
+    expect(installPage).toContain("selfHosted && pendingDnsTargets.length > 0");
   });
 });

--- a/apps/dashboard/src/lib/deployment-dns.ts
+++ b/apps/dashboard/src/lib/deployment-dns.ts
@@ -8,10 +8,90 @@ export interface DeploymentDnsTarget {
   domainId?: string | null;
 }
 
+interface PersistedDomainIdentity {
+  id?: unknown;
+  hostname?: unknown;
+}
+
+interface AppInstallRouteForDns {
+  mode?: string;
+  customDomain?: string | null;
+}
+
 function customHostname(endpoint: Pick<PublicEndpoint, "domainType" | "customDomain">) {
   return endpoint.domainType === "custom"
     ? normalizeCustomHostname(endpoint.customDomain)
     : "";
+}
+
+/**
+ * Attach real domain-row ids without mutating the caller's targets. A draft
+ * endpoint id is not a domain id, so the hostname join is the only safe bridge
+ * between pre-deploy configuration and the persisted rows used by Auto DNS.
+ */
+export function attachDeploymentDomainIds(
+  targets: readonly DeploymentDnsTarget[],
+  domains: readonly PersistedDomainIdentity[],
+): DeploymentDnsTarget[] {
+  const idByHostname = new Map<string, string>();
+  for (const domain of domains) {
+    if (typeof domain.hostname !== "string" || typeof domain.id !== "string") continue;
+    const hostname = normalizeCustomHostname(domain.hostname);
+    if (hostname) idByHostname.set(hostname, domain.id);
+  }
+
+  return targets.flatMap((target) => {
+    const hostname = normalizeCustomHostname(target.hostname);
+    // Never trust an id carried by an editable/draft target; only a row returned
+    // by the server is proof that `/domains/:id/*` is a valid destination.
+    const domainId = idByHostname.get(hostname) ?? null;
+    if (!target.includeWww) return [{ ...target, hostname, domainId }];
+
+    // `www` is an independent domain row with its own Auto-DNS operation. Once
+    // persisted identities are available, expand the preview-only grouping so
+    // both records can be planned/applied instead of configuring only the apex.
+    const wwwHostname = `www.${hostname}`;
+    const wwwDomainId = idByHostname.get(wwwHostname) ?? null;
+    if (domainId || wwwDomainId) {
+      return [
+        { hostname, includeWww: false, domainId },
+        { hostname: wwwHostname, includeWww: false, domainId: wwwDomainId },
+      ];
+    }
+
+    return [{ ...target, hostname, domainId: null }];
+  });
+}
+
+/** Custom-domain targets selected in the catalog app installer. */
+export function appInstallDnsTargets(
+  routes: readonly AppInstallRouteForDns[],
+): DeploymentDnsTarget[] {
+  const hostnames = routes
+    .filter((route) => route.mode === "custom")
+    .map((route) => normalizeCustomHostname(route.customDomain ?? ""));
+  return groupCustomHostnames(hostnames);
+}
+
+function groupCustomHostnames(hostnames: readonly string[]): DeploymentDnsTarget[] {
+  const unique = hostnames.filter(
+    (hostname, index) => hostname && hostnames.indexOf(hostname) === index,
+  );
+  const set = new Set(unique);
+  const consumed = new Set<string>();
+  const targets: DeploymentDnsTarget[] = [];
+  for (const hostname of unique) {
+    if (consumed.has(hostname)) continue;
+    const www = `www.${hostname}`;
+    if (!hostname.startsWith("www.") && set.has(www)) {
+      targets.push({ hostname, includeWww: true });
+      consumed.add(www);
+    } else {
+      targets.push({ hostname, includeWww: false });
+    }
+    consumed.add(hostname);
+  }
+  return targets;
 }
 
 /**
@@ -41,19 +121,5 @@ export function deploymentDnsTargets(
     if (service.domainType === "custom") add(normalizeCustomHostname(service.customDomain ?? ""));
   }
 
-  const set = new Set(hostnames);
-  const consumed = new Set<string>();
-  const targets: DeploymentDnsTarget[] = [];
-  for (const hostname of hostnames) {
-    if (consumed.has(hostname)) continue;
-    const www = `www.${hostname}`;
-    if (!hostname.startsWith("www.") && set.has(www)) {
-      targets.push({ hostname, includeWww: true });
-      consumed.add(www);
-    } else {
-      targets.push({ hostname, includeWww: false });
-    }
-    consumed.add(hostname);
-  }
-  return targets;
+  return groupCustomHostnames(hostnames);
 }

--- a/apps/dashboard/src/lib/deployment-dns.ts
+++ b/apps/dashboard/src/lib/deployment-dns.ts
@@ -5,6 +5,7 @@ import type { DeploymentConfig, PublicEndpoint } from "@/context/deployment/type
 export interface DeploymentDnsTarget {
   hostname: string;
   includeWww: boolean;
+  domainId?: string | null;
 }
 
 function customHostname(endpoint: Pick<PublicEndpoint, "domainType" | "customDomain">) {


### PR DESCRIPTION
Fixes #810

### Problem
When installing a catalog app (e.g. Excalidraw, Stirling-PDF) with a custom domain on self-hosted OpenShip, the installer created the project draft and pending domain rows, but immediately called `deployApi.buildAccess()`. Unlike the standard project deploy flow in `Sidebar.tsx` (which guards deployment with `continueDeploy` -> `DnsRecordsModal`), the app installer bypassed the pre-deploy DNS check completely. It neither prompted the operator nor offered `AutoDnsPanel` to write records to a connected DNS provider (e.g. Cloudflare). The deployment pipeline immediately initiated Certbot HTTP-01 challenge, which failed with Let's Encrypt `NXDOMAIN` because the DNS A record had not yet been created.

In addition, `Sidebar.tsx` omitted resolving `domainId` on `deploymentDnsTargets` even when `config.projectId` was already known, preventing `DnsRecordsModal` from rendering `AutoDnsPanel` for existing project deployments.

### Solution
- **App installer DNS gate**: In `apps/dashboard/src/app/(dashboard)/apps/new/[appId]/page.tsx`, check for custom routes in self-hosted deployments after creating the project draft. Query the project's domain rows to resolve `domainId` for each custom hostname. If custom domains exist, present `DnsRecordsModal` with `confirmLabel={w.install}` before calling `buildAccess()`.
- **Auto-DNS integration**: Because `domainId` is provided on the targets, `DnsRecordsModal` renders `AutoDnsPanel`, allowing operators to 1-click apply DNS records to their connected DNS provider (e.g. Cloudflare) or review required manual records before proceeding with the installation.
- **Customizable modal action button**: Add `confirmLabel?: string` to `DnsRecordsModalProps` so callers can display "Install" instead of defaulting to "Deploy".
- **Sidebar domain ID resolution**: When `config.projectId` exists in `Sidebar.tsx`, populate `domainId` on `dnsTargets` so `AutoDnsPanel` is rendered in `DnsRecordsModal` for existing project deployments.

### Validation
- Unit test in `dns-records-modal.render.test.tsx` verifying custom `confirmLabel` renders properly.
- Unit test in `deployment-dns.test.ts` verifying the app installer custom domain DNS gate.
- TypeScript check (`bunx tsc --noEmit`) passed with zero errors.
- Vitest suite in `apps/dashboard` passed.