### PR TITLE
fix(email): load attachment bytes only for downloads and forwards

### DIFF
--- a/apps/email/client/components/mail/mail-display.tsx
+++ b/apps/email/client/components/mail/mail-display.tsx
@@ -252,33 +252,14 @@ const cleanNameDisplay = (name?: string) => {
   return name.trim();
 };
 
-const ThreadAttachments = ({ attachments }: { attachments: Attachment[] }) => {
+const ThreadAttachments = ({
+  attachments,
+  onDownload,
+}: {
+  attachments: Attachment[];
+  onDownload: (attachment: Attachment) => void;
+}) => {
   if (!attachments || attachments.length === 0) return null;
-
-  const handleDownload = async (attachment: Attachment) => {
-    try {
-      // Convert base64 to blob
-      const byteCharacters = atob(attachment.body);
-      const byteNumbers: number[] = Array(byteCharacters.length);
-      for (let i = 0; i < byteCharacters.length; i++) {
-        byteNumbers[i] = byteCharacters.charCodeAt(i);
-      }
-      const byteArray = new Uint8Array(byteNumbers);
-      const blob = new Blob([byteArray], { type: attachment.mimeType });
-
-      // Create download link
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = attachment.filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Error downloading attachment:', error);
-    }
-  };
 
   return (
     <div className="mt-2 w-full">
@@ -291,7 +272,7 @@ const ThreadAttachments = ({ attachments }: { attachments: Attachment[] }) => {
         {attachments.map((attachment) => (
           <button
             key={`${attachment.attachmentId}-${attachment.filename}`}
-            onClick={() => handleDownload(attachment)}
+            onClick={() => onDownload(attachment)}
             className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-sm hover:bg-[#F0F0F0] dark:bg-[#262626] dark:hover:bg-[#303030]"
           >
             <span className="text-muted-foreground">{getFileIcon(attachment.filename)}</span>
@@ -381,10 +362,6 @@ const downloadAttachment = async (attachment: {
   try {
     const attachmentData = attachment.body;
 
-    if (!attachmentData) {
-      throw new Error('Attachment data not found');
-    }
-
     const byteCharacters = atob(attachmentData);
     const byteNumbers: number[] = Array(byteCharacters.length);
     for (let i = 0; i < byteCharacters.length; i++) {
@@ -415,7 +392,6 @@ const handleDownloadAllAttachments =
     const JSZip = (await import('jszip')).default;
     const zip = new JSZip();
 
-    console.log('attachments', attachments);
     attachments.forEach((attachment) => {
       try {
         const byteCharacters = atob(attachment.body);
@@ -457,22 +433,31 @@ const handleDownloadAllAttachments =
       .catch((error) => {
         console.error('Error generating zip file:', error);
       });
-
-    console.log('downloaded', subject, attachments);
   };
 
-const openAttachment = async (attachment: {
-  body: string;
-  mimeType: string;
-  filename: string;
-  attachmentId: string;
-}) => {
+const openAttachmentViewer = () => {
+  const width = 800;
+  const height = 600;
+  const left = (window.screen.width - width) / 2;
+  const top = (window.screen.height - height) / 2;
+  return window.open(
+    '',
+    'attachment-viewer',
+    `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=no,location=no,menubar=no`,
+  );
+};
+
+const openAttachment = async (
+  attachment: {
+    body: string;
+    mimeType: string;
+    filename: string;
+    attachmentId: string;
+  },
+  pendingPopup?: Window | null,
+) => {
   try {
     const attachmentData = attachment.body;
-
-    if (!attachmentData) {
-      throw new Error('Attachment data not found');
-    }
 
     const byteCharacters = atob(attachmentData);
     const byteNumbers: number[] = Array(byteCharacters.length);
@@ -483,18 +468,10 @@ const openAttachment = async (attachment: {
     const blob = new Blob([byteArray], { type: attachment.mimeType });
     const url = window.URL.createObjectURL(blob);
 
-    const width = 800;
-    const height = 600;
-    const left = (window.screen.width - width) / 2;
-    const top = (window.screen.height - height) / 2;
-
-    const popup = window.open(
-      url,
-      'attachment-viewer',
-      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=no,location=no,menubar=no`,
-    );
+    const popup = pendingPopup === undefined ? openAttachmentViewer() : pendingPopup;
 
     if (popup) {
+      popup.location.href = url;
       popup.focus();
       // Clean up the URL after a short delay to ensure the browser has time to load it
       setTimeout(() => window.URL.revokeObjectURL(url), 1000);
@@ -660,11 +637,14 @@ const MoreAboutQuery = ({
 const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }: Props) => {
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const { data: threadData } = useThread(emailData.threadId ?? null);
-  const { data: messageAttachments } = useAttachments(emailData.id);
+  const { folder } = useParams<{ folder: string }>();
+  const { data: loadedAttachments, refetch: fetchMessageAttachments } = useAttachments(
+    emailData.id,
+    folder,
+  );
   //   const [unsubscribed, setUnsubscribed] = useState(false);
   //   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
   const [preventCollapse, setPreventCollapse] = useState(false);
-  const { folder } = useParams<{ folder: string }>();
   //   const [selectedAttachment, setSelectedAttachment] = useState<null | {
   //     id: string;
   //     name: string;
@@ -683,6 +663,68 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
   const [researchSender, setResearchSender] = useState<Sender | null>(null);
   const [searchQuery, setSearchQuery] = useState<string | null>(null);
   //   const trpc = useTRPC();
+
+  const attachmentMetadata = emailData.attachments ?? [];
+  const loadAttachmentBytes = useCallback(async () => {
+    if (loadedAttachments) return loadedAttachments;
+    const result = await fetchMessageAttachments();
+    if (result.error) throw result.error;
+    return result.data ?? [];
+  }, [fetchMessageAttachments, loadedAttachments]);
+
+  const resolveAttachmentBytes = useCallback(
+    async (attachment: Attachment) => {
+      try {
+        const loaded = await loadAttachmentBytes();
+        const resolved = loaded.find(
+          (candidate) => candidate.attachmentId === attachment.attachmentId,
+        );
+        if (!resolved) throw new Error('Attachment data not found');
+        return resolved;
+      } catch (error) {
+        console.error('Error loading attachment:', error);
+        toast.error('Failed to load attachment');
+        return null;
+      }
+    },
+    [loadAttachmentBytes],
+  );
+
+  const handleAttachmentDownload = useCallback(
+    async (attachment: Attachment) => {
+      const resolved = await resolveAttachmentBytes(attachment);
+      if (resolved) await downloadAttachment(resolved);
+    },
+    [resolveAttachmentBytes],
+  );
+
+  const handleAttachmentOpen = useCallback(
+    async (attachment: Attachment) => {
+      // Open synchronously from the click event so popup blockers do not reject
+      // the preview while the attachment bytes are fetched.
+      const popup = openAttachmentViewer();
+      const resolved = await resolveAttachmentBytes(attachment);
+      if (!resolved) {
+        popup?.close();
+        return;
+      }
+      await openAttachment(resolved, popup);
+    },
+    [resolveAttachmentBytes],
+  );
+
+  const handleDownloadAll = useCallback(async () => {
+    try {
+      const loaded = await loadAttachmentBytes();
+      if (loaded.length !== attachmentMetadata.length) {
+        throw new Error('One or more attachments could not be loaded');
+      }
+      await handleDownloadAllAttachments(emailData.subject || 'email', loaded)();
+    } catch (error) {
+      console.error('Error loading attachments:', error);
+      toast.error('Failed to download attachments');
+    }
+  }, [attachmentMetadata.length, emailData.subject, loadAttachmentBytes]);
 
   const isLastEmail = useMemo(
     () => emailData.id === threadData?.latest?.id,
@@ -1100,11 +1142,11 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
 
             <!-- Attachments -->
             ${
-              messageAttachments && messageAttachments.length > 0
+              attachmentMetadata.length > 0
                 ? `
               <div class="attachments-section">
-                <h2 class="attachments-title">Attachments (${messageAttachments.length})</h2>
-                ${messageAttachments
+                <h2 class="attachments-title">Attachments (${attachmentMetadata.length})</h2>
+                ${attachmentMetadata
                   .map(
                     (attachment) => `
                   <div class="attachment-item">
@@ -1313,7 +1355,10 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                 </div>
                 <AiSummary />
                 {threadAttachments && threadAttachments.length > 0 && (
-                  <ThreadAttachments attachments={threadAttachments} />
+                  <ThreadAttachments
+                    attachments={threadAttachments}
+                    onDownload={(attachment) => void handleAttachmentDownload(attachment)}
+                  />
                 )}
               </>
             )}
@@ -1513,21 +1558,12 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                 <Printer className="fill-iconLight dark:fill-iconDark mr-2 h-4 w-4" />
                                 {m['common.mailDisplay.print']()}
                               </DropdownMenuItem>
-                              {(messageAttachments?.length ?? 0) > 0 && (
+                              {attachmentMetadata.length > 0 && (
                                 <DropdownMenuItem
-                                  disabled={!messageAttachments?.length}
-                                  className={
-                                    !messageAttachments?.length
-                                      ? 'data-disabled:pointer-events-auto'
-                                      : ''
-                                  }
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     e.preventDefault();
-                                    handleDownloadAllAttachments(
-                                      emailData.subject || 'email',
-                                      messageAttachments || [],
-                                    )();
+                                    void handleDownloadAll();
                                   }}
                                 >
                                   <HardDriveDownload className="fill-iconLight dark:text-iconDark dark:fill-iconLight mr-2 h-4 w-4" />
@@ -1659,16 +1695,16 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                   />
                 ) : null}
                 {/* mail attachments */}
-                {messageAttachments && messageAttachments.length > 0 ? (
+                {attachmentMetadata.length > 0 ? (
                   <div className="mb-4 flex flex-wrap items-center gap-2 px-4 pt-4">
-                    {messageAttachments.map((attachment) => (
+                    {attachmentMetadata.map((attachment, attachmentIndex) => (
                       <div
                         key={`${attachment.filename}-${attachment.attachmentId}`}
                         className="flex"
                       >
                         <button
                           className="flex cursor-pointer items-center gap-1 rounded-[5px] bg-[#FAFAFA] px-1.5 py-1 text-sm font-medium hover:bg-[#F0F0F0] dark:bg-[#262626] dark:hover:bg-[#303030]"
-                          onClick={() => openAttachment(attachment)}
+                          onClick={() => void handleAttachmentOpen(attachment)}
                         >
                           {getFileIcon(attachment.filename)}
                           <span className="max-w-[15ch] truncate text-sm text-black dark:text-white">
@@ -1679,12 +1715,12 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                           </span>
                         </button>
                         <button
-                          onClick={() => downloadAttachment(attachment)}
+                          onClick={() => void handleAttachmentDownload(attachment)}
                           className="flex cursor-pointer items-center gap-1 rounded-[5px] px-1.5 py-1 text-sm"
                         >
                           <HardDriveDownload className="text-muted-foreground dark:text-muted-foreground h-4 w-4 fill-[#FAFAFA] dark:fill-[#262626]" />
                         </button>
-                        {index < (messageAttachments?.length || 0) - 1 && (
+                        {attachmentIndex < attachmentMetadata.length - 1 && (
                           <div className="m-auto h-2 w-px bg-[#E0E0E0] dark:bg-[#424242]" />
                         )}
                       </div>

--- a/apps/email/client/components/mail/reply-composer.tsx
+++ b/apps/email/client/components/mail/reply-composer.tsx
@@ -15,6 +15,7 @@ import { m } from '@/paraglide/messages';
 import type { Sender } from '@/types';
 import { useQueryState } from 'nuqs';
 import { useEffect } from 'react';
+import { useParams } from 'react-router';
 import posthog from 'posthog-js';
 import { toast } from 'sonner';
 
@@ -24,6 +25,7 @@ interface ReplyComposeProps {
 
 export default function ReplyCompose({ messageId }: ReplyComposeProps) {
   const [mode, setMode] = useQueryState('mode');
+  const { folder } = useParams<{ folder: string }>();
   const { enableScope, disableScope } = useHotkeysContext();
   const { data: aliases } = useEmailAliases();
 
@@ -199,6 +201,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
         isForward: mode === 'forward',
         originalMessage: replyToMessage.decodedBody,
         originalMessageId: replyToMessage?.id,
+        originalFolder: folder,
         scheduleAt: data.scheduleAt,
       });
 
@@ -207,7 +210,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
       // Reset states
       setMode(null);
       await refetch();
-      
+
       handleUndoSend(result, settings, {
         to: data.to,
         cc: data.cc,

--- a/apps/email/client/components/mail/reply-composer.tsx
+++ b/apps/email/client/components/mail/reply-composer.tsx
@@ -198,6 +198,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
         threadId: replyToMessage?.threadId,
         isForward: mode === 'forward',
         originalMessage: replyToMessage.decodedBody,
+        originalMessageId: replyToMessage?.id,
         scheduleAt: data.scheduleAt,
       });
 
@@ -273,7 +274,14 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
         initialTo={ensureEmailArray(draft?.to)}
         initialCc={ensureEmailArray(draft?.cc)}
         initialBcc={ensureEmailArray(draft?.bcc)}
-        initialSubject={draft?.subject}
+        initialSubject={
+          draft?.subject ??
+          (mode === 'forward' && replyToMessage?.subject
+            ? /^fwd:\s/i.test(replyToMessage.subject)
+              ? replyToMessage.subject
+              : `Fwd: ${replyToMessage.subject}`
+            : undefined)
+        }
         autofocus={true}
         settingsLoading={settingsLoading}
         replyingTo={replyToMessage?.sender.email}

--- a/apps/email/client/hooks/use-attachments.ts
+++ b/apps/email/client/hooks/use-attachments.ts
@@ -1,14 +1,20 @@
 import { useTRPC } from '@/providers/query-provider';
 import { useQuery } from '@tanstack/react-query';
-import { useSession } from '@/lib/auth-client';
 
-export const useAttachments = (messageId: string) => {
-  const { data: session } = useSession();
+/**
+ * Prepare an attachment-byte query without running it during normal message
+ * rendering. Callers explicitly refetch after an open/download action.
+ */
+export const useAttachments = (messageId: string, folder?: string) => {
   const trpc = useTRPC();
   const AttachmentsQuery = useQuery(
     trpc.mail.getMessageAttachments.queryOptions(
-      { messageId },
-      { enabled: !!session?.user.id && !!messageId, staleTime: 1000 * 60 * 60 },
+      { messageId, folder },
+      {
+        enabled: false,
+        staleTime: 1000 * 60 * 60,
+        gcTime: 1000 * 60 * 5,
+      },
     ),
   );
 

--- a/apps/email/server/src/lib/imap-driver.ts
+++ b/apps/email/server/src/lib/imap-driver.ts
@@ -296,6 +296,17 @@ export interface AttachmentMeta {
   headers: Array<{ name?: string | null; value?: string | null }>;
 }
 
+export function encodeAttachmentBody(
+  content: Buffer | undefined,
+  includeAttachmentBytes = false,
+): string {
+  return includeAttachmentBytes && content ? content.toString('base64') : '';
+}
+
+export interface GetThreadOptions {
+  includeAttachmentBytes?: boolean;
+}
+
 export interface ListThreadsInput {
   folder: FolderSlug;
   cursor?: string;
@@ -856,6 +867,7 @@ export async function getThread(
   id: string,
   folder: FolderSlug = 'inbox',
   hint?: UidHint,
+  options: GetThreadOptions = {},
 ): Promise<ThreadResponse | null> {
   const mailbox = folderToMailbox(folder);
   const startedAt = performance.now();
@@ -1056,7 +1068,7 @@ export async function getThread(
             mimeType: ct,
             size: a.size ?? 0,
             inline: a.contentDisposition === 'inline',
-            body: '',
+            body: encodeAttachmentBody(a.content, options.includeAttachmentBytes),
             attachmentId: attId,
             headers: [],
           };

--- a/apps/email/server/src/trpc/routes/drafts.ts
+++ b/apps/email/server/src/trpc/routes/drafts.ts
@@ -93,7 +93,9 @@ export const draftsRouter = router({
   get: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      const thread = await getThread(ctx.imap, input.id, 'drafts');
+      const thread = await getThread(ctx.imap, input.id, 'drafts', undefined, {
+        includeAttachmentBytes: true,
+      });
       if (!thread || !thread.latest) return null;
       const msg = thread.latest;
       const flatten = (arr: Array<{ email?: string }> | undefined) =>

--- a/apps/email/server/src/trpc/routes/mail.ts
+++ b/apps/email/server/src/trpc/routes/mail.ts
@@ -156,24 +156,50 @@ export const mailRouter = router({
         threadId: z.string().nullable().optional(),
         isForward: z.boolean().optional(),
         originalMessage: z.string().optional(),
+        originalMessageId: z.string().optional(),
         scheduleAt: z.string().optional(),
         headers: z.record(z.string(), z.string()).optional(),
         inReplyTo: z.string().optional(),
         references: z.array(z.string()).optional(),
       }),
     )
-    .mutation(({ ctx, input }) => {
+    .mutation(async ({ ctx, input }) => {
       const refsHeader = input.headers?.References;
       const inReplyToHeader = input.headers?.['In-Reply-To'];
       const fromAddress = formatFromAddress(input.fromEmail, ctx.session.email, ctx.session.name);
+
+      let originalHtml = input.originalMessage;
+      let forwardedAttachments: typeof input.attachments;
+      if (input.isForward && input.originalMessageId) {
+        const original = await getThread(ctx.imap, input.originalMessageId, 'inbox', undefined, {
+          includeAttachmentBytes: true,
+        }).catch(() => null);
+        originalHtml = original?.latest.decodedBody ?? originalHtml;
+        forwardedAttachments = original?.latest.attachments
+          .filter((attachment) => attachment.body)
+          .map((attachment) => ({
+            name: attachment.filename,
+            type: attachment.contentType,
+            base64: attachment.body,
+          }));
+      }
+
+      const outgoingHtml = input.isForward
+        ? `${input.message ?? input.html ?? input.body ?? ''}${originalHtml ?? ''}`
+        : input.message ?? input.html ?? input.body ?? undefined;
+      const attachments =
+        forwardedAttachments?.length || input.attachments?.length
+          ? [...(forwardedAttachments ?? []), ...(input.attachments ?? [])]
+          : undefined;
+
       return driverSend(ctx.smtp, ctx.imap, fromAddress, {
         to: input.to.map(senderToAddress),
         cc: input.cc?.map(senderToAddress),
         bcc: input.bcc?.map(senderToAddress),
         subject: input.subject,
-        html: input.message ?? input.html ?? input.body ?? undefined,
+        html: outgoingHtml,
         text: input.text,
-        attachments: input.attachments,
+        attachments,
         inReplyTo: input.inReplyTo ?? inReplyToHeader ?? undefined,
         references:
           input.references ??
@@ -250,7 +276,9 @@ export const mailRouter = router({
   getMessageAttachments: protectedProcedure
     .input(z.object({ messageId: z.string() }))
     .query(async ({ ctx, input }) => {
-      const thread = await getThread(ctx.imap, input.messageId);
+      const thread = await getThread(ctx.imap, input.messageId, 'inbox', undefined, {
+        includeAttachmentBytes: true,
+      });
       return thread?.latest.attachments ?? [];
     }),
 

--- a/apps/email/server/src/trpc/routes/mail.ts
+++ b/apps/email/server/src/trpc/routes/mail.ts
@@ -55,6 +55,12 @@ export function formatFromAddress(
   return name ? `"${name}" <${raw.trim()}>` : raw;
 }
 
+/** Injectable seam for route-level tests; production uses the real IMAP/SMTP drivers. */
+export const mailRouteInternals = {
+  getThread,
+  send: driverSend,
+};
+
 // Folder comes in as a loose string (client uses `bin`/`draft`/`snoozed`
 // while the canonical enum is `trash`/`drafts`). Normalize on the way in
 // instead of rejecting; see normalizeFolderSlug.
@@ -127,7 +133,7 @@ export const mailRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const detail = await getThread(
+      const detail = await mailRouteInternals.getThread(
         ctx.imap,
         input.id,
         normalizeFolderSlug(input.folder),
@@ -157,6 +163,7 @@ export const mailRouter = router({
         isForward: z.boolean().optional(),
         originalMessage: z.string().optional(),
         originalMessageId: z.string().optional(),
+        originalFolder: folderInput,
         scheduleAt: z.string().optional(),
         headers: z.record(z.string(), z.string()).optional(),
         inReplyTo: z.string().optional(),
@@ -171,17 +178,25 @@ export const mailRouter = router({
       let originalHtml = input.originalMessage;
       let forwardedAttachments: typeof input.attachments;
       if (input.isForward && input.originalMessageId) {
-        const original = await getThread(ctx.imap, input.originalMessageId, 'inbox', undefined, {
-          includeAttachmentBytes: true,
-        }).catch(() => null);
-        originalHtml = original?.latest.decodedBody ?? originalHtml;
-        forwardedAttachments = original?.latest.attachments
-          .filter((attachment) => attachment.body)
-          .map((attachment) => ({
-            name: attachment.filename,
-            type: attachment.contentType,
-            base64: attachment.body,
-          }));
+        const original = await mailRouteInternals.getThread(
+          ctx.imap,
+          input.originalMessageId,
+          normalizeFolderSlug(input.originalFolder),
+          undefined,
+          { includeAttachmentBytes: true },
+        );
+        if (!original?.latest) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Original message could not be loaded for forwarding',
+          });
+        }
+        originalHtml = original.latest.decodedBody ?? originalHtml;
+        forwardedAttachments = original.latest.attachments.map((attachment) => ({
+          name: attachment.filename,
+          type: attachment.contentType,
+          base64: attachment.body,
+        }));
       }
 
       const outgoingHtml = input.isForward
@@ -192,7 +207,7 @@ export const mailRouter = router({
           ? [...(forwardedAttachments ?? []), ...(input.attachments ?? [])]
           : undefined;
 
-      return driverSend(ctx.smtp, ctx.imap, fromAddress, {
+      return mailRouteInternals.send(ctx.smtp, ctx.imap, fromAddress, {
         to: input.to.map(senderToAddress),
         cc: input.cc?.map(senderToAddress),
         bcc: input.bcc?.map(senderToAddress),
@@ -274,11 +289,15 @@ export const mailRouter = router({
   ]),
 
   getMessageAttachments: protectedProcedure
-    .input(z.object({ messageId: z.string() }))
+    .input(z.object({ messageId: z.string().min(1), folder: folderInput }))
     .query(async ({ ctx, input }) => {
-      const thread = await getThread(ctx.imap, input.messageId, 'inbox', undefined, {
-        includeAttachmentBytes: true,
-      });
+      const thread = await mailRouteInternals.getThread(
+        ctx.imap,
+        input.messageId,
+        normalizeFolderSlug(input.folder),
+        undefined,
+        { includeAttachmentBytes: true },
+      );
       return thread?.latest.attachments ?? [];
     }),
 

--- a/apps/email/server/test/attachment-body.test.ts
+++ b/apps/email/server/test/attachment-body.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test';
+import { encodeAttachmentBody } from '../src/lib/imap-driver';
+
+describe('encodeAttachmentBody', () => {
+  const content = Buffer.from('non-empty attachment');
+
+  it('keeps attachment bytes out of normal thread reads', () => {
+    expect(encodeAttachmentBody(content)).toBe('');
+  });
+
+  it('returns base64 bytes for explicit download and forward reads', () => {
+    expect(encodeAttachmentBody(content, true)).toBe(content.toString('base64'));
+  });
+});

--- a/apps/email/server/test/attachment-routes.test.ts
+++ b/apps/email/server/test/attachment-routes.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { AppContext } from '../src/ctx';
+import { mailRouteInternals, mailRouter } from '../src/trpc/routes/mail';
+
+const ctx = {
+  session: {
+    sessionId: 'session-1',
+    email: 'sender@example.com',
+    name: 'Sender',
+    password: 'password',
+    imapHost: 'imap.example.com',
+    imapPort: 993,
+    smtpHost: 'smtp.example.com',
+    smtpPort: 465,
+    expiresAt: new Date('2099-01-01T00:00:00.000Z'),
+  },
+  imap: { host: 'imap.example.com', port: 993, user: 'sender@example.com', pass: 'password' },
+  smtp: { host: 'smtp.example.com', port: 465, user: 'sender@example.com', pass: 'password' },
+  hono: null,
+} satisfies AppContext;
+
+const attachment = {
+  id: 'message-1-0',
+  attachmentId: 'message-1-0',
+  filename: 'report.txt',
+  contentType: 'text/plain',
+  mimeType: 'text/plain',
+  size: 6,
+  inline: false,
+  body: Buffer.from('report').toString('base64'),
+  headers: [],
+};
+
+const getThread = spyOn(mailRouteInternals, 'getThread');
+const send = spyOn(mailRouteInternals, 'send');
+const caller = mailRouter.createCaller(ctx);
+
+beforeEach(() => {
+  getThread.mockReset();
+  send.mockReset();
+});
+
+afterAll(() => {
+  getThread.mockRestore();
+  send.mockRestore();
+});
+
+describe('attachment byte routes', () => {
+  it('loads download bytes from the requested mailbox', async () => {
+    getThread.mockResolvedValueOnce({ latest: { attachments: [attachment] } } as never);
+
+    await expect(
+      caller.getMessageAttachments({ messageId: 'message-1', folder: 'sent' }),
+    ).resolves.toEqual([attachment]);
+    expect(getThread).toHaveBeenCalledWith(ctx.imap, 'message-1', 'sent', undefined, {
+      includeAttachmentBytes: true,
+    });
+  });
+
+  it('loads the original from its mailbox and keeps user-added forward attachments', async () => {
+    getThread.mockResolvedValueOnce({
+      latest: { decodedBody: '<p>Original</p>', attachments: [attachment] },
+    } as never);
+    send.mockResolvedValueOnce({ messageId: 'forwarded-message' });
+
+    await caller.send({
+      to: [{ email: 'recipient@example.com' }],
+      subject: 'Fwd: report',
+      message: '<p>Intro</p>',
+      attachments: [{ name: 'added.txt', type: 'text/plain', base64: 'YWRkZWQ=' }],
+      isForward: true,
+      originalMessageId: 'message-1',
+      originalFolder: 'archive',
+    });
+
+    expect(getThread).toHaveBeenCalledWith(ctx.imap, 'message-1', 'archive', undefined, {
+      includeAttachmentBytes: true,
+    });
+    expect(send).toHaveBeenCalledWith(
+      ctx.smtp,
+      ctx.imap,
+      '"Sender" <sender@example.com>',
+      expect.objectContaining({
+        html: '<p>Intro</p><p>Original</p>',
+        attachments: [
+          { name: 'report.txt', type: 'text/plain', base64: attachment.body },
+          { name: 'added.txt', type: 'text/plain', base64: 'YWRkZWQ=' },
+        ],
+      }),
+    );
+  });
+
+  it('does not silently send a forward when its original cannot be loaded', async () => {
+    getThread.mockResolvedValueOnce(null);
+
+    await expect(
+      caller.send({
+        to: [{ email: 'recipient@example.com' }],
+        subject: 'Fwd: missing',
+        message: '<p>Intro</p>',
+        isForward: true,
+        originalMessageId: 'missing-message',
+        originalFolder: 'trash',
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('preserves a valid zero-byte attachment when forwarding', async () => {
+    getThread.mockResolvedValueOnce({
+      latest: {
+        decodedBody: '<p>Original</p>',
+        attachments: [{ ...attachment, filename: 'empty.txt', size: 0, body: '' }],
+      },
+    } as never);
+    send.mockResolvedValueOnce({ messageId: 'forwarded-message' });
+
+    await caller.send({
+      to: ['recipient@example.com'],
+      subject: 'Fwd: empty attachment',
+      isForward: true,
+      originalMessageId: 'message-1',
+      originalFolder: 'sent',
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      ctx.smtp,
+      ctx.imap,
+      '"Sender" <sender@example.com>',
+      expect.objectContaining({
+        attachments: [{ name: 'empty.txt', type: 'text/plain', base64: '' }],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- return base64 attachment bytes for explicit download, draft, and forward reads
- keep normal thread reads metadata-only so opening a message does not transfer every attachment
- preserve the original body and attachments when forwarding
- retain user-added forward attachments and avoid repeated `Fwd:` prefixes
- add regression coverage for the attachment-byte gate

## Context

This builds on the diagnosis and implementation in #355 by @DiogoDuart3. It incorporates the maintainer feedback there: attachment bytes are gated behind `includeAttachmentBytes` instead of being included in every `getThread` response.

The current `main` branch and v0.7.0 still set every parsed attachment's `body` to an empty string, so downloads produce an empty file. The download, draft, and forward paths now opt into bytes explicitly; the ordinary reading-pane path keeps the documented empty-body behavior.

## Verification

- `bun run --cwd apps/email/server test` — 56 passed
- `bun run --cwd apps/email/server build`
- `bun run --cwd apps/email/client build`
- `git diff --check`
