### PR TITLE
fix(docker): prevent false build failures on exit code 0

### DIFF
--- a/packages/adapters/src/runtime/docker-build-diagnostics.test.ts
+++ b/packages/adapters/src/runtime/docker-build-diagnostics.test.ts
@@ -29,6 +29,14 @@ describe("Docker build diagnostics", () => {
     }
   });
 
+  it.each([
+    "@beacon/web build: Exited with code 0",
+    "Process exited with exit code: 0",
+    "process completed: exit code 0",
+  ])("does not treat a successful exit as failure evidence: %s", (line) => {
+    expect(extractDockerBuildFailureHint(line)).toBeNull();
+  });
+
   it("describes exit 137 accurately without claiming that SIGKILL proves OOM", () => {
     const hint = extractDockerBuildFailureHint(
       "The command '/bin/sh -c bun run build' returned a non-zero code: 137",
@@ -154,6 +162,40 @@ describe("DockerRuntime build failure paths", () => {
     if (previousTimeout === undefined) delete process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS;
     else process.env.OPENSHIP_BUILD_IDLE_TIMEOUT_MS = previousTimeout;
   });
+
+  it.each([null, "The command returned a non-zero code: 1"])(
+    "does not let a successful Bun step override the Docker result: %s",
+    async (dockerError) => {
+      const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime;
+      Object.assign(runtime, {
+        _docker: {
+          modem: {
+            followProgress: (
+              _stream: unknown,
+              finished: (error: Error | null) => void,
+              progress: (event: { stream?: string; error?: string }) => void,
+            ) => {
+              progress({ stream: "@beacon/web build: Exited with code 0\n" });
+              if (dockerError) {
+                progress({ error: dockerError });
+              } else {
+                progress({ stream: "Successfully built abc123\n" });
+                progress({ stream: "Successfully tagged openship/test:build\n" });
+              }
+              finished(null);
+            },
+          },
+        },
+      });
+
+      const result = (runtime as any).streamDockerodeBuild(new PassThrough(), new BuildLogger());
+      if (dockerError) {
+        await expect(result).rejects.toThrow(dockerError);
+      } else {
+        await expect(result).resolves.toBeUndefined();
+      }
+    },
+  );
 
   it("times out a daemon stream without discovering or killing host containers", async () => {
     const stream = new PassThrough();

--- a/packages/adapters/src/runtime/docker-build-diagnostics.ts
+++ b/packages/adapters/src/runtime/docker-build-diagnostics.ts
@@ -68,7 +68,7 @@ export function extractDockerBuildFailureHint(
   if (code === 143) {
     return `${line} — The build process received SIGTERM (exit code 143), usually because it was cancelled or stopped by another supervisor.`;
   }
-  if (code !== null) return line;
+  if (code !== null) return code === 0 ? null : line;
 
   if (
     /JavaScript heap out of memory|Fatal process out of memory|Ineffective mark-compacts near heap limit|Reached heap limit Allocation failed|fatal error:\s*(?:runtime:\s*)?out of memory/i.test(


### PR DESCRIPTION
Urgent v0.7.1 regression: this blocks staging deployments after Docker successfully builds and tags the image. Bun’s “Exited with code 0” is incorrectly treated as fatal.

Ignore successful exit codes; add regression coverage for successful builds and genuine failures. 

Validation (Bun 1.3.10): 65 focused tests, adapters lint, Prettier, and diff checks pass. Repro: `bun run --cwd packages/adapters test src/runtime/docker-build-diagnostics.test.ts`. Full `bun run test` timed out at 120s.