### PR TITLE
fix(data-transfer): reconcile runtime state after atomic import

### DIFF
--- a/apps/api/src/lib/auth-mode.ts
+++ b/apps/api/src/lib/auth-mode.ts
@@ -57,6 +57,7 @@ export function isAuthModePinned(): boolean {
 /** Cached ONLY for the unpinned (DB-backed) path — avoids a query per request
  *  through authMiddleware. Cleared by every authMode write. */
 let cached: AuthMode | null = null;
+let cacheGeneration = 0;
 
 export async function getAuthMode(): Promise<AuthMode> {
   // Declared → done. Nothing else is consulted, so there is no ordering, no
@@ -65,22 +66,26 @@ export async function getAuthMode(): Promise<AuthMode> {
   if (pinned) return pinned;
 
   if (cached !== null) return cached;
+  const generation = cacheGeneration;
 
   // Undeclared: the persisted value is the source. Fail CLOSED — an unreadable
   // settings table means "require a login", never "let everyone in".
+  let resolved: AuthMode;
   try {
     const { repos } = await import("@repo/db");
     const settings = await repos.instanceSettings.get();
     const stored = settings?.authMode;
-    cached = AUTH_MODES.includes(stored as AuthMode) ? (stored as AuthMode) : "local";
+    resolved = AUTH_MODES.includes(stored as AuthMode) ? (stored as AuthMode) : "local";
   } catch {
-    cached = "local";
+    resolved = "local";
   }
 
-  return cached;
+  if (generation === cacheGeneration) cached = resolved;
+  return resolved;
 }
 
 /** Clear the cached value - called after setup.controller writes. */
 export function clearAuthModeCache() {
+  cacheGeneration += 1;
   cached = null;
 }

--- a/apps/api/src/lib/box-org.ts
+++ b/apps/api/src/lib/box-org.ts
@@ -3,6 +3,13 @@ import { repos } from "@repo/db";
 import { resolvesToLocalHost } from "./self-host";
 
 let cachedBoxOrgId: string | null = null;
+let cacheGeneration = 0;
+
+/** Drop the founding-org memo after a whole-instance restore. */
+export function clearBoxOwningOrgCache(): void {
+  cacheGeneration += 1;
+  cachedBoxOrgId = null;
+}
 
 /**
  * The organization that OWNS this control-plane box: the founding admin's
@@ -21,10 +28,12 @@ let cachedBoxOrgId: string | null = null;
  */
 export async function boxOwningOrgId(): Promise<string | null> {
   if (cachedBoxOrgId) return cachedBoxOrgId;
+  const generation = cacheGeneration;
   const admin = await repos.user.findFoundingAdmin();
   if (!admin?.id) return null;
-  cachedBoxOrgId = `org_${admin.id}`;
-  return cachedBoxOrgId;
+  const resolved = `org_${admin.id}`;
+  if (generation === cacheGeneration) cachedBoxOrgId = resolved;
+  return resolved;
 }
 
 type LocalServerRow = {

--- a/apps/api/src/lib/cache-store/index.ts
+++ b/apps/api/src/lib/cache-store/index.ts
@@ -112,6 +112,37 @@ export function describeCacheStore(): Backend | null {
   return backendDecision;
 }
 
+/**
+ * Invalidate every live cache namespace without disposing the stores.
+ *
+ * A whole-instance database restore can replace every credential, server and
+ * organization row in one commit. Keeping values derived from the previous
+ * snapshot after that commit is both incorrect and, for token caches, unsafe.
+ * This deliberately differs from shutdownCacheStores(): callers keep using the
+ * same Redis connection / memory stores after invalidation.
+ */
+export async function clearAllCacheStores(): Promise<void> {
+  // Include stores whose backend selection is still resolving. A store requested
+  // before the restore must not escape because its promise settled concurrently.
+  const resolved = await Promise.allSettled([...storesByNamespace.values()]);
+  const stores = new Set<CacheStore<unknown>>(trackedStores);
+  const failures: unknown[] = [];
+  for (const result of resolved) {
+    if (result.status === "fulfilled") stores.add(result.value);
+    else failures.push(result.reason);
+  }
+
+  const invalidated = await Promise.allSettled(
+    [...stores].map((store) => store.invalidateByPrefix("")),
+  );
+  for (const result of invalidated) {
+    if (result.status === "rejected") failures.push(result.reason);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "One or more runtime cache stores could not be cleared");
+  }
+}
+
 /** Graceful shutdown — disposes every tracked store and closes the
  *  shared Redis connection. Idempotent. */
 export async function shutdownCacheStores(): Promise<void> {

--- a/apps/api/src/lib/database-runtime-state.ts
+++ b/apps/api/src/lib/database-runtime-state.ts
@@ -1,0 +1,82 @@
+/**
+ * Reconcile process state after a whole-instance database import commits.
+ *
+ * The restore transaction is atomic, but several deliberately short-lived
+ * process caches sit above the database. A wipe can replace the identities,
+ * organizations, credentials, servers and instance settings those caches were
+ * derived from. Leaving even one old value alive creates a split-brain process:
+ * the database is new while requests still act on the previous instance.
+ *
+ * Keep this as the one post-commit boundary used by every import transport.
+ * None of these best-effort refreshes may turn an already committed restore into
+ * a reported failure; callers cannot safely retry an operation that did commit.
+ */
+
+import { withTimeout } from "@repo/core";
+
+import { clearAuthModeCache } from "./auth-mode";
+import { clearBoxOwningOrgCache } from "./box-org";
+import { clearAllCacheStores } from "./cache-store";
+import { clearHostControlCache, syncHostControlOverride } from "./host-control";
+import { invalidateLocalUserCache } from "./local-user";
+import { invalidateInstanceTransportCache, invalidatePlatformTransport } from "./mail";
+import { invalidateMcpSigningKeyCache } from "./mcp-oidc-keys";
+import { clearProductModeCache } from "./product-mode";
+import { invalidateSelfAppPublicUrl } from "./public-url";
+import { sshManager } from "./ssh-manager";
+import { clearMailPortReachabilityCache } from "../modules/mail/mail-port-reachability.service";
+import { clearServiceVolumeSizeCache } from "../modules/services/service.service";
+
+type RefreshFailure = { name: string; error: unknown };
+const ASYNC_RECONCILE_TIMEOUT_MS = 10_000;
+
+/** Run after, and only after, the restore transaction has committed. */
+export async function reconcileRuntimeStateAfterImport(): Promise<void> {
+  const failures: RefreshFailure[] = [];
+  const run = (name: string, operation: () => void): void => {
+    try {
+      operation();
+    } catch (error) {
+      failures.push({ name, error });
+    }
+  };
+
+  run("local user", invalidateLocalUserCache);
+  run("auth mode", clearAuthModeCache);
+  run("product mode", clearProductModeCache);
+  run("host control", clearHostControlCache);
+  run("box owner", clearBoxOwningOrgCache);
+  run("self-app URL", invalidateSelfAppPublicUrl);
+  run("instance SMTP", invalidateInstanceTransportCache);
+  run("platform SMTP", () => invalidatePlatformTransport());
+  run("MCP signing key", invalidateMcpSigningKeyCache);
+  run("SSH connections", () => sshManager.invalidate());
+  run("mail reachability", clearMailPortReachabilityCache);
+  run("service volume sizes", clearServiceVolumeSizeCache);
+
+  const asyncRefreshes = await Promise.allSettled([
+    withTimeout(
+      clearAllCacheStores(),
+      ASYNC_RECONCILE_TIMEOUT_MS,
+      "Timed out clearing shared runtime caches after database import",
+    ),
+    withTimeout(
+      syncHostControlOverride(),
+      ASYNC_RECONCILE_TIMEOUT_MS,
+      "Timed out synchronizing host-control state after database import",
+    ),
+  ]);
+  const names = ["shared cache stores", "host-control adapter"];
+  asyncRefreshes.forEach((result, index) => {
+    if (result.status === "rejected") {
+      failures.push({ name: names[index]!, error: result.reason });
+    }
+  });
+
+  if (failures.length > 0) {
+    console.error(
+      "[data-transfer] database import committed, but runtime-state reconciliation was incomplete:",
+      failures,
+    );
+  }
+}

--- a/apps/api/src/lib/host-control.ts
+++ b/apps/api/src/lib/host-control.ts
@@ -35,6 +35,7 @@ function envHostControlDisabled(): boolean {
 /** Cached because /health/env is unauthenticated and polled by every dashboard
  *  load. Cleared by every instance-settings write. */
 let cached: boolean | null = null;
+let cacheGeneration = 0;
 
 /**
  * Effective "host control is ENABLED" for THIS instance right now. This is the
@@ -47,19 +48,22 @@ export async function resolveHostControlEnabled(): Promise<boolean> {
   if (resolvePlatformConfig().target !== "selfhosted") return false;
 
   if (cached !== null) return cached;
+  const generation = cacheGeneration;
 
   // Unreadable settings fall back to the env default rather than failing closed —
   // refusing to honour a stored enable because one query blipped would silently
   // strand a box that the operator turned back on.
+  let resolved: boolean;
   try {
     const { repos } = await import("@repo/db");
     const stored = (await repos.instanceSettings.get())?.hostControlEnabled;
-    cached = stored ?? !envHostControlDisabled();
+    resolved = stored ?? !envHostControlDisabled();
   } catch {
-    cached = !envHostControlDisabled();
+    resolved = !envHostControlDisabled();
   }
 
-  return cached;
+  if (generation === cacheGeneration) cached = resolved;
+  return resolved;
 }
 
 /**
@@ -87,5 +91,6 @@ export async function syncHostControlOverride(): Promise<void> {
 
 /** Clear the cached effective value — called after setup.controller writes. */
 export function clearHostControlCache() {
+  cacheGeneration += 1;
   cached = null;
 }

--- a/apps/api/src/lib/local-user.ts
+++ b/apps/api/src/lib/local-user.ts
@@ -19,6 +19,7 @@ export const LOCAL_EMAIL = "local@openship.local";
 /** Reset the in-process cache. Use after mutating the local user row
  *  (e.g. the zero-auth → local-auth upgrade flow renames the user). */
 export function invalidateLocalUserCache(): void {
+  cacheGeneration += 1;
   cached = null;
 }
 
@@ -32,9 +33,11 @@ export interface LocalUser {
 }
 
 let cached: LocalUser | null = null;
+let cacheGeneration = 0;
 
 export async function ensureLocalUser(): Promise<LocalUser> {
   if (cached) return cached;
+  const generation = cacheGeneration;
 
   const existing = await repos.user.findByEmail(LOCAL_EMAIL);
   const id = existing?.id ?? randomUUID();
@@ -56,7 +59,7 @@ export async function ensureLocalUser(): Promise<LocalUser> {
   const row = await repos.user.findById(id);
   if (!row) throw new Error("Failed to provision local user");
 
-  cached = {
+  const resolved = {
     id: row.id,
     name: row.name,
     email: row.email,
@@ -65,5 +68,9 @@ export async function ensureLocalUser(): Promise<LocalUser> {
     autoProvisioned: row.autoProvisioned,
   };
 
-  return cached;
+  // A restore can commit while this request is awaiting the DB. Do not allow
+  // that older request to put the pre-restore identity back into the cache.
+  if (generation === cacheGeneration) cached = resolved;
+
+  return resolved;
 }

--- a/apps/api/src/lib/mail.ts
+++ b/apps/api/src/lib/mail.ts
@@ -81,6 +81,7 @@ interface CachedPlatformTransport {
 
 const PLATFORM_TRANSPORT_TTL_MS = 60_000;
 const platformTransportCache = new Map<string, CachedPlatformTransport>();
+let platformTransportGeneration = 0;
 
 /**
  * Resolving the platform mailbox SSHes into the mail server, so a server that is
@@ -143,6 +144,7 @@ async function getPlatformTransport(options?: { rotate?: boolean }): Promise<{
   transport: Transporter;
   from: string;
 } | null> {
+  const generation = platformTransportGeneration;
   // `@repo/db` is universal (every controller / service / repo consumer
   // already loads it eagerly at boot via `db = await createDb()`), so
   // a dynamic import buys nothing — kept static for clarity. The ONLY
@@ -180,9 +182,8 @@ async function getPlatformTransport(options?: { rotate?: boolean }): Promise<{
   }
 
   try {
-    const { ensureOpenshipPlatformMailbox } = await import(
-      "../modules/mail/admin/platform-mailbox.service"
-    );
+    const { ensureOpenshipPlatformMailbox } =
+      await import("../modules/mail/admin/platform-mailbox.service");
     const creds = await withTimeout(
       ensureOpenshipPlatformMailbox(installed.serverId, {
         rotate: options?.rotate === true,
@@ -212,13 +213,17 @@ async function getPlatformTransport(options?: { rotate?: boolean }): Promise<{
       from: creds.from,
       fetchedAt: Date.now(),
     };
-    platformTransportCache.set(cacheKey, entry);
-    platformTransportFailures.delete(cacheKey);
+    if (generation === platformTransportGeneration) {
+      platformTransportCache.set(cacheKey, entry);
+      platformTransportFailures.delete(cacheKey);
+    }
     return { transport, from: creds.from };
   } catch (err) {
     // Logged once per failure window (see the negative cache above) instead of
     // on every request.
-    platformTransportFailures.set(cacheKey, Date.now());
+    if (generation === platformTransportGeneration) {
+      platformTransportFailures.set(cacheKey, Date.now());
+    }
     console.warn(
       `[mail] platform mailbox unavailable on ${installed.serverId}; using the next transport ` +
         `(retrying in ${PLATFORM_TRANSPORT_FAILURE_TTL_MS / 1000}s): ${safeErrorMessage(err)}`,
@@ -231,6 +236,7 @@ async function getPlatformTransport(options?: { rotate?: boolean }): Promise<{
  *  next send/read re-probes immediately instead of waiting out the window. Call
  *  after an install/repair finishes. */
 export function invalidatePlatformTransport(serverId?: string): void {
+  platformTransportGeneration += 1;
   if (!serverId) {
     platformTransportCache.clear();
     platformTransportFailures.clear();
@@ -245,6 +251,7 @@ export function invalidatePlatformTransport(serverId?: string): void {
 const INSTANCE_TRANSPORT_TTL_MS = 60_000;
 let instanceTransportCache: { transport: Transporter; from: string | undefined } | null = null;
 let instanceTransportCheckedAt = 0;
+let instanceTransportGeneration = 0;
 
 /**
  * Operator-configured SMTP from `instance_settings` (Settings → Email). The
@@ -264,6 +271,7 @@ async function getInstanceTransport(): Promise<{
   // Self-hosted only. On the SaaS (CLOUD_MODE) a stray instance_settings SMTP
   // row must never override the platform's own multi-tenant transport.
   if (env.CLOUD_MODE) return null;
+  const generation = instanceTransportGeneration;
 
   const now = Date.now();
   if (now - instanceTransportCheckedAt < INSTANCE_TRANSPORT_TTL_MS) {
@@ -303,8 +311,9 @@ async function getInstanceTransport(): Promise<{
     secure: port === 465,
     auth: { user, pass },
   });
-  instanceTransportCache = { transport, from: settings?.smtpFrom?.trim() || user };
-  return instanceTransportCache;
+  const resolved = { transport, from: settings?.smtpFrom?.trim() || user };
+  if (generation === instanceTransportGeneration) instanceTransportCache = resolved;
+  return resolved;
 }
 
 /**
@@ -312,6 +321,7 @@ async function getInstanceTransport(): Promise<{
  * `instance_settings`. Call after saving the SMTP config.
  */
 export function invalidateInstanceTransportCache(): void {
+  instanceTransportGeneration += 1;
   instanceTransportCache = null;
   instanceTransportCheckedAt = 0;
 }
@@ -398,9 +408,11 @@ async function getTransportChain(
 ): Promise<ActiveTransport[]> {
   const chain: ActiveTransport[] = [];
   const instance = await getInstanceTransport();
-  if (instance) chain.push({ transport: instance.transport, from: instance.from, source: "instance" });
+  if (instance)
+    chain.push({ transport: instance.transport, from: instance.from, source: "instance" });
   const platform = await getPlatformTransport();
-  if (platform) chain.push({ transport: platform.transport, from: platform.from, source: "platform" });
+  if (platform)
+    chain.push({ transport: platform.transport, from: platform.from, source: "platform" });
   if (preferSource !== "platform" && envTransport) {
     chain.push({ transport: envTransport, from: envFrom, source: "env" });
   }

--- a/apps/api/src/lib/mcp-oidc-keys.ts
+++ b/apps/api/src/lib/mcp-oidc-keys.ts
@@ -41,6 +41,14 @@ export interface McpSigningKey {
 
 let cached: McpSigningKey | null = null;
 let inflight: Promise<McpSigningKey> | null = null;
+let cacheGeneration = 0;
+
+/** Drop key material derived from the verification table after a DB restore. */
+export function invalidateMcpSigningKeyCache(): void {
+  cacheGeneration += 1;
+  cached = null;
+  inflight = null;
+}
 
 /** RFC 7638 JWK thumbprint of an RSA public JWK — the standard, stable kid. */
 function thumbprint(jwk: { e: string; kty: string; n: string }): string {
@@ -90,20 +98,32 @@ async function loadOrCreate(): Promise<McpSigningKey> {
 /** The instance signing key — generated on first use, cached for the process. */
 export async function getMcpSigningKey(): Promise<McpSigningKey> {
   if (cached) return cached;
-  inflight ??= loadOrCreate().then((key) => {
-    cached = key;
-    inflight = null;
-    return key;
-  });
+  if (inflight) return inflight;
+  const generation = cacheGeneration;
+  let pending: Promise<McpSigningKey>;
+  pending = loadOrCreate().then(
+    (key) => {
+      // An import may commit while loadOrCreate is awaiting the DB. Return the
+      // value to that request, but do not poison the post-import cache with it.
+      if (generation === cacheGeneration) cached = key;
+      if (inflight === pending) inflight = null;
+      return key;
+    },
+    (error) => {
+      if (inflight === pending) inflight = null;
+      throw error;
+    },
+  );
+  inflight = pending;
   return inflight;
 }
 
 /** Sign an RS256 JWT with the instance key. */
 export async function signRs256Jwt(claims: Record<string, unknown>): Promise<string> {
   const key = await getMcpSigningKey();
-  const header = Buffer.from(
-    JSON.stringify({ alg: "RS256", typ: "JWT", kid: key.kid }),
-  ).toString("base64url");
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT", kid: key.kid })).toString(
+    "base64url",
+  );
   const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
   const signature = cryptoSign("sha256", Buffer.from(`${header}.${payload}`), key.privateKey);
   return `${header}.${payload}.${signature.toString("base64url")}`;

--- a/apps/api/src/lib/product-mode.ts
+++ b/apps/api/src/lib/product-mode.ts
@@ -41,6 +41,7 @@ export function isProductMode(value: unknown): value is ProductMode {
 /** Cached because /health/env is unauthenticated and polled by every dashboard
  *  load. Cleared by every instance-settings write. */
 let cached: ProductMode | null = null;
+let cacheGeneration = 0;
 
 export async function resolveProductMode(): Promise<ProductMode> {
   // Multi-tenant SaaS: mail is self-hosted-only infrastructure. Checked first so
@@ -48,23 +49,27 @@ export async function resolveProductMode(): Promise<ProductMode> {
   if (env.CLOUD_MODE) return "platform";
 
   if (cached !== null) return cached;
+  const generation = cacheGeneration;
 
   // Unreadable settings fall back to the env default rather than failing closed.
   // This value picks which nav to draw; there is nothing to fail closed ABOUT,
   // and refusing to honour a declared OPENSHIP_PRODUCT=mail because one query
   // failed would show a mail-only operator a platform UI they can't use.
+  let resolved: ProductMode;
   try {
     const { repos } = await import("@repo/db");
     const stored = (await repos.instanceSettings.get())?.productMode;
-    cached = isProductMode(stored) ? stored : env.OPENSHIP_PRODUCT;
+    resolved = isProductMode(stored) ? stored : env.OPENSHIP_PRODUCT;
   } catch {
-    cached = env.OPENSHIP_PRODUCT;
+    resolved = env.OPENSHIP_PRODUCT;
   }
 
-  return cached;
+  if (generation === cacheGeneration) cached = resolved;
+  return resolved;
 }
 
 /** Clear the cached value — called after setup.controller writes. */
 export function clearProductModeCache() {
+  cacheGeneration += 1;
   cached = null;
 }

--- a/apps/api/src/lib/public-url.ts
+++ b/apps/api/src/lib/public-url.ts
@@ -39,6 +39,7 @@ const SELF_APP_SLUG = "openship";
  * auth-mode / zero-auth / cookie / trustedOrigins gates — those stay env-only.
  */
 let cachedSelfAppUrl: string | null = null;
+let cacheGeneration = 0;
 
 /** Normalized public URL (no trailing slash): env seed wins, else the self-app's
  *  verified primary domain, else null (callers fall back to the runtime target). */
@@ -79,23 +80,27 @@ async function locateSelfAppProjectId(): Promise<string | null> {
  * Best-effort — keeps the prior value on error. Returns the resolved URL / null.
  */
 export async function refreshSelfAppPublicUrl(): Promise<string | null> {
+  const generation = cacheGeneration;
   try {
     const projectId = await locateSelfAppProjectId();
     if (!projectId) {
-      cachedSelfAppUrl = null;
+      if (generation === cacheGeneration) cachedSelfAppUrl = null;
       return null;
     }
     const project = await repos.project.findById(projectId);
     if (!project?.activeDeploymentId) {
-      cachedSelfAppUrl = null;
+      if (generation === cacheGeneration) cachedSelfAppUrl = null;
       return null;
     }
     const primary = await repos.domain.getPrimaryByProject(projectId);
-    cachedSelfAppUrl =
-      primary && primary.verified && (primary.sslStatus === "active" || primary.sslStatus === "external")
+    const resolved =
+      primary &&
+      primary.verified &&
+      (primary.sslStatus === "active" || primary.sslStatus === "external")
         ? `https://${primary.hostname}`
         : null;
-    return cachedSelfAppUrl;
+    if (generation === cacheGeneration) cachedSelfAppUrl = resolved;
+    return resolved;
   } catch {
     return cachedSelfAppUrl;
   }
@@ -103,6 +108,7 @@ export async function refreshSelfAppPublicUrl(): Promise<string | null> {
 
 /** Drop the cached self-app URL (call after a self-app domain change). */
 export function invalidateSelfAppPublicUrl(): void {
+  cacheGeneration += 1;
   cachedSelfAppUrl = null;
 }
 
@@ -158,7 +164,9 @@ export async function getInstanceReachability(): Promise<InstanceReachability> {
   }
   const primary = await repos.domain.getPrimaryByProject(selfAppProjectId).catch(() => null);
   const hasVerifiedDomain =
-    !!primary && primary.verified && (primary.sslStatus === "active" || primary.sslStatus === "external");
+    !!primary &&
+    primary.verified &&
+    (primary.sslStatus === "active" || primary.sslStatus === "external");
   await refreshSelfAppPublicUrl().catch(() => {});
   const url = publicUrl();
   return {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -125,8 +125,8 @@ async function finishBearer(
   boundOrg: string | null,
   patScope: { tokenId: string; scoped: boolean } | undefined,
   principalKind: PrincipalKind,
-): Promise<typeof PAT_HANDLED> {
-  await applyAuthedRequest(
+): Promise<Response | typeof PAT_HANDLED> {
+  const applied = await applyAuthedRequest(
     c,
     user,
     { id: principalId, activeOrganizationId: boundOrg },
@@ -134,6 +134,9 @@ async function finishBearer(
     patScope,
     principalKind,
   );
+  if (!applied) {
+    return c.json({ error: "Invalid or expired access token", code: "INVALID_TOKEN" }, 401);
+  }
   await next();
   return PAT_HANDLED;
 }
@@ -206,7 +209,10 @@ export async function resolveBearerIdentity(
   // row keyed by (user, client), written at consent. No binding → the token
   // never passed consent → DENY EVERYTHING (a scoped principal with a grant key
   // that has no rows), rather than fall through to the user's full role.
-  const binding = await repos.personalAccessToken.findOAuthBinding(session.userId, session.clientId);
+  const binding = await repos.personalAccessToken.findOAuthBinding(
+    session.userId,
+    session.clientId,
+  );
   return {
     kind: "oauth",
     userId: session.userId,
@@ -231,7 +237,10 @@ export async function resolveBearerIdentity(
  * Returns null (not a bearer / fall through), an error Response, or PAT_HANDLED
  * after a successful auth + next().
  */
-async function tryBearerAuth(c: Context, next: Next): Promise<Response | typeof PAT_HANDLED | null> {
+async function tryBearerAuth(
+  c: Context,
+  next: Next,
+): Promise<Response | typeof PAT_HANDLED | null> {
   const token = parseBearerToken(c);
   if (!token) return null; // no Authorization: Bearer → session path
   const isPat = isPatToken(token);
@@ -242,7 +251,10 @@ async function tryBearerAuth(c: Context, next: Next): Promise<Response | typeof 
   if (originIsBrowserTrusted(c)) {
     return isPat
       ? c.json(
-          { error: "Access tokens are not allowed from browser origins", code: "BEARER_NOT_ALLOWED_FROM_BROWSER" },
+          {
+            error: "Access tokens are not allowed from browser origins",
+            code: "BEARER_NOT_ALLOWED_FROM_BROWSER",
+          },
           401,
         )
       : null;
@@ -258,7 +270,8 @@ async function tryBearerAuth(c: Context, next: Next): Promise<Response | typeof 
   }
 
   const user = await repos.user.findById(resolved.userId);
-  if (!user) return c.json({ error: "Invalid or expired access token", code: "INVALID_TOKEN" }, 401);
+  if (!user)
+    return c.json({ error: "Invalid or expired access token", code: "INVALID_TOKEN" }, 401);
 
   const denied = enforceBoundOrgAndReadOnly(c, {
     boundOrg: resolved.organizationId,
@@ -269,7 +282,9 @@ async function tryBearerAuth(c: Context, next: Next): Promise<Response | typeof 
         ? "This access token is scoped to a different organization"
         : "This authorization is scoped to a different organization",
     readOnlyMessage:
-      resolved.kind === "pat" ? "This access token is read-only" : "This MCP authorization is read-only",
+      resolved.kind === "pat"
+        ? "This access token is read-only"
+        : "This MCP authorization is read-only",
   });
   if (denied) return denied;
 
@@ -310,10 +325,7 @@ export async function authMiddleware(c: Context, next: Next) {
     // path. Return a 503 with a typed code so callers can distinguish
     // "no session" (cookie missing) from "session machinery broken".
     console.error("[auth] getSession threw:", err);
-    return c.json(
-      { error: "Authentication service unavailable", code: "AUTH_UNAVAILABLE" },
-      503,
-    );
+    return c.json({ error: "Authentication service unavailable", code: "AUTH_UNAVAILABLE" }, 503);
   }
 
   if (session) {
@@ -336,7 +348,7 @@ export async function authMiddleware(c: Context, next: Next) {
     // a browser cookie session — both flow through Better Auth's
     // getSession, but only Bearer carries the Authorization header.
     const sessionKind: SessionKind = hasBearerHeader(c) ? "bearer" : "cookie";
-    await applyAuthedRequest(
+    const applied = await applyAuthedRequest(
       c,
       session.user,
       session.session as {
@@ -345,6 +357,12 @@ export async function authMiddleware(c: Context, next: Next) {
       },
       sessionKind,
     );
+    // Better Auth can serve a signed/cached session whose user or membership was
+    // removed by a wipe import. Treat it as stale authentication; never continue
+    // into permission/route handlers without a RequestContext.
+    if (!applied) {
+      return c.json({ error: "Unauthorized", code: "SESSION_STALE" }, 401);
+    }
     return next();
   }
 
@@ -361,8 +379,15 @@ export async function authMiddleware(c: Context, next: Next) {
   }
 
   const user = await ensureLocalUser();
-  c.set("session", { id: "zero-auth", userId: user.id });
-  await applyAuthedRequest(c, user, { id: "zero-auth" }, "zero-auth");
+  const applied = await applyAuthedRequest(
+    c,
+    user,
+    { id: "zero-auth", userId: user.id },
+    "zero-auth",
+  );
+  if (!applied) {
+    return c.json({ error: "Unauthorized", code: "AUTH_CONTEXT_UNAVAILABLE" }, 401);
+  }
   return next();
 }
 
@@ -381,34 +406,25 @@ export async function authMiddleware(c: Context, next: Next) {
 async function applyAuthedRequest(
   c: Context,
   user: { id: string; email?: string | null; name?: string | null },
-  session:
-    | { id?: string; activeOrganizationId?: string | null }
-    | null,
+  session: { id?: string; userId?: string; activeOrganizationId?: string | null } | null,
   sessionKind: SessionKind,
   patScope?: { tokenId: string; scoped: boolean },
   principalKind?: PrincipalKind,
-): Promise<void> {
-  c.set("user", user);
-  if (session && sessionKind !== "zero-auth") c.set("session", session);
-  const orgId = await resolveActiveOrganizationId(
-    user.id,
-    session?.activeOrganizationId ?? null,
-  );
-  if (orgId) c.set("activeOrganizationId", orgId);
-
-  // Build the RequestContext. If the user has no org membership yet
-  // (brand-new signup, mid-provisioning) we skip ctx — downstream
-  // handlers that call getRequestContext will get a clear error
-  // pointing at the missing org, which is correct behavior: org-bound
-  // routes shouldn't have run anyway.
-  if (!orgId) return;
+): Promise<boolean> {
+  const orgId = await resolveActiveOrganizationId(user.id, session?.activeOrganizationId ?? null);
+  if (!orgId) return false;
 
   const membership = await repos.member.find(orgId, user.id);
   // Zero-auth's synthetic user is owner of its personal org via
-  // provisionUser, so this lookup succeeds there too. If it doesn't,
-  // we still skip ctx rather than crash — better-auth-shield and
-  // other middlewares will reject the request appropriately.
-  if (!membership) return;
+  // provisionUser, so this lookup succeeds there too. Any authenticated
+  // principal without a current membership is stale and must fail here.
+  if (!membership) return false;
+
+  // Publish the legacy fields only once all context invariants hold. A stale
+  // session must not leave a half-authenticated request behind.
+  c.set("user", user);
+  if (session) c.set("session", session);
+  c.set("activeOrganizationId", orgId);
 
   // A scoped PAT acts as a restricted principal whose grants come from the
   // token (permission.assert / github-access read them via tokenScope), so
@@ -440,4 +456,5 @@ async function applyAuthedRequest(
       hono: c,
     }),
   );
+  return true;
 }

--- a/apps/api/src/modules/services/service.service.ts
+++ b/apps/api/src/modules/services/service.service.ts
@@ -1722,6 +1722,11 @@ const VOL_SIZE_TTL_MS = 60_000;
 // the exact container, so re-opening the tab doesn't re-`du` every time.
 const volSizeCache = new Map<string, { at: number; value: ServiceVolumeSizes }>();
 
+/** Drop measurements keyed by project/service rows replaced by an import. */
+export function clearServiceVolumeSizeCache(): void {
+  volSizeCache.clear();
+}
+
 /** Resolve a named volume's real on-host name (it may be namespaced at deploy
  *  time as `openship-<slug>-<name>`) and `du` its mountpoint. Only used as a
  *  fallback when the container isn't running to report authoritative mounts. */

--- a/apps/api/src/modules/system/data-transfer/import.service.ts
+++ b/apps/api/src/modules/system/data-transfer/import.service.ts
@@ -13,7 +13,8 @@
 import { db, eq, inArray, restoreSubgraphInTransaction, type DatabaseTransaction } from "@repo/db";
 
 import { env } from "../../../config/env";
-import { withMigrationLock } from "../migration/migration-lock";
+import { reconcileRuntimeStateAfterImport } from "../../../lib/database-runtime-state";
+import { reassertMigrationLockAfterRestore, withMigrationLock } from "../migration/migration-lock";
 import { CloudInstanceNotTransferableError } from "./errors";
 import { openTransferSecrets } from "./passphrase-crypto";
 import { sealForInstance } from "./secret-codec";
@@ -264,7 +265,18 @@ export async function importPreparedInstance(opts: {
         secretsSkipped,
         localPathProjects,
       });
+
+      // A wipe replaces instance_settings, including the row carrying the lock
+      // acquired above. Reassert it as the final transactional write so no new
+      // mutation can enter between commit and runtime-state reconciliation.
+      await reassertMigrationLockAfterRestore(tx);
     });
+
+    // The database commit is the atomic boundary. Everything cached above it
+    // must now forget the previous instance before the quiesce lock is released.
+    // This hook owns its own error handling: a committed destructive import must
+    // never be reported as failed/retryable.
+    await reconcileRuntimeStateAfterImport();
   });
 
   return { mode, rowsRestored, secretsRehydrated, secretsSkipped, localPathProjects };

--- a/apps/api/src/modules/system/migration/migration-lock.ts
+++ b/apps/api/src/modules/system/migration/migration-lock.ts
@@ -27,7 +27,7 @@
  * over before any worker would actually do anything.
  */
 
-import { db, sql } from "@repo/db";
+import { db, sql, type DatabaseTransaction } from "@repo/db";
 import { getJobRunner } from "../../../lib/job-runner";
 
 export class MigrationAlreadyInProgressError extends Error {
@@ -87,6 +87,27 @@ async function releaseLock(): Promise<void> {
 }
 
 /**
+ * Keep the quiesce flag alive when a destructive restore replaces the
+ * instance_settings row that originally held it. Call this as the final write
+ * in the restore transaction: once that transaction commits, mutation requests
+ * must remain blocked until post-commit process state has been reconciled.
+ */
+export async function reassertMigrationLockAfterRestore(tx: DatabaseTransaction): Promise<void> {
+  const result = await tx.execute(sql`
+    UPDATE instance_settings
+    SET migration_in_progress = true,
+        migration_started_at = NOW(),
+        updated_at = NOW()
+    WHERE id = 'default'
+    RETURNING id
+  `);
+  const rows = (result as unknown as { rows?: unknown[] }).rows ?? (result as unknown as unknown[]);
+  if (!Array.isArray(rows) || rows.length !== 1) {
+    throw new Error("The restored instance settings row is missing; the migration lock was lost.");
+  }
+}
+
+/**
  * Wrap a migration body in the quiesce protocol.
  *
  * Order of operations:
@@ -118,9 +139,7 @@ export async function withMigrationLock<T>(fn: () => Promise<T>): Promise<T> {
     // The compare-and-swap UPDATE never committed, so no lock leak.
     // Wrap the raw drizzle/pg error in a typed error so the controller
     // surfaces a clean 503 instead of a raw 500 with a stack trace.
-    throw new MigrationLockAcquireError(
-      err instanceof Error ? err.message : String(err),
-    );
+    throw new MigrationLockAcquireError(err instanceof Error ? err.message : String(err));
   }
   if (!acquired) {
     throw new MigrationAlreadyInProgressError();
@@ -151,7 +170,9 @@ export async function withMigrationLock<T>(fn: () => Promise<T>): Promise<T> {
       try {
         if (typeof (pausedRunner as { resumeAll?: () => Promise<void> }).resumeAll === "function") {
           await (pausedRunner as unknown as { resumeAll: () => Promise<void> }).resumeAll();
-        } else if (typeof (pausedRunner as { resume?: () => Promise<void> }).resume === "function") {
+        } else if (
+          typeof (pausedRunner as { resume?: () => Promise<void> }).resume === "function"
+        ) {
           await (pausedRunner as unknown as { resume: () => Promise<void> }).resume();
         }
       } catch (err) {
@@ -176,8 +197,9 @@ export async function isMigrationInProgress(): Promise<boolean> {
     FROM instance_settings
     WHERE id = 'default'
   `);
-  const rows = (row as unknown as { rows?: Array<{ in_progress?: boolean }> }).rows
-    ?? (row as unknown as Array<{ in_progress?: boolean }>);
+  const rows =
+    (row as unknown as { rows?: Array<{ in_progress?: boolean }> }).rows ??
+    (row as unknown as Array<{ in_progress?: boolean }>);
   if (!Array.isArray(rows) || rows.length === 0) return false;
   return rows[0]?.in_progress === true;
 }

--- a/apps/api/test/e2e/data-transfer-http.e2e.test.ts
+++ b/apps/api/test/e2e/data-transfer-http.e2e.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Whole-instance transfer through the real HTTP stack.
+ *
+ * This intentionally starts two API processes with separate PGlite databases
+ * and encryption keys. It covers the boundaries a service-level test cannot:
+ * body limits, public capability routes, bounded encrypted chunks, retry after
+ * an accepted response is lost, SSE finalization, post-wipe runtime caches,
+ * destination-key secret re-encryption, and file-upload resume after restart.
+ */
+
+import { createHash } from "node:crypto";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, expect, it } from "vitest";
+import { readSseTerminalEvent } from "@repo/core";
+
+import { openTransferSecrets } from "../../src/modules/system/data-transfer/passphrase-crypto";
+import type {
+  DataTransferFile,
+  ImportResult,
+  SecretBundle,
+} from "../../src/modules/system/data-transfer/types";
+import { TRANSFER_CHUNK_BYTES } from "../../src/modules/system/data-transfer/chunk-store";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const API_ENTRY = join(REPO_ROOT, "apps/api/src/index.ts");
+const MAX_PROXY_BODY = TRANSFER_CHUNK_BYTES + 64;
+const SECRET_VALUE = "transfer-secret-816-✓";
+const FILE_SECRET_VALUE = "file-resume-secret-816-✓";
+const FILE_PASSPHRASE = "issue-816-http-e2e-passphrase";
+
+interface RunningApi {
+  child: ChildProcessWithoutNullStreams;
+  baseUrl: string;
+  dbDir: string;
+  port: number;
+  secret: string;
+  logs: () => string;
+}
+
+interface ProxyStats {
+  requestBytes: number[];
+  chunkAttempts: Map<string, number>;
+  droppedAcceptedChunk: boolean;
+  oversized: boolean;
+}
+
+let tempRoot: string | null = null;
+const children = new Set<RunningApi>();
+let proxy: Server | null = null;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function freePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not allocate a test port");
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
+async function waitForApi(api: RunningApi): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (api.child.exitCode !== null) {
+      throw new Error(`API exited during startup (${api.child.exitCode})\n${api.logs()}`);
+    }
+    try {
+      const response = await fetch(`${api.baseUrl}/api/health`);
+      if (response.ok) return;
+    } catch {
+      // Listener is not ready yet.
+    }
+    await delay(100);
+  }
+  throw new Error(`API did not become ready on ${api.baseUrl}\n${api.logs()}`);
+}
+
+async function startApi(input: {
+  dbDir: string;
+  port: number;
+  secret: string;
+}): Promise<RunningApi> {
+  let output = "";
+  const child = spawn("bun", [API_ENTRY], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      // Do not inherit Vitest's marker: @repo/db intentionally switches to an
+      // in-memory PGlite under VITEST, which would make a process restart look
+      // like data loss instead of reopening the explicit directory below.
+      VITEST: "",
+      NODE_ENV: "production",
+      DEPLOY_MODE: "desktop",
+      OPENSHIP_AUTH_MODE: "none",
+      CLOUD_MODE: "false",
+      DATABASE_URL: "",
+      PGLITE_DATA_DIR: input.dbDir,
+      BETTER_AUTH_SECRET: input.secret,
+      INTERNAL_TOKEN: "issue-816-http-e2e-internal-token-000000000000",
+      PORT: String(input.port),
+      OPENSHIP_API_HOST: "127.0.0.1",
+      OPENSHIP_ADVERTISED_ORIGIN: `http://127.0.0.1:${input.port}`,
+      OPENSHIP_JOB_RUNNER: "in-process",
+      OPENSHIP_CACHE_STORE: "memory",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const append = (chunk: Buffer | string) => {
+    output = `${output}${chunk.toString()}`.slice(-50_000);
+  };
+  child.stdout.on("data", append);
+  child.stderr.on("data", append);
+
+  const api: RunningApi = {
+    child,
+    baseUrl: `http://127.0.0.1:${input.port}`,
+    dbDir: input.dbDir,
+    port: input.port,
+    secret: input.secret,
+    logs: () => output,
+  };
+  children.add(api);
+  await waitForApi(api);
+  return api;
+}
+
+async function stopApi(api: RunningApi): Promise<void> {
+  if (api.child.exitCode === null) {
+    api.child.kill("SIGTERM");
+    const exited = new Promise<boolean>((resolve) => api.child.once("exit", () => resolve(true)));
+    if (!(await Promise.race([exited, delay(15_000).then(() => false)]))) {
+      api.child.kill("SIGKILL");
+      await new Promise<void>((resolve) => api.child.once("exit", () => resolve()));
+    }
+  }
+  children.delete(api);
+}
+
+async function jsonRequest<T>(apiBase: string, path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers: {
+      ...(init.body ? { "content-type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${init.method ?? "GET"} ${path} returned ${response.status}: ${text}`);
+  }
+  return JSON.parse(text) as T;
+}
+
+async function terminalSse<T>(apiBase: string, path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${apiBase}${path}`, {
+    method: "POST",
+    headers: { accept: "text/event-stream", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok || !response.body) {
+    throw new Error(`${path} returned ${response.status}: ${await response.text()}`);
+  }
+  const terminal = await readSseTerminalEvent(response.body);
+  if (terminal.event !== "complete") {
+    throw new Error(`${path} ended with ${terminal.event}: ${terminal.data}`);
+  }
+  return JSON.parse(terminal.data) as T;
+}
+
+async function createProject(
+  apiBase: string,
+  name: string,
+  slug: string,
+  routingConfig?: Record<string, unknown>,
+): Promise<{ id: string }> {
+  const response = await jsonRequest<{ data: { id: string } }>(apiBase, "/api/projects", {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      slug,
+      gitProvider: "github",
+      gitOwner: "example",
+      gitRepo: slug,
+      gitBranch: "main",
+      framework: "static",
+      packageManager: "npm",
+      productionMode: "static",
+      port: 3000,
+      hasServer: false,
+      hasBuild: false,
+      sourceKind: "git",
+      buildKind: "static",
+      workloadType: "static",
+      routingConfig,
+    }),
+  });
+  return response.data;
+}
+
+async function mergeEnv(
+  apiBase: string,
+  projectId: string,
+  upserts: Array<{ key: string; value: string; isSecret: boolean }>,
+): Promise<void> {
+  await jsonRequest(apiBase, `/api/projects/${projectId}/env`, {
+    method: "PATCH",
+    body: JSON.stringify({ environment: "production", upserts, deletes: [] }),
+  });
+}
+
+function findSecret(bundle: SecretBundle | null, value: string): boolean {
+  return !!bundle?.entries.some((entry) => entry.value === value);
+}
+
+async function startRetryProxy(destinationPort: number): Promise<{
+  baseUrl: string;
+  stats: ProxyStats;
+}> {
+  const stats: ProxyStats = {
+    requestBytes: [],
+    chunkAttempts: new Map(),
+    droppedAcceptedChunk: false,
+    oversized: false,
+  };
+
+  proxy = createServer((incoming, outgoing) => {
+    const path = incoming.url ?? "/";
+    const chunkPath = /^\/api\/system\/data-transfer\/direct\/chunk\/[^/]+\/(\d+)$/.exec(path);
+    if (chunkPath) {
+      stats.chunkAttempts.set(chunkPath[1]!, (stats.chunkAttempts.get(chunkPath[1]!) ?? 0) + 1);
+    }
+
+    const headers = { ...incoming.headers, host: `127.0.0.1:${destinationPort}` };
+    delete headers.connection;
+    delete headers["transfer-encoding"];
+    const upstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port: destinationPort,
+        method: incoming.method,
+        path,
+        headers,
+      },
+      (upstreamResponse) => {
+        const dropThisResponse =
+          !!chunkPath && !stats.droppedAcceptedChunk && (upstreamResponse.statusCode ?? 500) < 300;
+        if (dropThisResponse) {
+          stats.droppedAcceptedChunk = true;
+          upstreamResponse.resume();
+          upstreamResponse.once("end", () => outgoing.destroy());
+          return;
+        }
+        // Node owns framing on this hop. Forwarding the upstream hop-by-hop
+        // transfer-encoding header makes Bun correctly reject a doubly-framed
+        // streamed response as UnsupportedTransferEncoding.
+        const responseHeaders = { ...upstreamResponse.headers };
+        delete responseHeaders.connection;
+        delete responseHeaders["transfer-encoding"];
+        delete responseHeaders["content-length"];
+        outgoing.writeHead(upstreamResponse.statusCode ?? 502, responseHeaders);
+        upstreamResponse.pipe(outgoing);
+      },
+    );
+
+    let bytes = 0;
+    let rejected = false;
+    incoming.on("data", (chunk: Buffer) => {
+      bytes += chunk.byteLength;
+      if (bytes > MAX_PROXY_BODY && !rejected) {
+        rejected = true;
+        stats.oversized = true;
+        upstream.destroy();
+        outgoing.writeHead(413).end();
+        return;
+      }
+      if (!rejected) upstream.write(chunk);
+    });
+    incoming.on("end", () => {
+      stats.requestBytes.push(bytes);
+      if (!rejected) upstream.end();
+    });
+    incoming.on("error", (error) => upstream.destroy(error));
+    upstream.on("error", (error) => {
+      if (!outgoing.destroyed) outgoing.destroy(error);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    proxy!.once("error", reject);
+    proxy!.listen(0, "127.0.0.1", resolve);
+  });
+  const address = proxy.address();
+  if (!address || typeof address === "string") throw new Error("Proxy did not bind a TCP port");
+  return { baseUrl: `http://127.0.0.1:${address.port}`, stats };
+}
+
+afterAll(async () => {
+  if (proxy) {
+    await new Promise<void>((resolve) => proxy!.close(() => resolve()));
+    proxy = null;
+  }
+  for (const child of [...children]) await stopApi(child);
+  if (tempRoot) await rm(tempRoot, { recursive: true, force: true });
+});
+
+it("transfers multiple HTTP chunks atomically and resumes a file import after restart", async () => {
+  tempRoot = await mkdtemp(join(tmpdir(), "openship-data-transfer-http-e2e-"));
+  const sourcePort = await freePort();
+  let destinationPort = await freePort();
+  while (destinationPort === sourcePort) destinationPort = await freePort();
+
+  const source = await startApi({
+    dbDir: join(tempRoot, "source"),
+    port: sourcePort,
+    secret: "source-http-e2e-secret-816-00000000000000000",
+  });
+  let destination = await startApi({
+    dbDir: join(tempRoot, "destination"),
+    port: destinationPort,
+    secret: "destination-http-e2e-secret-816-0000000000000",
+  });
+
+  // Warm the destination's process-local synthetic-user cache. A wipe replaces
+  // this user; the next request is the regression that used to return 500.
+  const initiallyEmpty = await jsonRequest<{ data: unknown[] }>(
+    destination.baseUrl,
+    "/api/projects?perPage=100",
+  );
+  expect(initiallyEmpty.data).toEqual([]);
+
+  // One durable JSON column makes the payload cross the 8 MB boundary without
+  // creating hundreds of encrypted rows (which would make this transport test
+  // spend most of its time benchmarking per-row secret re-encryption).
+  const largeRoutingConfig = {
+    headers: Array.from({ length: 200 }, (_, group) => ({
+      source: `/fixture-${group}`,
+      headers: Array.from({ length: 11 }, (_, header) => ({
+        key: `x-e2e-${group}-${header}`,
+        value: `header-${group}-${header}-`.padEnd(3_900, String((group + header) % 10)),
+      })),
+    })),
+  };
+  const project = await createProject(
+    source.baseUrl,
+    "Transfer E2E Sentinel",
+    "transfer-e2e-sentinel",
+    largeRoutingConfig,
+  );
+  await mergeEnv(source.baseUrl, project.id, [
+    { key: "E2E_SECRET", value: SECRET_VALUE, isSecret: true },
+  ]);
+
+  const retryProxy = await startRetryProxy(destination.port);
+  const receive = await jsonRequest<{ code: string }>(
+    destination.baseUrl,
+    "/api/system/data-transfer/direct/session",
+    {
+      method: "POST",
+      body: JSON.stringify({ apiBase: `${retryProxy.baseUrl}/api/`, mode: "wipe" }),
+    },
+  );
+  const transferred = await terminalSse<ImportResult & { destination: string }>(
+    source.baseUrl,
+    "/api/system/data-transfer/direct/send/stream",
+    { code: receive.code, selection: { history: [] } },
+  );
+  expect(transferred.mode).toBe("wipe");
+  expect(transferred.secretsRehydrated).toBeGreaterThan(0);
+  expect(retryProxy.stats.droppedAcceptedChunk).toBe(true);
+  expect(retryProxy.stats.chunkAttempts.size).toBeGreaterThan(1);
+  expect([...retryProxy.stats.chunkAttempts.values()].some((attempts) => attempts > 1)).toBe(true);
+  expect(retryProxy.stats.oversized).toBe(false);
+  expect(Math.max(...retryProxy.stats.requestBytes)).toBeLessThanOrEqual(MAX_PROXY_BODY);
+
+  // No restart here: this proves the post-commit process cache is coherent.
+  const destinationProjects = await jsonRequest<{ data: Array<{ id: string; slug: string }> }>(
+    destination.baseUrl,
+    "/api/projects?perPage=100",
+  );
+  expect(destinationProjects.data).toContainEqual(
+    expect.objectContaining({ id: project.id, slug: "transfer-e2e-sentinel" }),
+  );
+  const masked = await jsonRequest<{
+    data: Array<{ key: string; value: string; isSecret: boolean }>;
+  }>(destination.baseUrl, `/api/projects/${project.id}/env`);
+  expect(masked.data).toContainEqual(
+    expect.objectContaining({ key: "E2E_SECRET", value: "••••••••", isSecret: true }),
+  );
+
+  const destinationExport = await jsonRequest<DataTransferFile>(
+    destination.baseUrl,
+    "/api/system/data-transfer/export",
+    {
+      method: "POST",
+      body: JSON.stringify({ passphrase: FILE_PASSPHRASE, selection: { history: [] } }),
+    },
+  );
+  expect(
+    findSecret(openTransferSecrets(destinationExport.secrets, FILE_PASSPHRASE), SECRET_VALUE),
+  ).toBe(true);
+
+  // File upload uses the same import boundary. Upload one chunk, restart the
+  // destination process against the same DB, then resume and finalize.
+  const fileProject = await createProject(
+    source.baseUrl,
+    "File Resume Sentinel",
+    "file-resume-sentinel",
+  );
+  await mergeEnv(source.baseUrl, fileProject.id, [
+    { key: "FILE_RESUME_SECRET", value: FILE_SECRET_VALUE, isSecret: true },
+  ]);
+  const transferFile = await jsonRequest<DataTransferFile>(
+    source.baseUrl,
+    "/api/system/data-transfer/export",
+    {
+      method: "POST",
+      body: JSON.stringify({ passphrase: FILE_PASSPHRASE, selection: { history: [] } }),
+    },
+  );
+  const fileBytes = Buffer.from(JSON.stringify(transferFile), "utf8");
+  expect(fileBytes.byteLength).toBeGreaterThan(TRANSFER_CHUNK_BYTES);
+  const upload = await jsonRequest<{
+    uploadId: string;
+    chunkSize: number;
+    totalChunks: number;
+  }>(destination.baseUrl, "/api/system/data-transfer/import/session", {
+    method: "POST",
+    body: JSON.stringify({ size: fileBytes.byteLength }),
+  });
+  expect(upload.chunkSize).toBe(TRANSFER_CHUNK_BYTES);
+  expect(upload.totalChunks).toBeGreaterThan(1);
+
+  const uploadChunk = async (index: number): Promise<void> => {
+    const chunk = fileBytes.subarray(index * upload.chunkSize, (index + 1) * upload.chunkSize);
+    const response = await fetch(
+      `${destination.baseUrl}/api/system/data-transfer/import/session/${upload.uploadId}/chunk/${index}`,
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-openship-chunk-sha256": createHash("sha256").update(chunk).digest("hex"),
+        },
+        body: chunk,
+      },
+    );
+    if (!response.ok)
+      throw new Error(`file chunk ${index} returned ${response.status}: ${await response.text()}`);
+  };
+
+  await uploadChunk(0);
+  await stopApi(destination);
+  destination = await startApi({
+    dbDir: destination.dbDir,
+    port: destination.port,
+    secret: destination.secret,
+  });
+  for (let index = 1; index < upload.totalChunks; index += 1) await uploadChunk(index);
+
+  const imported = await terminalSse<ImportResult>(
+    destination.baseUrl,
+    `/api/system/data-transfer/import/session/${upload.uploadId}/finalize/stream`,
+    { passphrase: FILE_PASSPHRASE, mode: "wipe" },
+  );
+  expect(imported.mode).toBe("wipe");
+  expect(imported.secretsRehydrated).toBeGreaterThan(0);
+
+  const afterResume = await jsonRequest<{ data: Array<{ id: string; slug: string }> }>(
+    destination.baseUrl,
+    "/api/projects?perPage=100",
+  );
+  expect(afterResume.data).toContainEqual(
+    expect.objectContaining({ id: fileProject.id, slug: "file-resume-sentinel" }),
+  );
+  const finalExport = await jsonRequest<DataTransferFile>(
+    destination.baseUrl,
+    "/api/system/data-transfer/export",
+    {
+      method: "POST",
+      body: JSON.stringify({ passphrase: FILE_PASSPHRASE, selection: { history: [] } }),
+    },
+  );
+  expect(
+    findSecret(openTransferSecrets(finalExport.secrets, FILE_PASSPHRASE), FILE_SECRET_VALUE),
+  ).toBe(true);
+}, 300_000);

--- a/apps/api/test/middleware/auth-stale-session.test.ts
+++ b/apps/api/test/middleware/auth-stale-session.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+const h = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  listByUser: vi.fn(),
+  findMembership: vi.fn(),
+  findOrganizations: vi.fn(),
+}));
+
+vi.mock("../../src/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: h.getSession,
+      getMcpSession: vi.fn(async () => null),
+    },
+  },
+}));
+
+vi.mock("../../src/config/env", () => ({ env: {}, trustedOrigins: [] }));
+vi.mock("../../src/lib/local-user", () => ({ ensureLocalUser: vi.fn() }));
+vi.mock("../../src/middleware/zero-auth-guard", () => ({ zeroAuthAllowed: vi.fn() }));
+vi.mock("@repo/db", () => ({
+  repos: {
+    member: { listByUser: h.listByUser, find: h.findMembership },
+    organization: { findManyById: h.findOrganizations },
+    personalAccessToken: {},
+    user: {},
+  },
+}));
+
+const { authMiddleware } = await import("../../src/middleware/auth");
+
+function appWithProtectedHandler() {
+  const app = new Hono();
+  const handler = vi.fn((c) => c.json({ ok: true }));
+  app.use("*", authMiddleware);
+  app.get("/", handler);
+  return { app, handler };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getSession.mockResolvedValue({
+    user: { id: "user_old", email: "old@example.com", name: "Old User" },
+    session: { id: "session_old", activeOrganizationId: "org_old" },
+  });
+  h.findOrganizations.mockResolvedValue([]);
+});
+
+describe("auth middleware stale-session boundary", () => {
+  it("returns 401 instead of running handlers without a RequestContext when memberships are gone", async () => {
+    h.listByUser.mockResolvedValue([]);
+    const { app, handler } = appWithProtectedHandler();
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized", code: "SESSION_STALE" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the resolved membership disappears between resolution and context build", async () => {
+    h.listByUser.mockResolvedValue([
+      { id: "member_old", userId: "user_old", organizationId: "org_old", role: "owner" },
+    ]);
+    h.findMembership.mockResolvedValue(null);
+    const { app, handler } = appWithProtectedHandler();
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized", code: "SESSION_STALE" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("still builds context and calls the handler for a current membership", async () => {
+    h.listByUser.mockResolvedValue([
+      { id: "member_1", userId: "user_old", organizationId: "org_old", role: "owner" },
+    ]);
+    h.findMembership.mockResolvedValue({ id: "member_1", role: "owner" });
+    const { app, handler } = appWithProtectedHandler();
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- invalidate every database-derived process and shared cache after a committed whole-instance import
- prevent pre-import async reads from repopulating caches after invalidation
- reject stale cookie and bearer principals before protected handlers run without a request context
- keep the migration lock asserted across wipe commit and post-commit runtime reconciliation
- add a real two-process HTTP E2E covering large chunked direct transfer and resumable file import

## Root cause

PR #823 made the database restore and transfer protocol durable, but a successful wipe could leave the running destination process holding its old synthetic local user and other DB-derived state. The next request resolved an identity that no longer existed and reached a handler without a RequestContext. Also, wipe restored instance_settings from the source, briefly replacing the destination migration-lock flag before reconciliation.

## Production-path validation

The E2E starts two real Bun API processes with separate disk-backed PGlite databases and different encryption keys. It sends an export larger than 8 MB through a bounded proxy, drops the first successful chunk response to force the production retry path, completes an atomic wipe, uses the destination API immediately without restart, verifies masked and re-encrypted secrets, then uploads one file chunk, restarts the destination, resumes the remaining chunks, and finalizes over SSE.

- real HTTP E2E: 1 passed
- focused transfer/auth suites: 34 passed
- full API suite: 5,584 passed, 3 skipped
- API TypeScript check: passed
- API production build: passed

Follow-up to #823 and #816.