### PR TITLE
fix: use API origin for GitHub OAuth redirect

### DIFF
--- a/apps/api/src/modules/github/github.controller.ts
+++ b/apps/api/src/modules/github/github.controller.ts
@@ -22,6 +22,7 @@ import { resolveProjectInfo, projectInfoToScanResponse } from "../deployments/pr
 import { paginateRepoList, type RepoListParams } from "./repo-list";
 import { getRequestContext } from "../../lib/request-context";
 import { hasConfiguredGitHubSource } from "./github-source.service";
+import { resolveApiPublicUrl } from "../../lib/public-url";
 
 /** Map a MappedRepository to the owner/repo key the access filter needs.
  *  `full_name` is canonically "owner/repo"; fall back to the discrete
@@ -318,7 +319,7 @@ export async function connect(c: Context) {
       // degrades to a stateless GitHub installation URL.
       const install = mode === "app" ? await githubAuth.resolveInstallUrl(ctx) : { state: "" };
       const redirectUrl = install.state
-        ? `/api/github/connect/redirect?install_state=${encodeURIComponent(install.state)}`
+        ? `${resolveApiPublicUrl()}/api/github/connect/redirect?install_state=${encodeURIComponent(install.state)}`
         : undefined;
       return c.json({
         connected: false,
@@ -429,7 +430,7 @@ export async function connect(c: Context) {
   // install state.
   const install = mode === "app" ? await githubAuth.resolveInstallUrl(ctx) : { state: "" };
   const redirectUrl = install.state
-    ? `/api/github/connect/redirect?install_state=${encodeURIComponent(install.state)}`
+    ? `${resolveApiPublicUrl()}/api/github/connect/redirect?install_state=${encodeURIComponent(install.state)}`
     : undefined;
   return c.json({
     connected: false,

--- a/apps/api/test/modules/github/github.controller.test.ts
+++ b/apps/api/test/modules/github/github.controller.test.ts
@@ -1,8 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { linkSocialAccount, getGitHubAuthMode } = vi.hoisted(() => ({
+const {
+  linkSocialAccount,
+  getGitHubAuthMode,
+  resolveGitHubAuthMode,
+  getUserStatus,
+  resolveInstallUrl,
+  resolveApiPublicUrl,
+} = vi.hoisted(() => ({
   linkSocialAccount: vi.fn(),
   getGitHubAuthMode: vi.fn(),
+  resolveGitHubAuthMode: vi.fn(),
+  getUserStatus: vi.fn(),
+  resolveInstallUrl: vi.fn(),
+  resolveApiPublicUrl: vi.fn(),
 }));
 
 vi.mock("../../../src/lib/auth", () => ({
@@ -15,12 +26,18 @@ vi.mock("../../../src/lib/auth", () => ({
 
 vi.mock("../../../src/modules/github/github.auth", () => ({
   getGitHubAuthMode,
+  resolveGitHubAuthMode,
+  getUserStatus,
+  resolveInstallUrl,
 }));
 
 vi.mock("../../../src/modules/github/github.local-auth", () => ({}));
 vi.mock("../../../src/modules/github/github.service", () => ({}));
+vi.mock("../../../src/lib/public-url", () => ({
+  resolveApiPublicUrl,
+}));
 
-import { connectRedirect } from "../../../src/modules/github/github.controller";
+import { connect, connectRedirect } from "../../../src/modules/github/github.controller";
 
 function createContext(headers: Headers, query: Record<string, string> = {}) {
   return {
@@ -45,6 +62,37 @@ describe("connectRedirect", () => {
   beforeEach(() => {
     getGitHubAuthMode.mockReset();
     linkSocialAccount.mockReset();
+    resolveGitHubAuthMode.mockReset();
+    getUserStatus.mockReset();
+    resolveInstallUrl.mockReset();
+    resolveApiPublicUrl.mockReset();
+    resolveApiPublicUrl.mockReturnValue("https://api.example.com");
+  });
+
+  it("returns an absolute API URL for the OAuth handoff", async () => {
+    resolveGitHubAuthMode.mockResolvedValue("app");
+    getUserStatus.mockResolvedValue({ connected: false });
+    resolveInstallUrl.mockResolvedValue({ state: "workspace nonce" });
+
+    const response = await connect({
+      get: (key: string) =>
+        key === "ctx"
+          ? {
+              userId: "user-1",
+              organizationId: "org-1",
+            }
+          : undefined,
+      req: {
+        json: async () => ({}),
+      },
+      json: (body: unknown) => Response.json(body),
+    } as any);
+
+    expect(await response.json()).toMatchObject({
+      connected: false,
+      flow: "redirect",
+      url: "https://api.example.com/api/github/connect/redirect?install_state=workspace%20nonce",
+    });
   });
 
   it("starts a GitHub link flow and forwards the OAuth state cookie", async () => {
@@ -52,12 +100,15 @@ describe("connectRedirect", () => {
     const headers = new Headers({ cookie: "openship.session_token=test" });
 
     linkSocialAccount.mockResolvedValue(
-      new Response(JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }), {
-        headers: {
-          "content-type": "application/json",
-          "set-cookie": "oauth_state=test-state; Path=/; HttpOnly",
+      new Response(
+        JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }),
+        {
+          headers: {
+            "content-type": "application/json",
+            "set-cookie": "oauth_state=test-state; Path=/; HttpOnly",
+          },
         },
-      }),
+      ),
     );
 
     const response = await connectRedirect(createContext(headers));
@@ -83,11 +134,14 @@ describe("connectRedirect", () => {
     getGitHubAuthMode.mockReturnValue("app");
 
     linkSocialAccount.mockResolvedValue(
-      new Response(JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }), {
-        headers: {
-          "content-type": "application/json",
+      new Response(
+        JSON.stringify({ url: "https://github.com/login/oauth/authorize?client_id=test" }),
+        {
+          headers: {
+            "content-type": "application/json",
+          },
         },
-      }),
+      ),
     );
 
     await connectRedirect(createContext(new Headers()));


### PR DESCRIPTION
Fix GitHub OAuth redirects for hosted split-origin deployments by returning an absolute API URL instead of a dashboard-relative path.

Motivation

#825 

When hosted on separate origins, the dashboard received:

 /api/github/connect/redirect?install_state=... 

The browser resolved this against  https://app.openship.io , resulting in a 404. The redirect must target the API origin at  https://api.openship.io .

Related issue

None — bug fix.

Changes

• apps/api
• Use  resolveApiPublicUrl()  for GitHub OAuth redirect URLs.
• Apply the fix to both App/OAuth connection paths.
• Add a regression test covering the absolute API origin and encoded install state.

Verification

DEPLOY_MODE=desktop bunx vitest run apps/api/test/modules/github/github.controller.test.ts

✓ apps/api/test/modules/github/github.controller.test.ts (4 tests) 106ms
Test Files  1 passed (1)
Tests  4 passed (4)

bun run --cwd apps/api lint

$ tsc --noEmit

The formatter was initially run repository-wide and generated unrelated changes across many files. Those changes were reverted, and only the two changed files were formatted individually:

bunx prettier --write \
  apps/api/src/modules/github/github.controller.ts \
  apps/api/test/modules/github/github.controller.test.ts

Checklist

✓ One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
✓ The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
✓ A test fails without this change and passes with it
•  bun run test ,  bun run --cwd <workspace> lint , and  bun format  all pass locally — targeted API tests and lint pass; repository-wide  bun format  was not retained because it modified unrelated files
✓ I understand every line of this diff and can explain it in review