### PR TITLE
fix(deployments): explain service DNS failures during Docker builds

### DIFF
--- a/apps/api/src/modules/deployments/compose/build-service-dns.test.ts
+++ b/apps/api/src/modules/deployments/compose/build-service-dns.test.ts
@@ -1,0 +1,213 @@
+import {
+  BuildLogger,
+  DEFAULT_RESOURCE_CONFIG,
+  type BuildResult,
+  type LogEntry,
+} from "@repo/adapters";
+import { describe, expect, it, vi } from "vitest";
+
+const { listByProject, broadcastServiceStatus } = vi.hoisted(() => ({
+  listByProject: vi.fn(),
+  broadcastServiceStatus: vi.fn(),
+}));
+vi.mock("@repo/db", () => ({ repos: { service: { listByProject } } }));
+vi.mock("../session-manager", () => ({
+  broadcastServiceStatus,
+  broadcastInstallPhase: vi.fn(),
+}));
+
+import { buildComposeImages } from "./build.service";
+import { ServiceBuildDnsDiagnostics } from "./build-service-dns";
+
+const DOCKER_FAILURE =
+  "Docker build failed: The command '/bin/sh -c pnpm --filter @zervo/admin build' returned a non-zero code: 1";
+
+async function buildWithLogs(
+  options: {
+    messages?: string[];
+    adminResult?: Partial<BuildResult>;
+    runtimeName?: "docker" | "cloud";
+  } = {},
+) {
+  broadcastServiceStatus.mockClear();
+  const services = [
+    { id: "db", name: "db", enabled: true, image: "postgres:17-alpine", build: null },
+    ...["admin", "worker"].map((name) => ({
+      id: name,
+      name,
+      enabled: true,
+      image: null,
+      kind: "compose",
+      build: ".",
+      dockerfile: "Dockerfile",
+    })),
+  ];
+  listByProject.mockResolvedValue(services);
+  const entries: LogEntry[] = [];
+  const result = await buildComposeImages({
+    project: { id: "project", slug: "example", name: "example", localPath: null } as never,
+    dep: { id: "deployment", branch: "main", trigger: "deploy", meta: null } as never,
+    snapshot: {
+      repoUrl: "https://example.com/repo.git",
+      branch: "main",
+      framework: "docker",
+      buildImage: "",
+      runtimeImage: "",
+      packageManager: "",
+      installCommand: "",
+      buildCommand: "",
+      outputDirectory: "",
+      productionPaths: [],
+      rootDirectory: "",
+      port: 3000,
+      startCommand: "",
+      hasServer: true,
+      hasBuild: false,
+    } as never,
+    runtime: {
+      name: options.runtimeName ?? "docker",
+      build: vi.fn(),
+      buildImages: async (
+        items: Array<{
+          serviceName: string;
+          logger: BuildLogger;
+          onResult: (result: BuildResult) => void;
+        }>,
+      ) => {
+        for (const item of items) {
+          if (item.serviceName === "admin") {
+            for (const message of options.messages ?? []) {
+              item.logger.observeBuildOutput(message);
+              item.logger.log(message.trim());
+            }
+          }
+          item.onResult({
+            sessionId: "build",
+            status: "failed",
+            errorMessage: DOCKER_FAILURE,
+            ...(item.serviceName === "admin" ? options.adminResult : {}),
+          });
+        }
+      },
+    } as never,
+    logger: new BuildLogger((entry) => entries.push(entry)),
+    buildSessionId: "build",
+    composeInterpolationEnv: {},
+    buildEnvVars: {},
+    buildResources: DEFAULT_RESOURCE_CONFIG,
+  });
+  return { result, entries };
+}
+
+describe("service DNS failures during Docker builds", () => {
+  it("adds actionable guidance to the failed service without losing the Docker error", async () => {
+    const { result, entries } = await buildWithLogs({
+      messages: [
+        "[21:53:30] ERROR: Error: cannot connect to Postgres. Details: getaddrinfo ENOTFOUND db\n",
+        "Error: Failed to collect page data for /api/hours\n",
+      ],
+    });
+
+    const failure = result.buildFailures.get("admin")!;
+    expect(failure).toContain("getaddrinfo ENOTFOUND db");
+    expect(failure).toContain("dependsOn");
+    expect(failure).toContain("request handler");
+    expect(failure).toContain(DOCKER_FAILURE);
+    expect(failure.startsWith(DOCKER_FAILURE)).toBe(true);
+    expect(result.buildFailures.get("worker")).toBe(DOCKER_FAILURE);
+    expect(
+      entries.some((entry) => entry.serviceName === "admin" && entry.message.includes(failure)),
+    ).toBe(true);
+    expect(broadcastServiceStatus).toHaveBeenCalledWith("deployment", {
+      serviceName: "admin",
+      serviceId: "admin",
+      status: "failed",
+      error: failure,
+    });
+  });
+
+  it.each([
+    "getaddrinfo ENOTFOUND registry.npmjs.org",
+    "getaddrinfo ENOTFOUND db.example.com",
+    "connect ETIMEDOUT 172.18.0.2:5432",
+    "getaddrinfo ENOTFOUND db:5432",
+    "password authentication failed for user demo",
+  ])("does not attribute an unrelated failure to the service network: %s", async (message) => {
+    const { result } = await buildWithLogs({ messages: [message] });
+    expect(result.buildFailures.get("admin")).toBe(DOCKER_FAILURE);
+  });
+
+  it("copies only the known service name into guidance, never adjacent credentials", async () => {
+    const { result } = await buildWithLogs({
+      messages: [
+        "Connecting to postgres://demo:do-not-repeat@db:5432/app?token=private-token\nError: getaddrinfo ENOTFOUND db",
+      ],
+    });
+    const failure = result.buildFailures.get("admin")!;
+    expect(failure).toContain("getaddrinfo ENOTFOUND db");
+    expect(failure).not.toContain("do-not-repeat");
+    expect(failure).not.toContain("private-token");
+    expect(failure).not.toContain("postgres://");
+  });
+
+  it.each(["deploying", "cancelled"] as const)(
+    "does not turn a %s build into a failure after an earlier DNS error",
+    async (status) => {
+      const { result, entries } = await buildWithLogs({
+        messages: ["getaddrinfo ENOTFOUND db"],
+        adminResult: { status, imageRef: "openship/example-admin:built" },
+      });
+      expect(result.buildFailures.has("admin")).toBe(false);
+      expect(entries.some((entry) => entry.message.includes("dependsOn"))).toBe(false);
+      if (status === "deploying") {
+        expect(result.imageRefs.get("admin")).toBe("openship/example-admin:built");
+      } else {
+        expect(result.cancelled).toBe(true);
+      }
+    },
+  );
+
+  it("also recognizes DNS evidence in the final error when no log was streamed", async () => {
+    const errorMessage = "Docker build failed: getaddrinfo ENOTFOUND db";
+    const { result } = await buildWithLogs({ adminResult: { errorMessage } });
+    const failure = result.buildFailures.get("admin")!;
+    expect(failure).toContain(errorMessage);
+    expect(failure).toContain("dependsOn");
+  });
+
+  it("does not assume Docker networking for a cloud build", async () => {
+    const { result } = await buildWithLogs({
+      runtimeName: "cloud",
+      messages: ["getaddrinfo ENOTFOUND db"],
+    });
+    expect(result.buildFailures.get("admin")).toBe(DOCKER_FAILURE);
+  });
+
+  it.each([
+    { label: "split error marker", messages: ["getaddrinfo ENO", "TFOUND db\n"] },
+    { label: "split hostname", messages: ["getaddrinfo ENOTFOUND d", "b\n"] },
+    { label: "unterminated final line", messages: ["getaddrinfo ENOTFOUND db"] },
+    { label: "colored error", messages: ["getaddrinfo \u001b[31mENOTFOUND\u001b[0m db\n"] },
+    {
+      label: "split color sequence",
+      messages: ["getaddrinfo \u001b[3", "1mENOTFOUND\u001b[0m db\n"],
+    },
+  ])("recognizes streamed output with a $label", async ({ messages }) => {
+    const { result } = await buildWithLogs({ messages });
+    expect(result.buildFailures.get("admin")).toContain("dependsOn");
+  });
+
+  it("waits for the whole hostname before identifying a project service", async () => {
+    const { result } = await buildWithLogs({
+      messages: ["getaddrinfo ENOTFOUND db", ".example.com\n"],
+    });
+    expect(result.buildFailures.get("admin")).toBe(DOCKER_FAILURE);
+  });
+
+  it("does not join fragments from different output streams or BuildKit steps", () => {
+    const diagnostics = new ServiceBuildDnsDiagnostics(new Set(["db"]));
+    diagnostics.observe("getaddrinfo ENOTFOUND d", "stdout");
+    diagnostics.observe("b\n", "stderr");
+    expect(diagnostics.finish(DOCKER_FAILURE)).toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/deployments/compose/build-service-dns.ts
+++ b/apps/api/src/modules/deployments/compose/build-service-dns.ts
@@ -1,0 +1,63 @@
+import { stripVTControlCharacters } from "node:util";
+
+/**
+ * A build-time DNS error for a known project service needs different guidance
+ * from a package-registry failure. Output is observed before Docker's renderer
+ * trims or prefixes it: a transport chunk is not a complete line or hostname.
+ *
+ * This is advisory evidence. The caller adds it only after the runtime reports
+ * a failed build, so a retried lookup cannot turn a successful build into a
+ * failure. It does not establish the cause of unrelated timeouts or auth errors.
+ */
+export class ServiceBuildDnsDiagnostics {
+  private readonly tails = new Map<string, string>();
+  private hostname?: string;
+
+  constructor(private readonly serviceNames: ReadonlySet<string>) {}
+
+  observe(output: string, streamId = "default"): void {
+    if (this.hostname) return;
+    const rawText = (this.tails.get(streamId) ?? "") + output;
+    const text = stripVTControlCharacters(rawText);
+    // A delimiter is required. End-of-chunk cannot confirm "db": the next
+    // chunk could be ".example.com". finish() supplies the end-of-stream boundary.
+    for (const match of text.matchAll(
+      /\bgetaddrinfo\s+ENOTFOUND\s+([a-zA-Z0-9_.-]+)(?=[\s"'`),;}\]])/g,
+    )) {
+      const hostname = match[1]!;
+      if (!this.serviceNames.has(hostname)) continue;
+      this.hostname = hostname;
+      this.tails.clear();
+      return;
+    }
+
+    // Only the unfinished line can contain a split marker/hostname. Bound its
+    // size, and never copy it into the diagnostic: it may contain credentials.
+    // Retain raw escapes: a color sequence can also span transport chunks.
+    const lineStart = Math.max(rawText.lastIndexOf("\n"), rawText.lastIndexOf("\r")) + 1;
+    const tail = rawText.slice(lineStart).slice(-2048);
+    this.tails.delete(streamId);
+    if (tail) {
+      this.tails.set(streamId, tail);
+      // BuildKit may have many vertices. Keep only the 64 most recent partial
+      // streams so a noisy build cannot accumulate unbounded diagnostic state.
+      if (this.tails.size > 64) this.tails.delete(this.tails.keys().next().value!);
+    }
+  }
+
+  finish(finalError: string): string | undefined {
+    for (const streamId of this.tails.keys()) this.observe("\n", streamId);
+    this.observe(`${finalError}\n`, "final-error");
+    this.tails.clear();
+    if (!this.hostname) return;
+
+    return (
+      `Build output also reported getaddrinfo ENOTFOUND ${this.hostname}, a project service hostname. ` +
+      "Docker builds do not automatically join the service network, even when the service is running; dependsOn only controls container startup. " +
+      "Move connections needed only at runtime into a request handler or startup code. " +
+      "For Next.js/Payload, check the route and its imports for top-level getPayload() calls; force-dynamic alone does not prevent module initialization. " +
+      "If the build needs data, use a source reachable from the build environment. " +
+      "See https://openship.io/docs/guides/compose-multi-service#database-access-during-a-nextjs-build"
+    );
+  }
+}

--- a/apps/api/src/modules/deployments/compose/build.service.ts
+++ b/apps/api/src/modules/deployments/compose/build.service.ts
@@ -40,6 +40,7 @@ import {
   resolveComposeInterpolation,
 } from "../../../lib/compose-parser";
 import { resolveServicePort } from "./domain-helpers";
+import { ServiceBuildDnsDiagnostics } from "./build-service-dns";
 
 function sanitizeComposeImageName(value: string): string {
   return (
@@ -437,6 +438,8 @@ export async function buildComposeImages(opts: {
 }): Promise<ComposeBuildImagesResult> {
   const services = await repos.service.listByProject(opts.project.id);
   const enabled = services.filter((service) => service.enabled);
+  const serviceNames = new Set(enabled.map((service) => service.name));
+  const buildDnsDiagnostics = new Map<string, ServiceBuildDnsDiagnostics>();
   const imageRefs = new Map<string, string>();
   const preparedLocalImages = new Map<string, string>();
   const builtImageRefs = new Map<string, string>();
@@ -655,16 +658,22 @@ export async function buildComposeImages(opts: {
       // Per-service logger keeps native terminal bytes intact and routes by
       // serviceName. Inner step events are forwarded as plain service logs;
       // the outer orchestrator owns the top-level step lifecycle.
-      const serviceLogger = new BuildLogger((entry) => {
-        opts.logger.callback({
-          timestamp: entry.timestamp,
-          message: entry.message,
-          level: entry.level,
-          serviceName: service.name,
-          serviceId: service.id,
-          rawData: entry.rawData,
-        });
-      });
+      const dnsDiagnostics =
+        opts.runtime.name === "docker" ? new ServiceBuildDnsDiagnostics(serviceNames) : undefined;
+      if (dnsDiagnostics) buildDnsDiagnostics.set(service.id, dnsDiagnostics);
+      const serviceLogger = new BuildLogger(
+        (entry) => {
+          opts.logger.callback({
+            timestamp: entry.timestamp,
+            message: entry.message,
+            level: entry.level,
+            serviceName: service.name,
+            serviceId: service.id,
+            rawData: entry.rawData,
+          });
+        },
+        (data, streamId) => dnsDiagnostics?.observe(data, streamId),
+      );
 
       if (opts.runtime.name === "cloud" && !opts.project.localPath) {
         opts.logger.log(
@@ -768,6 +777,8 @@ export async function buildComposeImages(opts: {
 
     // Record a per-service build result: image refs / failures + status broadcast.
     const applyBuildResult = (service: Service, buildResult: BuildResult) => {
+      const dnsDiagnostics = buildDnsDiagnostics.get(service.id);
+      buildDnsDiagnostics.delete(service.id);
       // Cancelled ≠ failed: tracked separately so the pipeline can stop without
       // recording a build failure on the deployment. The per-service SSE status
       // union has no "cancelled" member, so the tab reports the reason instead of
@@ -787,8 +798,10 @@ export async function buildComposeImages(opts: {
       }
 
       if (buildResult.status === "failed" || !buildResult.imageRef) {
-        const failureMessage =
+        const originalFailure =
           buildResult.errorMessage ?? `Failed to build service "${service.name}"`;
+        const hint = dnsDiagnostics?.finish(originalFailure);
+        const failureMessage = hint ? `${originalFailure}\n\n${hint}` : originalFailure;
         buildFailures.set(service.id, failureMessage);
         opts.logger.log(
           `Compose service "${service.name}" build failed: ${failureMessage}\n`,

--- a/apps/web/content/docs/guides/compose-multi-service.mdx
+++ b/apps/web/content/docs/guides/compose-multi-service.mdx
@@ -99,6 +99,51 @@ never changed. If you want the file itself to reflect a change (so a teammate or
 the file in your repo and push.
 </Callout>
 
+#### Database access during a Next.js build
+
+If `next build` reports `getaddrinfo ENOTFOUND db`, followed by an error such as
+`Failed to collect page data for /api/hours`, code evaluated during the build tried to resolve
+the `db` hostname. Check the named route and its imported helpers for database initialization.
+
+Use `"dependsOn": ["db"]` in `openship.json` (or `depends_on: [db]` in Compose). This orders
+container startup; it does not start Postgres before image builds or attach the builder to the
+services' network. Even an already-running database is not automatically reachable by its
+service name from the builder.
+
+For a route that needs data only when handling a request, move Payload initialization into the
+existing `GET` or `POST` handler, or a helper called by that handler. Next.js can import route
+modules during the build, so `export const dynamic = 'force-dynamic'` alone does not prevent
+module-level `await getPayload(...)` or an eagerly created initialization promise from running.
+Check imported helpers and configuration for the same side effects.
+
+For example, this Next.js 15 / Payload 3 handler initializes Payload when a request arrives.
+It assumes an `hours` collection; when adapting your own route, keep its existing authentication,
+query options, access checks, and response shape:
+
+```ts
+import config from "@payload-config";
+import { getPayload } from "payload";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const payload = await getPayload({ config });
+  const result = await payload.find({
+    collection: "hours",
+    overrideAccess: false,
+  });
+  return Response.json(result);
+}
+```
+
+`overrideAccess: false` applies the collection's access rules; retain any existing authenticated
+user context in your own queries. Keep the runtime connection string pointing at `db:5432`
+when both running services share the project network.
+
+If a page intentionally queries data during static generation, deferring an API handler will
+not remove that requirement. Supply a data source reachable from the build environment, or
+change that page to load its data at request time if that matches the application.
+
 ### 2. Added by hand
 
 Any project can get extra services from a built-in catalog of common images — databases, caches, search,

--- a/apps/web/content/docs/reference/openship-json.mdx
+++ b/apps/web/content/docs/reference/openship-json.mdx
@@ -286,6 +286,10 @@ re-read on every deploy, and `build:` contexts resolve relative to it, exactly a
   }}
 />
 
+`dependsOn` takes service names such as `["db"]`, without a port. It controls container startup
+order, not database availability during an image build. For `ENOTFOUND db` during `next build`,
+see [Database access during a Next.js build](/docs/guides/compose-multi-service#database-access-during-a-nextjs-build).
+
 Top-level `env` is available to Dockerfile builds as well as running containers. Use
 `buildArgs` when a service needs an explicit override or when you want the config to document
 which Dockerfile arguments it consumes. A service's own `env` is runtime-only and is never shared

--- a/packages/adapters/src/runtime/build-pipeline.ts
+++ b/packages/adapters/src/runtime/build-pipeline.ts
@@ -37,7 +37,15 @@ export {
  * instead of constructing raw LogEntry objects.
  */
 export class BuildLogger {
-  constructor(private readonly onLog?: LogCallback) {}
+  constructor(
+    private readonly onLog?: LogCallback,
+    private readonly onBuildOutput?: (data: string, streamId: string) => void,
+  ) {}
+
+  /** Observe command output before rendering, without emitting another log entry. */
+  observeBuildOutput(data: string, streamId = "default"): void {
+    this.onBuildOutput?.(data, streamId);
+  }
 
   /** Emit a plain log line. */
   log(

--- a/packages/adapters/src/runtime/docker-build-output-observer.test.ts
+++ b/packages/adapters/src/runtime/docker-build-output-observer.test.ts
@@ -1,0 +1,124 @@
+import { PassThrough } from "node:stream";
+import Dockerode from "dockerode";
+import { describe, expect, it, vi } from "vitest";
+
+import { statusResponse } from "../../test/fixtures/docker-buildkit";
+import type { BuildConfig, CommandExecutor, LogEntry } from "../types";
+import { BuildLogger } from "./build-pipeline";
+import { DockerRuntime } from "./docker";
+import { BuildKitTraceDecoder } from "./docker-buildkit-trace";
+
+describe("raw Docker build output observers", () => {
+  it("does not publish an observed fragment as another user-visible log entry", () => {
+    const onLog = vi.fn();
+    const onOutput = vi.fn();
+    const logger = new BuildLogger(onLog, onOutput);
+
+    logger.observeBuildOutput("an unfinished fragment");
+    expect(onOutput).toHaveBeenCalledWith("an unfinished fragment", "default");
+    expect(onLog).not.toHaveBeenCalled();
+
+    logger.log("rendered output");
+    expect(onLog).toHaveBeenCalledOnce();
+    expect(onLog.mock.calls[0]?.[0].message).toBe("rendered output");
+    expect(onOutput).toHaveBeenCalledOnce();
+  });
+
+  it.each(["classic", "buildkit stdout", "buildkit stderr"])(
+    "observes %s fragments before rendering while leaving build success intact",
+    async (builder) => {
+      const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime;
+      Object.assign(runtime, {
+        _docker: new Dockerode({ socketPath: "/tmp/openship-test-absent.sock" }),
+      });
+      const chunks = ["getaddrinfo ENO", "TFOUND db", ".example.com\n", "\n"];
+      const outputStream = builder === "buildkit stderr" ? 2 : 1;
+      const events = chunks.map((chunk) =>
+        builder === "classic"
+          ? { stream: chunk }
+          : {
+              id: "moby.buildkit.trace",
+              aux: statusResponse({
+                logs: [{ vertex: "sha256:build", stream: outputStream, msg: chunk }],
+              }),
+            },
+      );
+
+      const run = async (onOutput?: (data: string, streamId: string) => void) => {
+        const entries: LogEntry[] = [];
+        const stream = new PassThrough();
+        const result = (runtime as any).streamDockerodeBuild(
+          stream,
+          new BuildLogger((entry) => entries.push(entry), onOutput),
+          { trace: new BuildKitTraceDecoder() },
+        );
+        stream.end(events.map((event) => `${JSON.stringify(event)}\n`).join(""));
+        await expect(result).resolves.toBeUndefined();
+        return entries.map(({ message, level, rawData }) => ({ message, level, rawData }));
+      };
+
+      const baseline = await run();
+      const onOutput = vi.fn();
+      expect(await run(onOutput)).toEqual(baseline);
+      expect(onOutput.mock.calls).toEqual(
+        chunks.map((chunk) => [
+          chunk,
+          builder === "classic" ? "default" : `sha256:build:${outputStream}`,
+        ]),
+      );
+    },
+  );
+
+  it("keeps SSH stdout and stderr fragments separate without duplicating visible logs", async () => {
+    const chunks: LogEntry[] = [
+      { timestamp: "", level: "info", message: "getaddrinfo ENO" },
+      { timestamp: "", level: "warn", message: "unrelated stderr\n" },
+      { timestamp: "", level: "info", message: "TFOUND db\n" },
+    ];
+    const executor = {
+      exec: vi.fn(async () => ""),
+      streamExec: vi.fn(
+        async (_command: string, onLog: Parameters<CommandExecutor["streamExec"]>[1]) => {
+          for (const chunk of chunks) onLog(chunk);
+          return { code: 0, output: "" };
+        },
+      ),
+    } as unknown as CommandExecutor;
+    const runtime = Object.create(DockerRuntime.prototype) as DockerRuntime;
+    Object.assign(runtime, { connectionOptions: { executor } });
+    const onOutput = vi.fn();
+    const entries: LogEntry[] = [];
+    const config: BuildConfig = {
+      sessionId: "observer-build",
+      projectId: "project",
+      slug: "example",
+      repoUrl: "https://example.com/repo.git",
+      branch: "main",
+      stack: "docker",
+      buildImage: "",
+      packageManager: "",
+      installCommand: "",
+      buildCommand: "",
+      outputDirectory: "",
+      port: 3000,
+      runtimeImage: "",
+      envVars: {},
+      resources: { cpuCores: 0, memoryMb: 0, diskMb: 0 },
+    };
+
+    await expect(
+      (runtime as any).buildImageOnRemote(
+        config,
+        "/tmp/observer-build",
+        "Dockerfile",
+        "openship/example:build",
+        new BuildLogger((entry) => entries.push(entry), onOutput),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(onOutput.mock.calls).toEqual(chunks.map((chunk) => [chunk.message, chunk.level]));
+    for (const chunk of chunks) {
+      expect(entries.filter((entry) => entry.message === chunk.message)).toHaveLength(1);
+    }
+  });
+});

--- a/packages/adapters/src/runtime/docker-buildkit-trace.test.ts
+++ b/packages/adapters/src/runtime/docker-buildkit-trace.test.ts
@@ -72,6 +72,27 @@ describe("BuildKitTraceDecoder", () => {
     ]);
   });
 
+  it("observes raw fragments separately by vertex and stream without changing rendering", () => {
+    const decoder = new BuildKitTraceDecoder();
+    const baseline = new BuildKitTraceDecoder();
+    const observed: Array<[string, string]> = [];
+    const logs = [
+      { vertex: DIGEST, stream: 1, msg: "getaddrinfo ENO" },
+      { vertex: "sha256:other", stream: 1, msg: "another build step\n" },
+      { vertex: DIGEST, stream: 2, msg: "stderr output\n" },
+      { vertex: DIGEST, stream: 1, msg: "TFOUND db\n\n" },
+    ];
+
+    for (const log of logs) {
+      const payload = statusResponse({ logs: [log] });
+      expect(decoder.push(payload, (data, streamId) => observed.push([data, streamId]))).toEqual(
+        baseline.push(payload),
+      );
+    }
+
+    expect(observed).toEqual(logs.map((log) => [log.msg, `${log.vertex}:${log.stream}`]));
+  });
+
   it("reports a cached step as cached, and a plain one as done", () => {
     const decoder = new BuildKitTraceDecoder();
     expect(

--- a/packages/adapters/src/runtime/docker-buildkit-trace.ts
+++ b/packages/adapters/src/runtime/docker-buildkit-trace.ts
@@ -124,6 +124,7 @@ interface TraceVertex {
 
 interface TraceLog {
   vertex: string;
+  stream: number;
   msg: string;
 }
 
@@ -174,6 +175,7 @@ function decodeVertex(bytes: Uint8Array): TraceVertex | null {
 function decodeLog(bytes: Uint8Array): TraceLog | null {
   const reader = new WireReader(bytes);
   let vertex = "";
+  let stream = 0;
   let msg: Uint8Array | null = null;
 
   while (!reader.done) {
@@ -183,6 +185,10 @@ function decodeLog(bytes: Uint8Array): TraceLog | null {
       const value = reader.bytes();
       if (!value) return null;
       vertex = text(value);
+    } else if (key.field === 3 && key.wire === WIRE_VARINT) {
+      const value = reader.varint();
+      if (value === null) return null;
+      stream = value;
     } else if (key.field === 4 && key.wire === WIRE_LENGTH) {
       const value = reader.bytes();
       if (!value) return null;
@@ -198,7 +204,7 @@ function decodeLog(bytes: Uint8Array): TraceLog | null {
   // log. Dropping it degrades to "no per-command output", never to garbage.
   if (!vertex.startsWith("sha256:") || !msg?.length) return null;
 
-  return { vertex, msg: text(msg) };
+  return { vertex, stream, msg: text(msg) };
 }
 
 /**
@@ -212,7 +218,10 @@ export class BuildKitTraceDecoder {
   private readonly settled = new Set<string>();
 
   /** Decode one `aux` payload into the lines it should add to the build log. */
-  push(auxBase64: string): BuildKitTraceLine[] {
+  push(
+    auxBase64: string,
+    onOutput?: (data: string, streamId: string) => void,
+  ): BuildKitTraceLine[] {
     let payload: Uint8Array;
     try {
       payload = Uint8Array.from(Buffer.from(auxBase64, "base64"));
@@ -240,7 +249,12 @@ export class BuildKitTraceDecoder {
         const bytes = reader.bytes();
         if (!bytes) break;
         const entry = decodeLog(bytes);
-        if (entry) lines.push(...this.renderLog(entry));
+        if (entry) {
+          // Preserve fragment boundaries and stdout/stderr identity before the
+          // renderer splits lines or adds step prefixes.
+          onOutput?.(entry.msg, `${entry.vertex}:${entry.stream}`);
+          lines.push(...this.renderLog(entry));
+        }
         continue;
       }
 

--- a/packages/adapters/src/runtime/docker.ts
+++ b/packages/adapters/src/runtime/docker.ts
@@ -1299,7 +1299,10 @@ export class DockerRuntime implements RuntimeAdapter {
     // string check matters — it is not decoration.
     if (event.id === "moby.buildkit.trace" && typeof event.aux === "string") {
       let hint: string | null = null;
-      for (const line of trace?.push(event.aux) ?? []) {
+      const lines = trace?.push(event.aux, (data, streamId) =>
+        logger.observeBuildOutput(data, streamId),
+      );
+      for (const line of lines ?? []) {
         // Same treatment the classic builder's `stream` lines get, deliberately: the
         // failure hints (OOM-killed install, wrong rootDirectory, BuildKit refused)
         // are the only thing that turns a bare exit code into an explanation, and
@@ -1315,6 +1318,7 @@ export class DockerRuntime implements RuntimeAdapter {
     }
 
     if (event.stream) {
+      logger.observeBuildOutput(event.stream);
       const line = event.stream.trim();
       if (!line) return null;
 
@@ -1655,6 +1659,7 @@ export class DockerRuntime implements RuntimeAdapter {
         buildCmd,
         (entry) => {
           idleMonitor.progress();
+          log.observeBuildOutput(entry.message, entry.level);
           buildContainerTracker?.observeChunk(entry.message);
           streamedFailureHint = chooseDockerBuildFailureHint(
             streamedFailureHint,


### PR DESCRIPTION
## Summary

When a failed Docker build logs `getaddrinfo ENOTFOUND db` for a project service, the service's failure message now preserves the Docker error and adds actionable guidance about build networking and database initialization.

## Motivation

A Next.js/Payload build can initialize Postgres while collecting route data, before its container starts. A running `db` service and `dependsOn` do not automatically make that hostname resolvable inside the image builder. The final exit-code error currently leaves users without that distinction.

This change improves diagnosis and documents the application fix. It does not attach image builds to the service network or change deployment ordering.

## Related issue

Related to #795, specifically the subsequent `ENOTFOUND db` / `Failed to collect page data` build failure. This PR does not close the broader issue.

## Changes

- **apps/api:** append advice only to failed Docker builds with DNS evidence for an enabled project service; preserve the original error in logs and service status events.
- **packages/adapters:** observe raw classic Docker, BuildKit, and SSH build output before rendering, preserving fragmented messages and stream boundaries without duplicating visible logs.
- **apps/web:** document startup-only `dependsOn`, request-time Payload initialization, and intentional static-generation database access.

Diagnostics retain bounded partial output and copy only the matched service name into the advice. Successful builds, cancellations, cloud builds, and unrelated DNS/authentication failures retain their existing behavior.

## Verification

Node 22.23.2 (matching `.nvmrc`), Bun 1.3.14. The complete root test graph passed with two workers and a 10-second test timeout; the timeout accommodates the CLI's existing six-second remembered-port wait while port 3001 is occupied locally.

```bash
node_modules/.bin/turbo run test --filter='!@repo/email' --concurrency=1 -- --maxWorkers=2 --testTimeout=10000
# Tasks: 7 successful, 7 total
# 896 test files passed; 12,165 tests passed, 3 skipped

bun run --cwd apps/api lint
bun run --cwd packages/adapters lint
# Both exit 0

bun run format
# Completed; unrelated baseline formatting changes were restored

git diff --check
# Exit 0
```

Both edited MDX documents compile. A final Prettier check passes for all changed TypeScript files.

The primary regression test fails when loaded against the original compose build module: it receives only the Docker exit-code error. It passes with this change, along with cases for fragmented/colored output, separate streams, unrelated hostnames, original-error preservation, and successful or cancelled builds.

## Checklist

- [x] One change per PR — one bug, or one agreed feature, with nothing unrelated bundled in
- [x] The diff is scoped — no reformatting or lint fixes on lines I wasn't otherwise changing
- [x] A test fails without this change and passes with it
- [x] The root test suite (with the worker/timeout options above), relevant typechecks, and formatting pass locally
- [x] I understand every line of this diff and can explain it in review
