### PR TITLE
feat(dashboard): allow toggling secret env vars per service

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/projects/[id]/components/services/ServiceDetailPanel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/projects/[id]/components/services/ServiceDetailPanel.tsx
@@ -17,7 +17,12 @@ import {
 } from "@/lib/api/services";
 import { deployApi } from "@/lib/api/deploy";
 import { formatBytes } from "@/lib/formatBytes";
-import { internalServiceAddress, effectiveServiceAlias, looksLikeSecretKey, type ComposeAdvanced } from "@repo/core";
+import {
+  internalServiceAddress,
+  effectiveServiceAlias,
+  looksLikeSecretKey,
+  type ComposeAdvanced,
+} from "@repo/core";
 import { serviceDisplayUrl } from "@/utils/route-display";
 import {
   Play,
@@ -71,12 +76,29 @@ const SERVICE_TAB_DEFS: TabDef<ServiceTab>[] = [
 const SERVICE_TABS = SERVICE_TAB_DEFS.map((t) => t.key);
 const SERVICE_ENVIRONMENT = "production" as const;
 
-type EnvRow = { sourceId?: string; key: string; value: string; visible: boolean; isSecret?: boolean };
+type EnvRow = {
+  sourceId?: string;
+  key: string;
+  value: string;
+  visible: boolean;
+  isSecret?: boolean;
+};
 const envRowsFromVars = (vars: ServiceEnvVar[]): EnvRow[] =>
-  vars.map((v) => ({ sourceId: v.id, key: v.key, value: v.value, visible: !v.isSecret, isSecret: v.isSecret }));
+  vars.map((v) => ({
+    sourceId: v.id,
+    key: v.key,
+    value: v.value,
+    visible: !v.isSecret,
+    isSecret: v.isSecret,
+  }));
 const comparableEnvRows = (rows: EnvRow[]) =>
   rows
-    .map((row) => ({ sourceId: row.sourceId, key: row.key.trim(), value: row.value, isSecret: row.isSecret ?? looksLikeSecretKey(row.key) }))
+    .map((row) => ({
+      sourceId: row.sourceId,
+      key: row.key.trim(),
+      value: row.value,
+      isSecret: row.isSecret ?? looksLikeSecretKey(row.key),
+    }))
     .filter((row) => row.key)
     .sort((a, b) => a.key.localeCompare(b.key));
 
@@ -236,7 +258,9 @@ export function ServiceDetailPanel({
     if (targetId === service.id) return;
     const target = switchableServices.find((s) => s.id === targetId);
     const targetTab =
-      activeTab === "backup" && target && serviceKind(target) !== "compose" ? "overview" : activeTab;
+      activeTab === "backup" && target && serviceKind(target) !== "compose"
+        ? "overview"
+        : activeTab;
     if (onSwitchService) onSwitchService(targetId, targetTab);
     else router.push(`/projects/${projectId}/services/${targetId}/${targetTab}`);
   };
@@ -250,7 +274,8 @@ export function ServiceDetailPanel({
   useEffect(() => {
     let cancelled = false;
     setEnvLoading(true);
-    servicesApi.getEnv(projectId, service.id, SERVICE_ENVIRONMENT)
+    servicesApi
+      .getEnv(projectId, service.id, SERVICE_ENVIRONMENT)
       .then((result) => {
         if (cancelled) return;
         const rows = envRowsFromVars(result.vars ?? []);
@@ -258,13 +283,25 @@ export function ServiceDetailPanel({
         setSavedEnvRows(rows);
       })
       .catch((err) => {
-        if (!cancelled) showToast(err instanceof Error ? err.message : t.projectDetail.services.detail.toast.envSaveFailed, "error");
+        if (!cancelled)
+          showToast(
+            err instanceof Error
+              ? err.message
+              : t.projectDetail.services.detail.toast.envSaveFailed,
+            "error",
+          );
       })
-      .finally(() => { if (!cancelled) setEnvLoading(false); });
-    return () => { cancelled = true; };
+      .finally(() => {
+        if (!cancelled) setEnvLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [projectId, service.id, showToast, t.projectDetail.services.detail.toast.envSaveFailed]);
   const envDirty = useMemo(
-    () => JSON.stringify(comparableEnvRows(envRows)) !== JSON.stringify(comparableEnvRows(savedEnvRows)),
+    () =>
+      JSON.stringify(comparableEnvRows(envRows)) !==
+      JSON.stringify(comparableEnvRows(savedEnvRows)),
     [envRows, savedEnvRows],
   );
   const handleSaveEnv = async () => {
@@ -281,7 +318,10 @@ export function ServiceDetailPanel({
       setSavedEnvRows(rows);
       showToast(t.projectDetail.services.detail.toast.envUpdated, "success", service.name);
     } catch (err) {
-      showToast(err instanceof Error ? err.message : t.projectDetail.services.detail.toast.envSaveFailed, "error");
+      showToast(
+        err instanceof Error ? err.message : t.projectDetail.services.detail.toast.envSaveFailed,
+        "error",
+      );
     } finally {
       setEnvSaving(false);
     }
@@ -428,10 +468,18 @@ export function ServiceDetailPanel({
       const res = await servicesApi.start(projectId, service.id);
       if ((res as any)?.success === false) {
         setDeploying(false);
-        showToast((res as any)?.error || t.projectDetail.services.detail.toast.deployFailed, "error", service.name);
+        showToast(
+          (res as any)?.error || t.projectDetail.services.detail.toast.deployFailed,
+          "error",
+          service.name,
+        );
         return;
       }
-      showToast(interpolate(t.projectDetail.services.detail.toast.serviceStarting, { name: service.name }), "success", t.projectDetail.services.detail.toast.serviceTitle);
+      showToast(
+        interpolate(t.projectDetail.services.detail.toast.serviceStarting, { name: service.name }),
+        "success",
+        t.projectDetail.services.detail.toast.serviceTitle,
+      );
       setDeploying(false);
       onRefresh();
     } catch (err) {
@@ -463,7 +511,11 @@ export function ServiceDetailPanel({
       const res = await deployApi.trigger({ projectId, serviceIds: [service.id] });
       if ((res as any)?.success === false) {
         setRedeploying(false);
-        showToast((res as any)?.error || t.projectDetail.services.detail.toast.redeployFailed, "error", service.name);
+        showToast(
+          (res as any)?.error || t.projectDetail.services.detail.toast.redeployFailed,
+          "error",
+          service.name,
+        );
         return;
       }
       const newId = res?.data?.deployment?.id;
@@ -516,7 +568,11 @@ export function ServiceDetailPanel({
     }
 
     await onRefresh();
-    showToast(t.projectDetail.services.detail.toast.serviceUpdated, "success", data.name ?? service.name);
+    showToast(
+      t.projectDetail.services.detail.toast.serviceUpdated,
+      "success",
+      data.name ?? service.name,
+    );
   };
 
   const handleDeleteService = async () => {
@@ -531,7 +587,10 @@ export function ServiceDetailPanel({
       onDeleted?.();
       await onRefresh();
     } catch (error) {
-      showToast(error instanceof Error ? error.message : t.projectDetail.services.detail.toast.deleteFailed, "error");
+      showToast(
+        error instanceof Error ? error.message : t.projectDetail.services.detail.toast.deleteFailed,
+        "error",
+      );
     } finally {
       setDeleting(false);
     }
@@ -550,7 +609,9 @@ export function ServiceDetailPanel({
               triggerClassName="group inline-flex items-center gap-1.5 rounded-lg -ms-1.5 px-1.5 py-0.5 transition-colors hover:bg-muted/50"
               trigger={
                 <>
-                  <span className="text-xl font-semibold tracking-tight text-foreground">{service.name}</span>
+                  <span className="text-xl font-semibold tracking-tight text-foreground">
+                    {service.name}
+                  </span>
                   <ChevronDown className="size-4 text-muted-foreground transition-colors group-hover:text-foreground" />
                 </>
               }
@@ -561,7 +622,9 @@ export function ServiceDetailPanel({
                   s.id === service.id ? (
                     <Check className="size-4 text-primary" />
                   ) : (
-                    <span className={`size-1.5 rounded-full ${s.enabled ? "bg-success-solid" : "bg-muted-foreground/40"}`} />
+                    <span
+                      className={`size-1.5 rounded-full ${s.enabled ? "bg-success-solid" : "bg-muted-foreground/40"}`}
+                    />
                   ),
                 disabled: s.id === service.id,
                 onClick: () => switchService(s.id),
@@ -657,14 +720,32 @@ export function ServiceDetailPanel({
                   />
                 )}
                 {service.ports && service.ports.length > 0 && (
-                  <InfoCard label={t.projectDetail.services.detail.ports} value={service.ports.join(", ")} mono onCopy={() => copy(service.ports!.join(", "), "ports")} copied={copied === "ports"} />
+                  <InfoCard
+                    label={t.projectDetail.services.detail.ports}
+                    value={service.ports.join(", ")}
+                    mono
+                    onCopy={() => copy(service.ports!.join(", "), "ports")}
+                    copied={copied === "ports"}
+                  />
                 )}
                 {container?.hostPort && (
-                  <InfoCard label={t.projectDetail.services.detail.hostPort} value={String(container.hostPort)} mono onCopy={() => copy(String(container.hostPort), "hostPort")} copied={copied === "hostPort"} />
+                  <InfoCard
+                    label={t.projectDetail.services.detail.hostPort}
+                    value={String(container.hostPort)}
+                    mono
+                    onCopy={() => copy(String(container.hostPort), "hostPort")}
+                    copied={copied === "hostPort"}
+                  />
                 )}
                 {container?.ip && (
                   <div>
-                    <InfoCard label={t.projectDetail.services.detail.currentIp} value={container.ip} mono onCopy={() => copy(container.ip!, "ip")} copied={copied === "ip"} />
+                    <InfoCard
+                      label={t.projectDetail.services.detail.currentIp}
+                      value={container.ip}
+                      mono
+                      onCopy={() => copy(container.ip!, "ip")}
+                      copied={copied === "ip"}
+                    />
                     <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground/80">
                       {t.projectDetail.services.detail.currentIpHint}
                     </p>
@@ -672,7 +753,11 @@ export function ServiceDetailPanel({
                 )}
                 {container?.containerId && (
                   <InfoCard
-                    label={deployTarget === "cloud" ? t.projectDetail.services.detail.workspaceId : t.projectDetail.services.detail.containerId}
+                    label={
+                      deployTarget === "cloud"
+                        ? t.projectDetail.services.detail.workspaceId
+                        : t.projectDetail.services.detail.containerId
+                    }
                     // Docker ids are 64 chars — the 12-char short id is enough
                     // to `docker exec`. Cloud workspace ids are short/opaque, so
                     // show them in full (you need the whole thing to find it).
@@ -691,16 +776,35 @@ export function ServiceDetailPanel({
           )}
 
           {/* Configuration */}
-          {(service.restart || service.command || (service.dependsOn && service.dependsOn.length > 0)) && (
+          {(service.restart ||
+            service.command ||
+            (service.dependsOn && service.dependsOn.length > 0)) && (
             <div className="bg-card rounded-2xl border border-border/50 p-5">
-              <SectionHeader title={t.projectDetail.services.detail.configuration} icon={Settings} />
+              <SectionHeader
+                title={t.projectDetail.services.detail.configuration}
+                icon={Settings}
+              />
               <div className="space-y-3">
-                {service.restart && <InfoCard label={t.projectDetail.services.detail.restartPolicy} value={service.restart} />}
+                {service.restart && (
+                  <InfoCard
+                    label={t.projectDetail.services.detail.restartPolicy}
+                    value={service.restart}
+                  />
+                )}
                 {service.command && (
-                  <InfoCard label={t.projectDetail.services.detail.command} value={service.command} mono onCopy={() => copy(service.command!, "cmd")} copied={copied === "cmd"} />
+                  <InfoCard
+                    label={t.projectDetail.services.detail.command}
+                    value={service.command}
+                    mono
+                    onCopy={() => copy(service.command!, "cmd")}
+                    copied={copied === "cmd"}
+                  />
                 )}
                 {service.dependsOn && service.dependsOn.length > 0 && (
-                  <InfoCard label={t.projectDetail.services.detail.dependsOn} value={service.dependsOn.join(", ")} />
+                  <InfoCard
+                    label={t.projectDetail.services.detail.dependsOn}
+                    value={service.dependsOn.join(", ")}
+                  />
                 )}
               </div>
             </div>
@@ -740,7 +844,11 @@ export function ServiceDetailPanel({
                             {formatBytes(vs.bytes)}
                           </span>
                         ) : null}
-                        <CopyBtn onCopy={() => copy(vol, `vol-${vol}`)} copied={copied === `vol-${vol}`} size="sm" />
+                        <CopyBtn
+                          onCopy={() => copy(vol, `vol-${vol}`)}
+                          copied={copied === `vol-${vol}`}
+                          size="sm"
+                        />
                       </div>
                     </div>
                   );
@@ -778,7 +886,9 @@ export function ServiceDetailPanel({
             projectName={service.name}
             streamTarget={endpoints.services.logsStream(projectId, service.id)}
             historyTarget={endpoints.services.logs(projectId, service.id)}
-            onLogsChange={() => { /* view-only; the panel doesn't need the buffer */ }}
+            onLogsChange={() => {
+              /* view-only; the panel doesn't need the buffer */
+            }}
           />
         </div>
       )}
@@ -794,13 +904,17 @@ export function ServiceDetailPanel({
               envVars={envRows}
               onEnvVarsChange={setEnvRows}
               isEditingMode={true}
-              setIsEditingMode={() => { /* always editing in the Env tab */ }}
+              setIsEditingMode={() => {
+                /* always editing in the Env tab */
+              }}
               showSettingsActions={false}
+              showSecretToggle={true}
               // #336: env values arrive masked; reveal only the keys the operator
               // actually opens (the endpoint is write-gated, so read-only members
               // can't reveal at all).
               onReveal={async (keys) =>
-                (await servicesApi.revealEnv(projectId, service.id, keys, SERVICE_ENVIRONMENT)).environment
+                (await servicesApi.revealEnv(projectId, service.id, keys, SERVICE_ENVIRONMENT))
+                  .environment
               }
               borderless
             />
@@ -811,7 +925,11 @@ export function ServiceDetailPanel({
               disabled={envLoading || envSaving || !envDirty}
               className="inline-flex h-11 items-center gap-2 rounded-xl bg-primary px-4 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-40"
             >
-              {envSaving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+              {envSaving ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Save className="size-4" />
+              )}
               {t.projectDetail.services.detail.saveEnvironment}
             </button>
           </div>
@@ -833,12 +951,30 @@ export function ServiceDetailPanel({
                         gets Start. */}
                     {status !== "stopped" && status !== "failed" && (
                       <>
-                        <ActionButton icon={Square} label={t.projectDetail.services.detail.stop} loading={actionLoading === "stop"} onClick={() => handleContainerAction("stop")} variant="danger" />
-                        <ActionButton icon={RotateCw} label={t.projectDetail.services.detail.restart} loading={actionLoading === "restart"} onClick={() => handleContainerAction("restart")} variant="warning" />
+                        <ActionButton
+                          icon={Square}
+                          label={t.projectDetail.services.detail.stop}
+                          loading={actionLoading === "stop"}
+                          onClick={() => handleContainerAction("stop")}
+                          variant="danger"
+                        />
+                        <ActionButton
+                          icon={RotateCw}
+                          label={t.projectDetail.services.detail.restart}
+                          loading={actionLoading === "restart"}
+                          onClick={() => handleContainerAction("restart")}
+                          variant="warning"
+                        />
                       </>
                     )}
                     {(status === "stopped" || status === "failed") && (
-                      <ActionButton icon={Play} label={t.projectDetail.services.detail.start} loading={actionLoading === "start"} onClick={() => handleContainerAction("start")} variant="success" />
+                      <ActionButton
+                        icon={Play}
+                        label={t.projectDetail.services.detail.start}
+                        loading={actionLoading === "start"}
+                        onClick={() => handleContainerAction("start")}
+                        variant="success"
+                      />
                     )}
                   </>
                 ) : (
@@ -849,7 +985,11 @@ export function ServiceDetailPanel({
                   canStartWithoutBuild && (
                     <ActionButton
                       icon={Play}
-                      label={deploying ? t.projectDetail.services.detail.starting : t.projectDetail.services.detail.start}
+                      label={
+                        deploying
+                          ? t.projectDetail.services.detail.starting
+                          : t.projectDetail.services.detail.start
+                      }
                       loading={deploying}
                       onClick={handleDeployStart}
                       variant="success"
@@ -861,7 +1001,11 @@ export function ServiceDetailPanel({
                 {usesDeployPipeline && service.enabled && activeDeploymentId && (
                   <ActionButton
                     icon={Rocket}
-                    label={redeploying ? t.projectDetail.services.detail.redeploying : t.projectDetail.services.detail.redeploy}
+                    label={
+                      redeploying
+                        ? t.projectDetail.services.detail.redeploying
+                        : t.projectDetail.services.detail.redeploy
+                    }
                     loading={redeploying}
                     onClick={handleRedeployService}
                     variant="primary"
@@ -879,8 +1023,14 @@ export function ServiceDetailPanel({
                       : "bg-success-bg text-success hover:bg-success-solid/20"
                   }`}
                 >
-                  {saving ? <Loader2 className="size-4 animate-spin" /> : <Power className="size-4" />}
-                  {service.enabled ? t.projectDetail.services.detail.disableService : t.projectDetail.services.detail.enableService}
+                  {saving ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Power className="size-4" />
+                  )}
+                  {service.enabled
+                    ? t.projectDetail.services.detail.disableService
+                    : t.projectDetail.services.detail.enableService}
                 </button>
                 <button
                   onClick={() => setConfirmDelete(true)}
@@ -974,7 +1124,9 @@ export function ServiceDetailPanel({
             className="w-full max-w-md rounded-2xl border border-border/60 bg-card p-5 shadow-xl"
             onClick={(event) => event.stopPropagation()}
           >
-            <h3 className="text-base font-semibold text-foreground">{t.projectDetail.services.detail.deleteTitle}</h3>
+            <h3 className="text-base font-semibold text-foreground">
+              {t.projectDetail.services.detail.deleteTitle}
+            </h3>
             <p className="mt-2 text-sm text-muted-foreground">
               {interpolate(t.projectDetail.services.detail.deleteBody, { name: service.name })}
             </p>
@@ -1004,7 +1156,17 @@ export function ServiceDetailPanel({
 
 /* ── Primitives ─────────────────────────────────────────────────────── */
 
-function SectionHeader({ title, subtitle, icon: Icon, right }: { title: string; subtitle?: string; icon: React.ComponentType<{ className?: string }>; right?: React.ReactNode }) {
+function SectionHeader({
+  title,
+  subtitle,
+  icon: Icon,
+  right,
+}: {
+  title: string;
+  subtitle?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  right?: React.ReactNode;
+}) {
   return (
     <div className="mb-5">
       <div className="flex items-start justify-between gap-3">
@@ -1014,7 +1176,9 @@ function SectionHeader({ title, subtitle, icon: Icon, right }: { title: string; 
         </div>
         {right}
       </div>
-      {subtitle && <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">{subtitle}</p>}
+      {subtitle && (
+        <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+      )}
     </div>
   );
 }
@@ -1026,12 +1190,32 @@ function StatusBadge({ status }: { status: string }) {
   const labels = t.projectDetail.services.detail.status;
   const map: Record<string, { ring: string; text: string; label: string }> = {
     running: { ring: "border-success-solid", text: "text-success", label: labels.running },
-    starting: { ring: "border-warning-solid animate-pulse", text: "text-warning", label: labels.starting },
-    restarting: { ring: "border-warning-solid animate-pulse", text: "text-warning", label: labels.restarting },
+    starting: {
+      ring: "border-warning-solid animate-pulse",
+      text: "text-warning",
+      label: labels.starting,
+    },
+    restarting: {
+      ring: "border-warning-solid animate-pulse",
+      text: "text-warning",
+      label: labels.restarting,
+    },
     failed: { ring: "border-danger-solid", text: "text-danger", label: labels.failed },
-    stopped: { ring: "border-muted-foreground/40", text: "text-muted-foreground", label: labels.stopped },
-    disabled: { ring: "border-muted-foreground/30", text: "text-muted-foreground/60", label: labels.disabled },
-    unknown: { ring: "border-muted-foreground/40", text: "text-muted-foreground", label: labels.unknown },
+    stopped: {
+      ring: "border-muted-foreground/40",
+      text: "text-muted-foreground",
+      label: labels.stopped,
+    },
+    disabled: {
+      ring: "border-muted-foreground/30",
+      text: "text-muted-foreground/60",
+      label: labels.disabled,
+    },
+    unknown: {
+      ring: "border-muted-foreground/40",
+      text: "text-muted-foreground",
+      label: labels.unknown,
+    },
   };
   const s = map[status] ?? map.stopped;
   return (
@@ -1042,8 +1226,18 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function ActionButton({ icon: Icon, label, loading, onClick, variant }: {
-  icon: React.ComponentType<{ className?: string }>; label: string; loading: boolean; onClick: () => void; variant: "success" | "danger" | "warning" | "primary";
+function ActionButton({
+  icon: Icon,
+  label,
+  loading,
+  onClick,
+  variant,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  loading: boolean;
+  onClick: () => void;
+  variant: "success" | "danger" | "warning" | "primary";
 }) {
   const colors = {
     success: "bg-success-bg text-success hover:bg-success-solid/20",
@@ -1052,8 +1246,14 @@ function ActionButton({ icon: Icon, label, loading, onClick, variant }: {
     primary: "bg-primary/10 text-primary hover:bg-primary/20",
   };
   return (
-    <button onClick={(e) => { e.stopPropagation(); onClick(); }} disabled={loading}
-      className={`inline-flex h-9 items-center gap-2 rounded-xl px-4 text-[13px] font-medium transition-colors disabled:opacity-50 ${colors[variant]}`}>
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      disabled={loading}
+      className={`inline-flex h-9 items-center gap-2 rounded-xl px-4 text-[13px] font-medium transition-colors disabled:opacity-50 ${colors[variant]}`}
+    >
       {loading ? <Loader2 className="size-4 animate-spin" /> : <Icon className="size-4" />}
       {label}
     </button>
@@ -1061,7 +1261,15 @@ function ActionButton({ icon: Icon, label, loading, onClick, variant }: {
 }
 
 /** Persistent icon-only copy affordance (Copy → Check on success). */
-function CopyBtn({ onCopy, copied, size = "sm" }: { onCopy: () => void; copied: boolean; size?: "sm" | "md" }) {
+function CopyBtn({
+  onCopy,
+  copied,
+  size = "sm",
+}: {
+  onCopy: () => void;
+  copied: boolean;
+  size?: "sm" | "md";
+}) {
   const dim = size === "md" ? "h-9 w-9" : "h-8 w-8";
   const glyph = size === "md" ? "size-4" : "size-3.5";
   return (
@@ -1076,14 +1284,32 @@ function CopyBtn({ onCopy, copied, size = "sm" }: { onCopy: () => void; copied: 
 }
 
 /** Prominent labelled value field — mono value in a filled chip with a copy action. */
-function FieldChip({ label, value, mono = true, onCopy, copied, hint }: {
-  label: string; value: string; mono?: boolean; onCopy?: () => void; copied?: boolean; hint?: string;
+function FieldChip({
+  label,
+  value,
+  mono = true,
+  onCopy,
+  copied,
+  hint,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  onCopy?: () => void;
+  copied?: boolean;
+  hint?: string;
 }) {
   return (
     <div>
-      <label className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">{label}</label>
+      <label className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </label>
       <div className="mt-2 flex min-h-11 items-center gap-0.5 rounded-xl bg-muted py-1 pe-1 ps-3.5">
-        <code className={`min-w-0 flex-1 truncate text-[13px] text-foreground ${mono ? "font-mono" : ""}`}>{value}</code>
+        <code
+          className={`min-w-0 flex-1 truncate text-[13px] text-foreground ${mono ? "font-mono" : ""}`}
+        >
+          {value}
+        </code>
         {onCopy && <CopyBtn onCopy={onCopy} copied={!!copied} size="md" />}
       </div>
       {hint && <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground/80">{hint}</p>}
@@ -1092,14 +1318,29 @@ function FieldChip({ label, value, mono = true, onCopy, copied, hint }: {
 }
 
 /** Compact label → value fact row, with an optional copy action on the value. */
-function InfoCard({ label, value, mono, onCopy, copied }: {
-  icon?: React.ComponentType<{ className?: string }>; label: string; value: string; mono?: boolean; onCopy?: () => void; copied?: boolean;
+function InfoCard({
+  label,
+  value,
+  mono,
+  onCopy,
+  copied,
+}: {
+  icon?: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  mono?: boolean;
+  onCopy?: () => void;
+  copied?: boolean;
 }) {
   return (
     <div className="flex items-center justify-between gap-4">
       <p className="shrink-0 text-[13px] text-muted-foreground">{label}</p>
       <div className="flex min-w-0 items-center gap-1">
-        <p className={`max-w-[200px] truncate text-[13px] font-medium text-foreground ${mono ? "font-mono" : ""}`}>{value}</p>
+        <p
+          className={`max-w-[200px] truncate text-[13px] font-medium text-foreground ${mono ? "font-mono" : ""}`}
+        >
+          {value}
+        </p>
         {onCopy && <CopyBtn onCopy={onCopy} copied={!!copied} size="sm" />}
       </div>
     </div>

--- a/apps/dashboard/src/components/import-project/EnvironmentVariables.tsx
+++ b/apps/dashboard/src/components/import-project/EnvironmentVariables.tsx
@@ -8,6 +8,7 @@ import {
   EyeOff,
   FileText,
   Key,
+  KeyRound,
   Pencil,
   Plus,
   RotateCcw,
@@ -15,7 +16,7 @@ import {
   Upload,
   X,
 } from "lucide-react";
-import { ENV_MASK, isMaskedValue } from "@repo/core";
+import { ENV_MASK, isMaskedValue, looksLikeSecretKey } from "@repo/core";
 import { useOptionalDeployment } from "@/context/DeploymentContext";
 import { useToast } from "@/context/ToastContext";
 import { useI18n, interpolate } from "@/components/i18n-provider";
@@ -33,6 +34,7 @@ type EnvironmentVariableRow = {
   visible: boolean;
   /** Saved secret whose plaintext is intentionally absent from local state. */
   preserveValue?: boolean;
+  isSecret?: boolean;
 };
 
 type EnvironmentVariableMeta = {
@@ -72,6 +74,11 @@ interface EnvironmentVariablesPropsOptional {
   envMeta?: Record<string, EnvironmentVariableMeta>;
   onEnvVarsChange?: (envVars: EnvironmentVariableRow[]) => void;
   /**
+   * Whether to show the secret toggle button on each row.
+   * When true, operators can explicitly mark/unmark variables as secret.
+   */
+  showSecretToggle?: boolean;
+  /**
    * #336: fetch the REAL (unmasked) values for EXACTLY `keys` — one row's eye
    * asks for that one key, the header's "Show values" asks for every masked key.
    * Never a "give me everything" call: the API requires the key names, so a
@@ -98,6 +105,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
   mode = "deploy",
   showEditControls = true,
   isEditingMode: externalIsEditingMode,
+  showSecretToggle = false,
   setIsEditingMode: externalSetIsEditingMode,
   onSave,
   onCancel,
@@ -125,9 +133,10 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
   // paste / upload handlers below so the user sees parsed rows land
   // without an extra click.
   const [expanded, setExpanded] = useState(!collapsible);
-  
+
   // Use external state if provided, otherwise use internal state
-  const isEditingMode = externalIsEditingMode !== undefined ? externalIsEditingMode : internalIsEditingMode;
+  const isEditingMode =
+    externalIsEditingMode !== undefined ? externalIsEditingMode : internalIsEditingMode;
   const setIsEditingMode = externalSetIsEditingMode || setInternalIsEditingMode;
 
   // Use external env vars in settings mode, deployment context in deploy mode
@@ -135,13 +144,13 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
     throw new Error("EnvironmentVariables in deploy mode must be used within DeploymentProvider");
   }
 
-  const currentEnvVars = mode === "settings"
-    ? (externalEnvVars ?? [])
-    : (deployment?.config.envVars ?? []);
+  const currentEnvVars =
+    mode === "settings" ? (externalEnvVars ?? []) : (deployment?.config.envVars ?? []);
 
-  const updateEnvVars = mode === "settings" && onEnvVarsChange
-    ? onEnvVarsChange
-    : (newVars: EnvironmentVariableRow[]) => deployment?.updateConfig({ envVars: newVars });
+  const updateEnvVars =
+    mode === "settings" && onEnvVarsChange
+      ? onEnvVarsChange
+      : (newVars: EnvironmentVariableRow[]) => deployment?.updateConfig({ envVars: newVars });
 
   const addEnvVar = useCallback(() => {
     // Default visible so you can see what you type; the eye toggles to hide.
@@ -158,19 +167,31 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       const newEnvVars = currentEnvVars.filter((_, i) => i !== index);
       updateEnvVars(newEnvVars);
     },
-    [currentEnvVars, updateEnvVars]
+    [currentEnvVars, updateEnvVars],
   );
 
   const updateEnvVar = useCallback(
-    (
-      index: number,
-      field: keyof (typeof currentEnvVars)[0],
-      value: string | boolean
-    ) => {
-      const newEnvVars = currentEnvVars.map((env, i) => (i === index ? { ...env, [field]: value } : env));
+    (index: number, field: keyof (typeof currentEnvVars)[0], value: string | boolean) => {
+      const newEnvVars = currentEnvVars.map((env, i) =>
+        i === index ? { ...env, [field]: value } : env,
+      );
       updateEnvVars(newEnvVars);
     },
-    [currentEnvVars, updateEnvVars]
+    [currentEnvVars, updateEnvVars],
+  );
+
+  const toggleSecret = useCallback(
+    (index: number) => {
+      const env = currentEnvVars[index];
+      if (!env) return;
+      const currentSecret = env.isSecret ?? looksLikeSecretKey(env.key);
+      const nextSecret = !currentSecret;
+      const newEnvVars = currentEnvVars.map((item, i) =>
+        i === index ? { ...item, isSecret: nextSecret, visible: !nextSecret } : item,
+      );
+      updateEnvVars(newEnvVars);
+    },
+    [currentEnvVars, updateEnvVars],
   );
 
   // #336: display-only overlay of revealed real values (keyed by env key). Kept
@@ -243,7 +264,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       if (pending.length === 0) return known;
       return Object.assign(known, ...(await Promise.all(pending)));
     },
-    [revealedValues, onReveal, showToast, ev]
+    [revealedValues, onReveal, showToast, ev],
   );
 
   // Reveal `keys` and show exactly the ones that came back. A key the source no
@@ -259,7 +280,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       }
       if (got.length > 0) setShownKeys((prev) => new Set([...prev, ...got]));
     },
-    [ensureRevealed, showToast, ev]
+    [ensureRevealed, showToast, ev],
   );
 
   // `revealOnOpen`: fetch every masked row once, so an editor opened on existing env
@@ -288,7 +309,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
     const dropped = new Set(keys);
     setShownKeys((prev) => new Set([...prev].filter((key) => !dropped.has(key))));
     setRevealedValues((prev) =>
-      Object.fromEntries(Object.entries(prev).filter(([key]) => !dropped.has(key)))
+      Object.fromEntries(Object.entries(prev).filter(([key]) => !dropped.has(key))),
     );
   }, []);
 
@@ -305,10 +326,10 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
         return;
       }
       updateEnvVars(
-        currentEnvVars.map((env, i) => (i === index ? { ...env, visible: !env.visible } : env))
+        currentEnvVars.map((env, i) => (i === index ? { ...env, visible: !env.visible } : env)),
       );
     },
-    [currentEnvVars, updateEnvVars, shownKeys, hideKeys, revealAndShow]
+    [currentEnvVars, updateEnvVars, shownKeys, hideKeys, revealAndShow],
   );
 
   // Header "Show values" / "Hide values": the explicit bulk action — the only
@@ -355,7 +376,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
     // any host whose rows start `visible: false` (the migration wizard's do).
     if (row && isMaskedValue(row.value) && shownKeys.has(row.key)) {
       updateEnvVars(
-        currentEnvVars.map((env, i) => (i === index ? { ...env, value, visible: true } : env))
+        currentEnvVars.map((env, i) => (i === index ? { ...env, value, visible: true } : env)),
       );
       return;
     }
@@ -399,7 +420,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       updateEnvVars(merged);
       return { added, updated };
     },
-    [currentEnvVars, updateEnvVars]
+    [currentEnvVars, updateEnvVars],
   );
 
   const showEnvPasteResult = useCallback(
@@ -415,10 +436,10 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
           detail,
         }),
         "success",
-        ev.toast.title
+        ev.toast.title,
       );
     },
-    [showToast, ev]
+    [showToast, ev],
   );
 
   const maybeAutoApplyDetectedPort = useCallback(
@@ -451,7 +472,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       });
       showToast(interpolate(ev.toast.portSet, { port: detectedPort }), "success", ev.toast.title);
     },
-    [deployment, mode, showToast, ev]
+    [deployment, mode, showToast, ev],
   );
 
   const applyEnvText = useCallback(
@@ -466,7 +487,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       showEnvPasteResult(parsed.length, added, updated);
       return true;
     },
-    [maybeAutoApplyDetectedPort, mergeParsedEnvVars, showEnvPasteResult]
+    [maybeAutoApplyDetectedPort, mergeParsedEnvVars, showEnvPasteResult],
   );
 
   const handleContainerPaste = useCallback(
@@ -477,7 +498,9 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       if (!text) return;
 
       const target = e.target instanceof HTMLElement ? e.target : null;
-      const isTextInputPaste = Boolean(target?.closest("input, textarea, [contenteditable='true']"));
+      const isTextInputPaste = Boolean(
+        target?.closest("input, textarea, [contenteditable='true']"),
+      );
 
       if (!looksLikeEnvPaste(text, !isTextInputPaste)) {
         return;
@@ -496,7 +519,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
 
       applyEnvText(text, replaceEmptyRowIndex);
     },
-    [applyEnvText, currentEnvVars, isEditingMode]
+    [applyEnvText, currentEnvVars, isEditingMode],
   );
 
   const handlePasteFromClipboard = useCallback(async () => {
@@ -511,11 +534,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       !window.isSecureContext ||
       !navigator.clipboard?.readText
     ) {
-      showToast(
-        ev.toast.clipboardUnavailable,
-        "error",
-        ev.toast.title
-      );
+      showToast(ev.toast.clipboardUnavailable, "error", ev.toast.title);
       return;
     }
 
@@ -528,61 +547,59 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       }
 
       if (!looksLikeEnvPaste(text, true) || !applyEnvText(text)) {
-        showToast(
-          ev.toast.clipboardInvalid,
-          "error",
-          ev.toast.title
-        );
+        showToast(ev.toast.clipboardInvalid, "error", ev.toast.title);
       } else {
         // Successful paste — reveal the body so the operator sees the
         // rows that just landed (no-op if not in collapsible mode).
         setExpanded(true);
       }
     } catch {
-      showToast(
-        ev.toast.clipboardBlocked,
-        "error",
-        ev.toast.title
-      );
+      showToast(ev.toast.clipboardBlocked, "error", ev.toast.title);
     }
   }, [applyEnvText, isEditingMode, showToast, ev]);
 
-  const handlePasteZoneClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    if (!isEditingMode) return;
+  const handlePasteZoneClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isEditingMode) return;
 
-    const target = e.target as HTMLElement;
-    if (target.closest("input, button, a, select, textarea, label")) {
-      return;
-    }
-
-    pasteZoneRef.current?.focus();
-  }, [isEditingMode]);
-
-  const handleFileUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const content = e.target?.result as string;
-      const parsedVars = parseEnvFile(content);
-
-      if (parsedVars.length > 0) {
-        // Merge with existing vars, avoiding duplicates
-        const existingKeys = new Set(currentEnvVars.map(v => v.key));
-        const newVars = parsedVars.filter(v => !existingKeys.has(v.key));
-        updateEnvVars([...currentEnvVars, ...newVars]);
-        maybeAutoApplyDetectedPort(parsedVars);
-        setExpanded(true);
+      const target = e.target as HTMLElement;
+      if (target.closest("input, button, a, select, textarea, label")) {
+        return;
       }
-    };
-    reader.readAsText(file);
-    
-    // Reset input so same file can be uploaded again
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-  }, [currentEnvVars, maybeAutoApplyDetectedPort, updateEnvVars]);
+
+      pasteZoneRef.current?.focus();
+    },
+    [isEditingMode],
+  );
+
+  const handleFileUpload = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const content = e.target?.result as string;
+        const parsedVars = parseEnvFile(content);
+
+        if (parsedVars.length > 0) {
+          // Merge with existing vars, avoiding duplicates
+          const existingKeys = new Set(currentEnvVars.map((v) => v.key));
+          const newVars = parsedVars.filter((v) => !existingKeys.has(v.key));
+          updateEnvVars([...currentEnvVars, ...newVars]);
+          maybeAutoApplyDetectedPort(parsedVars);
+          setExpanded(true);
+        }
+      };
+      reader.readAsText(file);
+
+      // Reset input so same file can be uploaded again
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [currentEnvVars, maybeAutoApplyDetectedPort, updateEnvVars],
+  );
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();
@@ -591,10 +608,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
   // Check if a file is a .env file
   const isEnvFile = (file: File) => {
     const name = file.name.toLowerCase();
-    return name === '.env' || 
-           name.startsWith('.env.') || 
-           name === 'env' || 
-           name.startsWith('env.');
+    return name === ".env" || name.startsWith(".env.") || name === "env" || name.startsWith("env.");
   };
 
   // Process dropped file
@@ -607,10 +621,10 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
     reader.onload = (e) => {
       const content = e.target?.result as string;
       const parsedVars = parseEnvFile(content);
-      
+
       if (parsedVars.length > 0) {
-        const existingKeys = new Set(currentEnvVars.map(v => v.key));
-        const newVars = parsedVars.filter(v => !existingKeys.has(v.key));
+        const existingKeys = new Set(currentEnvVars.map((v) => v.key));
+        const newVars = parsedVars.filter((v) => !existingKeys.has(v.key));
         updateEnvVars([...currentEnvVars, ...newVars]);
         maybeAutoApplyDetectedPort(parsedVars);
         setExpanded(true);
@@ -623,7 +637,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    
+
     // Check if dragged items contain files
     if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
       setIsDragging(true);
@@ -633,12 +647,12 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    
+
     // Only set dragging to false if we're leaving the component entirely
     const rect = e.currentTarget.getBoundingClientRect();
     const x = e.clientX;
     const y = e.clientY;
-    
+
     if (x <= rect.left || x >= rect.right || y <= rect.top || y >= rect.bottom) {
       setIsDragging(false);
     }
@@ -648,23 +662,26 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
     e.preventDefault();
     e.stopPropagation();
     // Set the drop effect
-    e.dataTransfer.dropEffect = 'copy';
+    e.dataTransfer.dropEffect = "copy";
   }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
 
-    const files = Array.from(e.dataTransfer.files);
-    
-    // Process only .env files
-    files.forEach(file => {
-      if (isEnvFile(file)) {
-        processFile(file);
-      }
-    });
-  }, [processFile]);
+      const files = Array.from(e.dataTransfer.files);
+
+      // Process only .env files
+      files.forEach((file) => {
+        if (isEnvFile(file)) {
+          processFile(file);
+        }
+      });
+    },
+    [processFile],
+  );
 
   // One class for every secondary toolbar action (paste / upload / edit / reveal).
   const actionBtn =
@@ -677,142 +694,130 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
     collapsible;
 
   return (
-    <div className={borderless ? '' : 'bg-card rounded-2xl border border-border/50'}>
+    <div className={borderless ? "" : "bg-card rounded-2xl border border-border/50"}>
       {(!hideTitle || hasHeaderActions) && (
-      <div className="flex items-center justify-between gap-3 px-5 py-4">
-        {!hideTitle && (
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="size-9 shrink-0 rounded-xl bg-violet-500/10 flex items-center justify-center">
-            <Key className="size-[18px] text-violet-500" />
-          </div>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-foreground">{ev.title}</p>
-            <p className="truncate text-xs text-muted-foreground">
-              {currentEnvVars.length === 0 ? ev.noneSet : interpolate(currentEnvVars.length === 1 ? t.importProject.counts.variableOne : t.importProject.counts.variableOther, { count: String(currentEnvVars.length) })}
-            </p>
-          </div>
-        </div>
-        )}
-        <div className="ms-auto flex shrink-0 items-center gap-2">
-          {mode === "settings" && !isEditingMode && (
-            <>
-              {/* Paste / Upload always available — clicking either
+        <div className="flex items-center justify-between gap-3 px-5 py-4">
+          {!hideTitle && (
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="size-9 shrink-0 rounded-xl bg-violet-500/10 flex items-center justify-center">
+                <Key className="size-[18px] text-violet-500" />
+              </div>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">{ev.title}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {currentEnvVars.length === 0
+                    ? ev.noneSet
+                    : interpolate(
+                        currentEnvVars.length === 1
+                          ? t.importProject.counts.variableOne
+                          : t.importProject.counts.variableOther,
+                        { count: String(currentEnvVars.length) },
+                      )}
+                </p>
+              </div>
+            </div>
+          )}
+          <div className="ms-auto flex shrink-0 items-center gap-2">
+            {mode === "settings" && !isEditingMode && (
+              <>
+                {/* Paste / Upload always available — clicking either
                   flips the section into edit mode and runs the action.
                   Matches the deploy-page UI so the operator doesn't
                   have to click Edit first just to dump in a .env. */}
-              <button
-                onClick={() => {
-                  setIsEditingMode(true);
-                  void handlePasteFromClipboard();
-                }}
-                className={actionBtn}
-              >
-                <FileText className="size-3.5" />
-                {ev.pasteEnv}
-              </button>
-              <button
-                onClick={() => {
-                  setIsEditingMode(true);
-                  handleUploadClick();
-                }}
-                className={actionBtn}
-              >
-                <Upload className="size-3.5" />
-                {ev.uploadEnv}
-              </button>
-              <button
-                onClick={() => setIsEditingMode(true)}
-                className={actionBtn}
-              >
-                <Pencil className="size-3.5" />
-                {ev.edit}
-              </button>
-            </>
-          )}
-          {mode === "settings" && isEditingMode && (
-            <>
-              {showSettingsActions && (
                 <button
-                  onClick={onCancel}
-                  className="p-2 text-muted-foreground hover:text-danger hover:bg-danger-bg rounded-lg transition-colors"
-                  title={ev.cancel}
+                  onClick={() => {
+                    setIsEditingMode(true);
+                    void handlePasteFromClipboard();
+                  }}
+                  className={actionBtn}
                 >
-                  <X className="size-4" />
+                  <FileText className="size-3.5" />
+                  {ev.pasteEnv}
                 </button>
-              )}
-              <button
-                onClick={() => void handlePasteFromClipboard()}
-                className={actionBtn}
-              >
-                <FileText className="size-3.5" />
-                {ev.pasteEnv}
-              </button>
-              <button
-                onClick={handleUploadClick}
-                className={actionBtn}
-              >
-                <Upload className="size-3.5" />
-                {ev.uploadEnv}
-              </button>
-              {showSettingsActions && (
                 <button
-                  onClick={onSave}
-                  disabled={isSaving}
-                  className="inline-flex h-8 shrink-0 items-center rounded-lg bg-primary px-4 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={() => {
+                    setIsEditingMode(true);
+                    handleUploadClick();
+                  }}
+                  className={actionBtn}
                 >
-                  {isSaving ? ev.saving : ev.saveChanges}
+                  <Upload className="size-3.5" />
+                  {ev.uploadEnv}
                 </button>
-              )}
-            </>
-          )}
-          {mode === "deploy" && isEditingMode && (
-            <>
-              <button
-                onClick={() => void handlePasteFromClipboard()}
-                className={actionBtn}
-              >
-                <FileText className="size-3.5" />
-                {ev.pasteEnv}
-              </button>
-              <button
-                onClick={handleUploadClick}
-                className={actionBtn}
-              >
-                <Upload className="size-3.5" />
-                {ev.uploadEnv}
-              </button>
-            </>
-          )}
-          {/* #336: bulk reveal — the one action that asks for every masked key at
+                <button onClick={() => setIsEditingMode(true)} className={actionBtn}>
+                  <Pencil className="size-3.5" />
+                  {ev.edit}
+                </button>
+              </>
+            )}
+            {mode === "settings" && isEditingMode && (
+              <>
+                {showSettingsActions && (
+                  <button
+                    onClick={onCancel}
+                    className="p-2 text-muted-foreground hover:text-danger hover:bg-danger-bg rounded-lg transition-colors"
+                    title={ev.cancel}
+                  >
+                    <X className="size-4" />
+                  </button>
+                )}
+                <button onClick={() => void handlePasteFromClipboard()} className={actionBtn}>
+                  <FileText className="size-3.5" />
+                  {ev.pasteEnv}
+                </button>
+                <button onClick={handleUploadClick} className={actionBtn}>
+                  <Upload className="size-3.5" />
+                  {ev.uploadEnv}
+                </button>
+                {showSettingsActions && (
+                  <button
+                    onClick={onSave}
+                    disabled={isSaving}
+                    className="inline-flex h-8 shrink-0 items-center rounded-lg bg-primary px-4 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isSaving ? ev.saving : ev.saveChanges}
+                  </button>
+                )}
+              </>
+            )}
+            {mode === "deploy" && isEditingMode && (
+              <>
+                <button onClick={() => void handlePasteFromClipboard()} className={actionBtn}>
+                  <FileText className="size-3.5" />
+                  {ev.pasteEnv}
+                </button>
+                <button onClick={handleUploadClick} className={actionBtn}>
+                  <Upload className="size-3.5" />
+                  {ev.uploadEnv}
+                </button>
+              </>
+            )}
+            {/* #336: bulk reveal — the one action that asks for every masked key at
               once. Only when a reveal source is wired and something is masked. */}
-          {onReveal && hasMaskedRow && (
-            <button
-              type="button"
-              onClick={() => void toggleRevealAll()}
-              disabled={revealingKeys.size > 0}
-              className={actionBtn}
-              title={allShown ? ev.reveal?.hide : ev.reveal?.show}
-            >
-              {allShown ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
-              {allShown ? ev.reveal?.hide : ev.reveal?.show}
-            </button>
-          )}
-          {collapsible && (
-            <button
-              type="button"
-              onClick={() => setExpanded((v) => !v)}
-              className="flex size-8 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-              aria-label={expanded ? ev.collapse : ev.expand}
-            >
-              {expanded ? (
-                <ChevronUp className="size-4" />
-              ) : (
-                <ChevronDown className="size-4" />
-              )}
-            </button>
-          )}
+            {onReveal && hasMaskedRow && (
+              <button
+                type="button"
+                onClick={() => void toggleRevealAll()}
+                disabled={revealingKeys.size > 0}
+                className={actionBtn}
+                title={allShown ? ev.reveal?.hide : ev.reveal?.show}
+              >
+                {allShown ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+                {allShown ? ev.reveal?.hide : ev.reveal?.show}
+              </button>
+            )}
+            {collapsible && (
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                className="flex size-8 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                aria-label={expanded ? ev.collapse : ev.expand}
+              >
+                {expanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+              </button>
+            )}
+          </div>
         </div>
-      </div>
       )}
 
       <input
@@ -824,150 +829,180 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesPropsOptional> = ({
       />
 
       {expanded && (
-      <div
-        ref={pasteZoneRef}
-        className={`px-5 pb-5 space-y-3 pt-4 transition-all ${
-          borderless ? 'rounded-b-xl' : 'border-t border-border/50 rounded-b-2xl'
-        } ${
-          isDragging ? 'ring-2 ring-primary/30 bg-primary/5' : ''
-        }`}
-        tabIndex={isEditingMode ? 0 : -1}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        onPasteCapture={handleContainerPaste}
-        onClick={handlePasteZoneClick}
-      >
-        {currentEnvVars.map((env, index) => {
-          const resolution = getEnvResolutionState(
-            envMeta?.[env.key],
-            env.preserveValue ? ENV_MASK : env.value,
-            t,
-          );
-          const inputStateClass = resolution?.inputClass ?? "";
-          // #336: a masked row holds only the sentinel — the real value arrives in
-          // the overlay when THAT key is revealed, and its visibility lives in
-          // `shownKeys`. A plaintext row (new / typed) shows its own value and keeps
-          // its own `visible` flag. Masked with no reveal source wired: no eye at
-          // all, since the toggle could only ever display the sentinel as text.
-          const masked = Boolean(env.preserveValue) || isMaskedValue(env.value);
-          const showAsText = masked ? shownKeys.has(env.key) : env.visible;
-          const displayValue =
-            masked && Object.hasOwn(revealedValues, env.key)
-              ? revealedValues[env.key]
-              : env.preserveValue
-                ? ""
-                : env.value;
-          const canToggleValue = !masked || Boolean(onReveal);
-          return (
-            <div key={index} data-env-index={index} className="space-y-1.5">
-              {resolution && (
-                <div className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium ${resolution.badgeClass}`}>
-                  <EnvResolutionIcon icon={resolution.icon} />
-                  {resolution.label}
-                </div>
-              )}
-              <div className="flex items-center gap-2">
-                <input
-                  type="text"
-                  value={env.key}
-                  onChange={(e) => handleKeyChange(index, e.target.value)}
-                  placeholder="KEY"
-                  readOnly={!isEditingMode}
-                  className={`flex-1 px-3.5 py-2.5 border border-border/50 rounded-lg text-sm font-mono text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all ${
-                    !isEditingMode ? 'cursor-default bg-muted/20' : 'bg-muted/30'
-                  } ${inputStateClass}`}
-                />
-                <div className="relative flex-1">
+        <div
+          ref={pasteZoneRef}
+          className={`px-5 pb-5 space-y-3 pt-4 transition-all ${
+            borderless ? "rounded-b-xl" : "border-t border-border/50 rounded-b-2xl"
+          } ${isDragging ? "ring-2 ring-primary/30 bg-primary/5" : ""}`}
+          tabIndex={isEditingMode ? 0 : -1}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          onPasteCapture={handleContainerPaste}
+          onClick={handlePasteZoneClick}
+        >
+          {currentEnvVars.map((env, index) => {
+            const resolution = getEnvResolutionState(
+              envMeta?.[env.key],
+              env.preserveValue ? ENV_MASK : env.value,
+              t,
+            );
+            const inputStateClass = resolution?.inputClass ?? "";
+            // #336: a masked row holds only the sentinel — the real value arrives in
+            // the overlay when THAT key is revealed, and its visibility lives in
+            // `shownKeys`. A plaintext row (new / typed) shows its own value and keeps
+            // its own `visible` flag. Masked with no reveal source wired: no eye at
+            // all, since the toggle could only ever display the sentinel as text.
+            const masked = Boolean(env.preserveValue) || isMaskedValue(env.value);
+            const showAsText = masked ? shownKeys.has(env.key) : env.visible;
+            const displayValue =
+              masked && Object.hasOwn(revealedValues, env.key)
+                ? revealedValues[env.key]
+                : env.preserveValue
+                  ? ""
+                  : env.value;
+            const canToggleValue = !masked || Boolean(onReveal);
+            const isSecret = env.isSecret ?? looksLikeSecretKey(env.key);
+            return (
+              <div key={index} data-env-index={index} className="space-y-1.5">
+                {resolution && (
+                  <div
+                    className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium ${resolution.badgeClass}`}
+                  >
+                    <EnvResolutionIcon icon={resolution.icon} />
+                    {resolution.label}
+                  </div>
+                )}
+                <div className="flex items-center gap-2">
                   <input
-                    type={showAsText ? "text" : "password"}
-                    value={displayValue}
-                    onChange={(e) => handleValueChange(index, e.target.value)}
-                    placeholder={env.preserveValue ? ENV_MASK : ev.valuePlaceholder}
+                    type="text"
+                    value={env.key}
+                    onChange={(e) => handleKeyChange(index, e.target.value)}
+                    placeholder="KEY"
                     readOnly={!isEditingMode}
-                    className={`w-full px-3.5 py-2.5 pe-9 border border-border/50 rounded-lg text-sm font-mono text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all ${
-                      !isEditingMode ? 'cursor-default bg-muted/20' : 'bg-muted/30'
+                    className={`flex-1 px-3.5 py-2.5 border border-border/50 rounded-lg text-sm font-mono text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all ${
+                      !isEditingMode ? "cursor-default bg-muted/20" : "bg-muted/30"
                     } ${inputStateClass}`}
                   />
-                  {canToggleValue && (
+                  <div className="relative flex-1">
+                    <input
+                      type={showAsText ? "text" : "password"}
+                      value={displayValue}
+                      onChange={(e) => handleValueChange(index, e.target.value)}
+                      placeholder={env.preserveValue ? ENV_MASK : ev.valuePlaceholder}
+                      readOnly={!isEditingMode}
+                      className={`w-full px-3.5 py-2.5 pe-9 border border-border/50 rounded-lg text-sm font-mono text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all ${
+                        !isEditingMode ? "cursor-default bg-muted/20" : "bg-muted/30"
+                      } ${inputStateClass}`}
+                    />
+                    {canToggleValue && (
+                      <button
+                        onClick={() => void toggleEnvVisibility(index)}
+                        disabled={revealingKeys.has(env.key)}
+                        className="absolute end-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors disabled:opacity-40"
+                        type="button"
+                      >
+                        {showAsText ? (
+                          <EyeOff className="size-3.5" />
+                        ) : (
+                          <Eye className="size-3.5" />
+                        )}
+                      </button>
+                    )}
+                  </div>
+
+                  {showSecretToggle && (
                     <button
-                      onClick={() => void toggleEnvVisibility(index)}
-                      disabled={revealingKeys.has(env.key)}
-                      className="absolute end-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors disabled:opacity-40"
                       type="button"
+                      disabled={!isEditingMode}
+                      onClick={() => toggleSecret(index)}
+                      title={
+                        isSecret
+                          ? t.projectSettings.envVars.markedSecret
+                          : t.projectSettings.envVars.markSecret
+                      }
+                      aria-label={
+                        isSecret
+                          ? t.projectSettings.envVars.markedSecret
+                          : t.projectSettings.envVars.markSecret
+                      }
+                      className={`flex size-8 shrink-0 items-center justify-center rounded-lg border transition-colors ${
+                        isSecret
+                          ? "border-warning-border bg-warning-bg text-warning"
+                          : "border-border/60 bg-muted/30 text-muted-foreground hover:bg-muted/50"
+                      } ${!isEditingMode ? "opacity-60 cursor-default" : ""}`}
                     >
-                      {showAsText ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+                      <KeyRound className="size-3.5" />
+                    </button>
+                  )}
+
+                  {showEditControls && isEditingMode && (
+                    <button
+                      onClick={() => removeEnvVar(index)}
+                      className="flex size-8 items-center justify-center rounded-lg text-muted-foreground/50 hover:text-danger hover:bg-danger-bg transition-colors"
+                      type="button"
+                      title={ev.delete}
+                    >
+                      <Trash2 className="size-3.5" />
                     </button>
                   )}
                 </div>
-
-                {showEditControls && isEditingMode && (
-                  <button
-                    onClick={() => removeEnvVar(index)}
-                    className="flex size-8 items-center justify-center rounded-lg text-muted-foreground/50 hover:text-danger hover:bg-danger-bg transition-colors"
-                    type="button"
-                    title={ev.delete}
-                  >
-                    <Trash2 className="size-3.5" />
-                  </button>
-                )}
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
 
-        {/* The box holds the add CTA but is NOT itself a button: clicking its empty
+          {/* The box holds the add CTA but is NOT itself a button: clicking its empty
             space focuses the paste zone, the documented fallback for when the
             clipboard API is blocked (see the clipboardBlocked toast). */}
-        {currentEnvVars.length === 0 && (
-          <div
-            className={`flex flex-col items-center justify-center rounded-xl border border-dashed px-6 py-8 text-center transition-colors ${
-              isDragging
-                ? 'border-primary bg-primary/5'
-                : 'border-border/60 bg-muted/15'
-            }`}
-          >
+          {currentEnvVars.length === 0 && (
             <div
-              className={`mb-3 flex size-10 items-center justify-center rounded-xl transition-colors ${
-                isDragging ? 'bg-primary/10 text-primary' : 'bg-muted/60 text-muted-foreground'
+              className={`flex flex-col items-center justify-center rounded-xl border border-dashed px-6 py-8 text-center transition-colors ${
+                isDragging ? "border-primary bg-primary/5" : "border-border/60 bg-muted/15"
               }`}
             >
-              <Key className="size-[18px]" />
+              <div
+                className={`mb-3 flex size-10 items-center justify-center rounded-xl transition-colors ${
+                  isDragging ? "bg-primary/10 text-primary" : "bg-muted/60 text-muted-foreground"
+                }`}
+              >
+                <Key className="size-[18px]" />
+              </div>
+              <p
+                className={`text-sm font-medium ${isDragging ? "text-primary" : "text-foreground"}`}
+              >
+                {isDragging ? ev.dropHere : ev.noneTitle}
+              </p>
+              <p className="mt-1 max-w-xs text-xs leading-relaxed text-muted-foreground">
+                {isEditingMode ? ev.emptyHintEditing : ev.emptyHintReadonly}
+              </p>
+              {isEditingMode && (
+                <button
+                  type="button"
+                  onClick={addEnvVar}
+                  className="mt-4 inline-flex h-9 items-center gap-1.5 rounded-lg bg-primary px-4 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  <Plus className="size-3.5" />
+                  {ev.addVariable}
+                </button>
+              )}
             </div>
-            <p className={`text-sm font-medium ${isDragging ? 'text-primary' : 'text-foreground'}`}>
-              {isDragging ? ev.dropHere : ev.noneTitle}
-            </p>
-            <p className="mt-1 max-w-xs text-xs leading-relaxed text-muted-foreground">
-              {isEditingMode ? ev.emptyHintEditing : ev.emptyHintReadonly}
-            </p>
-            {isEditingMode && (
+          )}
+
+          {isEditingMode && currentEnvVars.length > 0 && (
+            <div className="space-y-2 pt-1">
               <button
                 type="button"
                 onClick={addEnvVar}
-                className="mt-4 inline-flex h-9 items-center gap-1.5 rounded-lg bg-primary px-4 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border/60 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted/30 hover:text-foreground"
               >
                 <Plus className="size-3.5" />
                 {ev.addVariable}
               </button>
-            )}
-          </div>
-        )}
-
-        {isEditingMode && currentEnvVars.length > 0 && (
-          <div className="space-y-2 pt-1">
-            <button
-              type="button"
-              onClick={addEnvVar}
-              className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border/60 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted/30 hover:text-foreground"
-            >
-              <Plus className="size-3.5" />
-              {ev.addVariable}
-            </button>
-            <p className="text-[11px] text-muted-foreground">{ev.pasteHint}</p>
-          </div>
-        )}
-      </div>
+              <p className="text-[11px] text-muted-foreground">{ev.pasteHint}</p>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );
@@ -1009,7 +1044,9 @@ function parseEnvFile(content: string) {
 }
 
 function looksLikeEnvPaste(content: string, allowSingleLine: boolean) {
-  const lines = content.split(/\r?\n/).filter((line) => line.trim() && !line.trim().startsWith("#"));
+  const lines = content
+    .split(/\r?\n/)
+    .filter((line) => line.trim() && !line.trim().startsWith("#"));
   const envLines = lines.filter((line) => {
     const equalIndex = line.indexOf("=");
     if (equalIndex <= 0) return false;
@@ -1046,7 +1083,11 @@ function detectContainerPort(envVars: EnvironmentVariableRow[]) {
   return String(port);
 }
 
-function getEnvResolutionState(meta: EnvironmentVariableMeta | undefined, value: string, t: Dictionary) {
+function getEnvResolutionState(
+  meta: EnvironmentVariableMeta | undefined,
+  value: string,
+  t: Dictionary,
+) {
   if (!meta) return null;
   const res = t.importProject.environmentVariables.resolution;
 

--- a/apps/dashboard/src/components/import-project/environment-variables.render.test.tsx
+++ b/apps/dashboard/src/components/import-project/environment-variables.render.test.tsx
@@ -89,9 +89,7 @@ describe("EnvironmentVariables reveal affordance", () => {
 
   it("renders a preserved project secret as set without putting plaintext in state", () => {
     const html = render({
-      envVars: [
-        { key: "AUTH_SECRET", value: "", visible: true, preserveValue: true },
-      ],
+      envVars: [{ key: "AUTH_SECRET", value: "", visible: true, preserveValue: true }],
     });
     expect(html).toContain('placeholder="••••••••"');
     expect(eyeCount(html)).toBe(0);
@@ -102,7 +100,9 @@ describe("EnvironmentVariables reveal affordance", () => {
     // empty or typed value isn't masked, so it kept its eye while masked neighbours in
     // the SAME list had none.
     expect(eyeCount(render({ envVars: ROWS }))).toBe(1);
-    expect(eyeCount(render({ envVars: [{ key: "POSTGRES_PASSWORD", value: "", visible: false }] }))).toBe(1);
+    expect(
+      eyeCount(render({ envVars: [{ key: "POSTGRES_PASSWORD", value: "", visible: false }] })),
+    ).toBe(1);
   });
 
   it("gives every row in a mixed list an eye once a source is wired", () => {
@@ -148,5 +148,57 @@ describe("EnvironmentVariables embedded Compose requirements (#673)", () => {
     });
 
     expect(text(html)).toContain("Needs value");
+  });
+});
+
+describe("EnvironmentVariables showSecretToggle", () => {
+  it("omits the secret toggle by default", () => {
+    const html = render({ envVars: ROWS });
+    expect(html).not.toContain("Mark as secret");
+    expect(html).not.toContain("Marked secret");
+  });
+
+  it("renders the secret toggle when showSecretToggle is true", () => {
+    const html = render({ envVars: ROWS, showSecretToggle: true });
+    expect(html).toContain("Mark as secret");
+  });
+
+  it("marks a row as secret when isSecret is true", () => {
+    const html = render({
+      envVars: [{ key: "CUSTOM_VAR", value: "val", visible: false, isSecret: true }],
+      showSecretToggle: true,
+    });
+    expect(html).toContain("Marked secret");
+    expect(html).toContain("border-warning-border bg-warning-bg text-warning");
+  });
+
+  it("leaves a row un-marked when isSecret is explicitly false", () => {
+    const html = render({
+      envVars: [{ key: "API_KEY", value: "val", visible: true, isSecret: false }],
+      showSecretToggle: true,
+    });
+    expect(html).toContain("Mark as secret");
+    expect(html).toContain("border-border/60 bg-muted/30 text-muted-foreground");
+  });
+
+  it("falls back to looksLikeSecretKey when isSecret is undefined", () => {
+    const html = render({
+      envVars: [
+        { key: "STRIPE_SECRET_KEY", value: "sk_live_123", visible: false },
+        { key: "PORT", value: "3000", visible: true },
+      ],
+      showSecretToggle: true,
+    });
+    expect(html).toContain("Marked secret");
+    expect(html).toContain("Mark as secret");
+  });
+
+  it("disables the secret toggle button when not in editing mode", () => {
+    const html = render({
+      envVars: ROWS,
+      showSecretToggle: true,
+      isEditingMode: false,
+    });
+    expect(html).toContain("disabled");
   });
 });

--- a/apps/dashboard/src/components/import-project/types.ts
+++ b/apps/dashboard/src/components/import-project/types.ts
@@ -23,6 +23,8 @@ export interface EnvironmentVariable {
    * its stored ciphertext. Any key/value edit clears this marker.
    */
   preserveValue?: boolean;
+  /** Explicit secret flag: true = secret (masked on read), false = non-secret. */
+  isSecret?: boolean;
 }
 
 export type StartCommand = string;


### PR DESCRIPTION
Resolves #812

### Summary

This PR enables operators to explicitly mark and unmark environment variables as secret on a service's **Environment** tab in the dashboard UI.

While the database schema (`env_var.is_secret`), service API (`PUT /projects/:projectId/services/:serviceId/env`), and CLI (`openship service env set ... --secret`) all already supported per-service secret environment variables, the dashboard UI lacked an explicit secret toggle in the service Environment tab (`ServiceDetailPanel.tsx` -> `<EnvironmentVariables>`), forcing operators to rely on key-name heuristics (`looksLikeSecretKey`) or the CLI.

### Changes

1. **Types (`types.ts` & `EnvironmentVariables.tsx`)**:
   - Added `isSecret?: boolean` to `EnvironmentVariable` and `EnvironmentVariableRow`.
2. **Component (`EnvironmentVariables.tsx`)**:
   - Added `showSecretToggle?: boolean` prop (defaults to `false` for backwards compatibility with other wizard surfaces).
   - Rendered the `KeyRound` toggle button on each row when enabled, with active warning styling (`border-warning-border bg-warning-bg text-warning`) when marked secret, matching the project-level `EnvVarsEditor`.
   - Wired `toggleSecret` to flip `isSecret` and adjust value visibility.
   - Reused existing localized strings `t.projectSettings.envVars.markedSecret` and `t.projectSettings.envVars.markSecret` across all locales.
3. **Service Details (`ServiceDetailPanel.tsx`)**:
   - Passed `showSecretToggle={true}` to the `<EnvironmentVariables>` component in the service Environment tab.
4. **Tests (`environment-variables.render.test.tsx`)**:
   - Added unit tests covering:
     - Omission by default.
     - Rendering when `showSecretToggle` is enabled.
     - Active styling when `isSecret: true`.
     - Inactive styling when `isSecret: false`.
     - Heuristic fallback to `looksLikeSecretKey` when `isSecret` is undefined.
     - Disabled button state when `isEditingMode: false`.

### Verification

- `bun run test` in `apps/dashboard`: 109/109 test files passed (1,138 tests total).
- `bun run lint` (`tsc --noEmit`): passed with 0 errors.
- Prettier formatting applied to all modified files.