### PR TITLE
fix(data-transfer): make large transfers resilient

### DIFF
--- a/apps/api/src/lib/encryption.ts
+++ b/apps/api/src/lib/encryption.ts
@@ -47,11 +47,16 @@ function deriveKey(): Buffer {
  * Returns base64( iv:16 || authTag:16 || ciphertext ).
  */
 export function encryptWithKey(key: Buffer, plaintext: string): string {
+  return encryptBytesWithKey(key, Buffer.from(plaintext, "utf8")).toString("base64");
+}
+
+/** Binary twin used by bounded transfer chunks; keeps bytes binary on the wire. */
+export function encryptBytesWithKey(key: Buffer, plaintext: Uint8Array): Buffer {
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
-  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   const authTag = cipher.getAuthTag();
-  return Buffer.concat([iv, authTag, encrypted]).toString("base64");
+  return Buffer.concat([iv, authTag, encrypted]);
 }
 
 /**
@@ -59,7 +64,12 @@ export function encryptWithKey(key: Buffer, plaintext: string): string {
  * explicit key. Throws if the data is tampered with or the key is wrong.
  */
 export function decryptWithKey(key: Buffer, sealed: string): string {
-  const packed = Buffer.from(sealed, "base64");
+  return decryptBytesWithKey(key, Buffer.from(sealed, "base64")).toString("utf8");
+}
+
+/** Open one binary AES-GCM chunk without converting its payload through UTF-8. */
+export function decryptBytesWithKey(key: Buffer, sealed: Uint8Array): Buffer {
+  const packed = Buffer.from(sealed);
   if (packed.length < IV_LENGTH + AUTH_TAG_LENGTH) {
     throw new Error("Invalid encrypted data: too short");
   }
@@ -69,7 +79,7 @@ export function decryptWithKey(key: Buffer, sealed: string): string {
 
   const decipher = createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }
 
 /**

--- a/apps/api/src/lib/rate-limit/policies.ts
+++ b/apps/api/src/lib/rate-limit/policies.ts
@@ -26,6 +26,7 @@ export type PolicyId =
   | "default-authed"
   | "auth-tight"
   | "auth-loose"
+  | "transfer-chunk"
   | "mcp"
   | "read-authed"
   | "write-authed"
@@ -71,6 +72,16 @@ export const POLICIES: Record<PolicyId, RateLimitPolicy> = {
     windowMs: MINUTE_MS,
     subject: "user",
     description: "Authed session ops (logout, refresh) — per-user.",
+  },
+
+  /** Public direct-transfer chunks are cryptographically capability-gated but
+   *  arrive in bursts. Bound abuse per IP without throttling a valid 500 MB move. */
+  "transfer-chunk": {
+    id: "transfer-chunk",
+    limit: 240,
+    windowMs: MINUTE_MS,
+    subject: "ip",
+    description: "Encrypted direct-transfer chunks — per-IP burst allowance.",
   },
 
   /** MCP JSON-RPC endpoint (/api/mcp). Per-IP because the endpoint

--- a/apps/api/src/lib/route-permission.ts
+++ b/apps/api/src/lib/route-permission.ts
@@ -35,6 +35,7 @@ import {
   checkSourceTier,
   type SourceTier,
 } from "../modules/github/github-access";
+import type { PolicyId } from "./rate-limit/policies";
 
 /* ------------------------------------------------------------------ */
 /*  Tag types                                                          */
@@ -255,16 +256,7 @@ async function assertParentChain(
  * tagged routes). Override when a route warrants tighter or looser
  * limits than the default.
  */
-export type RateLimitPolicyId =
-  | "default-anon"
-  | "default-authed"
-  | "auth-tight"
-  | "auth-loose"
-  | "mcp"
-  | "read-authed"
-  | "write-authed"
-  | "webhook-ingress"
-  | "billing-portal";
+export type RateLimitPolicyId = PolicyId;
 
 /**
  * MCP exposure for a route. Presence of this block is the MCP allowlist:

--- a/apps/api/src/modules/system/data-transfer/chunk-store.ts
+++ b/apps/api/src/modules/system/data-transfer/chunk-store.ts
@@ -1,0 +1,593 @@
+/**
+ * Durable, bounded staging for whole-instance transfers.
+ *
+ * Session metadata and chunks live in the database so a request may land on a
+ * different API worker and a short process restart does not invalidate a receive
+ * code. The tables are explicitly excluded from instance dumps, so a wipe import
+ * cannot replace the upload that is currently feeding it.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import {
+  and,
+  count,
+  db,
+  eq,
+  gt,
+  inArray,
+  lte,
+  ne,
+  or,
+  schema,
+  type DatabaseTransaction,
+} from "@repo/db";
+
+import type { ImportMode, ImportResult } from "./types";
+
+export const TRANSFER_CHUNK_BYTES = 8_000_000;
+export const MAX_TRANSFER_BYTES = 500_000_000;
+export const MAX_TRANSFER_CHUNKS = Math.ceil(MAX_TRANSFER_BYTES / TRANSFER_CHUNK_BYTES);
+export const TRANSFER_CONTROL_BODY_BYTES = 32_000;
+
+// A receive code is a powerful bearer capability, so leave it usable for only
+// ten idle minutes. Active uploads refresh this lease on every chunk/heartbeat;
+// the absolute cap below prevents an abandoned transfer from living forever.
+const SESSION_IDLE_TTL_MS = 10 * 60_000;
+const SESSION_MAX_TTL_MS = 6 * 60 * 60_000;
+const COMPLETED_TTL_MS = 10 * 60_000;
+const MAX_ACTIVE_SESSIONS = 20;
+const CLAIM_HEARTBEAT_MS = 60_000;
+
+export type TransferSessionRow = typeof schema.dataTransferSession.$inferSelect;
+
+export interface TransferChunkMeta {
+  chunkIndex: number;
+  byteLength: number;
+  sha256: string;
+}
+
+export class TransferStoreError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "SESSION_UNAVAILABLE"
+      | "SESSION_BUSY"
+      | "PAYLOAD_TOO_LARGE"
+      | "INVALID_CHUNK"
+      | "MISSING_CHUNK",
+  ) {
+    super(message);
+    this.name = "TransferStoreError";
+  }
+}
+
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function nextLease(row: Pick<TransferSessionRow, "maxExpiresAt">, now = Date.now()): Date {
+  return new Date(Math.min(now + SESSION_IDLE_TTL_MS, row.maxExpiresAt.getTime()));
+}
+
+async function assertCapacity(now = new Date()): Promise<void> {
+  // An idle upload may be deleted immediately. A finalizer gets a renewable
+  // lease: retain its chunks until either another request recovers the stale
+  // claim or the six-hour absolute cap passes.
+  await db
+    .delete(schema.dataTransferSession)
+    .where(
+      or(
+        lte(schema.dataTransferSession.maxExpiresAt, now),
+        and(
+          ne(schema.dataTransferSession.status, "consuming"),
+          lte(schema.dataTransferSession.expiresAt, now),
+        ),
+      ),
+    );
+  const [row] = await db
+    .select({ value: count() })
+    .from(schema.dataTransferSession)
+    .where(
+      and(
+        gt(schema.dataTransferSession.expiresAt, now),
+        inArray(schema.dataTransferSession.status, ["ready", "uploading", "consuming"]),
+      ),
+    );
+  if (Number(row?.value ?? 0) >= MAX_ACTIVE_SESSIONS) {
+    throw new TransferStoreError(
+      "Too many active data transfers. Wait for an existing transfer to finish or expire.",
+      "SESSION_BUSY",
+    );
+  }
+}
+
+function expiryWindow(now = Date.now()): { expiresAt: Date; maxExpiresAt: Date } {
+  return {
+    expiresAt: new Date(now + SESSION_IDLE_TTL_MS),
+    maxExpiresAt: new Date(now + SESSION_MAX_TTL_MS),
+  };
+}
+
+export async function createDirectSession(input: {
+  mode: ImportMode;
+  tokenHash: string;
+  privateKey: string;
+}): Promise<TransferSessionRow> {
+  await assertCapacity();
+  const now = Date.now();
+  const [row] = await db
+    .insert(schema.dataTransferSession)
+    .values({
+      id: randomUUID(),
+      kind: "direct",
+      status: "ready",
+      mode: input.mode,
+      tokenHash: input.tokenHash,
+      privateKey: input.privateKey,
+      ...expiryWindow(now),
+      updatedAt: new Date(now),
+    })
+    .returning();
+  return row as TransferSessionRow;
+}
+
+export async function createFileSession(input: {
+  ownerUserId: string;
+  expectedBytes: number;
+}): Promise<TransferSessionRow> {
+  if (!Number.isSafeInteger(input.expectedBytes) || input.expectedBytes <= 0) {
+    throw new TransferStoreError(
+      "The selected export file is empty or has an invalid size.",
+      "INVALID_CHUNK",
+    );
+  }
+  if (input.expectedBytes > MAX_TRANSFER_BYTES) {
+    throw new TransferStoreError(
+      `Import file exceeds the ${Math.floor(MAX_TRANSFER_BYTES / 1_000_000)}MB limit.`,
+      "PAYLOAD_TOO_LARGE",
+    );
+  }
+  await assertCapacity();
+  const now = Date.now();
+  const [row] = await db
+    .insert(schema.dataTransferSession)
+    .values({
+      id: randomUUID(),
+      kind: "file",
+      status: "uploading",
+      ownerUserId: input.ownerUserId,
+      expectedBytes: input.expectedBytes,
+      expectedChunks: Math.ceil(input.expectedBytes / TRANSFER_CHUNK_BYTES),
+      ...expiryWindow(now),
+      updatedAt: new Date(now),
+    })
+    .returning();
+  return row as TransferSessionRow;
+}
+
+export async function getSession(id: string): Promise<TransferSessionRow | null> {
+  const [row] = await db
+    .select()
+    .from(schema.dataTransferSession)
+    .where(
+      and(
+        eq(schema.dataTransferSession.id, id),
+        gt(schema.dataTransferSession.expiresAt, new Date()),
+      ),
+    )
+    .limit(1);
+  if (row) return row as TransferSessionRow;
+
+  // A worker may die after claiming a complete chunk set but before its restore
+  // transaction commits. Once that worker stops renewing the claim, make the
+  // same durable upload resumable instead of wedging it until the absolute cap.
+  return db.transaction(async (tx) => {
+    const now = new Date();
+    const [stale] = await tx
+      .select()
+      .from(schema.dataTransferSession)
+      .where(
+        and(
+          eq(schema.dataTransferSession.id, id),
+          eq(schema.dataTransferSession.status, "consuming"),
+          lte(schema.dataTransferSession.expiresAt, now),
+          gt(schema.dataTransferSession.maxExpiresAt, now),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!stale) return null;
+    const [recovered] = await tx
+      .update(schema.dataTransferSession)
+      .set({
+        status: "uploading",
+        claimToken: null,
+        expiresAt: nextLease(stale as TransferSessionRow, now.getTime()),
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.dataTransferSession.id, id),
+          eq(schema.dataTransferSession.status, "consuming"),
+        ),
+      )
+      .returning();
+    return (recovered as TransferSessionRow | undefined) ?? null;
+  });
+}
+
+export async function beginDirectSession(
+  id: string,
+  senderPublicKey: string,
+): Promise<TransferSessionRow | null> {
+  return db.transaction(async (tx) => {
+    const now = new Date();
+    const [current] = await tx
+      .select()
+      .from(schema.dataTransferSession)
+      .where(
+        and(
+          eq(schema.dataTransferSession.id, id),
+          eq(schema.dataTransferSession.kind, "direct"),
+          gt(schema.dataTransferSession.expiresAt, now),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!current || (current.status !== "ready" && current.status !== "uploading")) return null;
+
+    // A source process that restarts creates a fresh ephemeral X25519 key. The
+    // encrypted token proof was already verified by the caller, so let that
+    // holder restart cleanly and discard ciphertext tied to the previous key.
+    if (current.status === "uploading" && current.senderPublicKey !== senderPublicKey) {
+      await tx.delete(schema.dataTransferChunk).where(eq(schema.dataTransferChunk.sessionId, id));
+    }
+
+    const [row] = await tx
+      .update(schema.dataTransferSession)
+      .set({
+        status: "uploading",
+        senderPublicKey,
+        expiresAt: nextLease(current as TransferSessionRow, now.getTime()),
+        updatedAt: now,
+      })
+      .where(eq(schema.dataTransferSession.id, id))
+      .returning();
+    return (row as TransferSessionRow | undefined) ?? null;
+  });
+}
+
+export async function touchSession(
+  id: string,
+  senderPublicKey: string,
+): Promise<TransferSessionRow | null> {
+  const current = await getSession(id);
+  if (
+    !current ||
+    current.kind !== "direct" ||
+    current.status !== "uploading" ||
+    current.senderPublicKey !== senderPublicKey
+  )
+    return null;
+  const now = new Date();
+  const [row] = await db
+    .update(schema.dataTransferSession)
+    .set({ expiresAt: nextLease(current, now.getTime()), updatedAt: now })
+    .where(
+      and(
+        eq(schema.dataTransferSession.id, id),
+        eq(schema.dataTransferSession.kind, "direct"),
+        eq(schema.dataTransferSession.status, "uploading"),
+        eq(schema.dataTransferSession.senderPublicKey, senderPublicKey),
+        gt(schema.dataTransferSession.expiresAt, now),
+      ),
+    )
+    .returning();
+  return (row as TransferSessionRow | undefined) ?? null;
+}
+
+export async function stageChunk(input: {
+  session: TransferSessionRow;
+  index: number;
+  bytes: Uint8Array;
+  sha256: string;
+}): Promise<void> {
+  if (
+    input.session.status !== "uploading" ||
+    !Number.isSafeInteger(input.index) ||
+    input.index < 0 ||
+    input.index >= MAX_TRANSFER_CHUNKS ||
+    input.bytes.byteLength === 0 ||
+    input.bytes.byteLength > TRANSFER_CHUNK_BYTES + 64
+  ) {
+    throw new TransferStoreError("The transfer chunk is invalid or out of range.", "INVALID_CHUNK");
+  }
+  const digest = sha256Hex(input.bytes);
+  if (!/^[a-f0-9]{64}$/.test(input.sha256) || digest !== input.sha256) {
+    throw new TransferStoreError(
+      "The transfer chunk checksum does not match its contents.",
+      "INVALID_CHUNK",
+    );
+  }
+
+  await db.transaction(async (tx) => {
+    // Lock/refresh the writable session in the same transaction as the INSERT.
+    // A concurrent finalize changes status to `consuming`; exactly one side wins
+    // the row update, so no chunk can appear after finalization has claimed the set.
+    const now = new Date();
+    const identity =
+      input.session.kind === "direct"
+        ? and(
+            eq(schema.dataTransferSession.kind, "direct"),
+            eq(schema.dataTransferSession.senderPublicKey, input.session.senderPublicKey!),
+          )
+        : and(
+            eq(schema.dataTransferSession.kind, "file"),
+            eq(schema.dataTransferSession.ownerUserId, input.session.ownerUserId!),
+          );
+    const writable = await tx
+      .update(schema.dataTransferSession)
+      .set({ expiresAt: nextLease(input.session, now.getTime()), updatedAt: now })
+      .where(
+        and(
+          eq(schema.dataTransferSession.id, input.session.id),
+          eq(schema.dataTransferSession.status, "uploading"),
+          identity,
+          gt(schema.dataTransferSession.expiresAt, now),
+        ),
+      )
+      .returning();
+    if (writable.length === 0) {
+      throw new TransferStoreError(
+        "The transfer session is no longer writable.",
+        "SESSION_UNAVAILABLE",
+      );
+    }
+
+    const inserted = await tx
+      .insert(schema.dataTransferChunk)
+      .values({
+        sessionId: input.session.id,
+        chunkIndex: input.index,
+        bytes: input.bytes,
+        byteLength: input.bytes.byteLength,
+        sha256: digest,
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    if (inserted.length === 0) {
+      const [existing] = await tx
+        .select({
+          sha256: schema.dataTransferChunk.sha256,
+          byteLength: schema.dataTransferChunk.byteLength,
+        })
+        .from(schema.dataTransferChunk)
+        .where(
+          and(
+            eq(schema.dataTransferChunk.sessionId, input.session.id),
+            eq(schema.dataTransferChunk.chunkIndex, input.index),
+          ),
+        )
+        .limit(1);
+      if (existing?.sha256 !== digest || existing.byteLength !== input.bytes.byteLength) {
+        throw new TransferStoreError(
+          `Chunk ${input.index} was already uploaded with different contents.`,
+          "INVALID_CHUNK",
+        );
+      }
+    }
+  });
+}
+
+export async function listChunkMetadata(sessionId: string): Promise<TransferChunkMeta[]> {
+  return db
+    .select({
+      chunkIndex: schema.dataTransferChunk.chunkIndex,
+      byteLength: schema.dataTransferChunk.byteLength,
+      sha256: schema.dataTransferChunk.sha256,
+    })
+    .from(schema.dataTransferChunk)
+    .where(eq(schema.dataTransferChunk.sessionId, sessionId))
+    .orderBy(schema.dataTransferChunk.chunkIndex);
+}
+
+export async function readChunk(sessionId: string, index: number): Promise<Uint8Array | null> {
+  const [row] = await db
+    .select({ bytes: schema.dataTransferChunk.bytes })
+    .from(schema.dataTransferChunk)
+    .where(
+      and(
+        eq(schema.dataTransferChunk.sessionId, sessionId),
+        eq(schema.dataTransferChunk.chunkIndex, index),
+      ),
+    )
+    .limit(1);
+  return row?.bytes ?? null;
+}
+
+export function assertCompleteChunkSet(
+  chunks: readonly TransferChunkMeta[],
+  expectedChunks: number,
+): void {
+  if (
+    !Number.isSafeInteger(expectedChunks) ||
+    expectedChunks <= 0 ||
+    expectedChunks > MAX_TRANSFER_CHUNKS ||
+    chunks.length !== expectedChunks ||
+    chunks.some((chunk, index) => chunk.chunkIndex !== index)
+  ) {
+    throw new TransferStoreError("One or more transfer chunks are missing.", "MISSING_CHUNK");
+  }
+}
+
+export async function claimSession(expected: TransferSessionRow): Promise<TransferSessionRow> {
+  if (expected.status !== "uploading") {
+    throw new TransferStoreError(
+      "The transfer is already being finalized or is no longer available.",
+      "SESSION_UNAVAILABLE",
+    );
+  }
+  const now = new Date();
+  const claimToken = randomUUID();
+  const identity =
+    expected.kind === "direct"
+      ? and(
+          eq(schema.dataTransferSession.kind, "direct"),
+          eq(schema.dataTransferSession.senderPublicKey, expected.senderPublicKey!),
+        )
+      : and(
+          eq(schema.dataTransferSession.kind, "file"),
+          eq(schema.dataTransferSession.ownerUserId, expected.ownerUserId!),
+        );
+  const [row] = await db
+    .update(schema.dataTransferSession)
+    .set({
+      status: "consuming",
+      claimToken,
+      expiresAt: nextLease(expected, now.getTime()),
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.dataTransferSession.id, expected.id),
+        eq(schema.dataTransferSession.status, "uploading"),
+        identity,
+        gt(schema.dataTransferSession.expiresAt, now),
+      ),
+    )
+    .returning();
+  if (!row) {
+    throw new TransferStoreError(
+      "The transfer is already being finalized or is no longer available.",
+      "SESSION_UNAVAILABLE",
+    );
+  }
+  return row as TransferSessionRow;
+}
+
+async function renewSessionClaim(session: TransferSessionRow): Promise<void> {
+  if (!session.claimToken) return;
+  const now = new Date();
+  await db
+    .update(schema.dataTransferSession)
+    .set({ expiresAt: nextLease(session, now.getTime()), updatedAt: now })
+    .where(
+      and(
+        eq(schema.dataTransferSession.id, session.id),
+        eq(schema.dataTransferSession.status, "consuming"),
+        eq(schema.dataTransferSession.claimToken, session.claimToken),
+        gt(schema.dataTransferSession.maxExpiresAt, now),
+      ),
+    );
+}
+
+/** Keep a finalizer's recoverable lease alive while it parses and restores. */
+export async function withSessionClaimLease<T>(
+  session: TransferSessionRow,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let renewalRunning = false;
+  const heartbeat = setInterval(() => {
+    if (renewalRunning) return;
+    renewalRunning = true;
+    void renewSessionClaim(session)
+      .catch(() => undefined)
+      .finally(() => {
+        renewalRunning = false;
+      });
+  }, CLAIM_HEARTBEAT_MS);
+  heartbeat.unref?.();
+  try {
+    return await operation();
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+export async function releaseSessionClaim(session: TransferSessionRow): Promise<void> {
+  if (!session.claimToken) return;
+  const now = new Date();
+  await db
+    .update(schema.dataTransferSession)
+    .set({
+      status: "uploading",
+      claimToken: null,
+      expiresAt: nextLease(session, now.getTime()),
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.dataTransferSession.id, session.id),
+        eq(schema.dataTransferSession.status, "consuming"),
+        eq(schema.dataTransferSession.claimToken, session.claimToken),
+      ),
+    );
+}
+
+export async function completeSessionInTransaction(
+  tx: DatabaseTransaction,
+  session: TransferSessionRow,
+  result: ImportResult,
+): Promise<void> {
+  if (!session.claimToken) {
+    throw new TransferStoreError("The transfer completion claim was lost.", "SESSION_UNAVAILABLE");
+  }
+  const now = new Date();
+  const completed = await tx
+    .update(schema.dataTransferSession)
+    .set({
+      status: "complete",
+      claimToken: null,
+      result: result as unknown as Record<string, unknown>,
+      expiresAt: new Date(now.getTime() + COMPLETED_TTL_MS),
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.dataTransferSession.id, session.id),
+        eq(schema.dataTransferSession.status, "consuming"),
+        eq(schema.dataTransferSession.claimToken, session.claimToken),
+      ),
+    )
+    .returning();
+  if (completed.length !== 1) {
+    throw new TransferStoreError("The transfer completion claim was lost.", "SESSION_UNAVAILABLE");
+  }
+  await tx
+    .delete(schema.dataTransferChunk)
+    .where(eq(schema.dataTransferChunk.sessionId, session.id));
+}
+
+export async function failSession(session: TransferSessionRow): Promise<void> {
+  if (!session.claimToken) return;
+  const claimToken = session.claimToken;
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    const failed = await tx
+      .update(schema.dataTransferSession)
+      .set({
+        status: "failed",
+        claimToken: null,
+        expiresAt: new Date(now.getTime() + COMPLETED_TTL_MS),
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.dataTransferSession.id, session.id),
+          eq(schema.dataTransferSession.status, "consuming"),
+          eq(schema.dataTransferSession.claimToken, claimToken),
+        ),
+      )
+      .returning();
+    if (failed.length === 1) {
+      await tx
+        .delete(schema.dataTransferChunk)
+        .where(eq(schema.dataTransferChunk.sessionId, session.id));
+    }
+  });
+}
+
+export async function clearTransferSessionsForTest(): Promise<void> {
+  if (process.env.NODE_ENV === "test") await db.delete(schema.dataTransferSession);
+}

--- a/apps/api/src/modules/system/data-transfer/data-transfer.controller.ts
+++ b/apps/api/src/modules/system/data-transfer/data-transfer.controller.ts
@@ -14,10 +14,12 @@
  */
 
 import type { Context } from "hono";
+import type { SSEStreamingApi } from "hono/streaming";
 import { PkCollisionError } from "@repo/db";
 
 import { audit, auditContextFrom } from "../../../lib/audit";
 import { getRequestContext } from "../../../lib/request-context";
+import { streamSSE } from "../../../lib/sse";
 import { assertInstanceAdmin } from "../../../middleware/instance-admin";
 import {
   MigrationAlreadyInProgressError,
@@ -32,15 +34,23 @@ import {
   createDirectReceiveSession,
   DirectTransferDestinationError,
   DirectTransferSessionError,
+  finalizeDirectChunkUpload,
+  heartbeatDirectChunkUpload,
+  initializeDirectChunkUpload,
   InvalidDirectTransferCodeError,
+  receiveDirectChunk,
   receiveDirectTransfer,
   sendDirectTransfer,
 } from "./direct-transfer.service";
+import { createFileUpload, finalizeFileUpload, uploadFileChunk } from "./file-upload.service";
+import { TransferStoreError } from "./chunk-store";
 import type {
   DataTransferFile,
   DirectTransferEnvelope,
+  DirectTransferResult,
   ExportSelection,
   ImportMode,
+  ImportResult,
 } from "./types";
 
 interface ExportBody {
@@ -60,9 +70,25 @@ interface SendDirectBody {
   code?: string;
   selection?: ExportSelection;
 }
+interface FileUploadSessionBody {
+  size?: number;
+}
 
 function readPassphrase(v: unknown): string | undefined {
   return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+async function readJsonBody<T>(c: Context): Promise<T | null> {
+  return c.req.json<T>().catch(() => null);
+}
+
+async function readFileFinalizeInput(c: Context): Promise<{
+  passphrase?: string;
+  mode: ImportMode;
+} | null> {
+  const body = await readJsonBody<{ passphrase?: unknown; mode?: unknown }>(c);
+  if (!body || (body.mode !== "wipe" && body.mode !== "merge")) return null;
+  return { passphrase: readPassphrase(body.passphrase), mode: body.mode };
 }
 
 export async function exportInstanceHandler(c: Context) {
@@ -117,12 +143,16 @@ export async function previewInstanceExportHandler(c: Context) {
 export async function createDirectReceiveSessionHandler(c: Context) {
   const ctx = getRequestContext(c);
   await assertInstanceAdmin(ctx);
-  const body = ((await c.req.json<CreateReceiveBody>().catch(() => ({}))) ?? {}) as CreateReceiveBody;
+  const body = ((await c.req.json<CreateReceiveBody>().catch(() => ({}))) ??
+    {}) as CreateReceiveBody;
   if (typeof body.apiBase !== "string") {
-    return c.json({ error: "Missing destination API URL.", code: "INVALID_DIRECT_TRANSFER_CODE" }, 400);
+    return c.json(
+      { error: "Missing destination API URL.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+      400,
+    );
   }
   try {
-    const session = createDirectReceiveSession({
+    const session = await createDirectReceiveSession({
       apiBase: body.apiBase,
       mode: body.mode === "merge" ? "merge" : "wipe",
     });
@@ -133,14 +163,271 @@ export async function createDirectReceiveSessionHandler(c: Context) {
     });
     return c.json(session);
   } catch (err) {
-    if (err instanceof InvalidDirectTransferCodeError) {
-      return c.json({ error: err.message, code: err.code }, 400);
-    }
-    if (err instanceof DirectTransferSessionError) {
-      return c.json({ error: err.message, code: err.code }, 409);
-    }
+    const response = transferProtocolError(c, err);
+    if (response) return response;
     throw err;
   }
+}
+
+type TransferFailureStatus = 400 | 403 | 409 | 410 | 413 | 500 | 502 | 503;
+interface TransferFailure {
+  status: TransferFailureStatus;
+  error: string;
+  code: string;
+}
+
+function transferProtocolFailure(err: unknown): TransferFailure | null {
+  if (err instanceof InvalidDirectTransferCodeError) {
+    return { status: 400, error: err.message, code: err.code };
+  }
+  if (err instanceof DirectTransferSessionError) {
+    return { status: 410, error: err.message, code: err.code };
+  }
+  if (err instanceof TransferStoreError) {
+    const status =
+      err.code === "PAYLOAD_TOO_LARGE"
+        ? 413
+        : err.code === "SESSION_BUSY"
+          ? 409
+          : err.code === "SESSION_UNAVAILABLE"
+            ? 410
+            : 400;
+    return { status, error: err.message, code: err.code };
+  }
+  return null;
+}
+
+function transferProtocolError(c: Context, err: unknown): Response | null {
+  const failure = transferProtocolFailure(err);
+  return failure ? c.json({ error: failure.error, code: failure.code }, failure.status) : null;
+}
+
+/** Shared mapping for every import transport (legacy JSON, chunked file, and
+ * direct transfer) so equivalent failures cannot drift by endpoint. */
+function importOperationFailure(err: unknown): TransferFailure | null {
+  const protocol = transferProtocolFailure(err);
+  if (protocol) return protocol;
+  if (err instanceof CloudInstanceNotTransferableError) {
+    return { status: 403, error: err.message, code: err.code };
+  }
+  if (err instanceof InvalidTransferFileError || err instanceof WrongPassphraseError) {
+    return { status: 400, error: err.message, code: err.code };
+  }
+  if (err instanceof PkCollisionError) {
+    return {
+      status: 409,
+      error:
+        "Some imported rows already exist on this instance. Use Replace mode, or remove the conflicting data first.",
+      code: "PK_COLLISION",
+    };
+  }
+  if (err instanceof MigrationAlreadyInProgressError || err instanceof MigrationLockAcquireError) {
+    return {
+      status: 503,
+      error: "The destination is busy with another migration or import. Try again shortly.",
+      code: "BUSY",
+    };
+  }
+  return null;
+}
+
+function importOperationError(c: Context, err: unknown): Response | null {
+  const failure = importOperationFailure(err);
+  return failure ? c.json({ error: failure.error, code: failure.code }, failure.status) : null;
+}
+
+function destinationFailureStatus(status: number | undefined): TransferFailureStatus {
+  if (
+    status === 400 ||
+    status === 403 ||
+    status === 409 ||
+    status === 410 ||
+    status === 413 ||
+    status === 500 ||
+    status === 503
+  )
+    return status;
+  if (status === 429) return 503;
+  return status === undefined || status >= 500 ? 502 : 400;
+}
+
+function sendOperationFailure(err: unknown): TransferFailure | null {
+  if (err instanceof InvalidDirectTransferCodeError) {
+    return { status: 400, error: err.message, code: err.code };
+  }
+  if (err instanceof DirectTransferSessionError) {
+    return { status: 410, error: err.message, code: err.code };
+  }
+  if (err instanceof DirectTransferDestinationError) {
+    return {
+      status: destinationFailureStatus(err.status),
+      error: err.message,
+      code: err.code,
+    };
+  }
+  if (err instanceof CloudInstanceNotTransferableError) {
+    return { status: 403, error: err.message, code: err.code };
+  }
+  if (err instanceof InvalidExportSelectionError) {
+    return { status: 400, error: err.message, code: err.code };
+  }
+  return null;
+}
+
+async function writeTransferStreamResult<T>(
+  stream: SSEStreamingApi,
+  operation: () => Promise<T>,
+  classify: (error: unknown) => TransferFailure | null,
+): Promise<T | null> {
+  try {
+    const result = await operation();
+    await stream.writeSSE({ event: "complete", data: JSON.stringify(result) });
+    return result;
+  } catch (error) {
+    const classified = classify(error);
+    const failure = classified ?? {
+      status: 500 as const,
+      error: "The data transfer failed unexpectedly.",
+      code: "DATA_TRANSFER_FAILED",
+    };
+    if (!classified) console.error("[data-transfer] streamed operation failed:", error);
+    await stream.writeSSE({ event: "error", data: JSON.stringify(failure) });
+    return null;
+  }
+}
+
+async function sendDirectAndAudit(
+  c: Context,
+  context: ReturnType<typeof getRequestContext>,
+  body: Required<Pick<SendDirectBody, "code">> & Pick<SendDirectBody, "selection">,
+): Promise<DirectTransferResult> {
+  const result = await sendDirectTransfer({ code: body.code, selection: body.selection });
+  audit.recordAsync(auditContextFrom(c, context.organizationId, context.userId), {
+    eventType: "instance.data.sent",
+    resourceType: "instance",
+    after: {
+      destination: result.destination,
+      rowsRestored: result.rowsRestored,
+      secretsRehydrated: result.secretsRehydrated,
+    },
+  });
+  return result;
+}
+
+async function finalizeFileAndAudit(
+  c: Context,
+  context: ReturnType<typeof getRequestContext>,
+  input: { uploadId: string; passphrase?: string; mode: ImportMode },
+): Promise<ImportResult> {
+  const result = await finalizeFileUpload({
+    uploadId: input.uploadId,
+    ownerUserId: context.userId,
+    passphrase: input.passphrase,
+    mode: input.mode,
+  });
+  audit.recordAsync(auditContextFrom(c, context.organizationId, context.userId), {
+    eventType: "instance.data.imported",
+    resourceType: "instance",
+    after: {
+      mode: result.mode,
+      rowsRestored: result.rowsRestored,
+      secretsRehydrated: result.secretsRehydrated,
+    },
+  });
+  return result;
+}
+
+export async function initializeDirectChunkUploadHandler(c: Context) {
+  const body = await readJsonBody<Parameters<typeof initializeDirectChunkUpload>[0]>(c);
+  if (!body) {
+    return c.json(
+      { error: "Invalid transfer handshake.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+      400,
+    );
+  }
+  try {
+    return c.json(await initializeDirectChunkUpload(body));
+  } catch (err) {
+    const response = transferProtocolError(c, err);
+    if (response) return response;
+    throw err;
+  }
+}
+
+export async function heartbeatDirectChunkUploadHandler(c: Context) {
+  const body = await readJsonBody<{ signature?: string }>(c);
+  if (!body) {
+    return c.json(
+      { error: "Invalid transfer heartbeat.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+      400,
+    );
+  }
+  try {
+    const sessionId = c.req.param("sessionId");
+    if (!sessionId || typeof body.signature !== "string") {
+      return c.json(
+        { error: "Missing transfer signature.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+        400,
+      );
+    }
+    return c.json(await heartbeatDirectChunkUpload(sessionId, body.signature));
+  } catch (err) {
+    const response = transferProtocolError(c, err);
+    if (response) return response;
+    throw err;
+  }
+}
+
+export async function receiveDirectChunkHandler(c: Context) {
+  try {
+    const sessionId = c.req.param("sessionId");
+    if (!sessionId) {
+      return c.json(
+        { error: "Missing transfer session.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+        400,
+      );
+    }
+    const index = Number(c.req.param("index"));
+    const sha256 = c.req.header("x-openship-chunk-sha256") ?? "";
+    const signature = c.req.header("x-openship-transfer-signature") ?? "";
+    await receiveDirectChunk({
+      sessionId,
+      index,
+      sha256,
+      signature,
+      readBytes: async () => new Uint8Array(await c.req.arrayBuffer()),
+    });
+    return c.json({ ok: true });
+  } catch (err) {
+    const response = transferProtocolError(c, err);
+    if (response) return response;
+    throw err;
+  }
+}
+
+/** Heartbeat stream for a potentially long atomic restore. */
+export async function finalizeDirectChunkUploadStreamHandler(c: Context) {
+  const sessionId = c.req.param("sessionId");
+  if (!sessionId) {
+    return c.json(
+      { error: "Missing transfer session.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+      400,
+    );
+  }
+  const body = await readJsonBody<Parameters<typeof finalizeDirectChunkUpload>[1]>(c);
+  if (!body) {
+    return c.json(
+      { error: "Invalid transfer manifest.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+      400,
+    );
+  }
+  return streamSSE(c, async (stream) => {
+    await writeTransferStreamResult(
+      stream,
+      () => finalizeDirectChunkUpload(sessionId, body),
+      importOperationFailure,
+    );
+  });
 }
 
 export async function sendDirectTransferHandler(c: Context) {
@@ -151,33 +438,30 @@ export async function sendDirectTransferHandler(c: Context) {
     return c.json({ error: "Missing receive code.", code: "INVALID_DIRECT_TRANSFER_CODE" }, 400);
   }
   try {
-    const result = await sendDirectTransfer({ code: body.code, selection: body.selection });
-    audit.recordAsync(auditContextFrom(c, ctx.organizationId, ctx.userId), {
-      eventType: "instance.data.sent",
-      resourceType: "instance",
-      after: {
-        destination: result.destination,
-        rowsRestored: result.rowsRestored,
-        secretsRehydrated: result.secretsRehydrated,
-      },
-    });
-    return c.json(result);
+    return c.json(await sendDirectAndAudit(c, ctx, { code: body.code, selection: body.selection }));
   } catch (err) {
-    if (
-      err instanceof InvalidDirectTransferCodeError ||
-      err instanceof DirectTransferSessionError ||
-      err instanceof DirectTransferDestinationError
-    ) {
-      return c.json({ error: err.message, code: err.code }, 400);
-    }
-    if (err instanceof CloudInstanceNotTransferableError) {
-      return c.json({ error: err.message, code: err.code }, 403);
-    }
-    if (err instanceof InvalidExportSelectionError) {
-      return c.json({ error: err.message, code: err.code }, 400);
-    }
+    const failure = sendOperationFailure(err);
+    if (failure) return c.json({ error: failure.error, code: failure.code }, failure.status);
     throw err;
   }
+}
+
+/** Streamed form used by the dashboard so export/upload/import cannot be cut off
+ * by a reverse proxy's idle response timeout. */
+export async function sendDirectTransferStreamHandler(c: Context) {
+  const ctx = getRequestContext(c);
+  await assertInstanceAdmin(ctx);
+  const body = ((await c.req.json<SendDirectBody>().catch(() => ({}))) ?? {}) as SendDirectBody;
+  if (typeof body.code !== "string") {
+    return c.json({ error: "Missing receive code.", code: "INVALID_DIRECT_TRANSFER_CODE" }, 400);
+  }
+  return streamSSE(c, async (stream) => {
+    await writeTransferStreamResult(
+      stream,
+      () => sendDirectAndAudit(c, ctx, { code: body.code!, selection: body.selection }),
+      sendOperationFailure,
+    );
+  });
 }
 
 /** Public capability endpoint: the encrypted receive code is the authorization. */
@@ -186,29 +470,16 @@ export async function receiveDirectTransferHandler(c: Context) {
   try {
     envelope = await c.req.json<DirectTransferEnvelope>();
   } catch {
-    return c.json({ error: "Invalid encrypted transfer body.", code: "INVALID_DIRECT_TRANSFER_CODE" }, 400);
+    return c.json(
+      { error: "Invalid encrypted transfer body.", code: "INVALID_DIRECT_TRANSFER_CODE" },
+      400,
+    );
   }
   try {
     return c.json(await receiveDirectTransfer(envelope));
   } catch (err) {
-    if (err instanceof InvalidDirectTransferCodeError) {
-      return c.json({ error: err.message, code: err.code }, 400);
-    }
-    if (err instanceof DirectTransferSessionError) {
-      return c.json({ error: err.message, code: err.code }, 410);
-    }
-    if (err instanceof CloudInstanceNotTransferableError) {
-      return c.json({ error: err.message, code: err.code }, 403);
-    }
-    if (err instanceof InvalidTransferFileError || err instanceof WrongPassphraseError) {
-      return c.json({ error: err.message, code: err.code }, 400);
-    }
-    if (err instanceof PkCollisionError) {
-      return c.json({ error: err.message, code: "PK_COLLISION" }, 409);
-    }
-    if (err instanceof MigrationAlreadyInProgressError || err instanceof MigrationLockAcquireError) {
-      return c.json({ error: "The destination is busy. Generate a new code and try again shortly.", code: "BUSY" }, 503);
-    }
+    const response = importOperationError(c, err);
+    if (response) return response;
     throw err;
   }
 }
@@ -249,31 +520,84 @@ export async function importInstanceHandler(c: Context) {
 
     return c.json(result);
   } catch (err) {
-    if (err instanceof CloudInstanceNotTransferableError) {
-      return c.json({ error: err.message, code: err.code }, 403);
-    }
-    if (err instanceof WrongPassphraseError || err instanceof InvalidTransferFileError) {
-      return c.json({ error: err.message, code: err.code }, 400);
-    }
-    if (err instanceof PkCollisionError) {
-      return c.json(
-        {
-          error:
-            "Some imported rows already exist on this instance. Use Replace mode, or remove the conflicting data first.",
-          code: "PK_COLLISION",
-        },
-        409,
-      );
-    }
-    if (
-      err instanceof MigrationAlreadyInProgressError ||
-      err instanceof MigrationLockAcquireError
-    ) {
-      return c.json(
-        { error: "The instance is busy with another migration or import. Try again shortly.", code: "BUSY" },
-        503,
-      );
-    }
+    const response = importOperationError(c, err);
+    if (response) return response;
     throw err;
   }
+}
+
+/** Open an authenticated chunk upload; the browser never reads the whole file. */
+export async function createFileUploadHandler(c: Context) {
+  const ctx = getRequestContext(c);
+  await assertInstanceAdmin(ctx);
+  const body = await readJsonBody<FileUploadSessionBody>(c);
+  if (!body) {
+    return c.json({ error: "Invalid upload session request.", code: "INVALID_CHUNK" }, 400);
+  }
+  try {
+    if (!Number.isSafeInteger(body.size) || (body.size ?? 0) <= 0) {
+      return c.json(
+        { error: "A positive export file size is required.", code: "INVALID_CHUNK" },
+        400,
+      );
+    }
+    return c.json(await createFileUpload({ ownerUserId: ctx.userId, size: body.size! }));
+  } catch (err) {
+    const response = transferProtocolError(c, err);
+    if (response) return response;
+    throw err;
+  }
+}
+
+export async function uploadFileChunkHandler(c: Context) {
+  const ctx = getRequestContext(c);
+  await assertInstanceAdmin(ctx);
+  try {
+    const uploadId = c.req.param("sessionId");
+    if (!uploadId) {
+      return c.json({ error: "Missing import upload session.", code: "SESSION_UNAVAILABLE" }, 400);
+    }
+    await uploadFileChunk({
+      uploadId,
+      ownerUserId: ctx.userId,
+      index: Number(c.req.param("index")),
+      sha256: c.req.header("x-openship-chunk-sha256") ?? "",
+      readBytes: async () => new Uint8Array(await c.req.arrayBuffer()),
+    });
+    return c.json({ ok: true });
+  } catch (err) {
+    const response = transferProtocolError(c, err);
+    if (response) return response;
+    throw err;
+  }
+}
+
+/** Streamed file finalization; upload requests stay bounded and the subsequent
+ * atomic restore receives heartbeat bytes until its terminal result. */
+export async function finalizeFileUploadStreamHandler(c: Context) {
+  const ctx = getRequestContext(c);
+  await assertInstanceAdmin(ctx);
+  const uploadId = c.req.param("sessionId");
+  if (!uploadId) {
+    return c.json({ error: "Missing import upload session.", code: "SESSION_UNAVAILABLE" }, 400);
+  }
+  const body = await readFileFinalizeInput(c);
+  if (!body) {
+    return c.json(
+      { error: "Import mode must be wipe or merge.", code: "INVALID_IMPORT_MODE" },
+      400,
+    );
+  }
+  const input = {
+    uploadId,
+    passphrase: body.passphrase,
+    mode: body.mode,
+  };
+  return streamSSE(c, async (stream) => {
+    await writeTransferStreamResult(
+      stream,
+      () => finalizeFileAndAudit(c, ctx, input),
+      importOperationFailure,
+    );
+  });
 }

--- a/apps/api/src/modules/system/data-transfer/direct-transfer.service.ts
+++ b/apps/api/src/modules/system/data-transfer/direct-transfer.service.ts
@@ -1,14 +1,17 @@
 /**
  * One-time, instance-to-instance transfer.
  *
- * The destination creates an ephemeral X25519 keypair and an unguessable
- * capability. The source encrypts the scrubbed dump + plaintext credential
- * bundle directly to that public key. Only the destination can open it, and it
- * immediately re-encrypts every credential under its own instance key.
+ * A receive capability is persisted in the destination database and the source
+ * uploads independently authenticated 8 MB ciphertext chunks. This keeps every
+ * request below the edge proxy limit, bounds request memory, survives API worker
+ * changes/restarts, and extends the lease while a large export is being prepared.
+ * The legacy one-envelope receiver remains for transfers from older sources.
  */
 
 import {
   createHash,
+  createHmac,
+  createPrivateKey,
   createPublicKey,
   diffieHellman,
   generateKeyPairSync,
@@ -18,10 +21,40 @@ import {
   timingSafeEqual,
   type KeyObject,
 } from "node:crypto";
+import { readSseTerminalEvent } from "@repo/core";
 
-import { decryptWithKey, encryptWithKey } from "../../../lib/encryption";
+import {
+  decrypt,
+  decryptBytesWithKey,
+  decryptWithKey,
+  encrypt,
+  encryptBytesWithKey,
+  encryptWithKey,
+} from "../../../lib/encryption";
+import {
+  assertCompleteChunkSet,
+  beginDirectSession,
+  claimSession,
+  clearTransferSessionsForTest,
+  completeSessionInTransaction,
+  createDirectSession,
+  failSession,
+  getSession,
+  listChunkMetadata,
+  MAX_TRANSFER_BYTES,
+  sha256Hex,
+  stageChunk,
+  touchSession,
+  TRANSFER_CHUNK_BYTES,
+  TRANSFER_CONTROL_BODY_BYTES,
+  TransferStoreError,
+  withSessionClaimLease,
+  type TransferSessionRow,
+} from "./chunk-store";
 import { prepareInstanceExport } from "./export.service";
 import { importPreparedInstance } from "./import.service";
+import { jsonByteChunks } from "./json-chunks";
+import { readStagedJson } from "./staged-payload";
 import type {
   DirectTransferConnection,
   DirectTransferEnvelope,
@@ -32,22 +65,34 @@ import type {
   ImportResult,
 } from "./types";
 
-const SESSION_TTL_MS = 10 * 60_000;
-const MAX_ACTIVE_SESSIONS = 20;
 const DIRECT_RECEIVE_PATH = "system/data-transfer/direct/receive";
+const DIRECT_CHUNK_INIT_PATH = "system/data-transfer/direct/chunk/init";
+const DIRECT_CHUNK_FINALIZE_STREAM_SUFFIX = "finalize/stream";
 const KEY_CONTEXT = Buffer.from("openship-direct-transfer-v1", "utf8");
 const DIRECT_RUNTIME_ID = randomUUID();
+const HEARTBEAT_INTERVAL_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 2 * 60_000;
+const FINALIZE_TIMEOUT_MS = 6 * 60 * 60_000;
 
-interface ReceiveSession {
-  id: string;
-  tokenHash: Buffer;
-  privateKey: KeyObject;
+interface DirectChunkInit {
+  version: 1;
+  sessionId: string;
   mode: ImportMode;
-  expiresAtMs: number;
-  consuming: boolean;
+  senderPublicKey: string;
+  proof: string;
 }
 
-const receiveSessions = new Map<string, ReceiveSession>();
+interface DirectChunkManifest {
+  totalChunks: number;
+  totalBytes: number;
+  sha256: string;
+  signature: string;
+}
+
+interface SenderContext {
+  key: Buffer;
+  senderPublicKey: string;
+}
 
 export class InvalidDirectTransferCodeError extends Error {
   readonly code = "INVALID_DIRECT_TRANSFER_CODE" as const;
@@ -59,7 +104,9 @@ export class InvalidDirectTransferCodeError extends Error {
 
 export class DirectTransferSessionError extends Error {
   readonly code = "DIRECT_TRANSFER_SESSION_UNAVAILABLE" as const;
-  constructor(message = "The receive code expired, was already used, or is not available on this instance.") {
+  constructor(
+    message = "The receive code expired, was already used, or is not available on this instance.",
+  ) {
     super(message);
     this.name = "DirectTransferSessionError";
   }
@@ -67,7 +114,12 @@ export class DirectTransferSessionError extends Error {
 
 export class DirectTransferDestinationError extends Error {
   readonly code = "DIRECT_TRANSFER_DESTINATION_FAILED" as const;
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly destinationCode?: string,
+    readonly retryable = false,
+  ) {
     super(message);
     this.name = "DirectTransferDestinationError";
   }
@@ -75,12 +127,6 @@ export class DirectTransferDestinationError extends Error {
 
 function tokenDigest(token: string): Buffer {
   return createHash("sha256").update(token).digest();
-}
-
-function cleanupSessions(now = Date.now()): void {
-  for (const [id, session] of receiveSessions) {
-    if (session.expiresAtMs <= now) receiveSessions.delete(id);
-  }
 }
 
 function normalizeApiBase(raw: string): string {
@@ -94,7 +140,9 @@ function normalizeApiBase(raw: string): string {
     throw new InvalidDirectTransferCodeError("The destination must use an HTTP or HTTPS URL.");
   }
   if (url.username || url.password || url.search || url.hash) {
-    throw new InvalidDirectTransferCodeError("The destination URL cannot contain credentials, query parameters, or a fragment.");
+    throw new InvalidDirectTransferCodeError(
+      "The destination URL cannot contain credentials, query parameters, or a fragment.",
+    );
   }
   url.pathname = `${url.pathname.replace(/\/+$/, "")}/`;
   return url.toString();
@@ -124,9 +172,13 @@ function assertConnection(value: unknown): DirectTransferConnection {
   ) {
     throw new InvalidDirectTransferCodeError();
   }
-  const expiresAtMs = Date.parse(item.expiresAt);
-  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
-    throw new DirectTransferSessionError("The receive code has expired. Generate a new one on the destination.");
+  // This timestamp is display metadata for the initial idle lease. An active
+  // transfer renews its authoritative database lease, but the already-copied
+  // code cannot be rewritten with each heartbeat. Reject malformed timestamps
+  // here and let the destination return 410 for an actually expired session;
+  // otherwise a source retry after ten minutes would reject a still-live lease.
+  if (!Number.isFinite(Date.parse(item.expiresAt))) {
+    throw new InvalidDirectTransferCodeError("The receive code expiry is invalid.");
   }
   return {
     version: 1,
@@ -151,7 +203,10 @@ export function decodeDirectTransferCode(code: string): DirectTransferConnection
   try {
     return assertConnection(JSON.parse(Buffer.from(code.trim(), "base64url").toString("utf8")));
   } catch (error) {
-    if (error instanceof InvalidDirectTransferCodeError || error instanceof DirectTransferSessionError) {
+    if (
+      error instanceof InvalidDirectTransferCodeError ||
+      error instanceof DirectTransferSessionError
+    ) {
       throw error;
     }
     throw new InvalidDirectTransferCodeError();
@@ -163,60 +218,112 @@ function deriveTransferKey(privateKey: KeyObject, publicKey: KeyObject, sessionI
   return Buffer.from(hkdfSync("sha256", shared, Buffer.from(sessionId, "utf8"), KEY_CONTEXT, 32));
 }
 
+function parsePublicKey(encoded: string): KeyObject {
+  const key = createPublicKey({ key: Buffer.from(encoded, "base64"), format: "der", type: "spki" });
+  if (key.asymmetricKeyType !== "x25519") throw new Error("wrong key type");
+  return key;
+}
+
+function senderContext(connection: DirectTransferConnection): SenderContext {
+  let recipientPublicKey: KeyObject;
+  try {
+    recipientPublicKey = parsePublicKey(connection.recipientPublicKey);
+  } catch {
+    throw new InvalidDirectTransferCodeError(
+      "The receive code contains an invalid destination key.",
+    );
+  }
+  const { publicKey, privateKey } = generateKeyPairSync("x25519");
+  return {
+    key: deriveTransferKey(privateKey, recipientPublicKey, connection.sessionId),
+    senderPublicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+  };
+}
+
+function sessionPrivateKey(session: TransferSessionRow): KeyObject {
+  if (!session.privateKey) throw new DirectTransferSessionError();
+  try {
+    const key = createPrivateKey({
+      key: Buffer.from(decrypt(session.privateKey), "base64"),
+      format: "der",
+      type: "pkcs8",
+    });
+    if (key.asymmetricKeyType !== "x25519") throw new Error("wrong key type");
+    return key;
+  } catch {
+    throw new DirectTransferSessionError(
+      "The receive session key is unavailable on this instance.",
+    );
+  }
+}
+
+function sessionKey(session: TransferSessionRow, senderPublicKey?: string): Buffer {
+  try {
+    return deriveTransferKey(
+      sessionPrivateKey(session),
+      parsePublicKey(senderPublicKey ?? session.senderPublicKey ?? ""),
+      session.id,
+    );
+  } catch (error) {
+    if (error instanceof DirectTransferSessionError) throw error;
+    throw new InvalidDirectTransferCodeError("The sender transfer key is invalid.");
+  }
+}
+
+function sign(key: Buffer, message: string): string {
+  return createHmac("sha256", key).update(message).digest("hex");
+}
+
+function signatureMatches(key: Buffer, message: string, supplied: string): boolean {
+  if (!/^[a-f0-9]{64}$/.test(supplied)) return false;
+  const expected = Buffer.from(sign(key, message), "hex");
+  const actual = Buffer.from(supplied, "hex");
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+function tokenMatches(session: TransferSessionRow, token: string): boolean {
+  if (!session.tokenHash || !/^[a-f0-9]{64}$/.test(session.tokenHash)) return false;
+  const expected = Buffer.from(session.tokenHash, "hex");
+  const actual = tokenDigest(token);
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+async function directSession(id: string): Promise<TransferSessionRow> {
+  const session = await getSession(id);
+  if (!session || session.kind !== "direct") throw new DirectTransferSessionError();
+  return session;
+}
+
 export function sealDirectTransferPayload(
   connection: DirectTransferConnection,
   payload: DirectTransferPayload,
 ): DirectTransferEnvelope {
-  let recipientPublicKey: KeyObject;
-  try {
-    recipientPublicKey = createPublicKey({
-      key: Buffer.from(connection.recipientPublicKey, "base64"),
-      format: "der",
-      type: "spki",
-    });
-    if (recipientPublicKey.asymmetricKeyType !== "x25519") throw new Error("wrong key type");
-  } catch {
-    throw new InvalidDirectTransferCodeError("The receive code contains an invalid destination key.");
-  }
-
-  const { publicKey: senderPublicKey, privateKey: senderPrivateKey } = generateKeyPairSync("x25519");
-  const key = deriveTransferKey(senderPrivateKey, recipientPublicKey, connection.sessionId);
+  const sender = senderContext(connection);
   return {
     version: 1,
     sessionId: connection.sessionId,
-    senderPublicKey: senderPublicKey.export({ format: "der", type: "spki" }).toString("base64"),
-    blob: encryptWithKey(key, JSON.stringify(payload)),
+    senderPublicKey: sender.senderPublicKey,
+    blob: encryptWithKey(sender.key, JSON.stringify(payload)),
   };
 }
 
-export function createDirectReceiveSession(opts: {
+export async function createDirectReceiveSession(opts: {
   apiBase: string;
   mode: ImportMode;
-}): { code: string; expiresAt: string; mode: ImportMode } {
-  cleanupSessions();
-  if (receiveSessions.size >= MAX_ACTIVE_SESSIONS) {
-    throw new DirectTransferSessionError("Too many active receive codes. Wait for an existing code to expire.");
-  }
-
-  const id = randomUUID();
+}): Promise<{ code: string; expiresAt: string; mode: ImportMode }> {
   const token = randomBytes(32).toString("base64url");
   const { publicKey, privateKey } = generateKeyPairSync("x25519");
-  const expiresAtMs = Date.now() + SESSION_TTL_MS;
-  receiveSessions.set(id, {
-    id,
-    tokenHash: tokenDigest(token),
-    privateKey,
+  const stored = await createDirectSession({
     mode: opts.mode,
-    expiresAtMs,
-    consuming: false,
+    tokenHash: tokenDigest(token).toString("hex"),
+    privateKey: encrypt(privateKey.export({ format: "der", type: "pkcs8" }).toString("base64")),
   });
-
-  const expiresAt = new Date(expiresAtMs).toISOString();
+  const expiresAt = stored.expiresAt.toISOString();
   const connection: DirectTransferConnection = {
     version: 1,
     apiBase: normalizeApiBase(opts.apiBase),
     recipientRuntimeId: DIRECT_RUNTIME_ID,
-    sessionId: id,
+    sessionId: stored.id,
     token,
     recipientPublicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
     mode: opts.mode,
@@ -225,49 +332,566 @@ export function createDirectReceiveSession(opts: {
   return { code: encodeDirectTransferCode(connection), expiresAt, mode: opts.mode };
 }
 
+async function responseBody(response: Response): Promise<Record<string, unknown> | null> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > TRANSFER_CONTROL_BODY_BYTES) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new DirectTransferDestinationError("Destination returned an oversized response.");
+  }
+  if (!response.body) return null;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > TRANSFER_CONTROL_BODY_BYTES) {
+        throw new DirectTransferDestinationError("Destination returned an oversized response.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks, total).toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+async function requireDestinationResponse(response: Response): Promise<Record<string, unknown>> {
+  const body = await responseBody(response);
+  if (!response.ok || !body) {
+    throw new DirectTransferDestinationError(
+      typeof body?.error === "string"
+        ? body.error
+        : `Destination returned HTTP ${response.status}.`,
+      response.status,
+      typeof body?.code === "string" ? body.code : undefined,
+    );
+  }
+  return body;
+}
+
+async function fetchDestination(
+  fetchImpl: typeof fetch,
+  url: URL,
+  init: RequestInit,
+  timeoutMs = REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  try {
+    return await fetchImpl(url, {
+      ...init,
+      redirect: "error",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new DirectTransferDestinationError(
+      error instanceof Error
+        ? `Could not reach the destination: ${error.message}`
+        : "Could not reach the destination.",
+      undefined,
+      undefined,
+      true,
+    );
+  }
+}
+
+async function initializeDestination(
+  connection: DirectTransferConnection,
+  sender: SenderContext,
+  fetchImpl: typeof fetch,
+): Promise<{ result?: ImportResult } | null> {
+  const proof = encryptWithKey(
+    sender.key,
+    JSON.stringify({
+      version: 1,
+      sessionId: connection.sessionId,
+      mode: connection.mode,
+      authorizationToken: connection.token,
+    }),
+  );
+  const response = await fetchDestination(
+    fetchImpl,
+    new URL(DIRECT_CHUNK_INIT_PATH, connection.apiBase),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        sessionId: connection.sessionId,
+        mode: connection.mode,
+        senderPublicKey: sender.senderPublicKey,
+        proof,
+      } satisfies DirectChunkInit),
+    },
+  );
+  // A pre-chunking destination still accepts the legacy encrypted envelope.
+  if (response.status === 404 || response.status === 405) return null;
+  const body = await requireDestinationResponse(response);
+  return {
+    result:
+      body.result && typeof body.result === "object"
+        ? (body.result as unknown as ImportResult)
+        : undefined,
+  };
+}
+
+async function heartbeatDestination(
+  connection: DirectTransferConnection,
+  sender: SenderContext,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const message = `heartbeat:${connection.sessionId}`;
+  const response = await fetchDestination(
+    fetchImpl,
+    new URL(
+      `system/data-transfer/direct/chunk/${encodeURIComponent(connection.sessionId)}/heartbeat`,
+      connection.apiBase,
+    ),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ signature: sign(sender.key, message) }),
+    },
+  );
+  await requireDestinationResponse(response);
+}
+
+async function uploadDestinationChunk(input: {
+  connection: DirectTransferConnection;
+  sender: SenderContext;
+  fetchImpl: typeof fetch;
+  index: number;
+  ciphertext: Buffer;
+}): Promise<void> {
+  const digest = sha256Hex(input.ciphertext);
+  const message = `chunk:${input.connection.sessionId}:${input.index}:${digest}`;
+  const url = new URL(
+    `system/data-transfer/direct/chunk/${encodeURIComponent(input.connection.sessionId)}/${input.index}`,
+    input.connection.apiBase,
+  );
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const response = await fetchDestination(input.fetchImpl, url, {
+        method: "PUT",
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-openship-chunk-sha256": digest,
+          "x-openship-transfer-signature": sign(input.sender.key, message),
+        },
+        body: input.ciphertext,
+      });
+      await requireDestinationResponse(response);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (
+        error instanceof DirectTransferDestinationError &&
+        error.status &&
+        error.status < 500 &&
+        error.status !== 429
+      ) {
+        throw error;
+      }
+      if (attempt < 2) await new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt));
+    }
+  }
+  throw lastError;
+}
+
+async function finalizeDestinationOnce(
+  connection: DirectTransferConnection,
+  sender: SenderContext,
+  manifest: Omit<DirectChunkManifest, "signature">,
+  fetchImpl: typeof fetch,
+): Promise<ImportResult> {
+  const message = `finalize:${connection.sessionId}:${manifest.totalChunks}:${manifest.totalBytes}:${manifest.sha256}`;
+  const response = await fetchDestination(
+    fetchImpl,
+    new URL(
+      `system/data-transfer/direct/chunk/${encodeURIComponent(connection.sessionId)}/${DIRECT_CHUNK_FINALIZE_STREAM_SUFFIX}`,
+      connection.apiBase,
+    ),
+    {
+      method: "POST",
+      headers: {
+        accept: "text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        ...manifest,
+        signature: sign(sender.key, message),
+      } satisfies DirectChunkManifest),
+    },
+    FINALIZE_TIMEOUT_MS,
+  );
+  if (!response.ok) await requireDestinationResponse(response);
+  if (
+    !(response.headers.get("content-type") ?? "").includes("text/event-stream") ||
+    !response.body
+  ) {
+    throw new DirectTransferDestinationError("Destination returned an invalid transfer stream.");
+  }
+  try {
+    const terminal = await readSseTerminalEvent(response.body);
+    if (terminal.event === "complete") return JSON.parse(terminal.data) as ImportResult;
+    const failure = JSON.parse(terminal.data) as {
+      status?: number;
+      error?: string;
+      code?: string;
+    };
+    throw new DirectTransferDestinationError(
+      typeof failure.error === "string" ? failure.error : "Destination import failed.",
+      typeof failure.status === "number" ? failure.status : undefined,
+      typeof failure.code === "string" ? failure.code : undefined,
+    );
+  } catch (error) {
+    if (error instanceof DirectTransferDestinationError) throw error;
+    const retryable =
+      !(error instanceof SyntaxError) &&
+      !(error instanceof Error && error.message.includes("oversized frame"));
+    throw new DirectTransferDestinationError(
+      error instanceof Error
+        ? `Destination transfer stream failed: ${error.message}`
+        : "Destination transfer stream failed.",
+      undefined,
+      undefined,
+      retryable,
+    );
+  }
+}
+
+function retryableFinalizeFailure(error: unknown): boolean {
+  if (!(error instanceof DirectTransferDestinationError)) return false;
+  if (error.destinationCode === "SESSION_BUSY") return true;
+  if (error.destinationCode === "BUSY") return false;
+  return (
+    error.retryable ||
+    error.status === 429 ||
+    error.status === 502 ||
+    error.status === 503 ||
+    error.status === 504
+  );
+}
+
+/**
+ * Retrying finalization is safe because the manifest and sender key are stable,
+ * and the destination keeps the completed result briefly. This closes the
+ * ambiguous-outcome gap where the restore commits but its terminal SSE frame is
+ * lost during a proxy or worker restart.
+ */
+async function finalizeDestination(
+  connection: DirectTransferConnection,
+  sender: SenderContext,
+  manifest: Omit<DirectChunkManifest, "signature">,
+  fetchImpl: typeof fetch,
+): Promise<ImportResult> {
+  const deadline = Date.now() + FINALIZE_TIMEOUT_MS;
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await finalizeDestinationOnce(connection, sender, manifest, fetchImpl);
+    } catch (error) {
+      if (!retryableFinalizeFailure(error) || Date.now() >= deadline) throw error;
+      const busy =
+        error instanceof DirectTransferDestinationError && error.destinationCode === "SESSION_BUSY";
+      if (!busy && attempt >= 2) throw error;
+      const delay = Math.min(1_000 * 2 ** Math.min(attempt, 3), 10_000);
+      attempt += 1;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+async function sendLegacyTransfer(
+  connection: DirectTransferConnection,
+  payload: DirectTransferPayload,
+  fetchImpl: typeof fetch,
+): Promise<ImportResult> {
+  const envelope = sealDirectTransferPayload(connection, payload);
+  const response = await fetchDestination(
+    fetchImpl,
+    new URL(DIRECT_RECEIVE_PATH, connection.apiBase),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(envelope),
+    },
+    FINALIZE_TIMEOUT_MS,
+  );
+  return (await requireDestinationResponse(response)) as unknown as ImportResult;
+}
+
 export async function sendDirectTransfer(opts: {
   code: string;
   selection?: ExportSelection;
   fetchImpl?: typeof fetch;
 }): Promise<DirectTransferResult> {
   const connection = decodeDirectTransferCode(opts.code);
-  if (connection.recipientRuntimeId === DIRECT_RUNTIME_ID) {
-    throw new InvalidDirectTransferCodeError("The receive code belongs to this same instance. Generate it on the destination instance.");
-  }
-  const prepared = await prepareInstanceExport(opts.selection);
-  const payload: DirectTransferPayload = {
-    version: 1,
-    authorizationToken: connection.token,
-    file: prepared.file,
-    secrets: prepared.secrets,
-  };
-  const envelope = sealDirectTransferPayload(connection, payload);
-
-  const receiveUrl = new URL(DIRECT_RECEIVE_PATH, connection.apiBase);
-  let response: Response;
-  try {
-    response = await (opts.fetchImpl ?? fetch)(receiveUrl, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(envelope),
-      redirect: "error",
-      signal: AbortSignal.timeout(10 * 60_000),
-    });
-  } catch (error) {
-    throw new DirectTransferDestinationError(
-      error instanceof Error ? `Could not reach the destination: ${error.message}` : "Could not reach the destination.",
+  // The process id is a fast legacy check, but is not stable across restarts or
+  // multiple API workers. The durable capability record is authoritative: if
+  // this database owns the session+token, sending would target ourselves.
+  const localSession = await getSession(connection.sessionId);
+  if (
+    connection.recipientRuntimeId === DIRECT_RUNTIME_ID ||
+    (localSession?.kind === "direct" && tokenMatches(localSession, connection.token))
+  ) {
+    throw new InvalidDirectTransferCodeError(
+      "The receive code belongs to this same instance. Generate it on the destination instance.",
     );
   }
 
-  const body = await response.json().catch(() => null) as (ImportResult & { error?: string }) | null;
-  if (!response.ok || !body) {
-    throw new DirectTransferDestinationError(body?.error || `Destination returned HTTP ${response.status}.`);
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sender = senderContext(connection);
+  const initialized = await initializeDestination(connection, sender, fetchImpl);
+  const chunked = initialized !== null;
+  if (initialized?.result) {
+    return {
+      ...initialized.result,
+      destination: new URL(connection.apiBase).origin,
+    };
   }
-  return { ...body, destination: receiveUrl.origin };
+
+  let heartbeatBusy = false;
+  const heartbeat = chunked
+    ? setInterval(() => {
+        if (heartbeatBusy) return;
+        heartbeatBusy = true;
+        void heartbeatDestination(connection, sender, fetchImpl)
+          .catch(() => undefined)
+          .finally(() => {
+            heartbeatBusy = false;
+          });
+      }, HEARTBEAT_INTERVAL_MS)
+    : null;
+  heartbeat?.unref?.();
+
+  try {
+    const prepared = await prepareInstanceExport(opts.selection);
+    const payload: DirectTransferPayload = {
+      version: 1,
+      authorizationToken: connection.token,
+      file: prepared.file,
+      secrets: prepared.secrets,
+    };
+
+    if (!chunked) {
+      const result = await sendLegacyTransfer(connection, payload, fetchImpl);
+      return { ...result, destination: new URL(connection.apiBase).origin };
+    }
+
+    const hash = createHash("sha256");
+    let totalBytes = 0;
+    let totalChunks = 0;
+    for (const plaintext of jsonByteChunks(payload, TRANSFER_CHUNK_BYTES)) {
+      totalBytes += plaintext.byteLength;
+      totalChunks += 1;
+      if (totalBytes > MAX_TRANSFER_BYTES) {
+        throw new DirectTransferDestinationError(
+          `Transfer exceeds the ${Math.floor(MAX_TRANSFER_BYTES / 1_000_000)}MB limit. Exclude optional history and retry.`,
+          413,
+        );
+      }
+      hash.update(plaintext);
+      await uploadDestinationChunk({
+        connection,
+        sender,
+        fetchImpl,
+        index: totalChunks - 1,
+        ciphertext: encryptBytesWithKey(sender.key, plaintext),
+      });
+    }
+    const result = await finalizeDestination(
+      connection,
+      sender,
+      { totalChunks, totalBytes, sha256: hash.digest("hex") },
+      fetchImpl,
+    );
+    return { ...result, destination: new URL(connection.apiBase).origin };
+  } finally {
+    if (heartbeat) clearInterval(heartbeat);
+  }
 }
 
-export async function receiveDirectTransfer(envelope: DirectTransferEnvelope): Promise<ImportResult> {
-  cleanupSessions();
+export async function initializeDirectChunkUpload(input: DirectChunkInit) {
+  if (
+    input?.version !== 1 ||
+    typeof input.sessionId !== "string" ||
+    (input.mode !== "wipe" && input.mode !== "merge") ||
+    typeof input.senderPublicKey !== "string" ||
+    typeof input.proof !== "string"
+  ) {
+    throw new InvalidDirectTransferCodeError("The chunked transfer handshake is invalid.");
+  }
+  const current = await directSession(input.sessionId);
+  if (input.mode !== current.mode) throw new DirectTransferSessionError();
+  if (
+    current.status !== "ready" &&
+    current.status !== "uploading" &&
+    current.status !== "complete"
+  ) {
+    throw new DirectTransferSessionError();
+  }
+  const key = sessionKey(current, input.senderPublicKey);
+  let proof: Record<string, unknown>;
+  try {
+    proof = JSON.parse(decryptWithKey(key, input.proof)) as Record<string, unknown>;
+  } catch {
+    throw new InvalidDirectTransferCodeError("The transfer handshake could not be authenticated.");
+  }
+  if (
+    proof.version !== 1 ||
+    proof.sessionId !== current.id ||
+    proof.mode !== current.mode ||
+    typeof proof.authorizationToken !== "string" ||
+    !tokenMatches(current, proof.authorizationToken)
+  ) {
+    throw new DirectTransferSessionError();
+  }
+  if (current.status === "complete" && current.result) {
+    return {
+      chunkSize: TRANSFER_CHUNK_BYTES,
+      expiresAt: current.expiresAt.toISOString(),
+      result: current.result as unknown as ImportResult,
+    };
+  }
+  const session = await beginDirectSession(current.id, input.senderPublicKey);
+  if (!session) throw new DirectTransferSessionError();
+  return { chunkSize: TRANSFER_CHUNK_BYTES, expiresAt: session.expiresAt.toISOString() };
+}
+
+function requireDirectSignature(
+  session: TransferSessionRow,
+  supplied: string,
+  message: string,
+): Buffer {
+  const key = sessionKey(session);
+  if (!signatureMatches(key, message, supplied)) {
+    throw new InvalidDirectTransferCodeError("The transfer request signature is invalid.");
+  }
+  return key;
+}
+
+export async function heartbeatDirectChunkUpload(sessionId: string, signature: string) {
+  const session = await directSession(sessionId);
+  if (session.status !== "uploading") throw new DirectTransferSessionError();
+  requireDirectSignature(session, signature, `heartbeat:${session.id}`);
+  const touched = await touchSession(session.id, session.senderPublicKey!);
+  if (!touched) throw new DirectTransferSessionError();
+  return { expiresAt: touched.expiresAt.toISOString() };
+}
+
+export async function receiveDirectChunk(input: {
+  sessionId: string;
+  index: number;
+  sha256: string;
+  signature: string;
+  readBytes: () => Promise<Uint8Array>;
+}): Promise<void> {
+  if (
+    !Number.isSafeInteger(input.index) ||
+    input.index < 0 ||
+    !/^[a-f0-9]{64}$/.test(input.sha256)
+  ) {
+    throw new TransferStoreError("The transfer chunk metadata is invalid.", "INVALID_CHUNK");
+  }
+  const session = await directSession(input.sessionId);
+  if (session.status !== "uploading") throw new DirectTransferSessionError();
+  requireDirectSignature(
+    session,
+    input.signature,
+    `chunk:${session.id}:${input.index}:${input.sha256}`,
+  );
+  // Resolve and authenticate the small capability metadata before materializing
+  // an untrusted multi-megabyte request body.
+  const bytes = await input.readBytes();
+  await stageChunk({
+    session,
+    index: input.index,
+    bytes,
+    sha256: input.sha256,
+  });
+}
+
+function assertDirectManifest(value: DirectChunkManifest): void {
+  if (
+    !value ||
+    !Number.isSafeInteger(value.totalChunks) ||
+    value.totalChunks <= 0 ||
+    !Number.isSafeInteger(value.totalBytes) ||
+    value.totalBytes <= 0 ||
+    value.totalBytes > MAX_TRANSFER_BYTES ||
+    typeof value.sha256 !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.sha256) ||
+    typeof value.signature !== "string"
+  ) {
+    throw new InvalidDirectTransferCodeError("The transfer manifest is invalid.");
+  }
+}
+
+export async function finalizeDirectChunkUpload(
+  sessionId: string,
+  manifest: DirectChunkManifest,
+): Promise<ImportResult> {
+  assertDirectManifest(manifest);
+  const current = await directSession(sessionId);
+  const key = requireDirectSignature(
+    current,
+    manifest.signature,
+    `finalize:${current.id}:${manifest.totalChunks}:${manifest.totalBytes}:${manifest.sha256}`,
+  );
+  if (current.status === "complete" && current.result) {
+    return current.result as unknown as ImportResult;
+  }
+  if (current.status === "consuming") {
+    throw new TransferStoreError(
+      "The destination is still finalizing this transfer.",
+      "SESSION_BUSY",
+    );
+  }
+  if (current.status !== "uploading") throw new DirectTransferSessionError();
+
+  const metadata = await listChunkMetadata(current.id);
+  assertCompleteChunkSet(metadata, manifest.totalChunks);
+  const session = await claimSession(current);
+  try {
+    return await withSessionClaimLease(session, async () => {
+      const payload = (await readStagedJson(session, manifest, (bytes) =>
+        decryptBytesWithKey(key, bytes),
+      )) as DirectTransferPayload;
+      if (
+        payload?.version !== 1 ||
+        typeof payload.authorizationToken !== "string" ||
+        !tokenMatches(session, payload.authorizationToken) ||
+        !payload.file
+      ) {
+        throw new InvalidDirectTransferCodeError("The decrypted transfer payload is invalid.");
+      }
+      return importPreparedInstance({
+        file: payload.file,
+        secrets: payload.secrets ?? null,
+        mode: session.mode === "merge" ? "merge" : "wipe",
+        onBeforeCommit: (tx, imported) => completeSessionInTransaction(tx, session, imported),
+      });
+    });
+  } catch (error) {
+    await failSession(session).catch(() => undefined);
+    throw error;
+  }
+}
+
+/** Legacy single-envelope receiver for a source that has not learned chunking. */
+export async function receiveDirectTransfer(
+  envelope: DirectTransferEnvelope,
+): Promise<ImportResult> {
   if (
     !envelope ||
     envelope.version !== 1 ||
@@ -278,52 +902,44 @@ export async function receiveDirectTransfer(envelope: DirectTransferEnvelope): P
     throw new InvalidDirectTransferCodeError("The encrypted transfer envelope is invalid.");
   }
 
-  const session = receiveSessions.get(envelope.sessionId);
-  if (!session || session.consuming || session.expiresAtMs <= Date.now()) {
-    throw new DirectTransferSessionError();
-  }
-
+  const current = await directSession(envelope.sessionId);
+  const key = sessionKey(current, envelope.senderPublicKey);
   let payload: DirectTransferPayload;
   try {
-    const senderPublicKey = createPublicKey({
-      key: Buffer.from(envelope.senderPublicKey, "base64"),
-      format: "der",
-      type: "spki",
-    });
-    if (senderPublicKey.asymmetricKeyType !== "x25519") throw new Error("wrong key type");
-    const key = deriveTransferKey(session.privateKey, senderPublicKey, session.id);
     payload = JSON.parse(decryptWithKey(key, envelope.blob)) as DirectTransferPayload;
   } catch {
-    throw new InvalidDirectTransferCodeError("The transfer could not be authenticated or decrypted.");
+    throw new InvalidDirectTransferCodeError(
+      "The transfer could not be authenticated or decrypted.",
+    );
   }
-
-  if (
-    payload?.version !== 1 ||
-    typeof payload.authorizationToken !== "string" ||
-    !payload.file
-  ) {
+  if (payload?.version !== 1 || typeof payload.authorizationToken !== "string" || !payload.file) {
     throw new InvalidDirectTransferCodeError("The decrypted transfer payload is invalid.");
   }
-  const suppliedHash = tokenDigest(payload.authorizationToken);
-  if (!timingSafeEqual(session.tokenHash, suppliedHash)) {
+  if (!tokenMatches(current, payload.authorizationToken)) {
     throw new DirectTransferSessionError();
   }
-
-  // Consume atomically before the first database await. A receive code can
-  // authorize exactly one import attempt, including when that import fails.
-  session.consuming = true;
+  if (current.status === "complete" && current.result) {
+    return current.result as unknown as ImportResult;
+  }
+  const begun = await beginDirectSession(current.id, envelope.senderPublicKey);
+  if (!begun) throw new DirectTransferSessionError();
+  const session = await claimSession(begun);
   try {
-    return await importPreparedInstance({
-      file: payload.file,
-      secrets: payload.secrets ?? null,
-      mode: session.mode,
-    });
-  } finally {
-    receiveSessions.delete(session.id);
+    return await withSessionClaimLease(session, () =>
+      importPreparedInstance({
+        file: payload.file,
+        secrets: payload.secrets ?? null,
+        mode: session.mode === "merge" ? "merge" : "wipe",
+        onBeforeCommit: (tx, imported) => completeSessionInTransaction(tx, session, imported),
+      }),
+    );
+  } catch (error) {
+    await failSession(session).catch(() => undefined);
+    throw error;
   }
 }
 
-/** Test-only visibility without exposing private session material. */
-export function clearDirectReceiveSessionsForTest(): void {
-  if (process.env.NODE_ENV === "test") receiveSessions.clear();
+/** Test-only cleanup without exposing key material. */
+export async function clearDirectReceiveSessionsForTest(): Promise<void> {
+  await clearTransferSessionsForTest();
 }

--- a/apps/api/src/modules/system/data-transfer/file-upload.service.ts
+++ b/apps/api/src/modules/system/data-transfer/file-upload.service.ts
@@ -1,0 +1,126 @@
+import {
+  assertCompleteChunkSet,
+  claimSession,
+  completeSessionInTransaction,
+  createFileSession,
+  getSession,
+  listChunkMetadata,
+  releaseSessionClaim,
+  stageChunk,
+  TRANSFER_CHUNK_BYTES,
+  TransferStoreError,
+  withSessionClaimLease,
+} from "./chunk-store";
+import { importInstance } from "./import.service";
+import { readStagedJson } from "./staged-payload";
+import type { DataTransferFile, ImportMode, ImportResult } from "./types";
+
+export async function createFileUpload(input: { ownerUserId: string; size: number }) {
+  const session = await createFileSession({
+    ownerUserId: input.ownerUserId,
+    expectedBytes: input.size,
+  });
+  return {
+    uploadId: session.id,
+    chunkSize: TRANSFER_CHUNK_BYTES,
+    totalChunks: session.expectedChunks!,
+    expiresAt: session.expiresAt.toISOString(),
+  };
+}
+
+function ownedFileSession(session: Awaited<ReturnType<typeof getSession>>, ownerUserId: string) {
+  if (!session || session.kind !== "file" || session.ownerUserId !== ownerUserId) {
+    throw new TransferStoreError(
+      "The import upload session is unavailable.",
+      "SESSION_UNAVAILABLE",
+    );
+  }
+  return session;
+}
+
+export async function uploadFileChunk(input: {
+  uploadId: string;
+  ownerUserId: string;
+  index: number;
+  sha256: string;
+  readBytes: () => Promise<Uint8Array>;
+}): Promise<void> {
+  const session = ownedFileSession(await getSession(input.uploadId), input.ownerUserId);
+  if (session.status !== "uploading") {
+    throw new TransferStoreError("The import upload is no longer writable.", "SESSION_UNAVAILABLE");
+  }
+  if (
+    !Number.isSafeInteger(input.index) ||
+    input.index < 0 ||
+    !/^[a-f0-9]{64}$/.test(input.sha256)
+  ) {
+    throw new TransferStoreError("The import chunk metadata is invalid.", "INVALID_CHUNK");
+  }
+  const expectedChunks = session.expectedChunks ?? 0;
+  const expectedBytes = session.expectedBytes ?? 0;
+  if (input.index >= expectedChunks) {
+    throw new TransferStoreError("The import chunk index is out of range.", "INVALID_CHUNK");
+  }
+  // Authenticate the owner/session and validate the index before buffering the
+  // request body. The body limit remains a second, transport-level boundary.
+  const bytes = await input.readBytes();
+  const expectedLength =
+    input.index === expectedChunks - 1
+      ? expectedBytes - TRANSFER_CHUNK_BYTES * input.index
+      : TRANSFER_CHUNK_BYTES;
+  if (bytes.byteLength !== expectedLength) {
+    throw new TransferStoreError(
+      `Import chunk ${input.index} has ${bytes.byteLength} bytes; expected ${expectedLength}.`,
+      "INVALID_CHUNK",
+    );
+  }
+  await stageChunk({ session, index: input.index, bytes, sha256: input.sha256 });
+}
+
+export async function finalizeFileUpload(input: {
+  uploadId: string;
+  ownerUserId: string;
+  passphrase?: string;
+  mode: ImportMode;
+}): Promise<ImportResult> {
+  const current = ownedFileSession(await getSession(input.uploadId), input.ownerUserId);
+  if (current.status === "complete" && current.result) {
+    return current.result as unknown as ImportResult;
+  }
+  if (current.status !== "uploading") {
+    throw new TransferStoreError(
+      "The import upload is already being finalized.",
+      "SESSION_UNAVAILABLE",
+    );
+  }
+
+  // Validate before claiming so a premature finalize remains resumable: the
+  // browser can upload the missing chunk and call finalize again.
+  assertCompleteChunkSet(await listChunkMetadata(current.id), current.expectedChunks ?? 0);
+  const session = await claimSession(current);
+  try {
+    return await withSessionClaimLease(session, async () => {
+      const file = (await readStagedJson(
+        session,
+        {
+          totalChunks: session.expectedChunks ?? 0,
+          totalBytes: session.expectedBytes ?? 0,
+        },
+        (bytes) => bytes,
+      )) as DataTransferFile;
+      return importInstance({
+        file,
+        passphrase: input.passphrase,
+        mode: input.mode,
+        onBeforeCommit: (tx, imported) => completeSessionInTransaction(tx, session, imported),
+      });
+    });
+  } catch (error) {
+    // Authenticated file uploads are owner-bound rather than one-time public
+    // capabilities. Preserve their verified chunks so a wrong passphrase,
+    // merge collision, or transient migration lock can be corrected without
+    // uploading hundreds of megabytes again.
+    await releaseSessionClaim(session).catch(() => undefined);
+    throw error;
+  }
+}

--- a/apps/api/src/modules/system/data-transfer/import.service.ts
+++ b/apps/api/src/modules/system/data-transfer/import.service.ts
@@ -1,8 +1,8 @@
 /**
  * Whole-instance import. Validates the envelope, opens the secret bundle FIRST
  * (a wrong passphrase aborts before any DB write), restores the dump under the
- * migration lock, then re-encrypts each secret under THIS instance's key and
- * writes it back.
+ * migration lock, then re-encrypts each secret under THIS instance's key. The
+ * row restore and those secret writes share one database transaction.
  *
  *   wipe  — truncate + insert everything; re-hydrate every restored row.
  *   merge — insert new rows only (singleton/auth rows kept via onConflictDoNothing);
@@ -10,7 +10,7 @@
  *           row's own secrets are never clobbered.
  */
 
-import { db, eq, inArray, restoreSubgraph } from "@repo/db";
+import { db, eq, inArray, restoreSubgraphInTransaction, type DatabaseTransaction } from "@repo/db";
 
 import { env } from "../../../config/env";
 import { withMigrationLock } from "../migration/migration-lock";
@@ -18,7 +18,13 @@ import { CloudInstanceNotTransferableError } from "./errors";
 import { openTransferSecrets } from "./passphrase-crypto";
 import { sealForInstance } from "./secret-codec";
 import { SECRET_COLUMNS, type SecretColumn } from "./secret-registry";
-import type { DataTransferFile, ImportMode, ImportResult, SecretBundle, SecretEntry } from "./types";
+import type {
+  DataTransferFile,
+  ImportMode,
+  ImportResult,
+  SecretBundle,
+  SecretEntry,
+} from "./types";
 
 export class InvalidTransferFileError extends Error {
   readonly code = "INVALID_TRANSFER_FILE" as const;
@@ -46,6 +52,19 @@ const SINGLETON_AND_AUTH = [
   "user_settings",
   "job",
 ];
+
+const SECRET_SPEC_BY_KEY = new Map<string, SecretColumn>(
+  SECRET_COLUMNS.map((spec) => [`${spec.sqlName}.${spec.column}`, spec]),
+);
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === "string")
+  );
+}
 
 function assertValidEnvelope(file: DataTransferFile): void {
   if (!file || file.kind !== "openship-instance-export") {
@@ -77,17 +96,20 @@ function assertValidSecretBundle(bundle: SecretBundle | null): void {
     ) {
       throw new InvalidTransferFileError("The credential bundle contains an invalid entry.");
     }
-    if (entry.value !== undefined && typeof entry.value !== "string") {
-      throw new InvalidTransferFileError("The credential bundle contains an invalid scalar value.");
+    const knownSpec = SECRET_SPEC_BY_KEY.get(`${entry.table}.${entry.column}`);
+    if (knownSpec && entry.scheme !== knownSpec.scheme) {
+      throw new InvalidTransferFileError(
+        "The credential bundle does not match the destination schema.",
+      );
     }
-    for (const values of [entry.map, entry.config]) {
-      if (
-        values !== undefined &&
-        (!values || typeof values !== "object" || Array.isArray(values) ||
-          Object.values(values).some((value) => typeof value !== "string"))
-      ) {
-        throw new InvalidTransferFileError("The credential bundle contains an invalid mapped value.");
-      }
+    const validValue =
+      entry.scheme === "map"
+        ? isStringRecord(entry.map)
+        : entry.scheme === "notification-config"
+          ? isStringRecord(entry.config)
+          : typeof entry.value === "string";
+    if (!validValue) {
+      throw new InvalidTransferFileError("The credential bundle contains an invalid secret value.");
     }
   }
 }
@@ -102,7 +124,12 @@ function secretTables(): Map<string, { table: SecretColumn["table"]; pk: SecretC
 }
 
 /** merge only: which ids in each secret table are NEW (didn't already exist). */
-async function computeNewIds(file: DataTransferFile): Promise<Map<string, Set<string>>> {
+const ID_LOOKUP_BATCH_SIZE = 10_000;
+
+async function computeNewIds(
+  file: DataTransferFile,
+  tx: DatabaseTransaction,
+): Promise<Map<string, Set<string>>> {
   const result = new Map<string, Set<string>>();
   for (const [sqlName, { table, pk }] of secretTables()) {
     const dumpIds = (file.dump.tables[sqlName] ?? [])
@@ -112,11 +139,19 @@ async function computeNewIds(file: DataTransferFile): Promise<Map<string, Set<st
       result.set(sqlName, new Set());
       continue;
     }
-    const existing = (await db
-      .select()
-      .from(table)
-      .where(inArray(pk, dumpIds))) as Array<Record<string, unknown>>;
-    const existingSet = new Set(existing.map((r) => r.id as string));
+    const existingSet = new Set<string>();
+    // Keep merge preflight below the driver's bind-parameter ceiling just like
+    // restoreSubgraph's inserts. Large env-var/deployment histories can easily
+    // contain tens of thousands of secret-bearing rows.
+    for (let i = 0; i < dumpIds.length; i += ID_LOOKUP_BATCH_SIZE) {
+      const existing = (await tx
+        .select()
+        .from(table)
+        .where(inArray(pk, dumpIds.slice(i, i + ID_LOOKUP_BATCH_SIZE)))) as Array<
+        Record<string, unknown>
+      >;
+      for (const row of existing) existingSet.add(row.id as string);
+    }
     result.set(sqlName, new Set(dumpIds.filter((id) => !existingSet.has(id))));
   }
   return result;
@@ -126,6 +161,7 @@ export async function importInstance(opts: {
   file: DataTransferFile;
   passphrase?: string;
   mode: ImportMode;
+  onBeforeCommit?: (tx: DatabaseTransaction, result: ImportResult) => Promise<void>;
 }): Promise<ImportResult> {
   if (env.CLOUD_MODE) throw new CloudInstanceNotTransferableError();
   assertValidEnvelope(opts.file);
@@ -133,6 +169,7 @@ export async function importInstance(opts: {
     file: opts.file,
     secrets: openTransferSecrets(opts.file.secrets, opts.passphrase),
     mode: opts.mode,
+    onBeforeCommit: opts.onBeforeCommit,
   });
 }
 
@@ -141,6 +178,7 @@ export async function importPreparedInstance(opts: {
   file: DataTransferFile;
   secrets: SecretBundle | null;
   mode: ImportMode;
+  onBeforeCommit?: (tx: DatabaseTransaction, result: ImportResult) => Promise<void>;
 }): Promise<ImportResult> {
   const { file, mode, secrets: bundle } = opts;
   // GATE 1: never import (esp. wipe) onto a multi-tenant SaaS instance — a
@@ -163,55 +201,69 @@ export async function importPreparedInstance(opts: {
   let secretsRehydrated = 0;
 
   await withMigrationLock(async () => {
-    const newIds = mode === "merge" ? await computeNewIds(file) : null;
+    await db.transaction(async (rawTx) => {
+      const tx = rawTx as DatabaseTransaction;
+      const newIds = mode === "merge" ? await computeNewIds(file, tx) : null;
 
-    await restoreSubgraph(file.dump, {
-      mode,
-      mergeConflictSkip: mode === "merge" ? SINGLETON_AND_AUTH : undefined,
-    });
+      await restoreSubgraphInTransaction(tx, file.dump, {
+        mode,
+        mergeConflictSkip: mode === "merge" ? SINGLETON_AND_AUTH : undefined,
+      });
 
-    if (!bundle) return;
+      if (bundle) {
+        // Group secret entries by row so a row with several secret columns
+        // (backup_destination, servers) gets one UPDATE.
+        type RowPatch = {
+          spec: SecretColumn;
+          entries: Array<{ spec: SecretColumn; entry: SecretEntry }>;
+        };
+        const rows = new Map<string, RowPatch>();
+        for (const entry of bundle.entries) {
+          if (mode === "merge" && !newIds?.get(entry.table)?.has(entry.id)) continue;
+          const spec = SECRET_SPEC_BY_KEY.get(`${entry.table}.${entry.column}`);
+          if (!spec) continue;
+          const key = `${entry.table}::${entry.id}`;
+          const patch = rows.get(key) ?? { spec, entries: [] };
+          patch.entries.push({ spec, entry });
+          rows.set(key, patch);
+        }
 
-    // Group secret entries by row so a row with several secret columns
-    // (backup_destination, servers) gets one UPDATE.
-    const specByKey = new Map<string, SecretColumn>();
-    for (const spec of SECRET_COLUMNS) specByKey.set(`${spec.sqlName}.${spec.column}`, spec);
+        for (const { spec: rowSpec, entries } of rows.values()) {
+          const id = entries[0]!.entry.id;
 
-    type RowPatch = { spec: SecretColumn; entries: Array<{ spec: SecretColumn; entry: SecretEntry }> };
-    const rows = new Map<string, RowPatch>();
-    for (const entry of bundle.entries) {
-      if (mode === "merge" && !newIds?.get(entry.table)?.has(entry.id)) continue;
-      const spec = specByKey.get(`${entry.table}.${entry.column}`);
-      if (!spec) continue;
-      const key = `${entry.table}::${entry.id}`;
-      const patch = rows.get(key) ?? { spec, entries: [] };
-      patch.entries.push({ spec, entry });
-      rows.set(key, patch);
-    }
+          // notification-config re-hydration merges secrets back into the
+          // restored (scrubbed) config, so read it first.
+          let currentCell: unknown;
+          if (entries.some((e) => e.spec.scheme === "notification-config")) {
+            const [current] = (await tx
+              .select()
+              .from(rowSpec.table)
+              .where(eq(rowSpec.pk, id))
+              .limit(1)) as Array<Record<string, unknown>>;
+            currentCell =
+              current?.[entries.find((e) => e.spec.scheme === "notification-config")!.spec.column];
+          }
 
-    await db.transaction(async (tx) => {
-      for (const { spec: rowSpec, entries } of rows.values()) {
-        const id = entries[0]!.entry.id;
-
-        // notification-config re-hydration merges secrets back into the
-        // restored (scrubbed) config, so read it first.
-        let currentCell: unknown;
-        if (entries.some((e) => e.spec.scheme === "notification-config")) {
-          const [current] = (await tx
-            .select()
-            .from(rowSpec.table)
+          const set: Record<string, unknown> = {};
+          for (const { spec, entry } of entries) {
+            set[spec.column] = sealForInstance(spec, entry, currentCell);
+          }
+          const updated = await tx
+            .update(rowSpec.table)
+            .set(set)
             .where(eq(rowSpec.pk, id))
-            .limit(1)) as Array<Record<string, unknown>>;
-          currentCell = current?.[entries.find((e) => e.spec.scheme === "notification-config")!.spec.column];
+            .returning();
+          if (updated.length > 0) secretsRehydrated += 1;
         }
-
-        const set: Record<string, unknown> = {};
-        for (const { spec, entry } of entries) {
-          set[spec.column] = sealForInstance(spec, entry, currentCell);
-        }
-        await tx.update(rowSpec.table).set(set).where(eq(rowSpec.pk, id));
-        secretsRehydrated += 1;
       }
+
+      await opts.onBeforeCommit?.(tx, {
+        mode,
+        rowsRestored,
+        secretsRehydrated,
+        secretsSkipped,
+        localPathProjects,
+      });
     });
   });
 

--- a/apps/api/src/modules/system/data-transfer/json-chunks.test.ts
+++ b/apps/api/src/modules/system/data-transfer/json-chunks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { jsonByteChunks } from "./json-chunks";
+
+describe("jsonByteChunks", () => {
+  it("matches JSON.stringify while keeping every emitted chunk bounded", () => {
+    const value = {
+      date: new Date("2026-01-02T03:04:05.000Z"),
+      rows: [
+        { id: "one", log: "🙂\\n".repeat(80) },
+        { id: "two", omitted: undefined, finite: Number.NaN },
+        undefined,
+      ],
+    };
+    const chunks = [...jsonByteChunks(value, 97)];
+
+    expect(chunks.length).toBeGreaterThan(2);
+    expect(chunks.every((chunk) => chunk.byteLength <= 97)).toBe(true);
+    expect(Buffer.concat(chunks).toString("utf8")).toBe(JSON.stringify(value));
+  });
+
+  it("does not allocate one fragment for a large string", () => {
+    const chunks = [...jsonByteChunks({ log: "x".repeat(1_000_000) }, 64_000)];
+    expect(chunks.length).toBeGreaterThan(10);
+    expect(JSON.parse(Buffer.concat(chunks).toString("utf8"))).toEqual({
+      log: "x".repeat(1_000_000),
+    });
+  });
+
+  it("matches JSON.stringify toJSON and omission semantics", () => {
+    const selfReturning = {
+      value: 42,
+      toJSON() {
+        return this;
+      },
+    };
+    const value = {
+      selfReturning,
+      omitted: { toJSON: () => undefined },
+      array: [{ toJSON: () => undefined }],
+    };
+    expect(Buffer.concat([...jsonByteChunks(value, 7)]).toString("utf8")).toBe(
+      JSON.stringify(value),
+    );
+    expect([...jsonByteChunks(undefined, 7)]).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/system/data-transfer/json-chunks.ts
+++ b/apps/api/src/modules/system/data-transfer/json-chunks.ts
@@ -1,0 +1,117 @@
+/** Bounded JSON encoding used by direct transfer.
+ *
+ * `JSON.stringify(wholeDump)` briefly duplicates the entire instance in memory.
+ * This encoder preserves JSON.stringify semantics for transfer payloads while
+ * yielding fixed-size UTF-8 chunks. Large string cells (notably build logs) are
+ * escaped in slices, so one oversized row cannot recreate the same spike.
+ */
+
+const STRING_SLICE_CHARS = 64 * 1024;
+
+function omitted(value: unknown): boolean {
+  return value === undefined || typeof value === "function" || typeof value === "symbol";
+}
+
+function* stringFragments(value: string): Generator<string> {
+  yield '"';
+  for (let start = 0; start < value.length; ) {
+    let end = Math.min(value.length, start + STRING_SLICE_CHARS);
+    // Never split a UTF-16 surrogate pair between independently escaped slices.
+    if (end < value.length) {
+      const last = value.charCodeAt(end - 1);
+      if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+    }
+    const encoded = JSON.stringify(value.slice(start, end));
+    yield encoded.slice(1, -1);
+    start = end;
+  }
+  yield '"';
+}
+
+function applyToJSON(value: unknown, key: string): unknown {
+  if (value && typeof value === "object") {
+    const toJSON = (value as { toJSON?: (key: string) => unknown }).toJSON;
+    if (typeof toJSON === "function") return toJSON.call(value, key);
+  }
+  return value;
+}
+
+/** Serialize a value after its own toJSON hook has already run. */
+function* fragments(value: unknown, seen: WeakSet<object>): Generator<string> {
+  if (typeof value === "string") {
+    yield* stringFragments(value);
+    return;
+  }
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    yield JSON.stringify(value);
+    return;
+  }
+  if (typeof value === "bigint") {
+    // Match JSON.stringify rather than silently changing database values.
+    throw new TypeError("Do not know how to serialize a BigInt");
+  }
+  if (omitted(value)) {
+    yield "null";
+    return;
+  }
+
+  const object = value as object;
+  if (seen.has(object)) throw new TypeError("Converting circular structure to JSON");
+
+  seen.add(object);
+  try {
+    if (Array.isArray(value)) {
+      yield "[";
+      for (let i = 0; i < value.length; i += 1) {
+        if (i > 0) yield ",";
+        const item = applyToJSON(value[i], String(i));
+        yield* fragments(omitted(item) ? null : item, seen);
+      }
+      yield "]";
+      return;
+    }
+
+    yield "{";
+    let first = true;
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      const item = applyToJSON((value as Record<string, unknown>)[key], key);
+      if (omitted(item)) continue;
+      if (!first) yield ",";
+      first = false;
+      yield JSON.stringify(key);
+      yield ":";
+      yield* fragments(item, seen);
+    }
+    yield "}";
+  } finally {
+    seen.delete(object);
+  }
+}
+
+export function* jsonByteChunks(value: unknown, maxBytes: number): Generator<Buffer> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new TypeError("maxBytes must be a positive safe integer");
+  }
+  let parts: Buffer[] = [];
+  let buffered = 0;
+  const root = applyToJSON(value, "");
+  if (omitted(root)) return;
+
+  for (const fragment of fragments(root, new WeakSet())) {
+    let bytes = Buffer.from(fragment, "utf8");
+    while (bytes.length > 0) {
+      const available = maxBytes - buffered;
+      const take = Math.min(available, bytes.length);
+      parts.push(bytes.subarray(0, take));
+      buffered += take;
+      bytes = bytes.subarray(take);
+      if (buffered === maxBytes) {
+        yield Buffer.concat(parts, buffered);
+        parts = [];
+        buffered = 0;
+      }
+    }
+  }
+
+  if (buffered > 0) yield Buffer.concat(parts, buffered);
+}

--- a/apps/api/src/modules/system/data-transfer/staged-payload.ts
+++ b/apps/api/src/modules/system/data-transfer/staged-payload.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, open, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  assertCompleteChunkSet,
+  listChunkMetadata,
+  MAX_TRANSFER_BYTES,
+  readChunk,
+  type TransferSessionRow,
+} from "./chunk-store";
+
+export interface StagedPayloadManifest {
+  totalChunks: number;
+  totalBytes: number;
+  sha256?: string;
+}
+
+/**
+ * Reassemble a staged upload with constant chunk memory, validating its complete
+ * ordered byte stream before JSON parsing. JSON.parse still needs one final
+ * in-memory document because the existing atomic DB restore consumes a coherent
+ * DatabaseDump; request/encryption/base64 copies no longer coexist with it.
+ */
+export async function readStagedJson(
+  session: TransferSessionRow,
+  manifest: StagedPayloadManifest,
+  decode: (chunk: Uint8Array, index: number) => Uint8Array,
+): Promise<unknown> {
+  if (
+    !Number.isSafeInteger(manifest.totalBytes) ||
+    manifest.totalBytes <= 0 ||
+    manifest.totalBytes > MAX_TRANSFER_BYTES ||
+    (manifest.sha256 !== undefined && !/^[a-f0-9]{64}$/.test(manifest.sha256))
+  ) {
+    throw new Error("The staged transfer manifest is invalid.");
+  }
+
+  const metadata = await listChunkMetadata(session.id);
+  assertCompleteChunkSet(metadata, manifest.totalChunks);
+
+  const dir = await mkdtemp(join(tmpdir(), "openship-transfer-"));
+  const path = join(dir, "payload.json");
+  const handle = await open(path, "wx", 0o600);
+  const hash = createHash("sha256");
+  let bytesWritten = 0;
+
+  try {
+    for (let index = 0; index < manifest.totalChunks; index += 1) {
+      const staged = await readChunk(session.id, index);
+      if (!staged) throw new Error(`Transfer chunk ${index} disappeared during finalization.`);
+      const plaintext = Buffer.from(decode(staged, index));
+      bytesWritten += plaintext.byteLength;
+      if (bytesWritten > MAX_TRANSFER_BYTES)
+        throw new Error("The staged transfer exceeds the size limit.");
+      hash.update(plaintext);
+      let offset = 0;
+      while (offset < plaintext.byteLength) {
+        const written = await handle.write(plaintext, offset, plaintext.byteLength - offset);
+        if (written.bytesWritten <= 0) {
+          throw new Error("The staged transfer could not be written to temporary storage.");
+        }
+        offset += written.bytesWritten;
+      }
+    }
+    await handle.sync();
+    await handle.close();
+
+    if (bytesWritten !== manifest.totalBytes) {
+      throw new Error(
+        `Transfer size mismatch: received ${bytesWritten} bytes, expected ${manifest.totalBytes}.`,
+      );
+    }
+    if (manifest.sha256 && hash.digest("hex") !== manifest.sha256) {
+      throw new Error("The complete transfer checksum does not match.");
+    }
+
+    return JSON.parse(await readFile(path, "utf8")) as unknown;
+  } finally {
+    await handle.close().catch(() => undefined);
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/apps/api/src/modules/system/system.routes.ts
+++ b/apps/api/src/modules/system/system.routes.ts
@@ -31,6 +31,10 @@ import * as serverModules from "./server-modules.controller";
 import * as serverContainers from "./server-containers.controller";
 import * as migration from "./migration/migration.controller";
 import * as dataTransfer from "./data-transfer/data-transfer.controller";
+import {
+  TRANSFER_CHUNK_BYTES,
+  TRANSFER_CONTROL_BODY_BYTES,
+} from "./data-transfer/chunk-store";
 import * as systemHealth from "./system-health.controller";
 import * as edgeOrphans from "./edge-orphans.controller";
 
@@ -38,6 +42,15 @@ const r = secureRouter(new Hono(), {
   module: "system",
   basePath: "/api/system",
   localOnly: true,
+});
+
+const transferControlBodyLimit = bodyLimit({
+  maxSize: TRANSFER_CONTROL_BODY_BYTES,
+  onError: (c) =>
+    c.json(
+      { error: "Transfer control request exceeds the size limit.", code: "PAYLOAD_TOO_LARGE" },
+      413,
+    ),
 });
 
 
@@ -288,8 +301,53 @@ r.post("/migration/switch-back", { tag: "settings:admin" }, requireInstanceAdmin
  * own personal org (GHSA-rwq6-r63g-3c8h). Do not "restore" it here.
  */
 r.get("/data-transfer/preview", { tag: "settings:admin" }, requireInstanceAdmin(), dataTransfer.previewInstanceExportHandler);
-r.post("/data-transfer/direct/session", { tag: "settings:admin" }, requireInstanceAdmin(), dataTransfer.createDirectReceiveSessionHandler);
-r.post("/data-transfer/direct/send", { tag: "settings:admin" }, requireInstanceAdmin(), dataTransfer.sendDirectTransferHandler);
+r.post("/data-transfer/direct/session", { tag: "settings:admin" }, requireInstanceAdmin(), transferControlBodyLimit, dataTransfer.createDirectReceiveSessionHandler);
+r.post("/data-transfer/direct/send", { tag: "settings:admin" }, requireInstanceAdmin(), transferControlBodyLimit, dataTransfer.sendDirectTransferHandler);
+r.post("/data-transfer/direct/send/stream", { tag: "settings:admin" }, requireInstanceAdmin(), transferControlBodyLimit, dataTransfer.sendDirectTransferStreamHandler);
+r.public(
+  "post",
+  "/data-transfer/direct/chunk/init",
+  {
+    reason: "Initializes an encrypted upload using the one-time receive capability.",
+    rateLimit: "auth-tight",
+  },
+  transferControlBodyLimit,
+  dataTransfer.initializeDirectChunkUploadHandler,
+);
+r.public(
+  "post",
+  "/data-transfer/direct/chunk/:sessionId/heartbeat",
+  {
+    reason: "Extends an authenticated in-progress direct-transfer lease.",
+    rateLimit: "transfer-chunk",
+  },
+  transferControlBodyLimit,
+  dataTransfer.heartbeatDirectChunkUploadHandler,
+);
+r.public(
+  "put",
+  "/data-transfer/direct/chunk/:sessionId/:index",
+  {
+    reason: "Accepts one bounded, encrypted, signed direct-transfer chunk.",
+    rateLimit: "transfer-chunk",
+  },
+  bodyLimit({
+    maxSize: TRANSFER_CHUNK_BYTES + 64,
+    onError: (c) =>
+      c.json({ error: "Transfer chunk exceeds the size limit.", code: "PAYLOAD_TOO_LARGE" }, 413),
+  }),
+  dataTransfer.receiveDirectChunkHandler,
+);
+r.public(
+  "post",
+  "/data-transfer/direct/chunk/:sessionId/finalize/stream",
+  {
+    reason: "Keeps an authenticated direct-transfer restore alive through proxy timeouts.",
+    rateLimit: "auth-tight",
+  },
+  transferControlBodyLimit,
+  dataTransfer.finalizeDirectChunkUploadStreamHandler,
+);
 r.public(
   "post",
   "/data-transfer/direct/receive",
@@ -303,7 +361,26 @@ r.public(
   }),
   dataTransfer.receiveDirectTransferHandler,
 );
-r.post("/data-transfer/export", { tag: "settings:admin" }, requireInstanceAdmin(), dataTransfer.exportInstanceHandler);
+r.post("/data-transfer/export", { tag: "settings:admin" }, requireInstanceAdmin(), transferControlBodyLimit, dataTransfer.exportInstanceHandler);
+r.post("/data-transfer/import/session", { tag: "settings:admin" }, requireInstanceAdmin(), transferControlBodyLimit, dataTransfer.createFileUploadHandler);
+r.put(
+  "/data-transfer/import/session/:sessionId/chunk/:index",
+  { tag: "settings:admin" },
+  requireInstanceAdmin(),
+  bodyLimit({
+    maxSize: TRANSFER_CHUNK_BYTES,
+    onError: (c) =>
+      c.json({ error: "Import chunk exceeds the size limit.", code: "PAYLOAD_TOO_LARGE" }, 413),
+  }),
+  dataTransfer.uploadFileChunkHandler,
+);
+r.post(
+  "/data-transfer/import/session/:sessionId/finalize/stream",
+  { tag: "settings:admin" },
+  requireInstanceAdmin(),
+  transferControlBodyLimit,
+  dataTransfer.finalizeFileUploadStreamHandler,
+);
 r.use(
   "/data-transfer/import",
   bodyLimit({

--- a/apps/api/test/modules/data-transfer.test.ts
+++ b/apps/api/test/modules/data-transfer.test.ts
@@ -1,4 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  createHash,
+  createHmac,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+} from "node:crypto";
+import { db, eq, schema } from "@repo/db";
 
 // Skip the full zod-validated env (which refuses to load outside desktop mode
 // without INTERNAL_TOKEN); the crypto helpers only need BETTER_AUTH_SECRET.
@@ -6,7 +15,7 @@ vi.mock("../../src/config/env", () => ({
   env: { BETTER_AUTH_SECRET: "test-secret-for-data-transfer-unit-tests", CLOUD_MODE: false },
 }));
 
-import { encrypt, decrypt } from "../../src/lib/encryption";
+import { decrypt, encrypt, encryptBytesWithKey, encryptWithKey } from "../../src/lib/encryption";
 import { encryptSecretField, decryptSecretField } from "../../src/lib/credential-encryption";
 import {
   sealSecretBundle,
@@ -14,8 +23,14 @@ import {
   openTransferSecrets,
   WrongPassphraseError,
 } from "../../src/modules/system/data-transfer/passphrase-crypto";
-import { extractPlaintext, sealForInstance } from "../../src/modules/system/data-transfer/secret-codec";
-import { SECRET_COLUMNS, type SecretColumn } from "../../src/modules/system/data-transfer/secret-registry";
+import {
+  extractPlaintext,
+  sealForInstance,
+} from "../../src/modules/system/data-transfer/secret-codec";
+import {
+  SECRET_COLUMNS,
+  type SecretColumn,
+} from "../../src/modules/system/data-transfer/secret-registry";
 import {
   EXPORT_HISTORY_CATEGORIES,
   HISTORY_TABLES,
@@ -29,23 +44,81 @@ import {
   createDirectReceiveSession,
   decodeDirectTransferCode,
   DirectTransferSessionError,
+  encodeDirectTransferCode,
+  finalizeDirectChunkUpload,
+  initializeDirectChunkUpload,
   receiveDirectTransfer,
+  receiveDirectChunk,
   sealDirectTransferPayload,
   sendDirectTransfer,
 } from "../../src/modules/system/data-transfer/direct-transfer.service";
-import { importPreparedInstance, InvalidTransferFileError } from "../../src/modules/system/data-transfer/import.service";
-import type { DataTransferFile, DirectTransferPayload } from "../../src/modules/system/data-transfer/types";
-
+import {
+  claimSession,
+  getSession,
+  listChunkMetadata,
+  releaseSessionClaim,
+  sha256Hex,
+  TransferStoreError,
+} from "../../src/modules/system/data-transfer/chunk-store";
+import {
+  createFileUpload,
+  finalizeFileUpload,
+  uploadFileChunk,
+} from "../../src/modules/system/data-transfer/file-upload.service";
+import {
+  importPreparedInstance,
+  InvalidTransferFileError,
+} from "../../src/modules/system/data-transfer/import.service";
+import type {
+  DataTransferFile,
+  DirectTransferConnection,
+  DirectTransferPayload,
+} from "../../src/modules/system/data-transfer/types";
 // The codec only reads scheme/secretPaths/sqlName/column, so a minimal cast is
 // enough to exercise it without touching the DB-backed registry.
-function spec(scheme: SecretColumn["scheme"], column: string, secretPaths?: string[]): SecretColumn {
-  return { sqlName: "t", table: {} as never, pk: {} as never, column, scheme, secretPaths } as SecretColumn;
+function spec(
+  scheme: SecretColumn["scheme"],
+  column: string,
+  secretPaths?: string[],
+): SecretColumn {
+  return {
+    sqlName: "t",
+    table: {} as never,
+    pk: {} as never,
+    column,
+    scheme,
+    secretPaths,
+  } as SecretColumn;
+}
+
+const DIRECT_KEY_CONTEXT = Buffer.from("openship-direct-transfer-v1", "utf8");
+
+function testSender(connection: DirectTransferConnection) {
+  const recipientPublicKey = createPublicKey({
+    key: Buffer.from(connection.recipientPublicKey, "base64"),
+    format: "der",
+    type: "spki",
+  });
+  const { publicKey, privateKey } = generateKeyPairSync("x25519");
+  const shared = diffieHellman({ privateKey, publicKey: recipientPublicKey });
+  return {
+    key: Buffer.from(
+      hkdfSync("sha256", shared, Buffer.from(connection.sessionId, "utf8"), DIRECT_KEY_CONTEXT, 32),
+    ),
+    publicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+  };
+}
+
+function testSignature(key: Buffer, value: string): string {
+  return createHmac("sha256", key).update(value).digest("hex");
 }
 
 describe("passphrase-crypto", () => {
   const bundle: SecretBundle = {
     version: 1,
-    entries: [{ table: "env_var", id: "env_1", column: "value", scheme: "scalar", value: "top-secret" }],
+    entries: [
+      { table: "env_var", id: "env_1", column: "value", scheme: "scalar", value: "top-secret" },
+    ],
   };
 
   it("round-trips with the correct passphrase", () => {
@@ -71,9 +144,12 @@ describe("passphrase-crypto", () => {
 });
 
 describe("one-time direct instance transfer", () => {
-  it("creates a decodable, expiring destination capability", () => {
-    clearDirectReceiveSessionsForTest();
-    const created = createDirectReceiveSession({ apiBase: "https://new.example/api/", mode: "wipe" });
+  it("creates a decodable, expiring destination capability", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "wipe",
+    });
     const decoded = decodeDirectTransferCode(created.code);
     expect(decoded.apiBase).toBe("https://new.example/api/");
     expect(decoded.mode).toBe("wipe");
@@ -81,9 +157,29 @@ describe("one-time direct instance transfer", () => {
     expect(Date.parse(decoded.expiresAt)).toBeGreaterThan(Date.now());
   });
 
+  it("lets the destination authoritatively validate a renewed lease", () => {
+    const code = encodeDirectTransferCode({
+      version: 1,
+      apiBase: "https://new.example/api/",
+      recipientRuntimeId: "remote-runtime-id-0000000000000000",
+      sessionId: "session-id",
+      token: "x".repeat(43),
+      recipientPublicKey: "public-key",
+      mode: "merge",
+      // An in-progress destination session may have renewed beyond this initial
+      // timestamp; decode must not prevent the request from reaching it.
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    expect(decodeDirectTransferCode(code).sessionId).toBe("session-id");
+  });
+
   it("authenticates and decrypts once, then consumes the receive code", async () => {
-    clearDirectReceiveSessionsForTest();
-    const created = createDirectReceiveSession({ apiBase: "https://new.example/api/", mode: "wipe" });
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "wipe",
+    });
     const connection = decodeDirectTransferCode(created.code);
     const payload: DirectTransferPayload = {
       version: 1,
@@ -100,8 +196,11 @@ describe("one-time direct instance transfer", () => {
   });
 
   it("rejects a payload that does not know the capability token", async () => {
-    clearDirectReceiveSessionsForTest();
-    const created = createDirectReceiveSession({ apiBase: "https://new.example/api/", mode: "merge" });
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
     const connection = decodeDirectTransferCode(created.code);
     const envelope = sealDirectTransferPayload(connection, {
       version: 1,
@@ -112,10 +211,355 @@ describe("one-time direct instance transfer", () => {
     await expect(receiveDirectTransfer(envelope)).rejects.toThrow(DirectTransferSessionError);
   });
 
-  it("refuses a receive code generated by the same instance before building a dump", async () => {
-    clearDirectReceiveSessionsForTest();
-    const created = createDirectReceiveSession({ apiBase: "https://same.example/api/", mode: "wipe" });
-    await expect(sendDirectTransfer({ code: created.code })).rejects.toThrow("same instance");
+  it("refuses a receive code owned by the same database even across API workers", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://same.example/api/",
+      mode: "wipe",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const differentWorkerCode = encodeDirectTransferCode({
+      ...connection,
+      recipientRuntimeId: "other-worker-runtime-000000000000",
+    });
+    await expect(sendDirectTransfer({ code: differentWorkerCode })).rejects.toThrow(
+      "same instance",
+    );
+  });
+
+  it("uses bounded chunks and safely retries an ambiguous finalization", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const code = encodeDirectTransferCode({
+      ...connection,
+      recipientRuntimeId: "remote-runtime-id-0000000000000000",
+    });
+    // The HTTP destination is mocked below; remove the locally-created fixture
+    // so the durable same-instance guard correctly treats it as remote.
+    await clearDirectReceiveSessionsForTest();
+    const requests: Array<{ url: URL; init: RequestInit }> = [];
+    let finalizeAttempts = 0;
+    const fetchImpl = (async (input: string | URL | Request, init: RequestInit = {}) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      requests.push({ url, init });
+      if (url.pathname.endsWith("/finalize/stream")) {
+        finalizeAttempts += 1;
+        if (finalizeAttempts === 1) throw new TypeError("socket closed after commit");
+        return new Response(
+          `: ok\n\nevent: complete\ndata: ${JSON.stringify({
+            mode: "merge",
+            rowsRestored: 0,
+            secretsRehydrated: 0,
+            secretsSkipped: true,
+            localPathProjects: [],
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const result = await sendDirectTransfer({ code, fetchImpl });
+
+    expect(result.destination).toBe("https://new.example");
+    expect(requests[0]?.url.pathname).toBe("/api/system/data-transfer/direct/chunk/init");
+    expect(String(requests[0]?.init.body)).not.toContain(connection.token);
+    const uploads = requests.filter(({ init }) => init.method === "PUT");
+    expect(uploads.length).toBeGreaterThan(0);
+    expect(
+      uploads.every(({ init }) => Buffer.from(init.body as Uint8Array).byteLength <= 8_000_032),
+    ).toBe(true);
+    expect(requests.at(-1)?.url.pathname).toContain("/finalize");
+    expect(finalizeAttempts).toBe(2);
+    expect(requests.some(({ url }) => url.pathname.endsWith("/direct/receive"))).toBe(false);
+  });
+
+  it("persists the receive capability and keeps a premature chunk finalize resumable", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const sender = testSender(connection);
+    const proof = encryptWithKey(
+      sender.key,
+      JSON.stringify({
+        version: 1,
+        sessionId: connection.sessionId,
+        mode: connection.mode,
+        authorizationToken: connection.token,
+      }),
+    );
+
+    await initializeDirectChunkUpload({
+      version: 1,
+      sessionId: connection.sessionId,
+      mode: connection.mode,
+      senderPublicKey: sender.publicKey,
+      proof,
+    });
+    expect(await getSession(connection.sessionId)).toMatchObject({
+      kind: "direct",
+      status: "uploading",
+      senderPublicKey: sender.publicKey,
+    });
+
+    const plaintext = Buffer.from(
+      JSON.stringify({
+        version: 1,
+        authorizationToken: connection.token,
+        file: { kind: "bad" },
+        secrets: null,
+      } as unknown as DirectTransferPayload),
+      "utf8",
+    );
+    const splitAt = Math.floor(plaintext.byteLength / 2);
+    const chunks = [plaintext.subarray(0, splitAt), plaintext.subarray(splitAt)];
+    const encryptedChunks = chunks.map((chunk) => encryptBytesWithKey(sender.key, chunk));
+
+    const upload = async (index: number) => {
+      const ciphertext = encryptedChunks[index]!;
+      const digest = sha256Hex(ciphertext);
+      await receiveDirectChunk({
+        sessionId: connection.sessionId,
+        index,
+        sha256: digest,
+        signature: testSignature(sender.key, `chunk:${connection.sessionId}:${index}:${digest}`),
+        readBytes: async () => ciphertext,
+      });
+    };
+    await upload(0);
+    await upload(0); // an identical retry is idempotent
+
+    const manifestBase = {
+      totalChunks: chunks.length,
+      totalBytes: plaintext.byteLength,
+      sha256: createHash("sha256").update(plaintext).digest("hex"),
+    };
+    const manifest = {
+      ...manifestBase,
+      signature: testSignature(
+        sender.key,
+        `finalize:${connection.sessionId}:${manifestBase.totalChunks}:${manifestBase.totalBytes}:${manifestBase.sha256}`,
+      ),
+    };
+    await expect(finalizeDirectChunkUpload(connection.sessionId, manifest)).rejects.toMatchObject({
+      code: "MISSING_CHUNK",
+    } satisfies Partial<TransferStoreError>);
+    expect((await getSession(connection.sessionId))?.status).toBe("uploading");
+
+    await upload(1);
+    await expect(finalizeDirectChunkUpload(connection.sessionId, manifest)).rejects.toThrow(
+      InvalidTransferFileError,
+    );
+    expect((await getSession(connection.sessionId))?.status).toBe("failed");
+  });
+
+  it("binds the destructive restore mode to the destination session", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const sender = testSender(connection);
+
+    await expect(
+      initializeDirectChunkUpload({
+        version: 1,
+        sessionId: connection.sessionId,
+        mode: "wipe",
+        senderPublicKey: sender.publicKey,
+        proof: encryptWithKey(
+          sender.key,
+          JSON.stringify({
+            version: 1,
+            sessionId: connection.sessionId,
+            mode: "wipe",
+            authorizationToken: connection.token,
+          }),
+        ),
+      }),
+    ).rejects.toThrow(DirectTransferSessionError);
+    expect((await getSession(connection.sessionId))?.status).toBe("ready");
+  });
+
+  it("lets an authenticated source restart with a fresh key without mixing chunks", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const first = testSender(connection);
+    const second = testSender(connection);
+    const initialize = (sender: ReturnType<typeof testSender>) =>
+      initializeDirectChunkUpload({
+        version: 1,
+        sessionId: connection.sessionId,
+        mode: connection.mode,
+        senderPublicKey: sender.publicKey,
+        proof: encryptWithKey(
+          sender.key,
+          JSON.stringify({
+            version: 1,
+            sessionId: connection.sessionId,
+            mode: connection.mode,
+            authorizationToken: connection.token,
+          }),
+        ),
+      });
+
+    await initialize(first);
+    const ciphertext = encryptBytesWithKey(first.key, Buffer.from("first attempt"));
+    const digest = sha256Hex(ciphertext);
+    await receiveDirectChunk({
+      sessionId: connection.sessionId,
+      index: 0,
+      sha256: digest,
+      signature: testSignature(first.key, `chunk:${connection.sessionId}:0:${digest}`),
+      readBytes: async () => ciphertext,
+    });
+    expect(await listChunkMetadata(connection.sessionId)).toHaveLength(1);
+
+    await initialize(second);
+    expect(await getSession(connection.sessionId)).toMatchObject({
+      status: "uploading",
+      senderPublicKey: second.publicKey,
+    });
+    expect(await listChunkMetadata(connection.sessionId)).toEqual([]);
+  });
+
+  it("recovers an abandoned finalizer lease without letting the old worker win", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const upload = await createFileUpload({ ownerUserId: "user_1", size: 4 });
+    const writable = await getSession(upload.uploadId);
+    const abandoned = await claimSession(writable!);
+
+    await db
+      .update(schema.dataTransferSession)
+      .set({ expiresAt: new Date(Date.now() - 1) })
+      .where(eq(schema.dataTransferSession.id, upload.uploadId));
+
+    const recovered = await getSession(upload.uploadId);
+    expect(recovered).toMatchObject({ status: "uploading", claimToken: null });
+    const replacement = await claimSession(recovered!);
+    expect(replacement.claimToken).not.toBe(abandoned.claimToken);
+
+    // A late catch/finally from the dead worker must not release the new claim.
+    await releaseSessionClaim(abandoned);
+    expect(await getSession(upload.uploadId)).toMatchObject({
+      status: "consuming",
+      claimToken: replacement.claimToken,
+    });
+    await releaseSessionClaim(replacement);
+  });
+
+  it("returns a committed result when the source retries with the same receive code", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const result = {
+      mode: "merge" as const,
+      rowsRestored: 12,
+      secretsRehydrated: 3,
+      secretsSkipped: false,
+      localPathProjects: [],
+    };
+    await db
+      .update(schema.dataTransferSession)
+      .set({ status: "complete", result })
+      .where(eq(schema.dataTransferSession.id, connection.sessionId));
+
+    const sender = testSender(connection);
+    const initialized = await initializeDirectChunkUpload({
+      version: 1,
+      sessionId: connection.sessionId,
+      mode: connection.mode,
+      senderPublicKey: sender.publicKey,
+      proof: encryptWithKey(
+        sender.key,
+        JSON.stringify({
+          version: 1,
+          sessionId: connection.sessionId,
+          mode: connection.mode,
+          authorizationToken: connection.token,
+        }),
+      ),
+    });
+
+    expect(initialized.result).toEqual(result);
+  });
+
+  it("retains an authenticated file upload when finalization can be retried", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const bytes = Buffer.from(JSON.stringify({ kind: "not-an-openship-export" }), "utf8");
+    const upload = await createFileUpload({ ownerUserId: "user_1", size: bytes.byteLength });
+    await uploadFileChunk({
+      uploadId: upload.uploadId,
+      ownerUserId: "user_1",
+      index: 0,
+      sha256: sha256Hex(bytes),
+      readBytes: async () => bytes,
+    });
+
+    const finalize = () =>
+      finalizeFileUpload({
+        uploadId: upload.uploadId,
+        ownerUserId: "user_1",
+        mode: "merge",
+      });
+    await expect(finalize()).rejects.toThrow(InvalidTransferFileError);
+    expect((await getSession(upload.uploadId))?.status).toBe("uploading");
+    await expect(finalize()).rejects.toThrow(InvalidTransferFileError);
+  });
+
+  it("authenticates chunk metadata before reading a large request body", async () => {
+    await clearDirectReceiveSessionsForTest();
+    const created = await createDirectReceiveSession({
+      apiBase: "https://new.example/api/",
+      mode: "merge",
+    });
+    const connection = decodeDirectTransferCode(created.code);
+    const sender = testSender(connection);
+    await initializeDirectChunkUpload({
+      version: 1,
+      sessionId: connection.sessionId,
+      mode: connection.mode,
+      senderPublicKey: sender.publicKey,
+      proof: encryptWithKey(
+        sender.key,
+        JSON.stringify({
+          version: 1,
+          sessionId: connection.sessionId,
+          mode: connection.mode,
+          authorizationToken: connection.token,
+        }),
+      ),
+    });
+    const readBytes = vi.fn(async () => Buffer.alloc(8_000_000));
+
+    await expect(
+      receiveDirectChunk({
+        sessionId: connection.sessionId,
+        index: 0,
+        sha256: "0".repeat(64),
+        signature: "0".repeat(64),
+        readBytes,
+      }),
+    ).rejects.toThrow("signature");
+    expect(readBytes).not.toHaveBeenCalled();
   });
 
   it("validates a decrypted credential bundle before the first restore operation", async () => {
@@ -124,11 +568,35 @@ describe("one-time direct instance transfer", () => {
       envelopeVersion: 1,
       dump: { scope: { kind: "instance" }, tables: {} },
     } as unknown as DataTransferFile;
-    await expect(importPreparedInstance({
-      file,
-      secrets: { version: 1, entries: [{ table: "env_var", id: "1", column: "value", scheme: "scalar", value: 42 }] } as never,
-      mode: "wipe",
-    })).rejects.toThrow(InvalidTransferFileError);
+    await expect(
+      importPreparedInstance({
+        file,
+        secrets: {
+          version: 1,
+          entries: [{ table: "env_var", id: "1", column: "value", scheme: "scalar", value: 42 }],
+        } as never,
+        mode: "wipe",
+      }),
+    ).rejects.toThrow(InvalidTransferFileError);
+
+    await expect(
+      importPreparedInstance({
+        file,
+        secrets: {
+          version: 1,
+          entries: [
+            {
+              table: "env_var",
+              id: "1",
+              column: "value",
+              scheme: "map",
+              map: { VALUE: "secret" },
+            },
+          ],
+        },
+        mode: "wipe",
+      }),
+    ).rejects.toThrow("does not match the destination schema");
   });
 });
 
@@ -186,9 +654,10 @@ describe("secret-codec round-trips (extract → seal → decrypt)", () => {
 
 describe("server credential transfer coverage (#656)", () => {
   it("registers every SSH credential column for decrypt and destination re-encryption", () => {
-    const columns = SECRET_COLUMNS
-      .filter((entry) => entry.sqlName === "servers")
-      .map((entry) => [entry.column, entry.scheme]);
+    const columns = SECRET_COLUMNS.filter((entry) => entry.sqlName === "servers").map((entry) => [
+      entry.column,
+      entry.scheme,
+    ]);
 
     expect(columns).toEqual([
       ["sshPassword", "enc1"],
@@ -200,18 +669,20 @@ describe("server credential transfer coverage (#656)", () => {
 
 describe("dependency-safe export filtering (#656)", () => {
   it("summarizes core and each optional history group for the pre-export UI", () => {
-    expect(summarizeExportCounts({
-      project: 3,
-      servers: 2,
-      resource_usage: 100,
-      server_analytics: 20,
-      audit_event: 7,
-      notification_delivery: 4,
-      backup_run: 5,
-      backup_restore: 2,
-      service_incident: 6,
-      docker_migration_run: 1,
-    })).toEqual({
+    expect(
+      summarizeExportCounts({
+        project: 3,
+        servers: 2,
+        resource_usage: 100,
+        server_analytics: 20,
+        audit_event: 7,
+        notification_delivery: 4,
+        backup_run: 5,
+        backup_restore: 2,
+        service_incident: 6,
+        docker_migration_run: 1,
+      }),
+    ).toEqual({
       core: 5,
       history: { analytics: 120, activity: 11, backups: 7, incidents: 6, migrations: 1 },
       total: 150,
@@ -240,8 +711,8 @@ describe("dependency-safe export filtering (#656)", () => {
   });
 
   it("rejects arbitrary table/category input", () => {
-    expect(() =>
-      resolveExportSelection({ history: ["servers" as never] }),
-    ).toThrow(InvalidExportSelectionError);
+    expect(() => resolveExportSelection({ history: ["servers" as never] })).toThrow(
+      InvalidExportSelectionError,
+    );
   });
 });

--- a/apps/api/test/modules/system/instance-global-routes.test.ts
+++ b/apps/api/test/modules/system/instance-global-routes.test.ts
@@ -79,7 +79,11 @@ const INSTANCE_GLOBAL: Array<[string, string]> = [
   ["get", "/data-transfer/preview"],
   ["post", "/data-transfer/direct/session"],
   ["post", "/data-transfer/direct/send"],
+  ["post", "/data-transfer/direct/send/stream"],
   ["post", "/data-transfer/export"],
+  ["post", "/data-transfer/import/session"],
+  ["put", "/data-transfer/import/session/:sessionId/chunk/:index"],
+  ["post", "/data-transfer/import/session/:sessionId/finalize/stream"],
   ["post", "/data-transfer/import"],
 ];
 

--- a/apps/dashboard/src/app/(dashboard)/settings/_components/DataTransferTab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/_components/DataTransferTab.tsx
@@ -8,18 +8,28 @@
  * user sets on export and re-enters on import; the API re-encrypts them under
  * the destination install's own key.
  *
- * Owner gating is enforced by the API (requireRole("owner")); this component
- * renders nothing for non-owners so the Instance tab stays clean.
+ * Instance-admin gating is enforced by the API; this component renders nothing
+ * for non-owners so the Instance tab stays clean.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ArrowRightLeft, Clipboard, DatabaseBackup, Download, Upload, Loader2, Send, TriangleAlert } from "lucide-react";
+import {
+  ArrowRightLeft,
+  Clipboard,
+  DatabaseBackup,
+  Download,
+  Upload,
+  Loader2,
+  Send,
+  TriangleAlert,
+} from "lucide-react";
 
 import { SettingsSection } from "./SettingsSection";
 import { Modal } from "@/components/ui/Modal";
 import { useSession, authClient } from "@/lib/auth-client";
 import { useToast } from "@/context/ToastContext";
 import { useI18n, interpolate } from "@/components/i18n-provider";
+import { formatBytes } from "@/lib/formatBytes";
 import {
   dataTransferApi,
   getApiErrorMessage,
@@ -33,11 +43,13 @@ import {
 
 // Resolve the org client once (stable ref) — same guard TeamTab uses to avoid
 // an effect-recreation loop.
-const orgClient = (authClient as unknown as {
-  organization: {
-    listMembers: () => Promise<{ data?: { members?: Array<{ userId: string; role: string }> } }>;
-  };
-}).organization;
+const orgClient = (
+  authClient as unknown as {
+    organization: {
+      listMembers: () => Promise<{ data?: { members?: Array<{ userId: string; role: string }> } }>;
+    };
+  }
+).organization;
 
 export function DataTransferTab() {
   const { data: session } = useSession();
@@ -69,6 +81,11 @@ export function DataTransferTab() {
 
   return (
     <div className="space-y-6">
+      <div className="rounded-lg border border-warning-border bg-warning-bg px-3 py-2.5 text-xs leading-relaxed text-warning">
+        These tools move the Openship database and credentials. Persistent Docker volume contents
+        are not included; move service data with project/server migration or restore it from a
+        backup.
+      </div>
       <DirectTransferCard onToast={showToast} />
       <ExportCard onToast={showToast} />
       <ImportCard onToast={showToast} />
@@ -92,10 +109,15 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
 
   useEffect(() => {
     let cancelled = false;
-    dataTransferApi.preview()
-      .then((result) => { if (!cancelled) setPreview(result); })
+    dataTransferApi
+      .preview()
+      .then((result) => {
+        if (!cancelled) setPreview(result);
+      })
       .catch(() => undefined);
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const createCode = async () => {
@@ -106,7 +128,11 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
       setExpiresAt(result.expiresAt);
       onToast("Receive code created.", "success", "Direct transfer");
     } catch (err) {
-      onToast(getApiErrorMessage(err, "Could not create a receive code."), "error", "Direct transfer");
+      onToast(
+        getApiErrorMessage(err, "Could not create a receive code."),
+        "error",
+        "Direct transfer",
+      );
     } finally {
       setCreating(false);
     }
@@ -118,14 +144,20 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
       await navigator.clipboard.writeText(receiveCode);
       onToast("Receive code copied.", "success", "Direct transfer");
     } catch (err) {
-      onToast(getApiErrorMessage(err, "Could not copy the receive code."), "error", "Direct transfer");
+      onToast(
+        getApiErrorMessage(err, "Could not copy the receive code."),
+        "error",
+        "Direct transfer",
+      );
     }
   };
 
   const sendNow = async () => {
     const code = sendCode.trim();
     if (!code) return;
-    const rowText = preview ? ` ${preview.total.toLocaleString()} rows and all credentials will be sent.` : " All data and credentials will be sent.";
+    const rowText = preview
+      ? ` ${preview.total.toLocaleString()} rows and all credentials will be sent.`
+      : " All data and credentials will be sent.";
     const destinationText = destinationInfo
       ? `${destinationInfo.destination} (${destinationInfo.mode === "wipe" ? "replace everything" : "merge"})`
       : "the destination in the receive code";
@@ -156,31 +188,40 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
     <SettingsSection
       icon={ArrowRightLeft}
       title="Move directly to another instance"
-      description="Transfer everything securely without downloading a file or managing an encryption password."
+      description="Transfer the Openship database and credentials securely without downloading a file or managing an encryption password."
       iconBg="bg-primary/10"
       iconColor="text-primary"
     >
       <div className="space-y-4">
         <div className="rounded-lg border border-primary/25 bg-primary/[0.04] px-3 py-2.5 text-xs leading-relaxed text-muted-foreground">
-          Start on the destination and generate a one-time receive code. Paste that code on the source instance. The code expires after 10 minutes, works once, and credentials are re-encrypted automatically for the destination.
+          Start on the destination and generate a one-time receive code. Paste that code on the
+          source instance. The code expires after 10 minutes, works once, and credentials are
+          re-encrypted automatically for the destination.
         </div>
-
         <div className="grid gap-4 lg:grid-cols-2">
           <div className="space-y-3 rounded-xl border border-border/60 p-4">
             <div>
               <p className="text-sm font-semibold text-foreground">1. Receive on this instance</p>
-              <p className="mt-1 text-xs text-muted-foreground">Choose how incoming data should be restored, then copy the generated code.</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Choose how incoming data should be restored, then copy the generated code.
+              </p>
             </div>
             <div className="grid grid-cols-2 gap-2">
               <ModeOption
                 selected={receiveMode === "wipe"}
-                onSelect={() => { setReceiveMode("wipe"); setReceiveCode(""); }}
+                onSelect={() => {
+                  setReceiveMode("wipe");
+                  setReceiveCode("");
+                }}
                 title="Replace everything"
                 description="Best for a new destination."
               />
               <ModeOption
                 selected={receiveMode === "merge"}
-                onSelect={() => { setReceiveMode("merge"); setReceiveCode(""); }}
+                onSelect={() => {
+                  setReceiveMode("merge");
+                  setReceiveCode("");
+                }}
                 title="Merge"
                 description="Keep existing destination data."
               />
@@ -204,7 +245,8 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
                 />
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <span className="text-[11px] text-muted-foreground">
-                    Expires {new Date(expiresAt).toLocaleTimeString()}. Do not share it with anyone except the source instance.
+                    Expires {new Date(expiresAt).toLocaleTimeString()}. Do not share it with anyone
+                    except the source instance.
                   </span>
                   <button
                     type="button"
@@ -222,7 +264,10 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
             <div>
               <p className="text-sm font-semibold text-foreground">2. Send from this instance</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Paste the destination code. {preview ? `${preview.total.toLocaleString()} rows plus all credentials will move.` : "All rows and credentials will move."}
+                Paste the destination code.{" "}
+                {preview
+                  ? `${preview.total.toLocaleString()} rows plus all credentials will move.`
+                  : "All rows and credentials will move."}
               </p>
             </div>
             <textarea
@@ -233,17 +278,20 @@ export function DirectTransferCard({ onToast }: { onToast: Toast }) {
               aria-label="Destination receive code"
               className="h-32 w-full resize-none rounded-lg border border-border/60 bg-background p-3 font-mono text-[11px] leading-relaxed text-foreground outline-none focus:border-primary/60"
             />
-            {sendCode.trim() && (
-              destinationInfo ? (
+            {sendCode.trim() &&
+              (destinationInfo ? (
                 <div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-                  Destination: <span className="font-medium text-foreground">{destinationInfo.destination}</span>
-                  {" · "}{destinationInfo.mode === "wipe" ? "Replace everything" : "Merge with existing data"}
+                  Destination:{" "}
+                  <span className="font-medium text-foreground">{destinationInfo.destination}</span>
+                  {" · "}
+                  {destinationInfo.mode === "wipe"
+                    ? "Replace everything"
+                    : "Merge with existing data"}
                   {" · "}expires {new Date(destinationInfo.expiresAt).toLocaleTimeString()}
                 </div>
               ) : (
                 <p className="text-xs text-danger">This does not look like a valid receive code.</p>
-              )
-            )}
+              ))}
             <button
               type="button"
               onClick={() => void sendNow()}
@@ -271,10 +319,7 @@ function ExportCard({ onToast }: { onToast: Toast }) {
   const [previewFailed, setPreviewFailed] = useState(false);
   // Preserve restorable backup records and open-incident memory by default.
   // High-volume analytics/activity and completed migration logs are opt-in.
-  const [history, setHistory] = useState<ExportHistoryCategory[]>([
-    "backups",
-    "incidents",
-  ]);
+  const [history, setHistory] = useState<ExportHistoryCategory[]>(["backups", "incidents"]);
 
   // A non-empty passphrase must be confirmed; otherwise a typo (or a blank
   // confirmation) can create a secret bundle the operator can never reopen.
@@ -282,14 +327,17 @@ function ExportCard({ onToast }: { onToast: Toast }) {
 
   useEffect(() => {
     let cancelled = false;
-    dataTransferApi.preview()
+    dataTransferApi
+      .preview()
       .then((result) => {
         if (!cancelled) setPreview(result);
       })
       .catch(() => {
         if (!cancelled) setPreviewFailed(true);
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const selectedRows = preview
@@ -300,7 +348,10 @@ function ExportCard({ onToast }: { onToast: Toast }) {
     if (passphraseMismatch) return;
     setBusy(true);
     try {
-      const file = (await dataTransferApi.export(passphrase || undefined, history)) as DataTransferFile;
+      const file = (await dataTransferApi.export(
+        passphrase || undefined,
+        history,
+      )) as DataTransferFile;
       const blob = new Blob([JSON.stringify(file)], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -316,7 +367,11 @@ function ExportCard({ onToast }: { onToast: Toast }) {
         t.settings.common.toast.export,
       );
     } catch (err) {
-      onToast(getApiErrorMessage(err, t.settings.dataTransfer.export.toastFailed), "error", t.settings.common.toast.export);
+      onToast(
+        getApiErrorMessage(err, t.settings.dataTransfer.export.toastFailed),
+        "error",
+        t.settings.common.toast.export,
+      );
     } finally {
       setBusy(false);
     }
@@ -342,9 +397,17 @@ function ExportCard({ onToast }: { onToast: Toast }) {
     if (!passphrase) return;
     try {
       await navigator.clipboard.writeText(passphrase);
-      onToast(t.settings.dataTransfer.export.copiedTransferSecret, "success", t.settings.common.toast.export);
+      onToast(
+        t.settings.dataTransfer.export.copiedTransferSecret,
+        "success",
+        t.settings.common.toast.export,
+      );
     } catch (err) {
-      onToast(getApiErrorMessage(err, t.settings.dataTransfer.export.toastFailed), "error", t.settings.common.toast.export);
+      onToast(
+        getApiErrorMessage(err, t.settings.dataTransfer.export.toastFailed),
+        "error",
+        t.settings.common.toast.export,
+      );
     }
   };
 
@@ -363,25 +426,41 @@ function ExportCard({ onToast }: { onToast: Toast }) {
 
         <div>
           <div className="mb-2">
-            <p className="text-xs font-medium text-foreground">{t.settings.dataTransfer.export.filterTitle}</p>
-            <p className="text-xs text-muted-foreground">{t.settings.dataTransfer.export.filterDescription}</p>
+            <p className="text-xs font-medium text-foreground">
+              {t.settings.dataTransfer.export.filterTitle}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {t.settings.dataTransfer.export.filterDescription}
+            </p>
           </div>
           <div className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-lg bg-muted/30 px-3 py-2 text-xs">
             <span className="text-muted-foreground">
-              {t.settings.dataTransfer.export.coreRows}: {preview ? preview.core.toLocaleString() : previewFailed ? t.settings.dataTransfer.export.countUnavailable : "…"}
+              {t.settings.dataTransfer.export.coreRows}:{" "}
+              {preview
+                ? preview.core.toLocaleString()
+                : previewFailed
+                  ? t.settings.dataTransfer.export.countUnavailable
+                  : "…"}
             </span>
             <span className="font-medium text-foreground">
-              {t.settings.dataTransfer.export.selectedRows}: {selectedRows === null ? previewFailed ? t.settings.dataTransfer.export.countUnavailable : "…" : selectedRows.toLocaleString()}
+              {t.settings.dataTransfer.export.selectedRows}:{" "}
+              {selectedRows === null
+                ? previewFailed
+                  ? t.settings.dataTransfer.export.countUnavailable
+                  : "…"
+                : selectedRows.toLocaleString()}
             </span>
           </div>
           <div className="grid gap-2 sm:grid-cols-2">
-            {([
-              ["analytics", t.settings.dataTransfer.export.filterAnalytics],
-              ["activity", t.settings.dataTransfer.export.filterActivity],
-              ["backups", t.settings.dataTransfer.export.filterBackups],
-              ["incidents", t.settings.dataTransfer.export.filterIncidents],
-              ["migrations", t.settings.dataTransfer.export.filterMigrations],
-            ] as const).map(([category, label]) => (
+            {(
+              [
+                ["analytics", t.settings.dataTransfer.export.filterAnalytics],
+                ["activity", t.settings.dataTransfer.export.filterActivity],
+                ["backups", t.settings.dataTransfer.export.filterBackups],
+                ["incidents", t.settings.dataTransfer.export.filterIncidents],
+                ["migrations", t.settings.dataTransfer.export.filterMigrations],
+              ] as const
+            ).map(([category, label]) => (
               <label
                 key={category}
                 className="flex cursor-pointer items-center gap-2 rounded-lg border border-border/50 bg-muted/20 px-3 py-2 text-xs text-foreground"
@@ -465,7 +544,9 @@ function ExportCard({ onToast }: { onToast: Toast }) {
           className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
         >
           {busy ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
-          {busy ? t.settings.dataTransfer.export.exporting : t.settings.dataTransfer.export.exportDownload}
+          {busy
+            ? t.settings.dataTransfer.export.exporting
+            : t.settings.dataTransfer.export.exportDownload}
         </button>
       </div>
     </SettingsSection>
@@ -515,9 +596,10 @@ function ImportModal({
   onToast: Toast;
 }) {
   const { t } = useI18n();
-  const [file, setFile] = useState<DataTransferFile | null>(null);
-  const [fileName, setFileName] = useState("");
-  const [fileHasSecrets, setFileHasSecrets] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<{ done: number; total: number } | null>(
+    null,
+  );
   const [passphrase, setPassphrase] = useState("");
   const [mode, setMode] = useState<ImportMode>("wipe");
   const [busy, setBusy] = useState(false);
@@ -528,32 +610,19 @@ function ImportModal({
 
   const reset = () => {
     setFile(null);
-    setFileName("");
-    setFileHasSecrets(false);
+    setUploadProgress(null);
     setPassphrase("");
     setMode("wipe");
     setError(null);
     setNotice(null);
   };
 
-  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
     if (!f) return;
     setError(null);
-    try {
-      const parsed = JSON.parse(await f.text()) as DataTransferFile;
-      if (parsed?.kind !== "openship-instance-export") {
-        setError(t.settings.dataTransfer.import.notExport);
-        setFile(null);
-        return;
-      }
-      setFile(parsed);
-      setFileName(f.name);
-      setFileHasSecrets(!!parsed.secrets);
-    } catch {
-      setError(t.settings.dataTransfer.import.cantRead);
-      setFile(null);
-    }
+    setUploadProgress(null);
+    setFile(f);
   };
 
   const handleImport = async () => {
@@ -564,16 +633,27 @@ function ImportModal({
     }
     setBusy(true);
     setError(null);
+    setUploadProgress(null);
     try {
-      const result = (await dataTransferApi.import(
+      const result = (await dataTransferApi.importFile(
         file,
         passphrase || undefined,
         mode,
+        (done, total) => setUploadProgress({ done, total }),
       )) as ImportResult;
 
-      const parts = [interpolate(t.settings.dataTransfer.import.rowsRestored, { count: String(result.rowsRestored) })];
-      if (result.secretsRehydrated > 0) parts.push(interpolate(t.settings.dataTransfer.import.secretsRestored, { count: String(result.secretsRehydrated) }));
-      if (result.secretsSkipped && fileHasSecrets) {
+      const parts = [
+        interpolate(t.settings.dataTransfer.import.rowsRestored, {
+          count: String(result.rowsRestored),
+        }),
+      ];
+      if (result.secretsRehydrated > 0)
+        parts.push(
+          interpolate(t.settings.dataTransfer.import.secretsRestored, {
+            count: String(result.secretsRehydrated),
+          }),
+        );
+      if (result.secretsSkipped) {
         parts.push(t.settings.dataTransfer.import.secretsNotRestored);
       }
       onToast(parts.join(" · "), "success", t.settings.common.toast.importComplete);
@@ -625,8 +705,12 @@ function ImportModal({
             <DatabaseBackup className="size-5" />
           </div>
           <div>
-            <h2 className="text-base font-semibold text-foreground">{t.settings.dataTransfer.import.modalTitle}</h2>
-            <p className="text-xs text-muted-foreground">{t.settings.dataTransfer.import.modalSubtitle}</p>
+            <h2 className="text-base font-semibold text-foreground">
+              {t.settings.dataTransfer.import.modalTitle}
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              {t.settings.dataTransfer.import.modalSubtitle}
+            </p>
           </div>
         </div>
 
@@ -663,36 +747,51 @@ function ImportModal({
             </label>
             <input
               type="file"
-              accept="application/json,.json"
+              accept="application/json,.json,.osx"
               onChange={handleFile}
               className="block w-full text-sm text-muted-foreground file:me-3 file:rounded-lg file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground hover:file:bg-muted/70"
             />
-            {fileName && (
+            {file && (
               <p className="mt-1 text-xs text-muted-foreground">
-                {fileName}
-                {fileHasSecrets ? t.settings.dataTransfer.import.fileContainsSecrets : t.settings.dataTransfer.import.fileNoSecrets}
+                {file.name} · {formatBytes(file.size)}
               </p>
+            )}
+            {uploadProgress && (
+              <div className="mt-2" aria-live="polite">
+                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary transition-[width]"
+                    style={{
+                      width: `${Math.round((uploadProgress.done / uploadProgress.total) * 100)}%`,
+                    }}
+                  />
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t.settings.dataTransfer.import.importing} {uploadProgress.done}/
+                  {uploadProgress.total}
+                </p>
+              </div>
             )}
           </div>
 
-          {fileHasSecrets && (
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                {t.settings.dataTransfer.import.passphrase}
-              </label>
-              <input
-                type="password"
-                value={passphrase}
-                onChange={(e) => setPassphrase(e.target.value)}
-                autoComplete="off"
-                placeholder={t.settings.dataTransfer.import.passphrasePlaceholder}
-                className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary/60"
-              />
-            </div>
-          )}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              {t.settings.dataTransfer.import.passphrase}
+            </label>
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              autoComplete="off"
+              placeholder={t.settings.dataTransfer.import.passphrasePlaceholder}
+              className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary/60"
+            />
+          </div>
 
           <div>
-            <label className="mb-2 block text-xs font-medium text-muted-foreground">{t.settings.dataTransfer.import.mode}</label>
+            <label className="mb-2 block text-xs font-medium text-muted-foreground">
+              {t.settings.dataTransfer.import.mode}
+            </label>
             <div className="space-y-2">
               <ModeOption
                 selected={mode === "wipe"}
@@ -712,9 +811,7 @@ function ImportModal({
           {mode === "wipe" && (
             <div className="flex items-start gap-2 rounded-lg border border-warning-border bg-warning-bg p-3">
               <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warning" />
-              <p className="text-xs text-warning">
-                {t.settings.dataTransfer.import.wipeWarn}
-              </p>
+              <p className="text-xs text-warning">{t.settings.dataTransfer.import.wipeWarn}</p>
             </div>
           )}
 
@@ -736,11 +833,13 @@ function ImportModal({
             <button
               type="button"
               onClick={handleImport}
-              disabled={busy || !file || (fileHasSecrets && !passphrase)}
+              disabled={busy || !file}
               className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
             >
               {busy && <Loader2 className="size-4 animate-spin" />}
-              {busy ? t.settings.dataTransfer.import.importing : t.settings.dataTransfer.import.import}
+              {busy
+                ? t.settings.dataTransfer.import.importing
+                : t.settings.dataTransfer.import.import}
             </button>
           </div>
         </div>
@@ -765,7 +864,9 @@ function ModeOption({
       type="button"
       onClick={onSelect}
       className={`w-full rounded-xl border p-3 text-start transition-colors ${
-        selected ? "border-primary/60 bg-primary/[0.05]" : "border-border/50 hover:bg-foreground/[0.03]"
+        selected
+          ? "border-primary/60 bg-primary/[0.05]"
+          : "border-border/50 hover:bg-foreground/[0.03]"
       }`}
     >
       <div className="flex items-center gap-2">

--- a/apps/dashboard/src/lib/api/client.ts
+++ b/apps/dashboard/src/lib/api/client.ts
@@ -272,8 +272,13 @@ async function doFetch<T>(
 
   /* --- Headers ---------------------------------------------------- */
   const headers = new Headers(init.headers);
+  const rawBody =
+    body instanceof FormData ||
+    (typeof Blob !== "undefined" && body instanceof Blob) ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body);
 
-  if (body && typeof body === "object" && !(body instanceof FormData)) {
+  if (body && typeof body === "object" && !rawBody) {
     headers.set("Content-Type", "application/json");
   }
 
@@ -291,12 +296,7 @@ async function doFetch<T>(
       headers,
       credentials: "include",
       signal: controller.signal,
-      body:
-        body instanceof FormData
-          ? body
-          : body !== undefined
-            ? JSON.stringify(body)
-            : undefined,
+      body: rawBody ? (body as BodyInit) : body !== undefined ? JSON.stringify(body) : undefined,
     });
 
     if (!res.ok) {

--- a/apps/dashboard/src/lib/api/data-transfer.test.ts
+++ b/apps/dashboard/src/lib/api/data-transfer.test.ts
@@ -3,12 +3,25 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { dataTransferApi, inspectDirectTransferCode } from "./data-transfer";
 
 function captureRequest() {
-  const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-    new Response(JSON.stringify({ kind: "openship-instance-export" }), {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+    if (String(input).endsWith("/direct/send/stream")) {
+      return new Response(
+        `: ok\n\nevent: complete\ndata: ${JSON.stringify({
+          mode: "wipe",
+          rowsRestored: 0,
+          secretsRehydrated: 0,
+          secretsSkipped: true,
+          localPathProjects: [],
+          destination: "https://destination.example",
+        })}\n\n`,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    }
+    return new Response(JSON.stringify({ kind: "openship-instance-export" }), {
       status: 200,
       headers: { "content-type": "application/json" },
-    }),
-  );
+    });
+  });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
@@ -17,11 +30,16 @@ afterEach(() => vi.unstubAllGlobals());
 
 describe("data-transfer export selection", () => {
   it("shows the destination and restore mode encoded in a receive code", () => {
-    const code = btoa(JSON.stringify({
-      apiBase: "https://destination.example/api/",
-      mode: "wipe",
-      expiresAt: "2099-01-01T00:00:00.000Z",
-    })).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const code = btoa(
+      JSON.stringify({
+        apiBase: "https://destination.example/api/",
+        mode: "wipe",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      }),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
     expect(inspectDirectTransferCode(code)).toEqual({
       destination: "https://destination.example",
       mode: "wipe",
@@ -68,7 +86,13 @@ describe("data-transfer export selection", () => {
 
   it("sends the one-time code and full migration history to the source API", async () => {
     const fetchMock = captureRequest();
-    await dataTransferApi.sendDirect("receive-code", ["analytics", "activity", "backups", "incidents", "migrations"]);
+    await dataTransferApi.sendDirect("receive-code", [
+      "analytics",
+      "activity",
+      "backups",
+      "incidents",
+      "migrations",
+    ]);
 
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("system/data-transfer/direct/send");
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
@@ -76,5 +100,163 @@ describe("data-transfer export selection", () => {
       code: "receive-code",
       selection: { history: ["analytics", "activity", "backups", "incidents", "migrations"] },
     });
+  });
+
+  it("imports a file as bounded raw chunks without reading the whole file", async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      const url = String(input);
+      requests.push({ url, init });
+      if (url.endsWith("/finalize/stream")) {
+        return new Response(
+          `event: complete\ndata: ${JSON.stringify({
+            mode: "merge",
+            rowsRestored: 2,
+            secretsRehydrated: 0,
+            secretsSkipped: true,
+            localPathProjects: [],
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      const value = url.endsWith("/import/session")
+        ? {
+            uploadId: "upload_1",
+            chunkSize: 4,
+            totalChunks: 3,
+            expiresAt: "2099-01-01T00:00:00.000Z",
+          }
+        : { ok: true };
+      return new Response(JSON.stringify(value), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const progress = vi.fn();
+    const file = new File(["hello world"], "export.osx", { type: "application/json" });
+
+    const result = await dataTransferApi.importFile(file, undefined, "merge", progress);
+
+    expect(result.rowsRestored).toBe(2);
+    expect(requests).toHaveLength(5);
+    expect(JSON.parse(String(requests[0]!.init.body))).toEqual({ size: 11 });
+    const chunks = requests.slice(1, 4);
+    expect(chunks.map(({ init }) => init.method)).toEqual(["PUT", "PUT", "PUT"]);
+    expect(chunks.every(({ init }) => init.body instanceof Blob)).toBe(true);
+    expect(
+      chunks.every(
+        ({ init }) => new Headers(init.headers).get("content-type") === "application/octet-stream",
+      ),
+    ).toBe(true);
+    expect(await Promise.all(chunks.map(({ init }) => (init.body as Blob).text()))).toEqual([
+      "hell",
+      "o wo",
+      "rld",
+    ]);
+    expect(progress.mock.calls).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+    expect(JSON.parse(String(requests[4]!.init.body))).toEqual({ mode: "merge" });
+  });
+
+  it("reuses verified chunks when the operator retries finalization", async () => {
+    let finalizes = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/import/session")) {
+        return Response.json({
+          uploadId: "upload_retry",
+          chunkSize: 20,
+          totalChunks: 1,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        });
+      }
+      if (url.endsWith("/finalize/stream")) {
+        finalizes += 1;
+        const terminal =
+          finalizes === 1
+            ? {
+                event: "error",
+                data: { status: 400, error: "Wrong transfer secret", code: "WRONG_PASSPHRASE" },
+              }
+            : {
+                event: "complete",
+                data: {
+                  mode: "merge",
+                  rowsRestored: 1,
+                  secretsRehydrated: 1,
+                  secretsSkipped: false,
+                  localPathProjects: [],
+                },
+              };
+        return new Response(
+          `event: ${terminal.event}\ndata: ${JSON.stringify(terminal.data)}\n\n`,
+          {
+            headers: { "content-type": "text/event-stream" },
+          },
+        );
+      }
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const file = new File(["small export"], "export.json");
+
+    await expect(dataTransferApi.importFile(file, "wrong", "merge")).rejects.toThrow();
+    await expect(dataTransferApi.importFile(file, "correct", "merge")).resolves.toMatchObject({
+      rowsRestored: 1,
+    });
+
+    const urls = fetchMock.mock.calls.map(([input]) => String(input));
+    expect(urls.filter((url) => url.endsWith("/import/session"))).toHaveLength(1);
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => (init as RequestInit).method === "PUT"),
+    ).toHaveLength(1);
+    expect(urls.filter((url) => url.endsWith("/finalize/stream"))).toHaveLength(2);
+  });
+
+  it("starts a fresh upload after a cached session expires during chunking", async () => {
+    let sessions = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/import/session")) {
+        sessions += 1;
+        return Response.json({
+          uploadId: sessions === 1 ? "expired" : "fresh",
+          chunkSize: 20,
+          totalChunks: 1,
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        });
+      }
+      if (init?.method === "PUT" && url.includes("/expired/")) {
+        return Response.json(
+          { error: "Upload expired", code: "SESSION_UNAVAILABLE" },
+          { status: 410 },
+        );
+      }
+      if (url.endsWith("/finalize/stream")) {
+        return new Response(
+          `event: complete\ndata: ${JSON.stringify({
+            mode: "merge",
+            rowsRestored: 1,
+            secretsRehydrated: 0,
+            secretsSkipped: true,
+            localPathProjects: [],
+          })}\n\n`,
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const file = new File(["small export"], "export.json");
+
+    await expect(dataTransferApi.importFile(file, undefined, "merge")).resolves.toMatchObject({
+      rowsRestored: 1,
+    });
+
+    expect(sessions).toBe(2);
   });
 });

--- a/apps/dashboard/src/lib/api/data-transfer.ts
+++ b/apps/dashboard/src/lib/api/data-transfer.ts
@@ -1,4 +1,6 @@
-import { api, getApiBaseUrl } from "./client";
+import { readSseTerminalEvent } from "@repo/core";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { api, ApiError, getActiveOrganizationId, getApiBaseUrl } from "./client";
 import { endpoints } from "./endpoints";
 
 /**
@@ -62,7 +64,8 @@ export function inspectDirectTransferCode(code: string): DirectCodeInfo | null {
       typeof parsed.apiBase !== "string" ||
       (parsed.mode !== "wipe" && parsed.mode !== "merge") ||
       typeof parsed.expiresAt !== "string"
-    ) return null;
+    )
+      return null;
     return {
       destination: new URL(parsed.apiBase).origin,
       mode: parsed.mode,
@@ -74,10 +77,103 @@ export function inspectDirectTransferCode(code: string): DirectCodeInfo | null {
 }
 
 const LONG_TIMEOUT = 600_000;
+const CHUNK_TIMEOUT = 120_000;
+const TRANSFER_STREAM_TIMEOUT = 6 * 60 * 60_000;
+
+interface ImportUploadSession {
+  uploadId: string;
+  chunkSize: number;
+  totalChunks: number;
+  expiresAt: string;
+}
+
+interface ResumableImportUpload {
+  session: ImportUploadSession;
+  completedChunks: number;
+}
+
+// A failed finalize (most commonly a mistyped transfer secret) must not force
+// the operator to upload the same large File again. Weak keys release the entry
+// automatically when the picker/modal releases its File object.
+const resumableImportUploads = new WeakMap<File, ResumableImportUpload>();
+
+async function sha256Hex(blob: Blob): Promise<string> {
+  const digest = sha256(new Uint8Array(await blob.arrayBuffer()));
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function uploadWithRetry(uploadId: string, index: number, chunk: Blob): Promise<void> {
+  const digest = await sha256Hex(chunk);
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await api.put(endpoints.system.dataTransfer.importChunk(uploadId, index), chunk, {
+        timeout: CHUNK_TIMEOUT,
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-openship-chunk-sha256": digest,
+        },
+      });
+      return;
+    } catch (error) {
+      lastError = error;
+      if (
+        error instanceof ApiError &&
+        error.status < 500 &&
+        error.status !== 408 &&
+        error.status !== 429
+      ) {
+        throw error;
+      }
+      if (attempt < 2) await new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt));
+    }
+  }
+  throw lastError;
+}
+
+async function postTransferStream<T>(path: string, body: unknown): Promise<T> {
+  const headers = new Headers({
+    accept: "text/event-stream",
+    "content-type": "application/json",
+  });
+  const organizationId = getActiveOrganizationId();
+  if (organizationId) headers.set("x-organization-id", organizationId);
+  const response = await fetch(new URL(path, getApiBaseUrl()), {
+    method: "POST",
+    credentials: "include",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(TRANSFER_STREAM_TIMEOUT),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let parsed: unknown = text;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // Keep the plain response for ApiError/getApiErrorMessage.
+    }
+    throw new ApiError(response.status, response.statusText, parsed);
+  }
+  if (
+    !(response.headers.get("content-type") ?? "").includes("text/event-stream") ||
+    !response.body
+  ) {
+    throw new Error("The data-transfer stream returned an invalid response.");
+  }
+
+  const terminal = await readSseTerminalEvent(response.body);
+  if (terminal.event === "complete") return JSON.parse(terminal.data) as T;
+  const failure = JSON.parse(terminal.data) as { status?: number; error?: string; code?: string };
+  throw new ApiError(
+    typeof failure.status === "number" ? failure.status : 500,
+    "Data transfer failed",
+    { error: failure.error, code: failure.code },
+  );
+}
 
 export const dataTransferApi = {
-  preview: () =>
-    api.get<ExportPreview>(endpoints.system.dataTransfer.preview),
+  preview: () => api.get<ExportPreview>(endpoints.system.dataTransfer.preview),
 
   createDirectReceiveSession: (mode: ImportMode) =>
     api.post<DirectReceiveSession>(endpoints.system.dataTransfer.directSession, {
@@ -86,11 +182,10 @@ export const dataTransferApi = {
     }),
 
   sendDirect: (code: string, history?: ExportHistoryCategory[]) =>
-    api.post<DirectTransferResult>(
-      endpoints.system.dataTransfer.directSend,
-      { code, ...(history ? { selection: { history } } : {}) },
-      { timeout: LONG_TIMEOUT },
-    ),
+    postTransferStream<DirectTransferResult>(endpoints.system.dataTransfer.directSendStream, {
+      code,
+      ...(history ? { selection: { history } } : {}),
+    }),
 
   export: (passphrase?: string, history?: ExportHistoryCategory[]) =>
     api.post<DataTransferFile>(
@@ -105,4 +200,59 @@ export const dataTransferApi = {
       { file, passphrase, mode },
       { timeout: LONG_TIMEOUT },
     ),
+
+  /** Upload a local export in bounded pieces; the browser never materializes the
+   * complete JSON document and every request stays below the edge body limit. */
+  importFile: async (
+    file: File,
+    passphrase: string | undefined,
+    mode: ImportMode,
+    onProgress?: (completed: number, total: number) => void,
+  ): Promise<ImportResult> => {
+    let lastError: unknown;
+    for (let sessionAttempt = 0; sessionAttempt < 2; sessionAttempt += 1) {
+      let upload = resumableImportUploads.get(file);
+      if (!upload) {
+        upload = {
+          session: await api.post<ImportUploadSession>(
+            endpoints.system.dataTransfer.importSession,
+            { size: file.size },
+          ),
+          completedChunks: 0,
+        };
+        resumableImportUploads.set(file, upload);
+      }
+      const { session } = upload;
+      try {
+        if (upload.completedChunks > 0) {
+          onProgress?.(upload.completedChunks, session.totalChunks);
+        }
+        for (let index = upload.completedChunks; index < session.totalChunks; index += 1) {
+          const start = index * session.chunkSize;
+          await uploadWithRetry(
+            session.uploadId,
+            index,
+            file.slice(start, Math.min(file.size, start + session.chunkSize)),
+          );
+          upload.completedChunks = index + 1;
+          onProgress?.(index + 1, session.totalChunks);
+        }
+        const result = await postTransferStream<ImportResult>(
+          endpoints.system.dataTransfer.importFinalizeStream(session.uploadId),
+          { passphrase, mode },
+        );
+        resumableImportUploads.delete(file);
+        return result;
+      } catch (error) {
+        lastError = error;
+        // A gone/expired session cannot be resumed. Transparently open one new
+        // session once; other failures retain the verified chunks so correcting
+        // a passphrase or merge choice is cheap.
+        if (!(error instanceof ApiError) || error.status !== 410) throw error;
+        resumableImportUploads.delete(file);
+        if (sessionAttempt > 0) throw error;
+      }
+    }
+    throw lastError;
+  },
 };

--- a/apps/dashboard/src/lib/api/endpoints.ts
+++ b/apps/dashboard/src/lib/api/endpoints.ts
@@ -367,8 +367,14 @@ export const endpoints = {
       preview: "system/data-transfer/preview",
       directSession: "system/data-transfer/direct/session",
       directSend: "system/data-transfer/direct/send",
+      directSendStream: "system/data-transfer/direct/send/stream",
       export: "system/data-transfer/export",
       import: "system/data-transfer/import",
+      importSession: "system/data-transfer/import/session",
+      importChunk: (sessionId: string, index: number) =>
+        `system/data-transfer/import/session/${encodeURIComponent(sessionId)}/chunk/${index}`,
+      importFinalizeStream: (sessionId: string) =>
+        `system/data-transfer/import/session/${encodeURIComponent(sessionId)}/finalize/stream`,
     },
   },
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,3 +68,4 @@ export * from "./host-profile";
 export * from "./host-firewall";
 export * from "./host-channel";
 export * from "./network";
+export * from "./sse-terminal";

--- a/packages/core/src/sse-terminal.test.ts
+++ b/packages/core/src/sse-terminal.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { readSseTerminalEvent } from "./sse-terminal";
+
+function splitStream(parts: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) controller.enqueue(encoder.encode(part));
+      controller.close();
+    },
+  });
+}
+
+describe("readSseTerminalEvent", () => {
+  it("ignores comments and heartbeats and reassembles a split terminal frame", async () => {
+    const result = await readSseTerminalEvent(
+      splitStream([
+        ": ok\n\nevent: ping\ndata: {}\n\nevent: comp",
+        'lete\ndata: {"ok":',
+        "true}\n\n",
+      ]),
+    );
+    expect(result).toEqual({ event: "complete", data: '{"ok":true}' });
+  });
+
+  it("supports CRLF and multiline data", async () => {
+    const result = await readSseTerminalEvent(
+      splitStream(["event: error\r\ndata: line one\r\ndata: line two\r\n\r\n"]),
+    );
+    expect(result).toEqual({ event: "error", data: "line one\nline two" });
+  });
+
+  it("fails closed when the stream ends without a terminal event", async () => {
+    await expect(readSseTerminalEvent(splitStream(["event: ping\ndata: {}\n\n"]))).rejects.toThrow(
+      "without a terminal result",
+    );
+  });
+
+  it("rejects an unbounded frame instead of buffering it indefinitely", async () => {
+    await expect(
+      readSseTerminalEvent(splitStream([`data: ${"x".repeat(1_000_001)}`])),
+    ).rejects.toThrow("oversized frame");
+  });
+});

--- a/packages/core/src/sse-terminal.ts
+++ b/packages/core/src/sse-terminal.ts
@@ -1,0 +1,53 @@
+/**
+ * Read one terminal `complete` or `error` event from an SSE response.
+ *
+ * Frames may be split at arbitrary byte boundaries and may use LF or CRLF.
+ * Heartbeats/comments and non-terminal progress events are ignored. Keeping
+ * this parser in core prevents server-to-server and browser transfer clients
+ * from implementing subtly different framing rules.
+ */
+const MAX_PENDING_SSE_CHARS = 1_000_000;
+
+export async function readSseTerminalEvent(
+  body: ReadableStream<Uint8Array>,
+): Promise<{ event: "complete" | "error"; data: string }> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+
+      let match = /\r?\n\r?\n/.exec(buffer);
+      while (match?.index !== undefined) {
+        const frame = buffer.slice(0, match.index);
+        buffer = buffer.slice(match.index + match[0].length);
+        const lines = frame.split(/\r?\n/);
+        const event = lines
+          .find((line) => line.startsWith("event:"))
+          ?.slice(6)
+          .trim();
+        const data = lines
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trimStart())
+          .join("\n");
+        if ((event === "complete" || event === "error") && data) {
+          return { event, data };
+        }
+        match = /\r?\n\r?\n/.exec(buffer);
+      }
+
+      if (buffer.length > MAX_PENDING_SSE_CHARS) {
+        throw new Error("The event stream sent an oversized frame.");
+      }
+
+      if (done) break;
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  throw new Error("The event stream ended without a terminal result.");
+}

--- a/packages/db/drizzle/0122_data_transfer_staging.sql
+++ b/packages/db/drizzle/0122_data_transfer_staging.sql
@@ -1,0 +1,45 @@
+-- Durable, bounded staging for browser imports and encrypted instance-to-instance
+-- transfers. Sessions survive API worker changes/restarts; chunks cascade away
+-- when the short-lived session is cleaned up.
+CREATE TABLE "data_transfer_session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kind" text NOT NULL,
+	"status" text DEFAULT 'ready' NOT NULL,
+	"mode" text,
+	"owner_user_id" text,
+	"token_hash" text,
+	"private_key" text,
+	"sender_public_key" text,
+	"claim_token" text,
+	"expected_bytes" bigint,
+	"expected_chunks" integer,
+	"result" jsonb,
+	"expires_at" timestamp NOT NULL,
+	"max_expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "ck_data_transfer_session_kind" CHECK ("kind" IN ('direct', 'file')),
+	CONSTRAINT "ck_data_transfer_session_status" CHECK ("status" IN ('ready', 'uploading', 'consuming', 'complete', 'failed')),
+	CONSTRAINT "ck_data_transfer_session_mode" CHECK ("mode" IS NULL OR "mode" IN ('wipe', 'merge')),
+	CONSTRAINT "ck_data_transfer_session_expected_bytes" CHECK ("expected_bytes" IS NULL OR "expected_bytes" BETWEEN 1 AND 500000000),
+	CONSTRAINT "ck_data_transfer_session_expected_chunks" CHECK ("expected_chunks" IS NULL OR "expected_chunks" BETWEEN 1 AND 63)
+);
+--> statement-breakpoint
+CREATE TABLE "data_transfer_chunk" (
+	"session_id" text NOT NULL,
+	"chunk_index" integer NOT NULL,
+	"bytes" bytea NOT NULL,
+	"byte_length" integer NOT NULL,
+	"sha256" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "data_transfer_chunk_session_id_chunk_index_pk" PRIMARY KEY("session_id","chunk_index"),
+	CONSTRAINT "ck_data_transfer_chunk_index" CHECK ("chunk_index" BETWEEN 0 AND 62),
+	CONSTRAINT "ck_data_transfer_chunk_length" CHECK ("byte_length" BETWEEN 1 AND 8000064),
+	CONSTRAINT "ck_data_transfer_chunk_bytes" CHECK (octet_length("bytes") = "byte_length")
+);
+--> statement-breakpoint
+ALTER TABLE "data_transfer_chunk" ADD CONSTRAINT "data_transfer_chunk_session_id_data_transfer_session_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."data_transfer_session"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "data_transfer_session_expires_idx" ON "data_transfer_session" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE INDEX "data_transfer_session_owner_idx" ON "data_transfer_session" USING btree ("owner_user_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1789424507325,
       "tag": "0121_host_port_claim_overlap",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1789510907325,
+      "tag": "0122_data_transfer_staging",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -15,6 +15,8 @@ import { acquirePgliteLock, releasePgliteLock } from "./pglite-lock";
  * Every repo and service receives this; they never know which driver runs beneath.
  */
 export type Database = NodePgDatabase<typeof schema> | PgliteDatabase<typeof schema>;
+/** Transaction handle shared by the Postgres and PGlite drivers. */
+export type DatabaseTransaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
 
 /** Which driver is active - useful for conditional logic in adapters */
 export type Driver = "pg" | "pglite";

--- a/packages/db/src/dump-roundtrip.test.ts
+++ b/packages/db/src/dump-roundtrip.test.ts
@@ -2,8 +2,15 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { getTableColumns } from "drizzle-orm";
 import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
 
-import { db } from "./client";
-import { countInstanceSubgraphTables, dumpSubgraph, restoreSubgraph, topoOrderedTables, type TableSpec } from "./dump";
+import { db, type DatabaseTransaction } from "./client";
+import {
+  countInstanceSubgraphTables,
+  dumpSubgraph,
+  restoreSubgraph,
+  restoreSubgraphInTransaction,
+  topoOrderedTables,
+  type TableSpec,
+} from "./dump";
 
 // The test the data-transfer feature never had: does a whole-instance dump actually
 // RESTORE?
@@ -206,6 +213,26 @@ describe("whole-instance dump → restore round trip", () => {
     )) as Array<Record<string, unknown>>;
     expect(domain?.serviceId).toBe(seeded.get("domain")?.serviceId);
     expect(domain?.serviceId).toBeTruthy();
+  });
+
+  it("lets callers include follow-up work in the same atomic restore transaction", async () => {
+    const projectSpec = topoOrderedTables().find((s) => s.sqlName === "project")!;
+    const [before] = (await db.select().from(projectSpec.table)) as Array<Record<string, unknown>>;
+    const dump = JSON.parse(JSON.stringify(await dumpSubgraph({ kind: "instance" }))) as Awaited<
+      ReturnType<typeof dumpSubgraph>
+    >;
+    dump.tables.project![0]!.name = "must-roll-back";
+
+    await expect(
+      db.transaction(async (rawTx) => {
+        await restoreSubgraphInTransaction(rawTx as DatabaseTransaction, dump, { mode: "wipe" });
+        throw new Error("follow-up write failed");
+      }),
+    ).rejects.toThrow("follow-up write failed");
+
+    const [after] = (await db.select().from(projectSpec.table)) as Array<Record<string, unknown>>;
+    expect(after?.name).toBe(before?.name);
+    expect(after?.name).not.toBe("must-roll-back");
   });
 
   it("skips explicitly excluded history tables at query time", async () => {

--- a/packages/db/src/dump.ts
+++ b/packages/db/src/dump.ts
@@ -26,7 +26,7 @@
 
 import { sql, eq, inArray, count, getTableColumns } from "drizzle-orm";
 import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
-import { db, getDriver } from "./client";
+import { db, getDriver, type DatabaseTransaction } from "./client";
 import * as schema from "./schema";
 
 export const DUMP_FORMAT_VERSION = 1;
@@ -732,6 +732,8 @@ export const EXCLUDED_TABLES: Record<string, string> = {
   verification: "Better Auth one-shot nonces, all short-TTL",
   github_install_state: "one-shot install nonce, deleted on callback",
   cloud_handoff_code: "60s one-time cloud-connect codes",
+  data_transfer_session: "short-lived whole-instance transfer capability and upload lease",
+  data_transfer_chunk: "short-lived chunk staging for a whole-instance transfer",
   oauth_access_token:
     "live MCP bearer/refresh tokens; the client re-authenticates against the " +
     "oauth_application + oauth_consent rows that DO travel, so shipping them adds " +
@@ -1307,7 +1309,16 @@ export function assertDumpSelfContained(dump: DatabaseDump): void {
   }
 }
 
-export async function restoreSubgraph(dump: DatabaseDump, opts: RestoreOptions): Promise<void> {
+/**
+ * Restore using a caller-owned transaction. This is the composition point for
+ * workflows that must commit follow-up writes (for example credential
+ * re-encryption) atomically with the restored rows.
+ */
+export async function restoreSubgraphInTransaction(
+  tx: DatabaseTransaction,
+  dump: DatabaseDump,
+  opts: RestoreOptions,
+): Promise<void> {
   if (dump.formatVersion !== DUMP_FORMAT_VERSION) {
     throw new Error(
       `Dump format version ${dump.formatVersion} cannot be restored by this build (expected ${DUMP_FORMAT_VERSION}).`,
@@ -1318,177 +1329,182 @@ export async function restoreSubgraph(dump: DatabaseDump, opts: RestoreOptions):
   // caller supplies a dump for a DIFFERENT org — reject cross-tenant FKs there.
   if (opts.remapOrgId) assertDumpSelfContained(dump);
 
-  await db.transaction(async (tx) => {
-    // Kept for the day the schema declares its FKs DEFERRABLE — but DO NOT rely on
-    // it. Postgres applies this only to constraints declared DEFERRABLE, and none of
-    // ours are, so today it is a silent no-op. Correctness comes from
-    // topoOrderedTables(), not from this line.
-    await tx.execute(sql`SET CONSTRAINTS ALL DEFERRED`);
+  // Kept for the day the schema declares its FKs DEFERRABLE — but DO NOT rely on
+  // it. Postgres applies this only to constraints declared DEFERRABLE, and none of
+  // ours are, so today it is a silent no-op. Correctness comes from
+  // topoOrderedTables(), not from this line.
+  await tx.execute(sql`SET CONSTRAINTS ALL DEFERRED`);
 
-    if (opts.mode === "wipe") {
-      // Engine-level last-resort gate: a whole-instance TRUNCATE must NEVER run
-      // on the multi-tenant SaaS. The API route is unmounted in CLOUD_MODE and
-      // exportInstance/importInstance refuse too, but this stops even a stray
-      // in-process restoreSubgraph({mode:'wipe'}) from truncating every tenant if
-      // those layers are ever bypassed. packages/db has no apps/api env → read raw.
-      if (process.env.CLOUD_MODE === "true") {
-        throw new Error(
-          "Refusing a wipe restore on a multi-tenant (CLOUD_MODE) instance — this would truncate every tenant.",
-        );
-      }
-      // Truncate only the tables this scope claims, in reverse order.
-      // For project / organization scope we don't TRUNCATE because that
-      // would wipe other tenants — `wipe` mode is conceptually a "this
-      // scope only" wipe and the caller is responsible for ensuring the
-      // dump covers every row in that scope. Today we only support wipe
-      // for instance scope; org/project use merge.
-      if (dump.scope.kind !== "instance") {
-        throw new Error(
-          `wipe mode is only supported for instance-scope dumps; got ${dump.scope.kind}.`,
-        );
-      }
-      // Reverse of the derived insert order = children before parents.
-      const reverse = [...topoOrderedTables()].reverse();
-      for (const spec of reverse) {
-        if (!pickResolver(spec, dump.scope)) continue;
-        await tx.execute(
-          sql`TRUNCATE TABLE ${sql.identifier(spec.sqlName)} RESTART IDENTITY CASCADE`,
-        );
-      }
+  if (opts.mode === "wipe") {
+    // Engine-level last-resort gate: a whole-instance TRUNCATE must NEVER run
+    // on the multi-tenant SaaS. The API route is unmounted in CLOUD_MODE and
+    // exportInstance/importInstance refuse too, but this stops even a stray
+    // in-process restoreSubgraph({mode:'wipe'}) from truncating every tenant if
+    // those layers are ever bypassed. packages/db has no apps/api env → read raw.
+    if (process.env.CLOUD_MODE === "true") {
+      throw new Error(
+        "Refusing a wipe restore on a multi-tenant (CLOUD_MODE) instance — this would truncate every tenant.",
+      );
     }
-
-    // Pre-compute the encrypted-column specs keyed by table so the insert
-    // loop below can redact those fields without re-scanning ENCRYPTED_COLUMNS
-    // per row. Redaction on restore is REQUIRED (not optional like the
-    // dump-side `stripEncrypted` flag): ciphertext from the wire was
-    // encrypted under a foreign instance's BETTER_AUTH_SECRET, so we
-    // could never decrypt it anyway, AND accepting it verbatim lets a
-    // malicious caller plant arbitrary bytes in slots that downstream
-    // code treats as "trusted encrypted blob" (env_var.value, notification
-    // config, clone tokens, backup destination secrets, etc.). Always
-    // redact these — receivers re-link credentials post-restore (the
-    // data-transfer module re-hydrates them under the local key separately).
-    const encryptedByTable = new Map<string, EncryptedColumnSpec[]>();
-    for (const spec of ENCRYPTED_COLUMNS) {
-      const list = encryptedByTable.get(spec.table) ?? [];
-      list.push(spec);
-      encryptedByTable.set(spec.table, list);
+    // Truncate only the tables this scope claims, in reverse order.
+    // For project / organization scope we don't TRUNCATE because that
+    // would wipe other tenants — `wipe` mode is conceptually a "this
+    // scope only" wipe and the caller is responsible for ensuring the
+    // dump covers every row in that scope. Today we only support wipe
+    // for instance scope; org/project use merge.
+    if (dump.scope.kind !== "instance") {
+      throw new Error(
+        `wipe mode is only supported for instance-scope dumps; got ${dump.scope.kind}.`,
+      );
     }
-
-    // Derived parent-before-child order — NOT `TABLES` order. See
-    // topoOrderedTables: the FKs are not DEFERRABLE, so this is what keeps the
-    // inserts legal.
-    for (const spec of topoOrderedTables()) {
+    // Reverse of the derived insert order = children before parents.
+    const reverse = [...topoOrderedTables()].reverse();
+    for (const spec of reverse) {
       if (!pickResolver(spec, dump.scope)) continue;
-      const rows = dump.tables[spec.sqlName];
-      if (!rows || rows.length === 0) continue;
+      await tx.execute(
+        sql`TRUNCATE TABLE ${sql.identifier(spec.sqlName)} RESTART IDENTITY CASCADE`,
+      );
+    }
+  }
 
-      const encryptedCols = encryptedByTable.get(spec.sqlName);
-      const colMeta = encryptedCols ? columnMetaFor(spec.sqlName) : {};
+  // Pre-compute the encrypted-column specs keyed by table so the insert
+  // loop below can redact those fields without re-scanning ENCRYPTED_COLUMNS
+  // per row. Redaction on restore is REQUIRED (not optional like the
+  // dump-side `stripEncrypted` flag): ciphertext from the wire was
+  // encrypted under a foreign instance's BETTER_AUTH_SECRET, so we
+  // could never decrypt it anyway, AND accepting it verbatim lets a
+  // malicious caller plant arbitrary bytes in slots that downstream
+  // code treats as "trusted encrypted blob" (env_var.value, notification
+  // config, clone tokens, backup destination secrets, etc.). Always
+  // redact these — receivers re-link credentials post-restore (the
+  // data-transfer module re-hydrates them under the local key separately).
+  const encryptedByTable = new Map<string, EncryptedColumnSpec[]>();
+  for (const spec of ENCRYPTED_COLUMNS) {
+    const list = encryptedByTable.get(spec.table) ?? [];
+    list.push(spec);
+    encryptedByTable.set(spec.table, list);
+  }
 
-      // The set of columns THIS build's schema knows for the table. `prepared`
-      // is filtered to it below so a version-skewed dump ingests cleanly:
-      //   - sender NEWER than receiver → a column the receiver lacks would make
-      //     Postgres reject the whole insert ("column X of relation Y does not
-      //     exist"), because Drizzle derives the INSERT column list from the
-      //     row's keys. Dropping the unknown key lets the row land (the receiver
-      //     can't store what it doesn't model anyway).
-      //   - sender OLDER than receiver → a column the receiver added is simply
-      //     absent from the row; Drizzle emits DEFAULT for it. Safe ONLY if that
-      //     column is nullable or has a default — the additive-migration rule.
-      // This is the cross-version robustness that DUMP_FORMAT_VERSION (bumped
-      // only on breaking shape changes) deliberately does not cover for plain
-      // column additions.
-      const columns = getTableColumns(spec.table);
-      const knownCols = new Set(Object.keys(columns));
+  // Derived parent-before-child order — NOT `TABLES` order. See
+  // topoOrderedTables: the FKs are not DEFERRABLE, so this is what keeps the
+  // inserts legal.
+  for (const spec of topoOrderedTables()) {
+    if (!pickResolver(spec, dump.scope)) continue;
+    const rows = dump.tables[spec.sqlName];
+    if (!rows || rows.length === 0) continue;
 
-      // Timestamp/date columns arrive as ISO strings whenever the dump crossed
-      // the wire as JSON (cloud ingest, project transfer) — JSON.stringify turns
-      // a Date into a string, and Drizzle's timestamp mapToDriverValue then calls
-      // `.toISOString()` on it and throws. Revive them to Date before insert.
-      // (In-process restores keep real Dates and skip the `typeof === string`
-      // branch, so this is a no-op there.)
-      const dateCols = Object.entries(columns)
-        .filter(([, col]) => (col as { dataType?: string }).dataType === "date")
-        .map(([name]) => name);
+    const encryptedCols = encryptedByTable.get(spec.sqlName);
+    const colMeta = encryptedCols ? columnMetaFor(spec.sqlName) : {};
 
-      // Shallow-clone each row (filtered to known columns) so we don't mutate the
-      // caller's input dump. redactEncryptedCell deep-clones any nested JSONB it
-      // edits (secretPaths), so a top-level copy is enough here.
-      const droppedCols = new Set<string>();
-      const prepared = rows.map((r) => {
-        const { row: next, dropped } = filterRowToKnownColumns(r, knownCols);
-        for (const d of dropped) droppedCols.add(d);
-        if (opts.remapOrgId && spec.hasOrganizationId) {
-          next.organizationId = opts.remapOrgId;
+    // The set of columns THIS build's schema knows for the table. `prepared`
+    // is filtered to it below so a version-skewed dump ingests cleanly:
+    //   - sender NEWER than receiver → a column the receiver lacks would make
+    //     Postgres reject the whole insert ("column X of relation Y does not
+    //     exist"), because Drizzle derives the INSERT column list from the
+    //     row's keys. Dropping the unknown key lets the row land (the receiver
+    //     can't store what it doesn't model anyway).
+    //   - sender OLDER than receiver → a column the receiver added is simply
+    //     absent from the row; Drizzle emits DEFAULT for it. Safe ONLY if that
+    //     column is nullable or has a default — the additive-migration rule.
+    // This is the cross-version robustness that DUMP_FORMAT_VERSION (bumped
+    // only on breaking shape changes) deliberately does not cover for plain
+    // column additions.
+    const columns = getTableColumns(spec.table);
+    const knownCols = new Set(Object.keys(columns));
+
+    // Timestamp/date columns arrive as ISO strings whenever the dump crossed
+    // the wire as JSON (cloud ingest, project transfer) — JSON.stringify turns
+    // a Date into a string, and Drizzle's timestamp mapToDriverValue then calls
+    // `.toISOString()` on it and throws. Revive them to Date before insert.
+    // (In-process restores keep real Dates and skip the `typeof === string`
+    // branch, so this is a no-op there.)
+    const dateCols = Object.entries(columns)
+      .filter(([, col]) => (col as { dataType?: string }).dataType === "date")
+      .map(([name]) => name);
+
+    // Shallow-clone each row (filtered to known columns) so we don't mutate the
+    // caller's input dump. redactEncryptedCell deep-clones any nested JSONB it
+    // edits (secretPaths), so a top-level copy is enough here.
+    const droppedCols = new Set<string>();
+    const prepared = rows.map((r) => {
+      const { row: next, dropped } = filterRowToKnownColumns(r, knownCols);
+      for (const d of dropped) droppedCols.add(d);
+      if (opts.remapOrgId && spec.hasOrganizationId) {
+        next.organizationId = opts.remapOrgId;
+      }
+      if (encryptedCols) {
+        for (const encSpec of encryptedCols) redactEncryptedCell(next, encSpec, colMeta);
+      }
+      for (const col of dateCols) {
+        if (typeof next[col] === "string") next[col] = new Date(next[col] as string);
+      }
+      return next;
+    });
+    if (droppedCols.size > 0) {
+      // Version skew, not a fault — the receiver's schema predates these
+      // columns. Log once per table so it's diagnosable without failing.
+      console.warn(
+        `[restore] ${spec.sqlName}: dropped ${droppedCols.size} unknown column(s) not in this build's schema: ${[...droppedCols].join(", ")}`,
+      );
+    }
+
+    // Shared parents (e.g. project_app, which owns many project environments
+    // via the `from-root-project` resolver) may already exist on the target
+    // — a re-promote re-supplies the same row, and inserting it again is a
+    // no-op, not a conflict. Skip on conflict for those; and, in merge mode,
+    // for tables the caller flagged as expected-to-collide (singleton/auth).
+    // Every other table keeps strict insert so a real collision still
+    // surfaces as PkCollision.
+    const skipOnConflict =
+      spec.scopes.some((s) => s.via === "from-root-project") ||
+      (opts.mode === "merge" && !!opts.mergeConflictSkip?.includes(spec.sqlName));
+
+    try {
+      // Chunked: one INSERT per `insertChunkSize(spec.table)` rows, so a large
+      // table cannot exceed the 65535 bind-parameter cap.
+      const chunk = insertChunkSize(spec.table);
+      for (let i = 0; i < prepared.length; i += chunk) {
+        const batch = prepared.slice(i, i + chunk);
+        if (skipOnConflict) {
+          await tx
+            .insert(spec.table)
+            .values(batch as never)
+            .onConflictDoNothing();
+        } else {
+          await tx.insert(spec.table).values(batch as never);
         }
-        if (encryptedCols) {
-          for (const encSpec of encryptedCols) redactEncryptedCell(next, encSpec, colMeta);
-        }
-        for (const col of dateCols) {
-          if (typeof next[col] === "string") next[col] = new Date(next[col] as string);
-        }
-        return next;
-      });
-      if (droppedCols.size > 0) {
-        // Version skew, not a fault — the receiver's schema predates these
-        // columns. Log once per table so it's diagnosable without failing.
-        console.warn(
-          `[restore] ${spec.sqlName}: dropped ${droppedCols.size} unknown column(s) not in this build's schema: ${[...droppedCols].join(", ")}`,
+      }
+    } catch (err) {
+      // PostgreSQL unique_violation = 23505 (PGlite mirrors this).
+      // Surface as a typed error so callers (project transfer wizard,
+      // cloud ingest) can distinguish "this row already exists on the
+      // target" from a real server fault. The code lives on the driver
+      // error, which Drizzle wraps — resolve it through the cause chain.
+      const pg = resolvePgError(err);
+      if (pg?.code === "23505") {
+        throw new PkCollisionError(spec.sqlName, pg);
+      }
+      // Drizzle's top-level `.message` is only the "Failed query: … params:"
+      // wrapper; the actual reason (column/constraint/detail) lives on the pg
+      // cause. Re-throw with that reason in the message so it survives error
+      // serialization to the transfer/ingest caller and reaches the operator,
+      // instead of the useless wrapper. Keep the original as `cause`.
+      if (pg) {
+        const detail = (pg as { detail?: string }).detail;
+        throw new Error(
+          `restore ${spec.sqlName}: ${pg.message}${pg.code ? ` [${pg.code}]` : ""}${detail ? ` (${detail})` : ""}`,
+          { cause: err },
         );
       }
-
-      // Shared parents (e.g. project_app, which owns many project environments
-      // via the `from-root-project` resolver) may already exist on the target
-      // — a re-promote re-supplies the same row, and inserting it again is a
-      // no-op, not a conflict. Skip on conflict for those; and, in merge mode,
-      // for tables the caller flagged as expected-to-collide (singleton/auth).
-      // Every other table keeps strict insert so a real collision still
-      // surfaces as PkCollision.
-      const skipOnConflict =
-        spec.scopes.some((s) => s.via === "from-root-project") ||
-        (opts.mode === "merge" && !!opts.mergeConflictSkip?.includes(spec.sqlName));
-
-      try {
-        // Chunked: one INSERT per `insertChunkSize(spec.table)` rows, so a large
-        // table cannot exceed the 65535 bind-parameter cap.
-        const chunk = insertChunkSize(spec.table);
-        for (let i = 0; i < prepared.length; i += chunk) {
-          const batch = prepared.slice(i, i + chunk);
-          if (skipOnConflict) {
-            await tx
-              .insert(spec.table)
-              .values(batch as never)
-              .onConflictDoNothing();
-          } else {
-            await tx.insert(spec.table).values(batch as never);
-          }
-        }
-      } catch (err) {
-        // PostgreSQL unique_violation = 23505 (PGlite mirrors this).
-        // Surface as a typed error so callers (project transfer wizard,
-        // cloud ingest) can distinguish "this row already exists on the
-        // target" from a real server fault. The code lives on the driver
-        // error, which Drizzle wraps — resolve it through the cause chain.
-        const pg = resolvePgError(err);
-        if (pg?.code === "23505") {
-          throw new PkCollisionError(spec.sqlName, pg);
-        }
-        // Drizzle's top-level `.message` is only the "Failed query: … params:"
-        // wrapper; the actual reason (column/constraint/detail) lives on the pg
-        // cause. Re-throw with that reason in the message so it survives error
-        // serialization to the transfer/ingest caller and reaches the operator,
-        // instead of the useless wrapper. Keep the original as `cause`.
-        if (pg) {
-          const detail = (pg as { detail?: string }).detail;
-          throw new Error(
-            `restore ${spec.sqlName}: ${pg.message}${pg.code ? ` [${pg.code}]` : ""}${detail ? ` (${detail})` : ""}`,
-            { cause: err },
-          );
-        }
-        throw err;
-      }
+      throw err;
     }
+  }
+}
+
+/** Restore a subgraph in one transaction. */
+export async function restoreSubgraph(dump: DatabaseDump, opts: RestoreOptions): Promise<void> {
+  await db.transaction(async (rawTx) => {
+    await restoreSubgraphInTransaction(rawTx as DatabaseTransaction, dump, opts);
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,5 +1,5 @@
 // ─── Database client ─────────────────────────────────────────────────────────
-export { db, getDriver, getPgPool, closeDb, type Database, type Driver } from "./client";
+export { db, getDriver, getPgPool, closeDb, type Database, type DatabaseTransaction, type Driver } from "./client";
 // The dev hot-reload contract: shutdown must free the PGlite lock inside the
 // successor's takeover grace, or every reload hard-kills the DB mid-close.
 export { DEV_LOCK_TAKEOVER_GRACE_MS, isDevWatchReload } from "./pglite-lock";
@@ -29,6 +29,7 @@ export {
   dumpSubgraph,
   countInstanceSubgraphTables,
   restoreSubgraph,
+  restoreSubgraphInTransaction,
   deleteProjectSubgraph,
   dumpDatabase,
   restoreDatabase,

--- a/packages/db/src/schema/data-transfer.ts
+++ b/packages/db/src/schema/data-transfer.ts
@@ -1,0 +1,89 @@
+import {
+  bigint,
+  check,
+  customType,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * Short-lived staging for whole-instance transfers.
+ *
+ * These rows deliberately live in Postgres instead of process memory: a receive
+ * code and its uploaded chunks must resolve on any API worker and survive a
+ * process restart. They are excluded from instance exports and removed lazily
+ * after expiry.
+ */
+export const dataTransferSession = pgTable(
+  "data_transfer_session",
+  {
+    id: text("id").primaryKey(),
+    kind: text("kind").notNull(), // direct | file
+    status: text("status").notNull().default("ready"),
+    mode: text("mode"), // wipe | merge; fixed by a direct receive code
+    ownerUserId: text("owner_user_id"), // file-upload sessions only; intentionally no FK
+    tokenHash: text("token_hash"), // direct sessions only (sha256 hex)
+    privateKey: text("private_key"), // instance-encrypted PKCS#8 X25519 key
+    senderPublicKey: text("sender_public_key"),
+    claimToken: text("claim_token"), // identifies the current finalizer lease
+    expectedBytes: bigint("expected_bytes", { mode: "number" }),
+    expectedChunks: integer("expected_chunks"),
+    result: jsonb("result").$type<Record<string, unknown> | null>(),
+    expiresAt: timestamp("expires_at").notNull(),
+    maxExpiresAt: timestamp("max_expires_at").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [
+    index("data_transfer_session_expires_idx").on(t.expiresAt),
+    index("data_transfer_session_owner_idx").on(t.ownerUserId),
+    check("ck_data_transfer_session_kind", sql`${t.kind} IN ('direct', 'file')`),
+    check(
+      "ck_data_transfer_session_status",
+      sql`${t.status} IN ('ready', 'uploading', 'consuming', 'complete', 'failed')`,
+    ),
+    check(
+      "ck_data_transfer_session_mode",
+      sql`${t.mode} IS NULL OR ${t.mode} IN ('wipe', 'merge')`,
+    ),
+    check(
+      "ck_data_transfer_session_expected_bytes",
+      sql`${t.expectedBytes} IS NULL OR ${t.expectedBytes} BETWEEN 1 AND 500000000`,
+    ),
+    check(
+      "ck_data_transfer_session_expected_chunks",
+      sql`${t.expectedChunks} IS NULL OR ${t.expectedChunks} BETWEEN 1 AND 63`,
+    ),
+  ],
+);
+
+/** Drizzle has no built-in bytea column; both pg and PGlite accept Uint8Array. */
+const bytea = customType<{ data: Uint8Array; driverData: Uint8Array }>({
+  dataType: () => "bytea",
+});
+
+export const dataTransferChunk = pgTable(
+  "data_transfer_chunk",
+  {
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => dataTransferSession.id, { onDelete: "cascade" }),
+    chunkIndex: integer("chunk_index").notNull(),
+    bytes: bytea("bytes").notNull(),
+    byteLength: integer("byte_length").notNull(),
+    sha256: text("sha256").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.sessionId, t.chunkIndex] }),
+    check("ck_data_transfer_chunk_index", sql`${t.chunkIndex} BETWEEN 0 AND 62`),
+    check("ck_data_transfer_chunk_length", sql`${t.byteLength} BETWEEN 1 AND 8000064`),
+    check("ck_data_transfer_chunk_bytes", sql`octet_length(${t.bytes}) = ${t.byteLength}`),
+  ],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -43,6 +43,7 @@ export { resourceUsage, RESOURCE_BUCKET_MINUTES, SINGLE_APP_SERVICE_KEY } from "
 export { terminalSessions } from "./terminal-sessions";
 export { serviceTerminalSessions } from "./service-terminal-sessions";
 export { cloudHandoffCode } from "./cloud-handoff-code";
+export { dataTransferSession, dataTransferChunk } from "./data-transfer";
 export { personalAccessToken } from "./personal-access-token";
 export { personalAccessTokenGrant } from "./personal-access-token-grant";
 export { oauthApplication, oauthAccessToken, oauthConsent } from "./oauth";


### PR DESCRIPTION
## Summary

- replace the single oversized direct-transfer request with durable, database-backed 8 MB chunks, authenticated encryption, checksums, bounded retries, heartbeats, and stale-finalizer recovery
- upload local export files with `File.slice()` so neither the browser nor an HTTP request buffers the entire file; retain verified chunks when a recoverable finalize attempt fails
- reconstruct staged uploads through a private temporary file, cap transfers at 500 MB, and bound all control requests and responses
- restore rows, re-encrypt secrets, and mark the transfer complete in one database transaction, using dependency ordering and parameter-safe insert batches
- keep legacy direct-transfer compatibility and explicitly disclose that Docker volume contents are not part of an instance-data export

## Safety and failure semantics

- direct-transfer public endpoints require possession of the one-time cryptographic receive capability; file-upload endpoints remain instance-admin-only and owner-bound
- every direct chunk is AES-GCM encrypted and HMAC-bound to its session/index/checksum; the final plaintext stream is verified against its signed manifest
- leases are persisted across API workers/restarts, renewed during active work, and fenced with a unique finalizer token so a stale worker cannot commit after recovery
- failed atomic restores roll back all imported rows and secret writes; successful finalization stores an idempotent result for ambiguous-response retries
- transfer staging tables are excluded from dumps and wipe restores, and expired staging data is removed lazily

## Validation

- `bun run test`: 11,957 passed, 3 skipped
- `bun run build`: 7/7 tasks successful
- changed-package TypeScript checks: API, dashboard, DB, and core passed
- `git diff --check` passed

Fixes #816
