### PR TITLE
fix(docker): safely terminate stalled builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,12 @@ INTERNAL_TOKEN=change-me-32-byte-random-hex
 #   docker context inspect --format '{{.Endpoints.docker.Host}}'
 # OPENSHIP_DOCKER_SOCKET=/var/run/docker.sock
 
+# Abort a Docker image build after this many milliseconds with no output from
+# the builder. This bounds genuinely stalled/OOM-thrashing builds without
+# guessing from unrelated host containers. Default 10 minutes; accepted range
+# is 1 minute to 24 hours.
+# OPENSHIP_BUILD_IDLE_TIMEOUT_MS=600000
+
 # ─── Host operations from the container (optional) ────────
 # The edge (routing/TLS) runs as the `edge` container; app containers run via
 # the mounted docker socket. For the few HOST-OS ops a container can't do to its

--- a/packages/adapters/src/runtime/docker-build-cancellation.test.ts
+++ b/packages/adapters/src/runtime/docker-build-cancellation.test.ts
@@ -352,17 +352,29 @@ describe("DockerRuntime build cancellation — dockerode path", () => {
     fakeBuildContext.current = { contextDir, cleanup: async () => {} };
 
     const verifyImageBuilt = vi.fn(async () => {});
-    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
-      Record<string, unknown>;
+    const buildImage = vi.fn(
+      async (body: { resume?: () => void }, _options: { extrahosts?: string }) => {
+        body.resume?.();
+        return {};
+      },
+    );
+    let runtime!: DockerRuntime & Record<string, unknown>;
+    const streamDockerodeBuild = vi.fn(
+      async (
+        _stream: unknown,
+        _logger: unknown,
+        _options: { legacyBuilder?: { ownershipHost?: string } },
+      ) => {
+        await (runtime as DockerRuntime).cancelBuild("session-late-abort");
+      },
+    );
+    runtime = Object.create(DockerRuntime.prototype) as DockerRuntime & Record<string, unknown>;
     Object.assign(runtime, {
       connectionOptions: {},
       transport: { kind: "socket", description: "local socket" },
       systemManager: null,
       _docker: {
-        buildImage: vi.fn(async (body: { resume?: () => void }) => {
-          body.resume?.();
-          return {};
-        }),
+        buildImage,
         listContainers: vi.fn(async () => []),
       },
       estimateContextSize: vi.fn(async () => 0),
@@ -371,9 +383,7 @@ describe("DockerRuntime build cancellation — dockerode path", () => {
       // cleanly, and the cancel lands during that drain. So the ONLY thing that can
       // stop a usable image from being reported "deploying" is build()'s last gate —
       // the branch that keeps a cancelled deployment from being deployed.
-      streamDockerodeBuild: vi.fn(async () => {
-        await (runtime as DockerRuntime).cancelBuild("session-late-abort");
-      }),
+      streamDockerodeBuild,
     });
 
     const config = { ...buildConfig("session-late-abort"), cloneOnServer: false };
@@ -383,6 +393,11 @@ describe("DockerRuntime build cancellation — dockerode path", () => {
       status: "cancelled",
     });
     expect(verifyImageBuilt).not.toHaveBeenCalled();
+    const ownershipEntry = buildImage.mock.calls[0]?.[1].extrahosts;
+    expect(ownershipEntry).toMatch(/^openship-build-[0-9a-f-]+\.invalid:127\.0\.0\.1$/);
+    expect(streamDockerodeBuild.mock.calls[0]?.[2]).toMatchObject({
+      legacyBuilder: { ownershipHost: ownershipEntry?.split(":")[0] },
+    });
   });
 });
 
@@ -412,6 +427,23 @@ describe("packBuildContext", () => {
     await writeFile(join(contextDir, "Dockerfile"), "FROM scratch\n");
 
     const packed = packBuildContext(contextDir, ["Dockerfile"], AbortSignal.abort());
+    expect(packed.abortSignal.aborted).toBe(true);
+    packed.body.resume();
+  });
+
+  it("hands cancellation ownership to the progress-stream phase after upload", async () => {
+    contextDir = await mkdtemp(join(tmpdir(), "openship-pack-"));
+    await writeFile(join(contextDir, "Dockerfile"), "FROM scratch\n");
+
+    const cancel = new AbortController();
+    const packed = packBuildContext(contextDir, ["Dockerfile"], cancel.signal);
+    packed.detachCancellation();
+    cancel.abort();
+
+    // streamDockerodeBuild now owns this phase and uses its short id-capture
+    // grace before invoking packed.abort itself.
+    expect(packed.abortSignal.aborted).toBe(false);
+    packed.abort();
     expect(packed.abortSignal.aborted).toBe(true);
     packed.body.resume();
   });

--- a/packages/adapters/src/runtime/docker-build-container-tracker.test.ts
+++ b/packages/adapters/src/runtime/docker-build-container-tracker.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LegacyBuildContainerTracker,
+  type LegacyBuildContainerClient,
+  type LegacyBuildContainerInspect,
+} from "./docker-build-container-tracker";
+
+const FIRST_ID = "111111111111";
+const SECOND_ID = "222222222222";
+const FOREIGN_ID = "ffffffffffff";
+const FIRST_PARENT = "aaaaaaaaaaaa";
+const SECOND_PARENT = "bbbbbbbbbbbb";
+const MEMORY_BYTES = 64 * 1024 * 1024;
+const OWNERSHIP_HOST = "openship-build-test.invalid";
+
+function runningContainer(
+  id: string,
+  parent: string,
+  command: string,
+  memory = MEMORY_BYTES,
+): LegacyBuildContainerInspect {
+  return {
+    Id: id.padEnd(64, id[0]),
+    Config: {
+      Image: `sha256:${parent.padEnd(64, parent[0])}`,
+      Cmd: ["/bin/sh", "-c", command],
+    },
+    HostConfig: { Memory: memory, ExtraHosts: [`${OWNERSHIP_HOST}:127.0.0.1`] },
+    State: { Running: true },
+  };
+}
+
+function clientWith(inspect: LegacyBuildContainerClient["inspect"]): LegacyBuildContainerClient & {
+  inspect: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  return {
+    inspect: vi.fn(inspect),
+    kill: vi.fn(async () => {}),
+  };
+}
+
+function announceRun(
+  tracker: LegacyBuildContainerTracker,
+  id = FIRST_ID,
+  parent = FIRST_PARENT,
+  command = "sleep 180",
+  step = 2,
+): void {
+  tracker.observe(`Step 1/3 : FROM alpine:3.20\n ---> ${parent}\n`);
+  tracker.observe(`Step ${step}/3 : RUN ${command}\n ---> Running in ${id}\n`);
+}
+
+describe("LegacyBuildContainerTracker", () => {
+  it("kills only the exact, fully verified RUN container from this build stream", async () => {
+    const client = clientWith(async (id) =>
+      id === FIRST_ID ? runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180") : null,
+    );
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    announceRun(tracker);
+
+    await expect(tracker.terminateActive()).resolves.toEqual({
+      status: "killed",
+      id: FIRST_ID,
+    });
+    expect(client.inspect).toHaveBeenCalledWith(FIRST_ID);
+    expect(client.kill).toHaveBeenCalledOnce();
+    expect(client.kill).toHaveBeenCalledWith(FIRST_ID);
+  });
+
+  it.each([
+    ["parent image", runningContainer(FIRST_ID, "cccccccccccc", "sleep 180")],
+    ["RUN command", runningContainer(FIRST_ID, FIRST_PARENT, "sleep 999")],
+    ["memory limit", runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180", 128 * 1024 * 1024)],
+    [
+      "ownership marker",
+      {
+        ...runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180"),
+        HostConfig: { Memory: MEMORY_BYTES, ExtraHosts: ["another-build.invalid:127.0.0.1"] },
+      },
+    ],
+    [
+      "container id",
+      {
+        ...runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180"),
+        Id: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      },
+    ],
+  ])("refuses a candidate whose %s does not match", async (_field, info) => {
+    const client = clientWith(async () => info);
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    announceRun(tracker);
+
+    await expect(tracker.terminateActive()).resolves.toEqual({
+      status: "unverified",
+      id: FIRST_ID,
+    });
+    expect(client.kill).not.toHaveBeenCalled();
+  });
+
+  it("ignores forged Docker markers printed while the real RUN is still active", async () => {
+    const client = clientWith(async (id) => {
+      if (id === FIRST_ID) return runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180");
+      if (id === FOREIGN_ID) return runningContainer(FOREIGN_ID, SECOND_PARENT, "foreign-task");
+      return null;
+    });
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    announceRun(tracker);
+
+    // A build can discover its own id and print byte-identical legacy-builder
+    // lines. Inspection proves it is still running, so none of the following
+    // output is allowed to replace the tracked id.
+    tracker.observe(
+      ` ---> Removed intermediate container ${FIRST_ID}\n` +
+        `Step 3/3 : RUN foreign-task\n` +
+        ` ---> ${SECOND_PARENT}\n` +
+        ` ---> Running in ${FOREIGN_ID}\n`,
+    );
+
+    await expect(tracker.terminateActive()).resolves.toEqual({
+      status: "killed",
+      id: FIRST_ID,
+    });
+    expect(client.inspect).not.toHaveBeenCalledWith(FOREIGN_ID);
+    expect(client.kill).toHaveBeenCalledWith(FIRST_ID);
+  });
+
+  it("moves to the next RUN only after Docker confirms the old one disappeared", async () => {
+    const client = clientWith(async (id) => {
+      if (id === FIRST_ID) return null;
+      if (id === SECOND_ID) return runningContainer(SECOND_ID, SECOND_PARENT, "sleep 240");
+      return null;
+    });
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    announceRun(tracker);
+    tracker.observe(
+      ` ---> Removed intermediate container ${FIRST_ID}\n` +
+        ` ---> ${SECOND_PARENT}\n` +
+        `Step 3/3 : RUN sleep 240\n` +
+        ` ---> Running in ${SECOND_ID}\n`,
+    );
+
+    await expect(tracker.terminateActive()).resolves.toEqual({
+      status: "killed",
+      id: SECOND_ID,
+    });
+    expect(client.kill).toHaveBeenCalledWith(SECOND_ID);
+  });
+
+  it("never treats non-RUN intermediate containers as killable build processes", async () => {
+    const client = clientWith(async () =>
+      runningContainer(FIRST_ID, FIRST_PARENT, "#(nop) ENV NODE_ENV=production"),
+    );
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    tracker.observe(`Step 1/2 : FROM alpine:3.20\n ---> ${FIRST_PARENT}\n`);
+    tracker.observe(`Step 2/2 : ENV NODE_ENV=production\n ---> Running in ${FIRST_ID}\n`);
+
+    await expect(tracker.terminateActive()).resolves.toEqual({ status: "none" });
+    expect(client.inspect).not.toHaveBeenCalled();
+    expect(client.kill).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent termination requests", async () => {
+    const client = clientWith(async () => runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180"));
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    announceRun(tracker);
+
+    const [first, second] = await Promise.all([
+      tracker.terminateActive(),
+      tracker.terminateActive(),
+    ]);
+    expect(first).toEqual(second);
+    expect(client.kill).toHaveBeenCalledOnce();
+  });
+
+  it("reassembles split SSH output chunks before interpreting markers", async () => {
+    const client = clientWith(async () => runningContainer(FIRST_ID, FIRST_PARENT, "sleep 180"));
+    const tracker = new LegacyBuildContainerTracker(client, MEMORY_BYTES, OWNERSHIP_HOST);
+    tracker.observeChunk(`Step 1/2 : FROM alpine:3.20\n ---> ${FIRST_PARENT}\nSte`);
+    tracker.observeChunk(`p 2/2 : RUN sleep 180\n ---> Running in ${FIRST_ID.slice(0, 6)}`);
+    tracker.observeChunk(`${FIRST_ID.slice(6)}\n`);
+    tracker.flush();
+
+    await expect(tracker.terminateActive()).resolves.toEqual({
+      status: "killed",
+      id: FIRST_ID,
+    });
+    expect(client.kill).toHaveBeenCalledWith(FIRST_ID);
+  });
+});

--- a/packages/adapters/src/runtime/docker-build-container-tracker.ts
+++ b/packages/adapters/src/runtime/docker-build-container-tracker.ts
@@ -1,0 +1,211 @@
+/**
+ * Tracks the exact intermediate container announced by Docker's legacy build
+ * stream. This is intentionally a stream state machine, not a host-wide search:
+ * creation time, memory percentage, and recency cannot establish ownership.
+ */
+
+export interface LegacyBuildContainerInspect {
+  Id?: string;
+  Config?: {
+    Image?: string;
+    Cmd?: string[] | null;
+  };
+  HostConfig?: {
+    Memory?: number;
+    ExtraHosts?: string[] | null;
+  };
+  State?: {
+    Running?: boolean;
+  };
+}
+
+export interface LegacyBuildContainerClient {
+  inspect(id: string): Promise<LegacyBuildContainerInspect | null>;
+  kill(id: string): Promise<void>;
+}
+
+interface BuildStep {
+  number: number;
+  total: number;
+  instruction: string;
+  parentImageId: string | null;
+}
+
+interface Candidate extends BuildStep {
+  id: string;
+}
+
+export type LegacyBuildContainerTermination =
+  | { status: "none" }
+  | { status: "not-running"; id: string }
+  | { status: "unverified"; id: string }
+  | { status: "killed"; id: string };
+
+function normalizedImageId(value: string | undefined): string {
+  return (value ?? "").replace(/^sha256:/, "").toLowerCase();
+}
+
+function commandMatches(instruction: string, actual: string[] | null | undefined): boolean {
+  const run = instruction.match(/^RUN\s+([\s\S]+)$/i)?.[1]?.trim();
+  if (!run || !actual?.length) return false;
+
+  // Exec-form RUN is stored as the argv itself. Shell-form RUN is stored as
+  // `<configured shell> -c <command>`, so its final argv item is authoritative
+  // even when the image changed SHELL away from /bin/sh.
+  if (run.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(run);
+      return (
+        Array.isArray(parsed) &&
+        parsed.every((part) => typeof part === "string") &&
+        parsed.length === actual.length &&
+        parsed.every((part, index) => part === actual[index])
+      );
+    } catch {
+      return false;
+    }
+  }
+  return actual[actual.length - 1] === run;
+}
+
+/**
+ * Provenance tracker for one classic-builder response stream.
+ *
+ * The first `Running in <id>` after a Docker `Step N/M : RUN ...` arrives
+ * before that RUN can emit user-controlled stdout. While that container is
+ * alive, all apparent Docker markers from its stdout are ignored. A matching
+ * removal marker clears it only after daemon inspection confirms it stopped or
+ * disappeared. Before a kill, inspection must also find the unguessable
+ * per-build ExtraHosts marker plus the expected parent image, command, and
+ * memory cap. A Dockerfile can print fake progress lines, but it cannot attach
+ * that marker to an unrelated container.
+ */
+export class LegacyBuildContainerTracker {
+  private parentImageId: string | null = null;
+  private pendingStep: BuildStep | null = null;
+  private active: Candidate | null = null;
+  private expectedStepTotal: number | null = null;
+  private lastStepNumber = 0;
+  private chunkBuffer = "";
+  private queue: Promise<void> = Promise.resolve();
+  private termination: Promise<LegacyBuildContainerTermination> | null = null;
+
+  constructor(
+    private readonly client: LegacyBuildContainerClient,
+    private readonly expectedMemoryBytes: number | undefined,
+    private readonly ownershipHost: string,
+  ) {}
+
+  /** Consume one complete dockerode `event.stream` field. */
+  observe(stream: string | undefined): void {
+    if (!stream) return;
+    for (const rawLine of stream.split(/\r?\n/)) {
+      this.enqueueLine(rawLine);
+    }
+  }
+
+  /** Consume an arbitrary SSH stdout/stderr chunk, retaining a partial line. */
+  observeChunk(chunk: string | undefined): void {
+    if (!chunk) return;
+    const parts = `${this.chunkBuffer}${chunk}`.split(/\r\n|\n|\r/);
+    this.chunkBuffer = parts.pop() ?? "";
+    // A process can stream an unlimited line. Docker's structural markers are
+    // tiny, so retain only a bounded suffix while waiting for a delimiter.
+    if (this.chunkBuffer.length > 8_192) this.chunkBuffer = this.chunkBuffer.slice(-8_192);
+    for (const line of parts) this.enqueueLine(line);
+  }
+
+  flush(): void {
+    this.enqueueLine(this.chunkBuffer);
+    this.chunkBuffer = "";
+  }
+
+  private enqueueLine(rawLine: string): void {
+    const line = rawLine.trim();
+    if (!line) return;
+    this.queue = this.queue.then(
+      () => this.observeLine(line),
+      () => this.observeLine(line),
+    );
+  }
+
+  private async observeLine(line: string): Promise<void> {
+    if (this.active) {
+      const removed = line.match(/^---> Removed intermediate container\s+([a-f0-9]{12,64})$/i);
+      if (removed?.[1]?.toLowerCase() === this.active.id) {
+        // User code can print a byte-identical marker. Do not trust it until the
+        // daemon says this exact candidate has really stopped/disappeared.
+        try {
+          const info = await this.client.inspect(this.active.id);
+          if (!info?.State?.Running) this.active = null;
+        } catch {
+          // A transient inspection failure is not proof that ownership ended.
+        }
+      }
+      return;
+    }
+
+    const layer = line.match(/^--->\s+([a-f0-9]{12,64})$/i);
+    if (layer?.[1]) {
+      this.parentImageId = layer[1].toLowerCase();
+      return;
+    }
+
+    const step = line.match(/^Step\s+(\d+)\/(\d+)\s*:\s*([\s\S]+)$/i);
+    if (step?.[1] && step[2] && step[3]) {
+      const number = Number(step[1]);
+      const total = Number(step[2]);
+      // Docker's legacy stream is monotonic. Refuse malformed counters rather
+      // than loosening the state machine around user-controlled build output.
+      const firstStep = this.lastStepNumber === 0 && number === 1;
+      const nextStep = number === this.lastStepNumber + 1;
+      const sameTotal = this.expectedStepTotal === null || total === this.expectedStepTotal;
+      if (number >= 1 && total >= number && sameTotal && (firstStep || nextStep)) {
+        this.expectedStepTotal ??= total;
+        this.lastStepNumber = number;
+        this.pendingStep = {
+          number,
+          total,
+          instruction: step[3].trim(),
+          parentImageId: this.parentImageId,
+        };
+      }
+      return;
+    }
+
+    const running = line.match(/^---> Running in\s+([a-f0-9]{12,64})$/i);
+    if (running?.[1] && this.pendingStep && /^RUN\s+/i.test(this.pendingStep.instruction)) {
+      this.active = { ...this.pendingStep, id: running[1].toLowerCase() };
+      this.pendingStep = null;
+    }
+  }
+
+  private async terminate(): Promise<LegacyBuildContainerTermination> {
+    await this.queue;
+    const candidate = this.active;
+    if (!candidate) return { status: "none" };
+
+    const info = await this.client.inspect(candidate.id);
+    if (!info?.State?.Running) return { status: "not-running", id: candidate.id };
+
+    const actualId = info.Id?.toLowerCase() ?? "";
+    const actualImage = normalizedImageId(info.Config?.Image);
+    const expectedMemory = this.expectedMemoryBytes ?? 0;
+    const ownershipEntry = `${this.ownershipHost}:127.0.0.1`;
+    const verified =
+      actualId.startsWith(candidate.id) &&
+      candidate.parentImageId !== null &&
+      actualImage.startsWith(candidate.parentImageId) &&
+      (info.HostConfig?.Memory ?? 0) === expectedMemory &&
+      info.HostConfig?.ExtraHosts?.includes(ownershipEntry) === true &&
+      commandMatches(candidate.instruction, info.Config?.Cmd);
+
+    if (!verified) return { status: "unverified", id: candidate.id };
+    await this.client.kill(candidate.id);
+    return { status: "killed", id: candidate.id };
+  }
+
+  terminateActive(): Promise<LegacyBuildContainerTermination> {
+    return (this.termination ??= this.terminate());
+  }
+}

--- a/packages/adapters/src/runtime/docker-build-diagnostics.test.ts
+++ b/packages/adapters/src/runtime/docker-build-diagnostics.test.ts
@@ -1,0 +1,388 @@
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BuildConfig, CommandExecutor } from "../types";
+import { BuildLogger } from "./build-pipeline";
+import {
+  DEFAULT_DOCKER_BUILD_IDLE_TIMEOUT_MS,
+  MAX_DOCKER_BUILD_IDLE_TIMEOUT_MS,
+  MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS,
+  chooseDockerBuildFailureHint,
+  dockerBuildExitMessage,
+  dockerBuildIdleTimeoutError,
+  extractDockerBuildFailureHint,
+  getDockerBuildIdleTimeoutMs,
+  startDockerBuildIdleMonitor,
+} from "./docker-build-diagnostics";
+import { DockerRuntime } from "./docker";
+
+describe("Docker build diagnostics", () => {
+  it("accepts only bounded integer inactivity timeouts", () => {
+    expect(getDockerBuildIdleTimeoutMs(undefined)).toBe(DEFAULT_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+    expect(getDockerBuildIdleTimeoutMs("60000")).toBe(MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+    expect(getDockerBuildIdleTimeoutMs(String(MAX_DOCKER_BUILD_IDLE_TIMEOUT_MS))).toBe(
+      MAX_DOCKER_BUILD_IDLE_TIMEOUT_MS,
+    );
+
+    for (const invalid of ["", "nope", "59999", "86400001", "90000.5", "Infinity", "-1"]) {
+      expect(getDockerBuildIdleTimeoutMs(invalid)).toBe(DEFAULT_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+    }
+  });
+
+  it("describes exit 137 accurately without claiming that SIGKILL proves OOM", () => {
+    const hint = extractDockerBuildFailureHint(
+      "The command '/bin/sh -c bun run build' returned a non-zero code: 137",
+      { configuredMemoryMb: 512, memoryLimitApplied: true },
+    );
+
+    expect(hint).toContain("killed by SIGKILL (exit code 137)");
+    expect(hint).toContain("does not prove OOM");
+    expect(hint).toContain("capped at 512 MB RAM");
+  });
+
+  it("does not claim the configured memory cap applied to SSH or BuildKit", () => {
+    const hint = dockerBuildExitMessage(137, null, {
+      configuredMemoryMb: 512,
+      memoryLimitApplied: false,
+    });
+
+    expect(hint).toContain("not under an OpenShip-enforced memory cap");
+    expect(hint).not.toContain("capped at 512 MB");
+  });
+
+  it.each([
+    "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory",
+    "fatal error: runtime: out of memory",
+    "npm ERR! code ENOMEM",
+    "fork: cannot allocate memory",
+  ])("recognizes explicit allocator failure: %s", (line) => {
+    expect(extractDockerBuildFailureHint(line)?.toLowerCase()).toMatch(
+      /ran out of memory|could not allocate memory/,
+    );
+  });
+
+  it("keeps explicit memory evidence over a later wrapper error", () => {
+    const memory = extractDockerBuildFailureHint("npm ERR! code ENOMEM")!;
+    const wrapper = "failed to solve: process did not complete successfully: exit code: 1";
+    expect(chooseDockerBuildFailureHint(memory, wrapper)).toBe(memory);
+    expect(dockerBuildExitMessage(1, memory)).toBe(memory);
+  });
+
+  it("reports an inactivity timeout as a timeout, not a proven OOM", () => {
+    const error = dockerBuildIdleTimeoutError(10 * 60_000, {
+      configuredMemoryMb: 1024,
+      memoryLimitApplied: true,
+    });
+    expect(error.message).toContain("no output for 10 minutes and was cancelled");
+    expect(error.message).toContain("memory pressure is one possible cause");
+  });
+});
+
+describe("Docker build inactivity monitor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-arms on real progress and reports elapsed silence", async () => {
+    const onIdle = vi.fn();
+    const onTimeout = vi.fn();
+    const monitor = startDockerBuildIdleMonitor({
+      timeoutMs: 2 * 60_000,
+      onIdle,
+      onTimeout,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onIdle).toHaveBeenLastCalledWith(60_000);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    monitor.progress();
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(onTimeout).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases its deadline when stopped", async () => {
+    const onTimeout = vi.fn();
+    const monitor = startDockerBuildIdleMonitor({
+      timeoutMs: 60_000,
+      onIdle: vi.fn(),
+      onTimeout,
+    });
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});
+
+function buildConfig(): BuildConfig {
+  return {
+    sessionId: "diagnostic-build",
+    projectId: "project-1",
+    slug: "diagnostic-build",
+    repoUrl: "https://example.com/repo.git",
+    branch: "main",
+    stack: "docker",
+    buildImage: "",
+    packageManager: "",
+    installCommand: "",
+    buildCommand: "",
+    outputDirectory: "",
+    port: 3000,
+    runtimeImage: "",
+    envVars: {},
+    resources: { cpuCores: 1, memoryMb: 512, diskMb: 0 },
+  };
+}
+
+describe("DockerRuntime build failure paths", () => {
+  const previousTimeout = process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = String(MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (previousTimeout === undefined) delete process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS;
+    else process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = previousTimeout;
+  });
+
+  it("times out a daemon stream without discovering or killing host containers", async () => {
+    const stream = new PassThrough();
+    stream.on("error", () => {});
+    const listContainers = vi.fn();
+    const getContainer = vi.fn();
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, {
+      _docker: {
+        listContainers,
+        getContainer,
+        modem: { followProgress: vi.fn() },
+      },
+    });
+    const abortBuild = vi.fn();
+
+    const result = (runtime as any)
+      .streamDockerodeBuild(stream, new BuildLogger(), {
+        diagnosticContext: {
+          configuredMemoryMb: 512,
+          memoryLimitApplied: true,
+        },
+        abortBuild,
+      })
+      .catch((error: Error) => error);
+    await vi.advanceTimersByTimeAsync(MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+
+    await expect(result).resolves.toMatchObject({
+      message: expect.stringContaining("no output for 1 minute and was cancelled"),
+    });
+    expect(abortBuild).toHaveBeenCalledOnce();
+    expect(abortBuild).toHaveBeenCalledWith(expect.any(Error));
+    expect(listContainers).not.toHaveBeenCalled();
+    expect(getContainer).not.toHaveBeenCalled();
+  });
+
+  it("kills only the verified legacy RUN container when its daemon stream times out", async () => {
+    const stream = new PassThrough();
+    stream.on("error", () => {});
+    const buildId = "111111111111";
+    const parentId = "aaaaaaaaaaaa";
+    const ownershipHost = "openship-build-test.invalid";
+    const kill = vi.fn(async () => {});
+    const getContainer = vi.fn((id: string) => ({
+      inspect: vi.fn(async () => ({
+        Id: id.padEnd(64, "1"),
+        Config: {
+          Image: `sha256:${parentId.padEnd(64, "a")}`,
+          Cmd: ["/bin/sh", "-c", "sleep 180"],
+        },
+        HostConfig: {
+          Memory: 512 * 1024 * 1024,
+          ExtraHosts: [`${ownershipHost}:127.0.0.1`],
+        },
+        State: { Running: true },
+      })),
+      kill,
+    }));
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, {
+      _docker: {
+        listContainers: vi.fn(),
+        getContainer,
+        modem: {
+          followProgress: vi.fn(
+            (
+              _stream: unknown,
+              _finished: unknown,
+              progress: (event: { stream: string }) => void,
+            ) => {
+              progress({ stream: "Step 1/2 : FROM alpine:3.20\n" });
+              progress({ stream: ` ---> ${parentId}\n` });
+              progress({ stream: "Step 2/2 : RUN sleep 180\n" });
+              progress({ stream: ` ---> Running in ${buildId}\n` });
+            },
+          ),
+        },
+      },
+    });
+
+    const result = (runtime as any)
+      .streamDockerodeBuild(stream, new BuildLogger(), {
+        diagnosticContext: { configuredMemoryMb: 512, memoryLimitApplied: true },
+        legacyBuilder: { expectedMemoryBytes: 512 * 1024 * 1024, ownershipHost },
+      })
+      .catch((error: Error) => error);
+    await vi.advanceTimersByTimeAsync(MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+
+    await expect(result).resolves.toMatchObject({
+      message: expect.stringContaining("no output for 1 minute and was cancelled"),
+    });
+    expect(getContainer).toHaveBeenCalledTimes(2);
+    expect(getContainer).toHaveBeenNthCalledWith(1, buildId);
+    expect(getContainer).toHaveBeenNthCalledWith(2, buildId);
+    expect(kill).toHaveBeenCalledOnce();
+  });
+
+  it("waits briefly for Docker's RUN id when cancellation lands at the step boundary", async () => {
+    const stream = new PassThrough();
+    stream.on("error", () => {});
+    const buildId = "111111111111";
+    const parentId = "aaaaaaaaaaaa";
+    const ownershipHost = "openship-build-test.invalid";
+    const kill = vi.fn(async () => {});
+    const getContainer = vi.fn((id: string) => ({
+      inspect: vi.fn(async () => ({
+        Id: id.padEnd(64, "1"),
+        Config: {
+          Image: `sha256:${parentId.padEnd(64, "a")}`,
+          Cmd: ["/bin/sh", "-c", "sleep 180"],
+        },
+        HostConfig: {
+          Memory: 512 * 1024 * 1024,
+          ExtraHosts: [`${ownershipHost}:127.0.0.1`],
+        },
+        State: { Running: true },
+      })),
+      kill,
+    }));
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, {
+      _docker: {
+        getContainer,
+        modem: {
+          followProgress: vi.fn(
+            (
+              _stream: unknown,
+              _finished: unknown,
+              progress: (event: { stream: string }) => void,
+            ) => {
+              progress({ stream: "Step 1/2 : FROM alpine:3.20\n" });
+              progress({ stream: ` ---> ${parentId}\n` });
+              progress({ stream: "Step 2/2 : RUN sleep 180\n" });
+              setTimeout(() => progress({ stream: ` ---> Running in ${buildId}\n` }), 100);
+            },
+          ),
+        },
+      },
+    });
+    const cancel = new AbortController();
+    const abortBuild = vi.fn();
+    const result = (runtime as any)
+      .streamDockerodeBuild(stream, new BuildLogger(), {
+        diagnosticContext: { configuredMemoryMb: 512, memoryLimitApplied: true },
+        legacyBuilder: { expectedMemoryBytes: 512 * 1024 * 1024, ownershipHost },
+        abortBuild,
+        cancelSignal: cancel.signal,
+      })
+      .catch((error: Error) => error);
+
+    cancel.abort();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toMatchObject({ name: "BuildCancelledError" });
+    expect(kill).toHaveBeenCalledOnce();
+    expect(abortBuild).toHaveBeenCalledOnce();
+  });
+
+  it("applies the same inactivity deadline to native SSH builds", async () => {
+    const streamExec = vi.fn(
+      async (
+        _command: string,
+        _onLog: Parameters<CommandExecutor["streamExec"]>[1],
+        opts?: Parameters<CommandExecutor["streamExec"]>[2],
+      ) => {
+        await new Promise<void>((resolve) => {
+          opts?.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return { code: 0, output: "" };
+      },
+    );
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec,
+    } as unknown as CommandExecutor;
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, { connectionOptions: { executor } });
+
+    const result = (runtime as any)
+      .buildImageOnRemote(
+        buildConfig(),
+        "/tmp/diagnostic-build",
+        "Dockerfile",
+        "openship/diagnostic:bld_test",
+        new BuildLogger(),
+      )
+      .catch((error: Error) => error);
+    await vi.advanceTimersByTimeAsync(MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS);
+
+    await expect(result).resolves.toMatchObject({
+      message: expect.stringContaining("no output for 1 minute and was cancelled"),
+    });
+    expect(streamExec.mock.calls[0]?.[2]?.signal?.aborted).toBe(true);
+  });
+
+  it("uses streamed exit-137 evidence for native SSH build failures", async () => {
+    const streamExec = vi.fn(
+      async (_command: string, onLog: Parameters<CommandExecutor["streamExec"]>[1]) => {
+        onLog({
+          timestamp: new Date().toISOString(),
+          level: "error",
+          message: "The command '/bin/sh -c npm run build' returned a non-zero code: 137\n",
+        });
+        return { code: 1, output: "" };
+      },
+    );
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec,
+    } as unknown as CommandExecutor;
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime &
+      Record<string, unknown>;
+    Object.assign(runtime, { connectionOptions: { executor } });
+
+    const error = await (runtime as any)
+      .buildImageOnRemote(
+        buildConfig(),
+        "/tmp/diagnostic-build",
+        "Dockerfile",
+        "openship/diagnostic:bld_test",
+        new BuildLogger(),
+      )
+      .catch((caught: Error) => caught);
+
+    expect(error.message).toContain("killed by SIGKILL (exit code 137)");
+    expect(error.message).toContain("not under an OpenShip-enforced memory cap");
+  });
+});

--- a/packages/adapters/src/runtime/docker-build-diagnostics.ts
+++ b/packages/adapters/src/runtime/docker-build-diagnostics.ts
@@ -1,0 +1,205 @@
+/**
+ * Docker-build failure diagnostics and inactivity handling shared by the
+ * Engine-API and SSH/CLI build paths.
+ *
+ * Keep this module daemon-agnostic. In particular, memory pressure is not
+ * inferred by scanning host containers: without an authoritative container id,
+ * that can target an unrelated workload. Exit signals and explicit allocator
+ * errors are evidence; a high memory percentage by itself is not.
+ */
+
+export const DEFAULT_DOCKER_BUILD_IDLE_TIMEOUT_MS = 10 * 60_000;
+export const MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS = 60_000;
+export const MAX_DOCKER_BUILD_IDLE_TIMEOUT_MS = 24 * 60 * 60_000;
+
+/**
+ * Resolve the one operator-facing build inactivity setting.
+ *
+ * Invalid and unsafe values fall back to the documented default instead of
+ * accidentally disabling the guard or turning a typo into an immediate abort.
+ */
+export function getDockerBuildIdleTimeoutMs(
+  raw = process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS,
+): number {
+  if (raw == null || raw.trim() === "") return DEFAULT_DOCKER_BUILD_IDLE_TIMEOUT_MS;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) &&
+    value >= MIN_DOCKER_BUILD_IDLE_TIMEOUT_MS &&
+    value <= MAX_DOCKER_BUILD_IDLE_TIMEOUT_MS
+    ? value
+    : DEFAULT_DOCKER_BUILD_IDLE_TIMEOUT_MS;
+}
+
+export interface DockerBuildDiagnosticContext {
+  /** The limit selected in OpenShip, when one was selected. */
+  configuredMemoryMb?: number;
+  /** True only when this particular builder actually received that limit. */
+  memoryLimitApplied?: boolean;
+}
+
+function memoryGuidance(context: DockerBuildDiagnosticContext): string {
+  const memoryMb = context.configuredMemoryMb;
+  if (context.memoryLimitApplied && memoryMb && memoryMb > 0) {
+    return `The classic Docker builder was capped at ${memoryMb} MB RAM; raise Build Memory in Project Settings → Resources if this build needs more.`;
+  }
+  return "This build path was not under an OpenShip-enforced memory cap; check available RAM/swap and the host or Docker daemon OOM logs.";
+}
+
+function exitCodeFromLine(line: string): number | null {
+  const match = line.match(
+    /(?:returned a non-zero code|exited? with(?: exit)? code|exit code)\s*:?\s*(\d+)\b/i,
+  );
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Turn Docker/compiler output into a useful failure while preserving the raw
+ * line. Exit 137 is described as SIGKILL and a likely OOM, never as proof of
+ * OOM: an operator or another supervisor can also send SIGKILL.
+ */
+export function extractDockerBuildFailureHint(
+  line: string,
+  context: DockerBuildDiagnosticContext = {},
+): string | null {
+  const code = exitCodeFromLine(line);
+  if (code === 137) {
+    return `${line} — The build process was killed by SIGKILL (exit code 137). Memory exhaustion is the most common cause, but exit 137 alone does not prove OOM. ${memoryGuidance(context)}`;
+  }
+  if (code === 143) {
+    return `${line} — The build process received SIGTERM (exit code 143), usually because it was cancelled or stopped by another supervisor.`;
+  }
+  if (code !== null) return line;
+
+  if (
+    /JavaScript heap out of memory|Fatal process out of memory|Ineffective mark-compacts near heap limit|Reached heap limit Allocation failed|fatal error:\s*(?:runtime:\s*)?out of memory/i.test(
+      line,
+    )
+  ) {
+    return `${line} — The build process explicitly reported that it ran out of memory. ${memoryGuidance(context)}`;
+  }
+
+  if (/\bENOMEM\b|cannot allocate memory/i.test(line)) {
+    return `${line} — The build process could not allocate memory (ENOMEM). ${memoryGuidance(context)}`;
+  }
+
+  return null;
+}
+
+/** Prefer root-cause evidence over a later generic Docker wrapper error. */
+export function chooseDockerBuildFailureHint(
+  current: string | null,
+  candidate: string | null,
+): string | null {
+  if (!candidate) return current;
+  if (!current) return candidate;
+
+  const score = (message: string): number => {
+    if (/explicitly reported that it ran out of memory|could not allocate memory/i.test(message)) {
+      return 4;
+    }
+    if (/SIGKILL \(exit code 137\)/i.test(message)) return 3;
+    if (/BuildKit|package\.json was not found/i.test(message)) return 2;
+    if (
+      /returned a non-zero code|failed to solve|executor failed running|error: build/i.test(message)
+    ) {
+      return 1;
+    }
+    return 0;
+  };
+
+  return score(candidate) > score(current) ? candidate : current;
+}
+
+/** Final SSH/CLI error, reusing any stronger evidence seen in streamed output. */
+export function dockerBuildExitMessage(
+  code: number,
+  streamedHint: string | null,
+  context: DockerBuildDiagnosticContext = {},
+): string {
+  if (streamedHint) return streamedHint;
+  const plain = `docker build exited with code ${code}`;
+  return extractDockerBuildFailureHint(plain, context) ?? plain;
+}
+
+function formatDuration(ms: number): string {
+  if (ms % 60_000 === 0) {
+    const minutes = ms / 60_000;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  const seconds = Math.ceil(ms / 1000);
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+}
+
+export function dockerBuildIdleTimeoutError(
+  timeoutMs: number,
+  context: DockerBuildDiagnosticContext = {},
+): Error {
+  const limit =
+    context.memoryLimitApplied && context.configuredMemoryMb && context.configuredMemoryMb > 0
+      ? ` The classic Docker builder was capped at ${context.configuredMemoryMb} MB RAM, so sustained memory pressure is one possible cause.`
+      : "";
+  return new Error(
+    `Docker build produced no output for ${formatDuration(timeoutMs)} and was cancelled.${limit} Other common causes are package-registry or DNS failures, a process waiting for input, and a stalled Docker daemon.`,
+  );
+}
+
+export interface DockerBuildIdleMonitor {
+  /** Record real output/progress and re-arm the inactivity deadline. */
+  progress(): void;
+  /** Permanently release both timers. Idempotent. */
+  stop(): void;
+}
+
+/**
+ * A single inactivity implementation for both Docker transports. It reports
+ * elapsed time from the last real progress event (not timer tick counts), so
+ * delayed event loops cannot produce misleading durations.
+ */
+export function startDockerBuildIdleMonitor(options: {
+  timeoutMs: number;
+  onIdle: (idleMs: number) => void;
+  onTimeout: () => void;
+}): DockerBuildIdleMonitor {
+  let stopped = false;
+  let lastProgressAt = Date.now();
+  let lastReportedMinute = 0;
+  let deadline: ReturnType<typeof setTimeout>;
+
+  const armDeadline = () => {
+    clearTimeout(deadline);
+    deadline = setTimeout(() => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(heartbeat);
+      options.onTimeout();
+    }, options.timeoutMs);
+    deadline.unref?.();
+  };
+
+  const heartbeat = setInterval(() => {
+    if (stopped) return;
+    const idleMs = Date.now() - lastProgressAt;
+    const idleMinutes = Math.floor(idleMs / 60_000);
+    if (idleMinutes > lastReportedMinute) {
+      lastReportedMinute = idleMinutes;
+      options.onIdle(idleMs);
+    }
+  }, 60_000);
+  heartbeat.unref?.();
+  armDeadline();
+
+  return {
+    progress() {
+      if (stopped) return;
+      lastProgressAt = Date.now();
+      lastReportedMinute = 0;
+      armDeadline();
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearTimeout(deadline);
+      clearInterval(heartbeat);
+    },
+  };
+}

--- a/packages/adapters/src/runtime/docker-build-subcontext.test.ts
+++ b/packages/adapters/src/runtime/docker-build-subcontext.test.ts
@@ -30,7 +30,10 @@ function tarEntries(archive: Buffer): string[] {
       continue;
     }
     const name = header.subarray(0, 100).toString("latin1").replace(/\0.*$/, "");
-    const size = parseInt(header.subarray(124, 136).toString("latin1").replace(/\0.*$/, "").trim() || "0", 8);
+    const size = parseInt(
+      header.subarray(124, 136).toString("latin1").replace(/\0.*$/, "").trim() || "0",
+      8,
+    );
     if (name) names.push(name.replace(/\/$/, ""));
     offset += 512 + Math.ceil(size / 512) * 512;
   }
@@ -62,7 +65,10 @@ async function makeRepo(): Promise<string> {
   await writeFile(join(repo, "Dockerfile"), "FROM node:22\n");
   await writeFile(join(repo, "root-only.txt"), "root\n");
   await mkdir(join(repo, "svc"), { recursive: true });
-  await writeFile(join(repo, "svc", "Dockerfile.api"), "FROM python:3.12\nCOPY requirements.txt /\n");
+  await writeFile(
+    join(repo, "svc", "Dockerfile.api"),
+    "FROM python:3.12\nCOPY requirements.txt /\n",
+  );
   await writeFile(join(repo, "svc", "requirements.txt"), "flask\n");
 
   await exec("git", ["-C", repo, "add", "-A", "-f"]);
@@ -239,6 +245,7 @@ describe("remote docker build — declared build context (#634)", () => {
     // exactly one builder.
     expect(buildCmd).toContain("--progress=plain");
     expect(buildCmd).not.toContain("--force-rm");
+    expect(buildCmd).not.toContain("--add-host");
   });
 
   it("keeps the legacy builder — and drops --progress — when the probe is unanswered", async () => {
@@ -250,6 +257,7 @@ describe("remote docker build — declared build context (#634)", () => {
     expect(buildCmd).not.toContain("DOCKER_BUILDKIT=1");
     expect(buildCmd).not.toContain("--progress");
     expect(buildCmd).toContain("--force-rm");
+    expect(buildCmd).toMatch(/--add-host 'openship-build-[0-9a-f-]+\.invalid:127\.0\.0\.1'/);
   });
 
   it("does not read a version banner as buildx", async () => {
@@ -303,7 +311,8 @@ describe("mixed batch — one tree, different contexts (#634)", () => {
       dockerfiles.set(name, String(opts.dockerfile));
       buildArgs.set(name, opts.buildargs);
       const chunks: Buffer[] = [];
-      for await (const chunk of body.pipe(createGunzip())) chunks.push(Buffer.from(chunk as Buffer));
+      for await (const chunk of body.pipe(createGunzip()))
+        chunks.push(Buffer.from(chunk as Buffer));
       packed.set(name, tarEntries(Buffer.concat(chunks)));
       return { on: () => {}, pipe: () => {} } as unknown as NodeJS.ReadableStream;
     });

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -31,6 +31,7 @@
 /// <reference path="./tar-fs.d.ts" />
 import Dockerode from "dockerode";
 import * as tarFs from "tar-fs";
+import { randomUUID } from "node:crypto";
 import { createGzip } from "node:zlib";
 
 import type {
@@ -185,6 +186,20 @@ import {
   type DockerTransport,
   resolveDockerTransport,
 } from "./docker-transport";
+import {
+  chooseDockerBuildFailureHint,
+  dockerBuildExitMessage,
+  dockerBuildIdleTimeoutError,
+  extractDockerBuildFailureHint,
+  getDockerBuildIdleTimeoutMs,
+  startDockerBuildIdleMonitor,
+  type DockerBuildDiagnosticContext,
+} from "./docker-build-diagnostics";
+import {
+  LegacyBuildContainerTracker,
+  type LegacyBuildContainerInspect,
+  type LegacyBuildContainerTermination,
+} from "./docker-build-container-tracker";
 
 // ─── Connection config ───────────────────────────────────────────────────────
 export type { DockerConnectionOptions } from "./docker-transport";
@@ -223,7 +238,64 @@ const RESTART_POLICIES: Record<string, { Name: string; MaximumRetryCount: number
   no: { Name: "no", MaximumRetryCount: 0 },
 };
 
-const DOCKER_BUILD_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+interface DockerodeBuildStreamOptions {
+  trace?: BuildKitTraceDecoder;
+  diagnosticContext?: DockerBuildDiagnosticContext;
+  abortBuild?: (reason?: unknown) => void;
+  cancelSignal?: AbortSignal;
+  /** Present only for the classic builder, whose RUN container id appears in the stream. */
+  legacyBuilder?: { expectedMemoryBytes?: number; ownershipHost: string };
+}
+
+const BUILD_CONTAINER_CLEANUP_TIMEOUT_MS = 5_000;
+const BUILD_CONTAINER_IDENTIFICATION_GRACE_MS = 500;
+
+function newBuildOwnershipHost(): string {
+  // ExtraHosts is transient container configuration: it neither persists in
+  // the image nor changes classic-builder cache keys. The random hostname is a
+  // proof that an intermediate container belongs to this exact build request.
+  return `openship-build-${randomUUID()}.invalid`;
+}
+
+async function boundedBuildContainerCleanup(
+  cleanup: Promise<LegacyBuildContainerTermination>,
+): Promise<LegacyBuildContainerTermination | null> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  // Handle a late rejection even if the deadline wins the race.
+  const guarded = cleanup.catch(() => null);
+  const deadline = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), BUILD_CONTAINER_CLEANUP_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([guarded, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function stopTrackedBuildContainer(
+  tracker: LegacyBuildContainerTracker | null,
+  log: BuildLogger,
+  reason: "timed-out" | "interrupted",
+): Promise<void> {
+  if (!tracker) return;
+  tracker.flush();
+  const cleanup = await boundedBuildContainerCleanup(tracker.terminateActive());
+  if (cleanup?.status === "killed") {
+    log.log(`Stopped ${reason} Docker build container ${cleanup.id.slice(0, 12)}.`);
+  } else if (cleanup?.status === "unverified") {
+    log.log(
+      `${reason === "timed-out" ? "Timed-out" : "Interrupted"} build container ${cleanup.id.slice(0, 12)} did not match this build's verified step; it was left untouched.`,
+      "warn",
+    );
+  } else if (cleanup === null) {
+    log.log(
+      `${reason === "timed-out" ? "Timed-out" : "Interrupted"} Docker build cleanup could not be confirmed within 5 seconds; Docker may still be releasing the build container.`,
+      "warn",
+    );
+  }
+}
 
 /**
  * A deployment build and its cancellation request may resolve separate
@@ -576,8 +648,17 @@ export function packBuildContext(
   entries: string[],
   cancelSignal?: AbortSignal,
   ignoreContextPath?: (relativePosixPath: string) => boolean,
-): { body: NodeJS.ReadableStream; abortSignal: AbortSignal; takeError: () => Error | null } {
+): {
+  body: NodeJS.ReadableStream;
+  abortSignal: AbortSignal;
+  abort: (reason?: unknown) => void;
+  detachCancellation: () => void;
+  takeError: () => Error | null;
+} {
   const controller = new AbortController();
+  const abort = (reason?: unknown) => {
+    if (!controller.signal.aborted) controller.abort(reason);
+  };
   // tar-fs hands the predicate an absolute path; `.dockerignore` matches
   // context-relative ones. Only set when the tree was NOT pruned destructively
   // (per-service build contexts) — see ResolvedDockerfile.ignoreContextPath.
@@ -590,21 +671,31 @@ export function packBuildContext(
   let contextError: Error | null = null;
   const capture = (err: unknown) => {
     contextError ??= err instanceof Error ? err : new Error(String(err));
-    if (!controller.signal.aborted) controller.abort();
+    abort(contextError);
   };
   // A cancelled build has to abort the in-flight buildImage request too: dockerode
   // forwards `abortSignal` to it, and on this path there is no remote process to
   // kill — aborting the request is the only thing that stops the daemon's build.
+  const onCancel = () => abort(cancelSignal?.reason);
   if (cancelSignal) {
-    if (cancelSignal.aborted) controller.abort();
-    else cancelSignal.addEventListener("abort", () => controller.abort(), { once: true });
+    if (cancelSignal.aborted) abort(cancelSignal.reason);
+    else cancelSignal.addEventListener("abort", onCancel, { once: true });
   }
   // pipe() does NOT forward source errors, so a tar-fs walk failure is only
   // observable on the pack itself — this listener is what keeps it from killing
   // the process. Guard the gzip side too for completeness.
   pack.once("error", capture);
   body.once("error", capture);
-  return { body, abortSignal: controller.signal, takeError: () => contextError };
+  return {
+    body,
+    abortSignal: controller.signal,
+    abort,
+    // Once buildImage has returned the response stream, streamDockerodeBuild
+    // owns cancellation. It briefly keeps that stream alive to receive Docker's
+    // exact intermediate-container id before aborting the request.
+    detachCancellation: () => cancelSignal?.removeEventListener("abort", onCancel),
+    takeError: () => contextError,
+  };
 }
 
 const DURATION_UNITS_NS: Record<string, number> = {
@@ -1191,11 +1282,12 @@ export class DockerRuntime implements RuntimeAdapter {
     },
     logger: BuildLogger,
     trace?: BuildKitTraceDecoder,
+    diagnosticContext: DockerBuildDiagnosticContext = {},
   ): string | null {
     const errorMessage = event.errorDetail?.message ?? event.error;
     if (errorMessage) {
       logger.log(errorMessage, "error");
-      return errorMessage;
+      return this.extractBuildFailureHint(errorMessage, diagnosticContext) ?? errorMessage;
     }
 
     // A BuildKit build emits its whole progress stream as protobuf traces instead of
@@ -1210,7 +1302,10 @@ export class DockerRuntime implements RuntimeAdapter {
         // are the only thing that turns a bare exit code into an explanation, and
         // BuildKit builds are precisely the ones with no other diagnostic.
         logger.log(line.message, line.level === "error" ? "error" : parseLogLevel(line.message));
-        hint ??= this.extractBuildFailureHint(line.message);
+        hint = chooseDockerBuildFailureHint(
+          hint,
+          this.extractBuildFailureHint(line.message, diagnosticContext),
+        );
       }
       return hint;
     }
@@ -1247,7 +1342,7 @@ export class DockerRuntime implements RuntimeAdapter {
       }
 
       logger.log(line, parseLogLevel(line));
-      return this.extractBuildFailureHint(line);
+      return this.extractBuildFailureHint(line, diagnosticContext);
     }
 
     if (event.status) {
@@ -1282,10 +1377,12 @@ export class DockerRuntime implements RuntimeAdapter {
     return DockerRuntime.DOCKER_BUILDER_NOISE.some((p) => p.test(line));
   }
 
-  private extractBuildFailureHint(line: string): string | null {
-    if (/returned a non-zero code:\s*\d+/i.test(line)) {
-      return line;
-    }
+  private extractBuildFailureHint(
+    line: string,
+    diagnosticContext: DockerBuildDiagnosticContext = {},
+  ): string | null {
+    const processFailure = extractDockerBuildFailureHint(line, diagnosticContext);
+    if (processFailure) return processFailure;
 
     // The legacy builder's own wording for "this Dockerfile needs BuildKit". Reached
     // when the syntax sniff missed a construct, or on a remote host whose docker CLI
@@ -1464,12 +1561,15 @@ export class DockerRuntime implements RuntimeAdapter {
     // containers to remove), so it goes when BuildKit is on.
     const buildKit = await this.remoteBuildKitAvailable();
     const builderEnv = buildKit ? "DOCKER_BUILDKIT=1 " : "";
+    const ownershipHost = buildKit ? null : newBuildOwnershipHost();
     // `--progress` is a buildx flag, NOT a docker-build flag: a CLI without the
     // plugin rejects it outright with `unknown flag: --progress` and exit 125, before
     // it ever looks at the context. `--force-rm` is the mirror image — a legacy-only
     // concept (BuildKit keeps no intermediate containers to remove). So the flag set
     // follows the builder; passing either unconditionally breaks one of the two.
-    const builderFlags = buildKit ? " --progress=plain" : " --force-rm";
+    const builderFlags = buildKit
+      ? " --progress=plain"
+      : ` --force-rm --add-host ${sq(`${ownershipHost}:127.0.0.1`)}`;
     if (buildKit) {
       log.log("Builder: BuildKit (docker buildx detected on the host)");
     } else if (opts?.requiresBuildKit) {
@@ -1509,22 +1609,92 @@ export class DockerRuntime implements RuntimeAdapter {
       "Running install inside container (docker build)",
     );
 
-    const { code } = await executor.streamExec(
-      buildCmd,
-      (entry) => {
-        // Pass docker's real output straight through.
-        log.log(entry.message, parseLogLevel(entry.message));
+    // Native SSH builds do not pass Docker's --memory flag, even when the
+    // project has a configured build limit. Keep that distinction explicit so
+    // an exit-137 diagnostic never claims a cap this path did not enforce.
+    const diagnosticContext: DockerBuildDiagnosticContext = {
+      configuredMemoryMb: config.resources.memoryMb,
+      memoryLimitApplied: false,
+    };
+    const buildContainerTracker = buildKit
+      ? null
+      : this.remoteLegacyBuildContainerTracker(executor, ownershipHost!);
+    const commandAbort = new AbortController();
+    const forwardCancellation = () => {
+      buildContainerTracker?.flush();
+      if (buildContainerTracker) void buildContainerTracker.terminateActive();
+      commandAbort.abort(signal?.reason);
+    };
+    if (signal?.aborted) forwardCancellation();
+    else signal?.addEventListener("abort", forwardCancellation, { once: true });
+
+    let timeoutError: Error | null = null;
+    let streamedFailureHint: string | null = null;
+    const timeoutMs = getDockerBuildIdleTimeoutMs();
+    const idleMonitor = startDockerBuildIdleMonitor({
+      timeoutMs,
+      onIdle: (idleMs) => {
+        log.log(`Still building... (no output for ${Math.floor(idleMs / 60_000)}m)`);
       },
-      { signal },
-    );
+      onTimeout: () => {
+        timeoutError = dockerBuildIdleTimeoutError(timeoutMs, diagnosticContext);
+        buildContainerTracker?.flush();
+        if (buildContainerTracker) void buildContainerTracker.terminateActive();
+        commandAbort.abort(timeoutError);
+      },
+    });
+
+    let code: number | null = null;
+    let execError: unknown = null;
+    try {
+      const result = await executor.streamExec(
+        buildCmd,
+        (entry) => {
+          idleMonitor.progress();
+          buildContainerTracker?.observeChunk(entry.message);
+          streamedFailureHint = chooseDockerBuildFailureHint(
+            streamedFailureHint,
+            this.extractBuildFailureHint(entry.message, diagnosticContext),
+          );
+          // Pass docker's real output straight through.
+          log.log(entry.message, parseLogLevel(entry.message));
+        },
+        { signal: commandAbort.signal },
+      );
+      code = result.code;
+    } catch (error) {
+      execError = error;
+    } finally {
+      idleMonitor.stop();
+      buildContainerTracker?.flush();
+      signal?.removeEventListener("abort", forwardCancellation);
+    }
 
     log.log("─── end docker build output ───");
     // SshExecutor intentionally resolves an aborted stream so browser log
     // teardown is not reported as a transport failure. A deployment cancel is
     // different: surface it as a cancelled BuildResult instead of continuing
     // through image verification and deploy.
-    if (signal?.aborted) throw new BuildCancelledError();
-    if (code !== 0) throw new Error(`docker build exited with code ${code}`);
+    if (timeoutError) {
+      await stopTrackedBuildContainer(buildContainerTracker, log, "timed-out");
+      throw timeoutError;
+    }
+    if (signal?.aborted) {
+      await stopTrackedBuildContainer(buildContainerTracker, log, "interrupted");
+      throw new BuildCancelledError();
+    }
+    if (execError) {
+      await stopTrackedBuildContainer(buildContainerTracker, log, "interrupted");
+      throw execError;
+    }
+    if (code === null) {
+      await stopTrackedBuildContainer(buildContainerTracker, log, "interrupted");
+      throw new Error("docker build ended without an exit code");
+    }
+    if (code !== 0) {
+      await stopTrackedBuildContainer(buildContainerTracker, log, "interrupted");
+      throw new Error(dockerBuildExitMessage(code, streamedFailureHint, diagnosticContext));
+    }
     this.emitDockerStep(log, "install", "completed", "Image build finished");
   }
 
@@ -1848,6 +2018,65 @@ export class DockerRuntime implements RuntimeAdapter {
   }
 
   /**
+   * Bind legacy-builder cleanup to the exact container id Docker announces in
+   * this build's own progress stream. A 404 is an ordinary "already cleaned"
+   * result; every other inspection failure remains inconclusive and therefore
+   * can never authorize a kill.
+   */
+  private legacyBuildContainerTracker(
+    expectedMemoryBytes: number | undefined,
+    ownershipHost: string,
+  ): LegacyBuildContainerTracker {
+    return new LegacyBuildContainerTracker(
+      {
+        inspect: async (id) => {
+          try {
+            return await this.docker.getContainer(id).inspect();
+          } catch (error) {
+            if (isDockerNotFoundError(error)) return null;
+            throw error;
+          }
+        },
+        kill: async (id) => {
+          await this.docker.getContainer(id).kill({ signal: "SIGKILL" });
+        },
+      },
+      expectedMemoryBytes,
+      ownershipHost,
+    );
+  }
+
+  /** Same proof model as the Engine-API tracker, using the already-live SSH executor. */
+  private remoteLegacyBuildContainerTracker(
+    executor: CommandExecutor,
+    ownershipHost: string,
+  ): LegacyBuildContainerTracker {
+    return new LegacyBuildContainerTracker(
+      {
+        inspect: async (id) => {
+          try {
+            const output = await executor.exec(`docker container inspect ${sq(id)}`);
+            const parsed: unknown = JSON.parse(output);
+            return Array.isArray(parsed) && parsed[0] && typeof parsed[0] === "object"
+              ? (parsed[0] as LegacyBuildContainerInspect)
+              : null;
+          } catch (error) {
+            if (/No such (?:object|container)|not found/i.test(safeErrorMessage(error)))
+              return null;
+            throw error;
+          }
+        },
+        kill: async (id) => {
+          await executor.exec(`docker container kill --signal KILL ${sq(id)} >/dev/null`);
+        },
+      },
+      // The native CLI path intentionally applies no OpenShip memory flag.
+      undefined,
+      ownershipHost,
+    );
+  }
+
+  /**
    * Dockerode build path. Used for local socket and TCP transports, plus
    * SSH transports that didn't get an executor wired in (shouldn't happen
    * in normal operation but kept as a safety net).
@@ -1865,7 +2094,7 @@ export class DockerRuntime implements RuntimeAdapter {
   ): Promise<void> {
     log.log(`Streaming build context to Docker daemon - image tag: ${tag}`);
 
-    const { body, abortSignal, takeError } = packBuildContext(
+    const { body, abortSignal, abort, detachCancellation, takeError } = packBuildContext(
       buildContext.buildContextDir,
       buildContext.contextEntries,
       cancelSignal,
@@ -1873,6 +2102,14 @@ export class DockerRuntime implements RuntimeAdapter {
     );
 
     const builder = this.selectDockerodeBuilder(config, buildContext.requiresBuildKit, log);
+    const buildLimits = dockerBuildResourceLimits(config.resources);
+    const ownershipHost = builder.options.version !== "2" ? newBuildOwnershipHost() : null;
+    const diagnosticContext: DockerBuildDiagnosticContext = {
+      configuredMemoryMb: config.resources.memoryMb,
+      // Engine API build limits work only with the classic builder. The
+      // BuildKit selection above already logs that its build runs uncapped.
+      memoryLimitApplied: builder.options.version !== "2" && buildLimits.memory !== undefined,
+    };
 
     try {
       const stream = await this.docker.buildImage(body, {
@@ -1883,14 +2120,24 @@ export class DockerRuntime implements RuntimeAdapter {
         // Omitted entirely unless the project set a build cap — a self-hosted
         // build should be free to use the machine (a production build often
         // needs several GB). Opt-in only; see dockerBuildResourceLimits.
-        ...dockerBuildResourceLimits(config.resources),
+        ...buildLimits,
+        ...(ownershipHost && { extrahosts: `${ownershipHost}:127.0.0.1` }),
         forcerm: true,
         ...builder.options,
         abortSignal,
       });
+      detachCancellation();
 
       log.log("Connected to Docker daemon. Build output follows:");
-      await this.streamDockerodeBuild(stream, log, builder.trace);
+      await this.streamDockerodeBuild(stream, log, {
+        trace: builder.trace,
+        diagnosticContext,
+        abortBuild: abort,
+        cancelSignal,
+        ...(ownershipHost && {
+          legacyBuilder: { expectedMemoryBytes: buildLimits.memory, ownershipHost },
+        }),
+      });
       log.log("Docker daemon finished streaming build output. Finalizing image...\n");
     } catch (err) {
       // A context-pack failure aborts the request, so the rejection here is the
@@ -1902,6 +2149,7 @@ export class DockerRuntime implements RuntimeAdapter {
           })
         : err;
     } finally {
+      detachCancellation();
       // Clean up only AFTER the daemon has fully consumed the context. dockerode's
       // buildImage promise resolves as soon as the response starts, while tar-fs
       // may still be walking contextDir — deleting it here (the old `finally`
@@ -1918,78 +2166,133 @@ export class DockerRuntime implements RuntimeAdapter {
   private async streamDockerodeBuild(
     stream: NodeJS.ReadableStream,
     log: BuildLogger,
-    trace?: BuildKitTraceDecoder,
+    options: DockerodeBuildStreamOptions = {},
   ): Promise<void> {
     let fatalBuildError: string | null = null;
+    const timeoutMs = getDockerBuildIdleTimeoutMs();
+    const diagnosticContext = options.diagnosticContext ?? {};
+    const buildContainerTracker = options.legacyBuilder
+      ? this.legacyBuildContainerTracker(
+          options.legacyBuilder.expectedMemoryBytes,
+          options.legacyBuilder.ownershipHost,
+        )
+      : null;
+    let inactivityTimedOut = false;
 
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      let idleTimer: NodeJS.Timeout | null = null;
-      let keepaliveTimer: NodeJS.Timeout | null = null;
-      let idleMinutes = 0;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let idleMonitor: ReturnType<typeof startDockerBuildIdleMonitor> | null = null;
+        let cancellationTimer: ReturnType<typeof setTimeout> | null = null;
 
-      const clearTimers = () => {
-        if (idleTimer) {
-          clearTimeout(idleTimer);
-          idleTimer = null;
-        }
-        if (keepaliveTimer) {
-          clearInterval(keepaliveTimer);
-          keepaliveTimer = null;
-        }
-        idleMinutes = 0;
-      };
+        const clearTimers = () => {
+          idleMonitor?.stop();
+          if (cancellationTimer) clearTimeout(cancellationTimer);
+          options.cancelSignal?.removeEventListener("abort", requestCancellation);
+        };
 
-      const fail = (error: Error) => {
-        if (settled) return;
-        settled = true;
-        clearTimers();
-        (stream as any).destroy?.(error);
-        reject(error);
-      };
+        const fail = (error: Error) => {
+          if (settled) return;
+          settled = true;
+          clearTimers();
+          (stream as any).destroy?.(error);
+          reject(error);
+        };
 
-      const succeed = () => {
-        if (settled) return;
-        settled = true;
-        clearTimers();
-        resolve();
-      };
+        const abortCancelledBuild = () => {
+          if (settled) return;
+          buildContainerTracker?.flush();
+          if (buildContainerTracker) void buildContainerTracker.terminateActive();
+          const error = new BuildCancelledError();
+          fail(error);
+          options.abortBuild?.(error);
+        };
 
-      const resetIdleTimer = () => {
-        clearTimers();
-        keepaliveTimer = setInterval(() => {
-          idleMinutes += 1;
-          log.log(`Still building... (no output for ${idleMinutes}m)`);
-        }, 60_000);
-        if ((keepaliveTimer as any).unref) (keepaliveTimer as any).unref();
-
-        idleTimer = setTimeout(() => {
-          fail(
-            new Error(
-              "Docker build produced no output for 30 minutes. This usually means the remote server cannot reach the package registry, has broken DNS, or the Docker daemon stalled during the build.",
-            ),
+        const requestCancellation = () => {
+          if (settled || cancellationTimer) return;
+          idleMonitor?.stop();
+          // A cancel can land after `Step ... : RUN` but just before Docker emits
+          // `Running in <id>`. Keep only the response stream alive for this tiny
+          // grace window so cleanup can identify the exact container; no new
+          // build step is allowed to outlive the cancellation request.
+          cancellationTimer = setTimeout(
+            abortCancelledBuild,
+            buildContainerTracker ? BUILD_CONTAINER_IDENTIFICATION_GRACE_MS : 0,
           );
-        }, DOCKER_BUILD_IDLE_TIMEOUT_MS);
-        if ((idleTimer as any).unref) (idleTimer as any).unref();
-      };
+          cancellationTimer.unref?.();
+        };
 
-      resetIdleTimer();
-
-      this.docker.modem.followProgress(
-        stream,
-        (err: Error | null) => {
-          if (err) {
-            fail(err);
+        const succeed = () => {
+          if (settled) return;
+          if (options.cancelSignal?.aborted) {
+            abortCancelledBuild();
             return;
           }
-          succeed();
-        },
-        (event) => {
-          resetIdleTimer();
-          fatalBuildError ??= this.handleBuildEvent(event, log, trace);
-        },
+          settled = true;
+          clearTimers();
+          resolve();
+        };
+
+        idleMonitor = startDockerBuildIdleMonitor({
+          timeoutMs,
+          onIdle: (idleMs) => {
+            log.log(`Still building... (no output for ${Math.floor(idleMs / 60_000)}m)`);
+          },
+          onTimeout: () => {
+            const error = dockerBuildIdleTimeoutError(timeoutMs, diagnosticContext);
+            // Start exact-container cleanup before closing the response. The
+            // Engine API does not reliably stop a legacy build when its client
+            // disconnects, so stream destruction alone can leave the compiler
+            // consuming the host after OpenShip has already reported failure.
+            inactivityTimedOut = true;
+            if (buildContainerTracker) {
+              void buildContainerTracker.terminateActive();
+            }
+            fail(error);
+            options.abortBuild?.(error);
+          },
+        });
+
+        if (options.cancelSignal?.aborted) requestCancellation();
+        else options.cancelSignal?.addEventListener("abort", requestCancellation, { once: true });
+
+        this.docker.modem.followProgress(
+          stream,
+          (err: Error | null) => {
+            if (err) {
+              fail(err);
+              return;
+            }
+            succeed();
+          },
+          (event) => {
+            idleMonitor?.progress();
+            buildContainerTracker?.observe(event.stream);
+            fatalBuildError = chooseDockerBuildFailureHint(
+              fatalBuildError,
+              this.handleBuildEvent(event, log, options.trace, diagnosticContext),
+            );
+          },
+        );
+      });
+    } catch (error) {
+      // Cancellation and transport failure can strand a legacy builder exactly
+      // like an inactivity timeout. The same proof gate applies to all three.
+      await stopTrackedBuildContainer(
+        buildContainerTracker,
+        log,
+        inactivityTimedOut ? "timed-out" : "interrupted",
       );
-    });
+      throw error;
+    }
+
+    // dockerode's followProgress may report a deliberately aborted response as
+    // a clean EOF. The caller's signal is the source of truth, and the daemon
+    // may still be running the intermediate container behind that closed stream.
+    if (options.cancelSignal?.aborted) {
+      await stopTrackedBuildContainer(buildContainerTracker, log, "interrupted");
+      throw new BuildCancelledError();
+    }
 
     if (fatalBuildError) {
       throw new Error(fatalBuildError);
@@ -2945,13 +3248,20 @@ export class DockerRuntime implements RuntimeAdapter {
             // failure fails just this service instead of crashing the API — see
             // packBuildContext (#448). tree.cleanup() only runs after the whole
             // loop (outer finally), so the context stays put while tar-fs walks.
-            const { body, abortSignal, takeError } = packBuildContext(
+            const { body, abortSignal, abort, detachCancellation, takeError } = packBuildContext(
               buildContextDir ?? tree!.contextDir,
               contextEntries ?? [],
               signal,
               ignoreContextPath,
             );
             const builder = this.selectDockerodeBuilder(spec.config, requiresBuildKit, spec.logger);
+            const buildLimits = dockerBuildResourceLimits(spec.config.resources);
+            const ownershipHost = builder.options.version !== "2" ? newBuildOwnershipHost() : null;
+            const diagnosticContext: DockerBuildDiagnosticContext = {
+              configuredMemoryMb: spec.config.resources.memoryMb,
+              memoryLimitApplied:
+                builder.options.version !== "2" && buildLimits.memory !== undefined,
+            };
             try {
               const stream = await this.docker.buildImage(body, {
                 t: tag,
@@ -2961,12 +3271,22 @@ export class DockerRuntime implements RuntimeAdapter {
                   sessionId: spec.config.sessionId,
                 }),
                 buildargs: resolveDockerBuildArgs(spec.config),
-                ...dockerBuildResourceLimits(spec.config.resources),
+                ...buildLimits,
+                ...(ownershipHost && { extrahosts: `${ownershipHost}:127.0.0.1` }),
                 forcerm: true,
                 ...builder.options,
                 abortSignal,
               });
-              await this.streamDockerodeBuild(stream, spec.logger, builder.trace);
+              detachCancellation();
+              await this.streamDockerodeBuild(stream, spec.logger, {
+                trace: builder.trace,
+                diagnosticContext,
+                abortBuild: abort,
+                cancelSignal: signal,
+                ...(ownershipHost && {
+                  legacyBuilder: { expectedMemoryBytes: buildLimits.memory, ownershipHost },
+                }),
+              });
             } catch (err) {
               const contextErr = takeError();
               throw contextErr
@@ -2975,6 +3295,8 @@ export class DockerRuntime implements RuntimeAdapter {
                     { cause: contextErr },
                   )
                 : err;
+            } finally {
+              detachCancellation();
             }
           }
 


### PR DESCRIPTION
## Summary

- apply one bounded, configurable build-idle timeout to Docker Engine and native SSH builds
- report SIGKILL/exit 137 accurately as commonly OOM without claiming it proves OOM, and preserve stronger allocator diagnostics
- clean up only the exact classic-builder RUN container announced by this build stream
- verify container ID, parent image, RUN command, memory limit, and a random per-build transient ownership marker before sending SIGKILL
- abort the daemon request on timeout/cancellation and cover the cancellation race where Docker has printed the RUN step but not its container ID yet

## Why this supersedes #796

#796 scans recently created containers on the entire Docker host, then can kill one based on recency and memory usage. Those signals do not establish ownership, so a concurrent unrelated workload can be terminated. This replacement never selects a container from a host-wide scan.

The ownership marker is passed through the classic builder as transient ExtraHosts configuration. It is not stored in the output image and does not invalidate classic-layer cache. BuildKit has no intermediate container requiring this legacy cleanup path.

Credit to @lagmandu for identifying the stalled/OOM-thrashing build behavior and proposing the original diagnostics in #796.

## Validation

- bun run --cwd packages/adapters lint
- bun run --cwd packages/adapters test (178 files, 3,523 tests)
- real Docker: idle timeout stopped the exact intermediate builder
- real Docker: manual cancellation stopped the exact intermediate builder in under one second
- real Docker: an unrelated running container remained untouched
- real Docker: ownership marker absent from the final image and classic cache remained reusable

Supersedes #796.