### PR TITLE
fix(catalog): align Supabase SAML external URL

### DIFF
--- a/packages/core/src/apps/catalog.json
+++ b/packages/core/src/apps/catalog.json
@@ -121,6 +121,7 @@
             "GOTRUE_API_HOST": "0.0.0.0",
             "GOTRUE_API_PORT": "9999",
             "API_EXTERNAL_URL": "{{publicUrl:kong}}",
+            "GOTRUE_SAML_EXTERNAL_URL": "{{publicUrl:kong}}/auth/v1",
             "GOTRUE_DB_DRIVER": "postgres",
             "GOTRUE_DB_DATABASE_URL": "postgres://supabase_auth_admin:{{config:POSTGRES_PASSWORD}}@db:5432/postgres",
             "GOTRUE_SITE_URL": "{{publicUrl:kong}}",

--- a/packages/core/src/apps/catalog.test.ts
+++ b/packages/core/src/apps/catalog.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { buildCatalog } from "../../scripts/gen-catalog";
 import { isValidAppTemplate, parseAppTemplate, templateEngineOk } from "./schema";
-import { APP_TEMPLATES } from "../app-templates";
+import { APP_TEMPLATES, getAppTemplate } from "../app-templates";
 
 const committed = JSON.parse(
   readFileSync(fileURLToPath(new URL("./catalog.json", import.meta.url)), "utf8"),
@@ -18,6 +18,20 @@ describe("app catalog (JSON)", () => {
     for (const app of APP_TEMPLATES) {
       expect(isValidAppTemplate(app), `${app.id} failed schema`).toBe(true);
     }
+  });
+
+  it("keeps Supabase's advertised SAML endpoints on its public Kong routes", () => {
+    const supabase = getAppTemplate("supabase");
+    const samlBase = supabase?.services?.find((service) => service.name === "auth")?.environment
+      ?.GOTRUE_SAML_EXTERNAL_URL;
+    const kongConfig = supabase?.files?.find(
+      (file) => file.service === "kong" && file.path === "/usr/local/kong/kong.yml",
+    )?.content;
+
+    expect(samlBase).toBe("{{publicUrl:kong}}/auth/v1");
+    const routePrefix = samlBase?.replace("{{publicUrl:kong}}", "");
+    expect(kongConfig).toContain(`- ${routePrefix}/sso/saml/acs`);
+    expect(kongConfig).toContain(`- ${routePrefix}/sso/saml/metadata`);
   });
 
   it("rejects a malformed template (missing required fields)", () => {

--- a/packages/core/src/apps/catalog/supabase.json
+++ b/packages/core/src/apps/catalog/supabase.json
@@ -97,6 +97,7 @@
         "GOTRUE_API_HOST": "0.0.0.0",
         "GOTRUE_API_PORT": "9999",
         "API_EXTERNAL_URL": "{{publicUrl:kong}}",
+        "GOTRUE_SAML_EXTERNAL_URL": "{{publicUrl:kong}}/auth/v1",
         "GOTRUE_DB_DRIVER": "postgres",
         "GOTRUE_DB_DATABASE_URL": "postgres://supabase_auth_admin:{{config:POSTGRES_PASSWORD}}@db:5432/postgres",
         "GOTRUE_SITE_URL": "{{publicUrl:kong}}",


### PR DESCRIPTION
## Summary

Configure Supabase Auth's SAML-specific external URL so the metadata and ACS URLs advertised by GoTrue match the public Kong routes added in #806.

## Motivation

PR #806 exposes `/auth/v1/sso/saml/metadata` and `/auth/v1/sso/saml/acs` without Kong API-key authentication. GoTrue v2.189.0 still derives its SAML base from `API_EXTERNAL_URL`, which remains the Kong origin, so it advertises `/sso/saml/...` instead of the reachable `/auth/v1/sso/saml/...` URLs.

This uses the SAML-only `GOTRUE_SAML_EXTERNAL_URL` override. It deliberately leaves `API_EXTERNAL_URL` unchanged because changing that variable also affects OAuth callbacks and mail links and is a broader, breaking migration upstream.

## Related issue

Follow-up to #806.

## Changes

- Set `GOTRUE_SAML_EXTERNAL_URL` to `{{publicUrl:kong}}/auth/v1` in the Supabase auth template.
- Regenerate the bundled catalog from the per-app source.
- Add a contract test tying the advertised SAML base to both public Kong SAML routes.

### Existing installations

Catalog values are copied into project service rows at install time, so this change applies automatically to new Supabase installs only. For an existing install:

1. Add `GOTRUE_SAML_EXTERNAL_URL=https://<kong-host>/auth/v1` to the `auth` service, then run a refresh/full redeploy; restarting the existing container is insufficient.
2. If the install predates #806, also add the public Kong metadata and ACS routes from that PR; a normal redeploy does not refresh its stored Kong file.
3. Refresh the IdP metadata/update its Entity ID, Audience, and ACS URL to the `/auth/v1/sso/saml/...` endpoints.

An automatic backfill is intentionally avoided because installed app env and generated files are operator-editable, and silently replacing them could break custom routing.

## Verification

```text
bun run test -- src/apps/catalog.test.ts
  Test Files  1 passed (1)
  Tests       28 passed (28)

bun run lint  # packages/core
  tsc --noEmit (passed)

bun run lint  # apps/api
  tsc --noEmit (passed)

bun run test
  Changed Core package: 53 files passed, 919 tests passed.
  The full local run hit timeout-only failures in two unrelated API route/import tests;
  both were rerun together and passed: 2 files, 8 tests.
```

## Checklist

- [x] One change per PR
- [x] No unrelated formatting or dependency changes
- [x] Regression test fails without the new environment value and passes with it
- [x] Relevant tests and typechecks pass locally; full GitHub CI will gate merge
- [x] Every changed line was reviewed independently
