### PR TITLE
fix(mail): warn on unverified inbound SMTP during setup

### DIFF
--- a/apps/api/src/modules/mail/mail-port-reachability.service.ts
+++ b/apps/api/src/modules/mail/mail-port-reachability.service.ts
@@ -3,8 +3,8 @@
  *
  * This combines two different facts without conflating them:
  *   1. a listener scan on the mail host; and
- *   2. an off-box TCP connection from the Openship control plane to the public
- *      DNS address.
+ *   2. a TCP connection from the Openship API to the public DNS address. On a
+ *      single-server install, this originates on the mail host itself.
  *
  * The first catches a stopped daemon or loopback-only bind. The second catches
  * host/provider firewalls and NAT rules. Neither fact alone can diagnose both.
@@ -22,25 +22,20 @@ export const REQUIRED_PUBLIC_MAIL_PORTS = [
   { key: "imaps", port: 993, label: "IMAP (TLS)" },
 ] as const;
 
-/** Mail-client ports. Unlike inbound SMTP, these are not filtered by cloud outbound-25 throttles. */
-export const CLIENT_PUBLIC_MAIL_PORTS = [465, 587, 993] as const;
-
-export const SMTP_INBOUND_PORT = 25;
+const SMTP_INBOUND_PORT = 25;
 
 /**
- * Why a public :25 timeout is often not a setup wall: AWS (and some other
- * clouds) filter TCP 25 originating FROM the instance. The wizard probe runs
- * on the Openship control plane, which on a single-box self-host is that same
- * instance, so the "public" dial of `mail.example.com:25` is actually outbound
- * port 25 from the box. That times out even when inbound MX from the internet
- * would succeed, and even when operators send through SES / another relay.
+ * The API's outbound-25 filter and the mail host's inbound firewall can produce
+ * the same timeout. Client-port handshakes cannot distinguish them, so keep
+ * inbound reachability unverified until it is checked independently.
  */
-export const SMTP_INBOUND_SOFT_BLOCK_DETAIL =
-  "Inbound TCP 25 could not be verified from the control plane. Many clouds " +
-  "(especially AWS) filter instance-originated port 25, so this probe can time " +
-  "out even when inbound MX delivery works. SMTP submission (465/587) and IMAP " +
-  "(993) are reachable. Route sending through an SMTP provider on the Sending " +
-  "tab if outbound port 25 is blocked.";
+const SMTP_INBOUND_UNVERIFIED_DETAIL =
+  "Inbound TCP 25 could not be verified from the Openship API server. Providers " +
+  "such as AWS can block this server's outbound port 25 even when inbound mail " +
+  "works. Submission (465/587) and IMAP (993) are reachable. Verify port 25 from " +
+  "an independent host or send a test message from another mail provider before " +
+  "relying on inbound delivery. An SMTP relay in the Sending tab handles " +
+  "outgoing mail only.";
 
 export type MailPortReachabilityStatus =
   | "reachable"
@@ -72,19 +67,23 @@ export interface MailPortReachability {
 }
 
 /**
- * True when :25 is listening on a public bind, the control-plane probe timed
- * out, and every mail-client port completed a TCP handshake. Local bind
- * failures (not listening / loopback-only) stay hard failures.
+ * Only an isolated :25 timeout is ambiguous. Refusals, routing errors, local
+ * bind failures, and unverified client ports must not receive this exception.
  */
-export function isControlPlaneSmtpInboundSoftBlock(
-  ports: readonly MailPortReachabilityCheck[],
-): boolean {
+function isSmtpInboundUnverified(ports: readonly MailPortReachabilityCheck[]): boolean {
   const smtp = ports.find((port) => port.port === SMTP_INBOUND_PORT);
-  if (!smtp || smtp.status !== "blocked" || !smtp.listening || !smtp.exposed) {
+  if (
+    !smtp ||
+    smtp.status !== "blocked" ||
+    smtp.failure !== "timeout" ||
+    !smtp.listening ||
+    !smtp.exposed
+  ) {
     return false;
   }
-  return CLIENT_PUBLIC_MAIL_PORTS.every(
-    (port) => ports.find((row) => row.port === port)?.status === "reachable",
+  return REQUIRED_PUBLIC_MAIL_PORTS.every(
+    ({ port }) =>
+      port === SMTP_INBOUND_PORT || ports.find((row) => row.port === port)?.status === "reachable",
   );
 }
 
@@ -263,22 +262,19 @@ async function runMailPortReachability(
     };
   });
 
-  const smtpInboundSoftBlock = isControlPlaneSmtpInboundSoftBlock(ports);
+  const smtpInboundUnverified = isSmtpInboundUnverified(ports);
   const hardFailure = ports.some((port) => {
-    if (smtpInboundSoftBlock && port.port === SMTP_INBOUND_PORT && port.status === "blocked") {
+    if (smtpInboundUnverified && port.port === SMTP_INBOUND_PORT) {
       return false;
     }
     return (
       port.status === "blocked" || port.status === "not_listening" || port.status === "not_exposed"
     );
   });
-  const unknown = ports.some((port) => port.status === "unknown");
-  const detail = [
-    resolutionDetail,
-    smtpInboundSoftBlock ? SMTP_INBOUND_SOFT_BLOCK_DETAIL : undefined,
-  ]
-    .filter((part): part is string => Boolean(part))
-    .join(" ");
+  // Preserve the failed probe in the per-port reading. The aggregate is unknown,
+  // never healthy, while setup can use its existing warning path to continue.
+  const unknown = smtpInboundUnverified || ports.some((port) => port.status === "unknown");
+  const detail = smtpInboundUnverified ? SMTP_INBOUND_UNVERIFIED_DETAIL : resolutionDetail;
   return {
     hostname,
     address,

--- a/apps/api/src/modules/mail/mail-port-reachability.service.ts
+++ b/apps/api/src/modules/mail/mail-port-reachability.service.ts
@@ -22,6 +22,26 @@ export const REQUIRED_PUBLIC_MAIL_PORTS = [
   { key: "imaps", port: 993, label: "IMAP (TLS)" },
 ] as const;
 
+/** Mail-client ports. Unlike inbound SMTP, these are not filtered by cloud outbound-25 throttles. */
+export const CLIENT_PUBLIC_MAIL_PORTS = [465, 587, 993] as const;
+
+export const SMTP_INBOUND_PORT = 25;
+
+/**
+ * Why a public :25 timeout is often not a setup wall: AWS (and some other
+ * clouds) filter TCP 25 originating FROM the instance. The wizard probe runs
+ * on the Openship control plane, which on a single-box self-host is that same
+ * instance, so the "public" dial of `mail.example.com:25` is actually outbound
+ * port 25 from the box. That times out even when inbound MX from the internet
+ * would succeed, and even when operators send through SES / another relay.
+ */
+export const SMTP_INBOUND_SOFT_BLOCK_DETAIL =
+  "Inbound TCP 25 could not be verified from the control plane. Many clouds " +
+  "(especially AWS) filter instance-originated port 25, so this probe can time " +
+  "out even when inbound MX delivery works. SMTP submission (465/587) and IMAP " +
+  "(993) are reachable. Route sending through an SMTP provider on the Sending " +
+  "tab if outbound port 25 is blocked.";
+
 export type MailPortReachabilityStatus =
   | "reachable"
   | "blocked"
@@ -49,6 +69,23 @@ export interface MailPortReachability {
   status: "ok" | "fail" | "unknown";
   ports: MailPortReachabilityCheck[];
   detail?: string;
+}
+
+/**
+ * True when :25 is listening on a public bind, the control-plane probe timed
+ * out, and every mail-client port completed a TCP handshake. Local bind
+ * failures (not listening / loopback-only) stay hard failures.
+ */
+export function isControlPlaneSmtpInboundSoftBlock(
+  ports: readonly MailPortReachabilityCheck[],
+): boolean {
+  const smtp = ports.find((port) => port.port === SMTP_INBOUND_PORT);
+  if (!smtp || smtp.status !== "blocked" || !smtp.listening || !smtp.exposed) {
+    return false;
+  }
+  return CLIENT_PUBLIC_MAIL_PORTS.every(
+    (port) => ports.find((row) => row.port === port)?.status === "reachable",
+  );
 }
 
 interface ReachabilityDependencies {
@@ -226,18 +263,29 @@ async function runMailPortReachability(
     };
   });
 
-  const hardFailure = ports.some(
-    (port) =>
-      port.status === "blocked" || port.status === "not_listening" || port.status === "not_exposed",
-  );
+  const smtpInboundSoftBlock = isControlPlaneSmtpInboundSoftBlock(ports);
+  const hardFailure = ports.some((port) => {
+    if (smtpInboundSoftBlock && port.port === SMTP_INBOUND_PORT && port.status === "blocked") {
+      return false;
+    }
+    return (
+      port.status === "blocked" || port.status === "not_listening" || port.status === "not_exposed"
+    );
+  });
   const unknown = ports.some((port) => port.status === "unknown");
+  const detail = [
+    resolutionDetail,
+    smtpInboundSoftBlock ? SMTP_INBOUND_SOFT_BLOCK_DETAIL : undefined,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
   return {
     hostname,
     address,
     checkedAt,
     status: hardFailure ? "fail" : unknown ? "unknown" : "ok",
     ports,
-    ...(resolutionDetail ? { detail: resolutionDetail } : {}),
+    ...(detail ? { detail } : {}),
   };
 }
 

--- a/apps/api/src/modules/mail/mail.service.ts
+++ b/apps/api/src/modules/mail/mail.service.ts
@@ -24,9 +24,7 @@ import type { CommandExecutor, SystemLogCallback, SystemLog } from "@repo/adapte
 import { checkMailHealth, requiresMailComponent } from "./mail-health.service";
 import {
   checkMailPortReachability,
-  isControlPlaneSmtpInboundSoftBlock,
   mailReachabilityFailureMessage,
-  SMTP_INBOUND_SOFT_BLOCK_DETAIL,
 } from "./mail-port-reachability.service";
 import { safeErrorMessage, mailHostname } from "@repo/core";
 import {
@@ -1149,11 +1147,10 @@ export async function stepConfigureSSL(
 /**
  * Step 9: prove the public path, not merely the local listener.
  *
- * A provider firewall sits outside the server and cannot be inspected or changed
- * through SSH. The only reliable signal is therefore an off-box connection from
- * the control plane to the public-DNS address. A real negative blocks completion;
- * an unavailable probe is a warning because the control plane itself may lack an
- * IPv6 route or public DNS at that moment.
+ * The API connects to the public DNS address after checking the host listeners.
+ * A known failure blocks completion. An unavailable probe or an isolated inbound
+ * SMTP timeout remains unverified: the API's own outbound-25 filter may prevent
+ * the check. These use the same warning path, without declaring mail healthy.
  */
 export async function stepVerifyMailReachability(
   exec: CommandExecutor,
@@ -1180,19 +1177,6 @@ export async function stepVerifyMailReachability(
       stepId,
       success: true,
       message: "Mail is listening, but public reachability could not be verified",
-      warning,
-      data: { reachability },
-    };
-  }
-
-  if (isControlPlaneSmtpInboundSoftBlock(reachability.ports)) {
-    const warning = reachability.detail ?? SMTP_INBOUND_SOFT_BLOCK_DETAIL;
-    log(stepId, "warn", warning);
-    return {
-      stepId,
-      success: true,
-      message:
-        "Public submission and IMAP are reachable; inbound TCP 25 could not be verified from the control plane",
       warning,
       data: { reachability },
     };

--- a/apps/api/src/modules/mail/mail.service.ts
+++ b/apps/api/src/modules/mail/mail.service.ts
@@ -24,7 +24,9 @@ import type { CommandExecutor, SystemLogCallback, SystemLog } from "@repo/adapte
 import { checkMailHealth, requiresMailComponent } from "./mail-health.service";
 import {
   checkMailPortReachability,
+  isControlPlaneSmtpInboundSoftBlock,
   mailReachabilityFailureMessage,
+  SMTP_INBOUND_SOFT_BLOCK_DETAIL,
 } from "./mail-port-reachability.service";
 import { safeErrorMessage, mailHostname } from "@repo/core";
 import {
@@ -1178,6 +1180,19 @@ export async function stepVerifyMailReachability(
       stepId,
       success: true,
       message: "Mail is listening, but public reachability could not be verified",
+      warning,
+      data: { reachability },
+    };
+  }
+
+  if (isControlPlaneSmtpInboundSoftBlock(reachability.ports)) {
+    const warning = reachability.detail ?? SMTP_INBOUND_SOFT_BLOCK_DETAIL;
+    log(stepId, "warn", warning);
+    return {
+      stepId,
+      success: true,
+      message:
+        "Public submission and IMAP are reachable; inbound TCP 25 could not be verified from the control plane",
       warning,
       data: { reachability },
     };

--- a/apps/api/test/modules/mail/mail-port-reachability.service.test.ts
+++ b/apps/api/test/modules/mail/mail-port-reachability.service.test.ts
@@ -91,6 +91,56 @@ describe("mail public-port reachability", () => {
     expect(mailReachabilityFailureMessage(result)).toMatch(/provider firewall|security group/i);
   });
 
+  it("does not fail overall when only inbound TCP 25 times out from the control plane", async () => {
+    const result = await checkMailPortReachability(executor, "mail.example.com", {
+      dependencies: {
+        scan: vi.fn(async () => scan(allListeners)),
+        resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
+        probe: vi.fn(async (_host, ports) =>
+          ports.map((port) => ({
+            port,
+            result:
+              port === 25
+                ? {
+                    ok: false as const,
+                    reason: "timeout" as const,
+                    message: "no response within 1500ms",
+                  }
+                : { ok: true as const },
+          })),
+        ),
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.ports.find((port) => port.port === 25)).toMatchObject({
+      status: "blocked",
+      listening: true,
+      exposed: true,
+      reachable: false,
+      failure: "timeout",
+    });
+    expect(
+      result.ports.filter((port) => port.port !== 25).every((port) => port.status === "reachable"),
+    ).toBe(true);
+    expect(result.detail).toMatch(/control plane|Amazon SES|Sending tab/i);
+  });
+
+  it("still fails when inbound TCP 25 is not listening on the host", async () => {
+    const result = await checkMailPortReachability(executor, "mail.example.com", {
+      dependencies: {
+        scan: vi.fn(async () => scan(allListeners.filter((row) => row.port !== 25))),
+        resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
+        probe: vi.fn(async (_host, ports) =>
+          ports.map((port) => ({ port, result: { ok: true as const } })),
+        ),
+      },
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.ports.find((port) => port.port === 25)?.status).toBe("not_listening");
+  });
+
   it("does not waste an external probe on a port with no listener", async () => {
     const probe = vi.fn(async (_host: string, ports: readonly number[]) =>
       ports.map((port) => ({ port, result: { ok: true as const } })),

--- a/apps/api/test/modules/mail/mail-port-reachability.service.test.ts
+++ b/apps/api/test/modules/mail/mail-port-reachability.service.test.ts
@@ -91,7 +91,7 @@ describe("mail public-port reachability", () => {
     expect(mailReachabilityFailureMessage(result)).toMatch(/provider firewall|security group/i);
   });
 
-  it("does not fail overall when only inbound TCP 25 times out from the control plane", async () => {
+  it("keeps inbound TCP 25 unverified when only its control-plane probe times out", async () => {
     const result = await checkMailPortReachability(executor, "mail.example.com", {
       dependencies: {
         scan: vi.fn(async () => scan(allListeners)),
@@ -112,7 +112,7 @@ describe("mail public-port reachability", () => {
       },
     });
 
-    expect(result.status).toBe("ok");
+    expect(result.status).toBe("unknown");
     expect(result.ports.find((port) => port.port === 25)).toMatchObject({
       status: "blocked",
       listening: true,
@@ -123,23 +123,108 @@ describe("mail public-port reachability", () => {
     expect(
       result.ports.filter((port) => port.port !== 25).every((port) => port.status === "reachable"),
     ).toBe(true);
-    expect(result.detail).toMatch(/control plane|Amazon SES|Sending tab/i);
+    expect(result.detail).toMatch(/independent host|another mail provider/i);
+    expect(result.detail).toContain("Sending tab");
+    expect(result.detail).toContain("outgoing mail only");
   });
 
-  it("still fails when inbound TCP 25 is not listening on the host", async () => {
-    const result = await checkMailPortReachability(executor, "mail.example.com", {
-      dependencies: {
-        scan: vi.fn(async () => scan(allListeners.filter((row) => row.port !== 25))),
-        resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
-        probe: vi.fn(async (_host, ports) =>
-          ports.map((port) => ({ port, result: { ok: true as const } })),
-        ),
-      },
-    });
+  it.each(["refused", "unresolved", "no_route", "error"] as const)(
+    "does not forgive a non-timeout inbound TCP 25 failure: %s",
+    async (failure) => {
+      const result = await checkMailPortReachability(executor, "mail.example.com", {
+        dependencies: {
+          scan: vi.fn(async () => scan(allListeners)),
+          resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
+          probe: vi.fn(async (_host, ports) =>
+            ports.map((port) => ({
+              port,
+              result: port === 25 ? { ok: false as const, reason: failure } : { ok: true as const },
+            })),
+          ),
+        },
+      });
 
-    expect(result.status).toBe("fail");
-    expect(result.ports.find((port) => port.port === 25)?.status).toBe("not_listening");
-  });
+      expect(result.status).toBe("fail");
+      expect(result.ports.find((port) => port.port === 25)).toMatchObject({
+        status: "blocked",
+        failure,
+        reachable: false,
+      });
+      expect(result.detail).toBeUndefined();
+    },
+  );
+
+  it.each([465, 587, 993])(
+    "still fails when TCP 25 and client port %s both time out",
+    async (clientPort) => {
+      const result = await checkMailPortReachability(executor, "mail.example.com", {
+        dependencies: {
+          scan: vi.fn(async () => scan(allListeners)),
+          resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
+          probe: vi.fn(async (_host, ports) =>
+            ports.map((port) => ({
+              port,
+              result:
+                port === 25 || port === clientPort
+                  ? { ok: false as const, reason: "timeout" as const }
+                  : { ok: true as const },
+            })),
+          ),
+        },
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.ports.find((port) => port.port === clientPort)?.status).toBe("blocked");
+    },
+  );
+
+  it.each([465, 587, 993])(
+    "requires a successful handshake from client port %s",
+    async (clientPort) => {
+      const result = await checkMailPortReachability(executor, "mail.example.com", {
+        dependencies: {
+          scan: vi.fn(async () => scan(allListeners)),
+          resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
+          probe: vi.fn(async (_host, ports) =>
+            ports
+              .filter((port) => port !== clientPort)
+              .map((port) => ({
+                port,
+                result:
+                  port === 25
+                    ? { ok: false as const, reason: "timeout" as const }
+                    : { ok: true as const },
+              })),
+          ),
+        },
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.ports.find((port) => port.port === clientPort)?.status).toBe("unknown");
+    },
+  );
+
+  it.each(["not_listening", "not_exposed"] as const)(
+    "still fails when inbound TCP 25 is %s",
+    async (status) => {
+      const listeners = allListeners.filter((row) => row.port !== 25);
+      if (status === "not_exposed") listeners.push(listener(25, false));
+      const probe = vi.fn(async (_host: string, ports: readonly number[]) =>
+        ports.map((port) => ({ port, result: { ok: true as const } })),
+      );
+      const result = await checkMailPortReachability(executor, "mail.example.com", {
+        dependencies: {
+          scan: vi.fn(async () => scan(listeners)),
+          resolvePublicAddress: vi.fn(async () => "203.0.113.10"),
+          probe,
+        },
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.ports.find((port) => port.port === 25)?.status).toBe(status);
+      expect(probe.mock.calls[0]?.[1]).not.toContain(25);
+    },
+  );
 
   it("does not waste an external probe on a port with no listener", async () => {
     const probe = vi.fn(async (_host: string, ports: readonly number[]) =>

--- a/apps/api/test/modules/mail/mail-setup-reachability-step.test.ts
+++ b/apps/api/test/modules/mail/mail-setup-reachability-step.test.ts
@@ -41,14 +41,14 @@ function reading(status: "ok" | "fail" | "unknown") {
   };
 }
 
-function awsSmtp25SoftBlock() {
+function unverifiedInboundSmtp() {
   return {
     hostname: "mail.example.com",
     address: "203.0.113.10",
     checkedAt: 0,
-    status: "ok" as const,
+    status: "unknown" as const,
     detail:
-      "Inbound TCP 25 could not be verified from the control plane. Route sending through an SMTP provider on the Sending tab if outbound port 25 is blocked.",
+      "Inbound TCP 25 could not be verified. Test receiving independently; an SMTP relay in the Sending tab handles outgoing mail only.",
     ports: [
       {
         key: "smtp" as const,
@@ -123,13 +123,27 @@ describe("mail setup public reachability gate", () => {
     expect(result.warning).toMatch(/Public DNS/i);
   });
 
-  it("completes with a warning when only inbound TCP 25 is filtered from the control plane", async () => {
-    h.check.mockResolvedValue(awsSmtp25SoftBlock());
+  it("completes with a warning without declaring unverified inbound SMTP healthy", async () => {
+    const reachability = unverifiedInboundSmtp();
+    const log = vi.fn();
+    h.check.mockResolvedValue(reachability);
+
+    const result = await stepVerifyMailReachability(executor, "example.com", log);
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBe(reachability.detail);
+    expect(result.message).toMatch(/could not be verified/i);
+    expect(result.data?.reachability).toMatchObject({ status: "unknown" });
+    expect(log).toHaveBeenCalledWith(9, "warn", reachability.detail);
+  });
+
+  it("completes without a warning after a successful public check", async () => {
+    h.check.mockResolvedValue(reading("ok"));
 
     const result = await stepVerifyMailReachability(executor, "example.com", vi.fn());
 
     expect(result.success).toBe(true);
-    expect(result.warning).toMatch(/control plane|Sending tab/i);
-    expect(result.message).toMatch(/TCP 25/i);
+    expect(result.warning).toBeUndefined();
+    expect(result.message).toBe("Public SMTP and IMAP ports are reachable");
   });
 });

--- a/apps/api/test/modules/mail/mail-setup-reachability-step.test.ts
+++ b/apps/api/test/modules/mail/mail-setup-reachability-step.test.ts
@@ -41,6 +41,56 @@ function reading(status: "ok" | "fail" | "unknown") {
   };
 }
 
+function awsSmtp25SoftBlock() {
+  return {
+    hostname: "mail.example.com",
+    address: "203.0.113.10",
+    checkedAt: 0,
+    status: "ok" as const,
+    detail:
+      "Inbound TCP 25 could not be verified from the control plane. Route sending through an SMTP provider on the Sending tab if outbound port 25 is blocked.",
+    ports: [
+      {
+        key: "smtp" as const,
+        port: 25,
+        label: "SMTP inbound",
+        status: "blocked" as const,
+        listening: true,
+        exposed: true,
+        reachable: false,
+        failure: "timeout" as const,
+      },
+      {
+        key: "smtps" as const,
+        port: 465,
+        label: "SMTP submission (TLS)",
+        status: "reachable" as const,
+        listening: true,
+        exposed: true,
+        reachable: true,
+      },
+      {
+        key: "submission" as const,
+        port: 587,
+        label: "SMTP submission (STARTTLS)",
+        status: "reachable" as const,
+        listening: true,
+        exposed: true,
+        reachable: true,
+      },
+      {
+        key: "imaps" as const,
+        port: 993,
+        label: "IMAP (TLS)",
+        status: "reachable" as const,
+        listening: true,
+        exposed: true,
+        reachable: true,
+      },
+    ],
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -71,5 +121,15 @@ describe("mail setup public reachability gate", () => {
 
     expect(result.success).toBe(true);
     expect(result.warning).toMatch(/Public DNS/i);
+  });
+
+  it("completes with a warning when only inbound TCP 25 is filtered from the control plane", async () => {
+    h.check.mockResolvedValue(awsSmtp25SoftBlock());
+
+    const result = await stepVerifyMailReachability(executor, "example.com", vi.fn());
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toMatch(/control plane|Sending tab/i);
+    expect(result.message).toMatch(/TCP 25/i);
   });
 });

--- a/apps/dashboard/src/app/(dashboard)/emails/_components/admin/health-tab.render.test.tsx
+++ b/apps/dashboard/src/app/(dashboard)/emails/_components/admin/health-tab.render.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { I18nProvider } from "@/components/i18n-provider";
+import type { MailPortReachability } from "@/lib/api";
+import en from "@/i18n/locales/en/emailsAdmin.json";
+import { ReachabilitySection } from "./health-tab";
+
+const warning =
+  "Inbound TCP 25 could not be verified. Test receiving independently; an SMTP relay handles outgoing mail only.";
+
+function reading(status: "fail" | "unknown"): MailPortReachability {
+  return {
+    hostname: "mail.example.com",
+    address: "203.0.113.10",
+    checkedAt: 0,
+    status,
+    ...(status === "unknown" ? { detail: warning } : {}),
+    ports: [
+      {
+        key: "smtp",
+        port: 25,
+        label: "SMTP inbound",
+        status: "blocked",
+        listening: true,
+        exposed: true,
+        reachable: false,
+        failure: status === "unknown" ? "timeout" : "refused",
+        detail: status === "unknown" ? "no response within 1500ms" : "ECONNREFUSED",
+      },
+      ...(["smtps", "submission", "imaps"] as const).map((key, index) => ({
+        key,
+        port: [465, 587, 993][index],
+        label: key,
+        status: "reachable" as const,
+        listening: true,
+        exposed: true,
+        reachable: true,
+      })),
+    ],
+  };
+}
+
+function render(reachability: MailPortReachability) {
+  return renderToStaticMarkup(
+    <I18nProvider>
+      <ReachabilitySection
+        reachability={reachability}
+        error={null}
+        refreshing={false}
+        onRefresh={() => {}}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe("mail public reachability", () => {
+  it("shows the inbound warning and raw timeout without diagnosing a firewall failure", () => {
+    const html = render(reading("unknown"));
+
+    expect(html).toContain(warning);
+    expect(html).toContain("no response within 1500ms");
+    expect(html).toContain(en.health.reachability.status.unknown);
+    expect(html).not.toContain(en.health.reachability.status.blocked);
+    expect(html).not.toContain(en.health.reachability.remediation);
+  });
+
+  it("keeps a refused SMTP connection visibly blocked", () => {
+    const html = render(reading("fail"));
+
+    expect(html).toContain(en.health.reachability.status.blocked);
+    expect(html).toContain(en.health.reachability.remediation);
+    expect(html).not.toContain(warning);
+  });
+
+  it("keeps a blocked client port actionable even when SMTP also times out", () => {
+    const reachability = reading("unknown");
+    reachability.status = "fail";
+    delete reachability.detail;
+    reachability.ports[1] = {
+      ...reachability.ports[1],
+      status: "blocked",
+      reachable: false,
+      failure: "timeout",
+    };
+    const html = render(reachability);
+
+    expect(html).toContain(en.health.reachability.status.blocked);
+    expect(html).toContain(en.health.reachability.remediation);
+    expect(html).not.toContain(en.health.reachability.status.unknown);
+  });
+});

--- a/apps/dashboard/src/app/(dashboard)/emails/_components/admin/health-tab.tsx
+++ b/apps/dashboard/src/app/(dashboard)/emails/_components/admin/health-tab.tsx
@@ -299,7 +299,7 @@ export function HealthTab({ serverId }: { serverId: string }) {
   );
 }
 
-function ReachabilitySection({
+export function ReachabilitySection({
   reachability,
   error,
   refreshing,
@@ -312,7 +312,9 @@ function ReachabilitySection({
 }) {
   const { t } = useI18n();
   const h = t.emailsAdmin.health;
-  const providerBlocked = reachability?.ports.some((port) => port.status === "blocked") ?? false;
+  const providerBlocked =
+    reachability?.status === "fail" &&
+    reachability.ports.some((port) => port.status === "blocked");
   return (
     <SectionCard
       title={h.reachability.title}
@@ -360,7 +362,11 @@ function ReachabilitySection({
           )}
           <div className="divide-y divide-border/40">
             {reachability.ports.map((port) => (
-              <ReachabilityRow key={port.key} port={port} />
+              <ReachabilityRow
+                key={port.key}
+                port={port}
+                unverified={reachability.status === "unknown" && port.status === "blocked"}
+              />
             ))}
           </div>
         </>
@@ -369,20 +375,29 @@ function ReachabilitySection({
   );
 }
 
-function ReachabilityRow({ port }: { port: MailPortReachabilityCheck }) {
+function ReachabilityRow({
+  port,
+  unverified,
+}: {
+  port: MailPortReachabilityCheck;
+  unverified: boolean;
+}) {
   const { t } = useI18n();
   const copy = t.emailsAdmin.health.reachability;
-  const status = reachabilityPresentation(port.status);
+  // Keep the raw failed probe in the API response, but do not present an
+  // ambiguous SMTP timeout as a confirmed inbound firewall failure.
+  const displayStatus = unverified ? "unknown" : port.status;
+  const status = reachabilityPresentation(displayStatus);
   const detail =
-    port.status === "reachable"
+    displayStatus === "reachable"
       ? copy.reachableHint
-      : port.status === "blocked"
+      : displayStatus === "blocked"
         ? port.failure === "timeout"
           ? copy.blockedTimeoutHint
           : copy.blockedHint
-        : port.status === "not_listening"
+        : displayStatus === "not_listening"
           ? copy.notListeningHint
-          : port.status === "not_exposed"
+          : displayStatus === "not_exposed"
             ? copy.notExposedHint
             : port.detail || copy.unknownHint;
 
@@ -398,7 +413,7 @@ function ReachabilityRow({ port }: { port: MailPortReachabilityCheck }) {
         </div>
         <p className="text-xs text-muted-foreground mt-0.5">{detail}</p>
       </div>
-      <StatusPill tone={status.tone}>{copy.status[port.status]}</StatusPill>
+      <StatusPill tone={status.tone}>{copy.status[displayStatus]}</StatusPill>
     </div>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/emails/_lib/health-summary.test.ts
+++ b/apps/dashboard/src/app/(dashboard)/emails/_lib/health-summary.test.ts
@@ -215,6 +215,34 @@ describe("summarizeHealth", () => {
     expect(s?.label).toBe(h.summary.allGoodLabel);
   });
 
+  it("warns instead of declaring mail healthy when inbound SMTP is unverified", () => {
+    const s = summarizeHealth(
+      NINE_UP,
+      [dns("pass")],
+      delivery(),
+      h,
+      reachability({
+        status: "unknown",
+        ports: [
+          {
+            key: "smtp",
+            port: 25,
+            label: "SMTP inbound",
+            status: "blocked",
+            listening: true,
+            exposed: true,
+            reachable: false,
+            failure: "timeout",
+          },
+        ],
+      }),
+    );
+
+    expect(s?.banner).toContain("warning");
+    expect(s?.label).toBe(h.summary.almostLabel);
+    expect(s?.sub).toBe(h.reachability.unknownHint);
+  });
+
   /**
    * The #565 defect: a dead ClamAV painted the same red "Issues need attention"
    * banner as a dead Postfix, so the one signal that means "stop what you are doing"

--- a/apps/dashboard/src/app/(dashboard)/emails/_lib/health-summary.ts
+++ b/apps/dashboard/src/app/(dashboard)/emails/_lib/health-summary.ts
@@ -13,8 +13,8 @@
  *           in the queue)
  *   green = all three readings clean
  *
- * A reading we couldn't take never colours the banner. `unknown` means "we didn't
- * look", and grading it would turn an unreachable probe into an outage.
+ * A reading we couldn't take never colours the banner. An observed SMTP timeout
+ * that the API could not attribute still warns: receiving mail is unverified.
  *
  * Lives out here, as a pure function, because that ordering is the part most
  * likely to be quietly wrong — see ./health-summary.test.ts.
@@ -80,6 +80,11 @@ export function summarizeHealth(
 
   const deliveryFails = delivery?.status === "fail";
   const reachabilityFails = reachability?.status === "fail";
+  // Trust the API's classification. An unknown result with a failed TCP probe
+  // needs attention even though it cannot establish an inbound-mail outage.
+  const reachabilityUnverified =
+    reachability?.status === "unknown" &&
+    reachability.ports.some((port) => port.status === "blocked");
   // Mail waiting in the queue is worth the operator's eyes, but a warn here is
   // also how a healthy MTA rides out a receiver's greylist - so it colours the
   // banner amber and points at the card, never red.
@@ -103,6 +108,7 @@ export function summarizeHealth(
     dnsWarns === 0 &&
     !deliveryFails &&
     !reachabilityFails &&
+    !reachabilityUnverified &&
     !queueNote;
 
   if (allClean && (components || checks || delivery || reachability)) {
@@ -147,6 +153,7 @@ export function summarizeHealth(
       );
     }
     if (queueNote) almost.push(queueNote);
+    if (reachabilityUnverified) almost.push(h.reachability.unknownHint);
     const label =
       advisoryDown.length > 0
         ? h.summary.degradedLabel

--- a/apps/web/content/docs/dashboard/emails.mdx
+++ b/apps/web/content/docs/dashboard/emails.mdx
@@ -106,8 +106,13 @@ Twice during the install, the wizard pauses and needs you to act — first for D
 
 The final **Verify Public Mail Ports** step is deliberately off-box: Openship first confirms the daemons are
 listening on the server, then connects from the control plane to the public DNS address on TCP 25, 465, 587,
-and 993. A real failure stops setup instead of producing a false green completion. If the daemons listen but
-the public connection times out, open the ports in the cloud provider's firewall as well as the host firewall.
+and 993. A real failure on mail-client ports (465, 587, 993) or a daemon that is not listening stops setup
+instead of producing a false green completion. If those ports listen but the public connection times out, open
+them in the cloud provider's firewall as well as the host firewall.
+
+A timeout on **TCP 25 only** is a warning, not a wall, when 465/587/993 succeed. On AWS the control plane is
+often the same instance, so the probe is outbound port 25 — which AWS filters — even when inbound MX would
+work. Finish setup and use the **Sending** tab if you deliver through Amazon SES or another SMTP relay.
 
 ### DNS hold — publish your records
 

--- a/apps/web/content/docs/dashboard/emails.mdx
+++ b/apps/web/content/docs/dashboard/emails.mdx
@@ -104,15 +104,19 @@ continuing.
 
 Twice during the install, the wizard pauses and needs you to act — first for DNS, then for reverse DNS.
 
-The final **Verify Public Mail Ports** step is deliberately off-box: Openship first confirms the daemons are
-listening on the server, then connects from the control plane to the public DNS address on TCP 25, 465, 587,
-and 993. A real failure on mail-client ports (465, 587, 993) or a daemon that is not listening stops setup
-instead of producing a false green completion. If those ports listen but the public connection times out, open
-them in the cloud provider's firewall as well as the host firewall.
+The final **Verify Public Mail Ports** step first confirms the daemons are listening on the server, then
+connects from the Openship API to the public DNS address on TCP 25, 465, 587, and 993. The API may run on the
+mail server itself. Missing or loopback-only listeners, failed client ports (465/587/993), and non-timeout
+errors on TCP 25 stop setup. Check both the host firewall and the cloud provider's firewall when a listening
+port cannot be reached.
 
-A timeout on **TCP 25 only** is a warning, not a wall, when 465/587/993 succeed. On AWS the control plane is
-often the same instance, so the probe is outbound port 25 — which AWS filters — even when inbound MX would
-work. Finish setup and use the **Sending** tab if you deliver through Amazon SES or another SMTP relay.
+A timeout on **TCP 25 only** lets setup finish with a warning when that port has a non-loopback listener and
+465/587/993 all complete a TCP handshake. Public reachability remains **unverified** in Health. AWS
+[blocks outbound port 25 to public addresses by default](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html),
+which can prevent the API's check even when inbound mail works. The same timeout can also mean inbound TCP 25
+is blocked, so verify it from an independent host or send a test message from another mail provider before
+relying on receiving mail. An SMTP relay configured in **Sending**, such as Amazon SES, handles outgoing mail
+only; it does not make a blocked inbound port reachable.
 
 ### DNS hold — publish your records
 

--- a/apps/web/content/docs/guides/email-webmail/index.mdx
+++ b/apps/web/content/docs/guides/email-webmail/index.mdx
@@ -269,10 +269,17 @@ plan it's hidden on purpose.
 </Callout>
 
 <Callout title="The “Check Port 25” step warns that port 25 is blocked" type="warn">
-This step is a check, not a wall — the install keeps going even when it warns. But outbound mail won't actually
-send until port 25 is open. Many hosting providers block it by default (some need a support request to open it).
-Ask your provider to open it, then use **Sending → Send test email** to confirm mail flows once setup has
-finished.
+This step is a check, not a wall — the install keeps going even when it warns. Direct-to-MX sending needs
+outbound port 25. Many hosting providers block it by default (AWS throttles it from the instance). You can
+finish setup and route sending through an SMTP provider from the **Sending** tab (Amazon SES, and similar),
+then use **Sending → Send test email** to confirm mail flows.
+</Callout>
+
+<Callout title="“Verify Public Mail Ports” warns about TCP 25 but 465/587/993 are open" type="warn">
+On a single-box install the probe runs from the same machine it is testing. Cloud outbound-25 filters (AWS in
+particular) make `mail.example.com:25` time out from that box even when the daemon is listening and a security
+group allows inbound 25. If submission and IMAP handshake, setup continues with a warning. Receiving from other
+mail servers can still work; sending can use the **Sending** tab relay.
 </Callout>
 
 <Callout title="Mail sends but lands in spam" type="warn">

--- a/apps/web/content/docs/guides/email-webmail/index.mdx
+++ b/apps/web/content/docs/guides/email-webmail/index.mdx
@@ -270,16 +270,21 @@ plan it's hidden on purpose.
 
 <Callout title="The “Check Port 25” step warns that port 25 is blocked" type="warn">
 This step is a check, not a wall — the install keeps going even when it warns. Direct-to-MX sending needs
-outbound port 25. Many hosting providers block it by default (AWS throttles it from the instance). You can
+outbound port 25. Many hosting providers block it by default, including AWS. You can
 finish setup and route sending through an SMTP provider from the **Sending** tab (Amazon SES, and similar),
 then use **Sending → Send test email** to confirm mail flows.
 </Callout>
 
 <Callout title="“Verify Public Mail Ports” warns about TCP 25 but 465/587/993 are open" type="warn">
-On a single-box install the probe runs from the same machine it is testing. Cloud outbound-25 filters (AWS in
-particular) make `mail.example.com:25` time out from that box even when the daemon is listening and a security
-group allows inbound 25. If submission and IMAP handshake, setup continues with a warning. Receiving from other
-mail servers can still work; sending can use the **Sending** tab relay.
+On a single-server install the probe runs from the same machine it is testing. An outbound port-25 restriction
+can make `mail.example.com:25` time out even when the daemon listens on a non-loopback interface. If all three
+client ports complete a TCP handshake and only TCP 25 times out, setup continues with a warning. Connection
+refusals, routing errors, missing or loopback-only listeners, and client-port failures still stop setup.
+
+Health keeps inbound SMTP **unverified**. Check TCP 25 from an independent host or send a test message from
+another mail provider: open client ports do not prove that other mail servers can reach your inbound SMTP.
+If receiving fails, check inbound TCP 25 in the host and provider firewalls. A relay configured in **Sending**
+handles outgoing mail only.
 </Callout>
 
 <Callout title="Mail sends but lands in spam" type="warn">


### PR DESCRIPTION
## Summary

Mail setup can stall at step 9 when an outbound port-25 restriction affects the Openship API's probe of the public mail address. Allow setup to finish with a warning for an isolated SMTP timeout, while keeping inbound reachability unverified in the API and Health tab.

## Motivation

The API's outbound restriction and an inbound firewall can produce the same timeout. Successful connections to 465/587/993 do not prove that other mail servers can reach TCP 25, and configuring an SMTP relay only addresses outgoing mail.

## Related issue

Closes #833.

## Changes

- **apps/api:** Only a TCP 25 `timeout`, a non-loopback SMTP listener, and successful handshakes on all three client ports qualify for the existing setup warning path. Preserve the raw failed probe and report aggregate reachability as `unknown`. Connection refusals, routing errors, missing or loopback-only listeners, and failed or unverified client ports remain failures.
- **apps/dashboard:** Show an amber health summary and an unknown SMTP row for this case, retain the raw timeout details, and explain how to verify receiving independently. Confirmed port failures retain their error presentation.
- **apps/web:** Document the probe's origin, AWS's outbound restriction, independent inbound verification, and the limits of an outgoing SMTP relay.

## Verification

- Targeted API/mail tests: **31 passed**.
- Health summary and rendered health card tests: **24 passed**.
- The original PR returned `ok` for TCP 25 `refused`, `no_route`, and `error`; the added regression cases now require and receive `fail`.
- API and dashboard typechecks passed.
- Ran the repository formatter and discarded unrelated formatting changes.
- Full workspace suite: **7 successful tasks; 12,160 tests passed, 3 skipped** (3 workspace tasks used valid Turbo cache results).
- [GitHub CI](https://github.com/oblien/openship/actions/runs/34007603859): **Typecheck, Test, and Test webmail server all passed** on `e266d66c560fadc337e4724db735e6078d0c9aaf`.

Repository checks were run with Bun 1.3.10:

```text
bun run test
Tasks: 7 successful, 7 total

bun run --cwd apps/api lint
bun run --cwd apps/dashboard lint
bun run format
git diff --check HEAD
```

No live EC2 deployment was exercised; the network outcomes are covered through deterministic probe fixtures.

## Checklist

- [x] One bug fix with scoped API, dashboard, documentation, and test changes
- [x] No unrelated formatting or changes bundled into the PR
- [x] Regression coverage for the reported timeout and failures that must still block setup
- [x] Targeted tests and both relevant typechecks pass
- [x] Full workspace tests pass
- [x] GitHub CI passes on the final commit
